### PR TITLE
Fix release workflow for v0.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,9 +89,14 @@ jobs:
           --output nupkgs
 
       - name: Push to NuGet.org
-        run: dotnet nuget push nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "NUGET_API_KEY not set — skipping NuGet publish"
+            exit 0
+          fi
+          dotnet nuget push nupkgs/*.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json
 
   create-release:
     name: Create GitHub Release

--- a/src/Connapse.CLI/Connapse.CLI.csproj
+++ b/src/Connapse.CLI/Connapse.CLI.csproj
@@ -18,12 +18,14 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>connapse</ToolCommandName>
     <PackageId>Connapse.CLI</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>Connapse Contributors</Authors>
     <Description>CLI for Connapse — the open-source AI knowledge management platform.</Description>
     <PackageProjectUrl>https://github.com/Destrayon/Connapse</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Destrayon/Connapse</RepositoryUrl>
     <PackageLicense>MIT</PackageLicense>
+
+    <AssemblyName>connapse</AssemblyName>
 
     <!-- Self-contained single-file publish (used by release.yml) -->
     <PublishSingleFile>true</PublishSingleFile>


### PR DESCRIPTION
## Summary
- Add `<AssemblyName>connapse</AssemblyName>` to `Connapse.CLI.csproj` — the published binary was defaulting to `Connapse.CLI`/`Connapse.CLI.exe`, causing the rename steps to fail
- Bump `<Version>` to `0.2.1`
- Make NuGet push skip gracefully when `NUGET_API_KEY` secret is not set (instead of erroring with a misleading "source not specified" message)

## Test plan
- [ ] Merge to main
- [ ] Delete and re-push the `v0.2.1` tag to re-trigger the Release workflow
- [ ] Verify all three jobs (`build-cli`, `publish-nuget`, `create-release`) pass
- [ ] Confirm GitHub Release is created with all four platform binaries attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)