### PR TITLE
feat: CLI self-update command and version display (v0.2.2)

### DIFF
--- a/.claude/state/progress.md
+++ b/.claude/state/progress.md
@@ -4,7 +4,36 @@ Current status and recent work. Update at end of each session. For detailed impl
 
 ---
 
-## Current Status (2026-02-26) — v0.2.0 COMPLETE
+## Current Status (2026-02-27) — v0.2.2 in progress (branch: feature/0.2.2)
+
+### Session 19 — CLI Self-Update + Version Check
+
+Added CLI update mechanism to `src/Connapse.CLI/Program.cs`:
+
+**New commands:**
+- `connapse version` — prints installed version (reads `AssemblyInformationalVersionAttribute`)
+- `connapse update [--check]` — checks GitHub Releases API for a newer binary, downloads and replaces in-place; `--check` previews without installing
+- Passive update notification — after every command (except `version`/`update`), checks once per 24h via `~/.connapse/last-update-check`; prints a yellow hint if a newer release exists
+
+**Implementation details:**
+- `GetCurrentVersion()` — reads `AssemblyInformationalVersionAttribute`, strips build metadata (`+abc123`)
+- `GetPlatformAssetName()` — maps current OS/arch to the release asset name (`connapse-win-x64.exe`, `connapse-linux-x64`, `connapse-osx-x64`, `connapse-osx-arm64`)
+- `IsNewer()` — semver comparison via `System.Version`; falls back to string compare
+- Windows binary swap: running `.exe` is locked, so update writes `{exe}.new` and launches a `connapse-update.bat` via `cmd /c` to move it after the process exits
+- Linux/macOS: `File.Move(overwrite: true)` + `File.SetUnixFileMode` to restore execute bit
+- GitHub API: uses separate `HttpClient` (3s timeout for passive check, 10s for `update`); `User-Agent: connapse-cli/{version}` header
+- `GitHubRelease` / `GitHubAsset` records with `[JsonPropertyName]` for snake_case fields
+- Version bumped to `0.2.2` in csproj
+
+**Files changed:**
+- `src/Connapse.CLI/Program.cs` — all update logic
+- `src/Connapse.CLI/Connapse.CLI.csproj` — version 0.2.1 → 0.2.2
+
+**Build:** 0 errors, same pre-existing IL2026 trimming warnings as before
+
+---
+
+## Previous Status (2026-02-26) — v0.2.0 COMPLETE
 
 ### Session 18 — Testing + Deployment + CLI Distribution (Session G)
 

--- a/src/Connapse.CLI/Connapse.CLI.csproj
+++ b/src/Connapse.CLI/Connapse.CLI.csproj
@@ -18,7 +18,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>connapse</ToolCommandName>
     <PackageId>Connapse.CLI</PackageId>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
     <Authors>Connapse Contributors</Authors>
     <Description>CLI for Connapse — the open-source AI knowledge management platform.</Description>
     <PackageProjectUrl>https://github.com/Destrayon/Connapse</PackageProjectUrl>
@@ -33,6 +33,8 @@
     <PublishTrimmed>true</PublishTrimmed>
     <TrimmerRootDescriptor>trimmer-roots.xml</TrimmerRootDescriptor>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+    <NoWarn>$(NoWarn);IL2026;IL2072</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/Connapse.CLI/Program.cs
+++ b/src/Connapse.CLI/Program.cs
@@ -3,9 +3,12 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Net.Sockets;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Configuration;
 
 // Load configuration
@@ -47,17 +50,20 @@ if (args.Length == 0)
 
 var command = args[0].ToLower();
 
+int exitCode;
 try
 {
-    return command switch
+    exitCode = command switch
     {
-        "auth" => await HandleAuth(args, httpClient, jsonOptions, apiBaseUrl),
+        "version" => HandleVersion(),
+        "update"  => await HandleUpdate(args),
+        "auth"    => await HandleAuth(args, httpClient, jsonOptions, apiBaseUrl),
         "container" => await HandleContainer(args, httpClient, jsonOptions),
-        "upload" => await HandleUpload(args, httpClient, jsonOptions),
-        "search" => await HandleSearch(args, httpClient, jsonOptions),
+        "upload"  => await HandleUpload(args, httpClient, jsonOptions),
+        "search"  => await HandleSearch(args, httpClient, jsonOptions),
         "reindex" => await HandleReindex(args, httpClient, jsonOptions),
         // Legacy aliases
-        "ingest" => await HandleUpload(args, httpClient, jsonOptions),
+        "ingest"  => await HandleUpload(args, httpClient, jsonOptions),
         _ => Error($"Unknown command '{command}'")
     };
 }
@@ -66,11 +72,24 @@ catch (Exception ex)
     return Error(ex.Message);
 }
 
+// Passive update check — runs once per day, silent on failure
+if (command is not ("version" or "update"))
+    await CheckForUpdateNotification();
+
+return exitCode;
+
 static void PrintUsage()
 {
-    Console.WriteLine("Connapse Platform CLI");
+    Console.WriteLine($"Connapse Platform CLI v{GetCurrentVersion()}");
     Console.WriteLine();
     Console.WriteLine("Usage: connapse <command> [options]");
+    Console.WriteLine();
+    Console.WriteLine("General:");
+    Console.WriteLine("  version");
+    Console.WriteLine("      Show the installed version");
+    Console.WriteLine();
+    Console.WriteLine("  update [--check]");
+    Console.WriteLine("      Update to the latest release (--check to preview without installing)");
     Console.WriteLine();
     Console.WriteLine("Authentication:");
     Console.WriteLine("  auth login [--url <server-url>] [--no-browser]");
@@ -1230,6 +1249,142 @@ static async Task<(string Code, string State)> WaitForCallbackAsync(
 }
 
 // ---------------------------------------------------------------------------
+// version / update
+// ---------------------------------------------------------------------------
+
+static int HandleVersion()
+{
+    Console.WriteLine($"connapse v{GetCurrentVersion()}");
+    return 0;
+}
+
+static async Task<int> HandleUpdate(string[] args)
+{
+    var checkOnly = args.Contains("--check");
+    var currentVersion = GetCurrentVersion();
+    Console.WriteLine($"Current version: v{currentVersion}");
+
+    using var ghClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+    ghClient.DefaultRequestHeaders.UserAgent.Add(
+        new ProductInfoHeaderValue("connapse-cli", currentVersion));
+
+    GitHubRelease? release;
+    try
+    {
+        release = await ghClient.GetFromJsonAsync<GitHubRelease>(
+            "https://api.github.com/repos/Destrayon/Connapse/releases/latest",
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+    }
+    catch (Exception ex)
+    {
+        return Error($"Could not reach GitHub: {ex.Message}");
+    }
+
+    if (release is null)
+        return Error("Could not parse release information from GitHub.");
+
+    var latestVersion = release.TagName.TrimStart('v');
+    Console.WriteLine($"Latest version:  v{latestVersion}");
+
+    if (!IsNewer(latestVersion, currentVersion))
+    {
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine("You are already up to date.");
+        Console.ResetColor();
+        return 0;
+    }
+
+    Console.ForegroundColor = ConsoleColor.Cyan;
+    Console.WriteLine($"Update available: v{currentVersion} → v{latestVersion}");
+    Console.ResetColor();
+
+    if (checkOnly) return 0;
+
+    var assetName = GetPlatformAssetName();
+    var asset = release.Assets.FirstOrDefault(a =>
+        string.Equals(a.Name, assetName, StringComparison.OrdinalIgnoreCase));
+
+    if (asset is null)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine($"No binary for this platform ({assetName}) in the release.");
+        Console.WriteLine("If you installed via NuGet, run:  dotnet tool update -g Connapse.CLI");
+        Console.ResetColor();
+        return 1;
+    }
+
+    // Detect global tool install — the shim lives in ~/.dotnet/tools/ and cannot
+    // be replaced with a self-contained native binary.
+    if (IsGlobalToolInstall())
+    {
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("Installed via .NET global tool. Run:");
+        Console.WriteLine("  dotnet tool update -g Connapse.CLI");
+        Console.ResetColor();
+        return 0;
+    }
+
+    Console.Write($"Download and install v{latestVersion}? [y/N] ");
+    var confirm = Console.ReadLine()?.Trim().ToLower();
+    if (confirm is not ("y" or "yes")) return 0;
+
+    var exePath = Environment.ProcessPath;
+    if (string.IsNullOrEmpty(exePath))
+        return Error("Could not determine current executable path.");
+
+    var tmpPath = exePath + ".new";
+    Console.Write($"Downloading {assetName}... ");
+    try
+    {
+        using var response = await ghClient.GetAsync(
+            asset.BrowserDownloadUrl, HttpCompletionOption.ResponseHeadersRead);
+        response.EnsureSuccessStatusCode();
+        await using var fs = new FileStream(tmpPath, FileMode.Create, FileAccess.Write);
+        await response.Content.CopyToAsync(fs);
+    }
+    catch (Exception ex)
+    {
+        if (File.Exists(tmpPath)) File.Delete(tmpPath);
+        return Error($"\nDownload failed: {ex.Message}");
+    }
+    Console.WriteLine("done.");
+
+    if (OperatingSystem.IsWindows())
+    {
+        // Running .exe is locked on Windows — hand off to a batch script
+        var batPath = Path.Combine(Path.GetTempPath(), "connapse-update.bat");
+        File.WriteAllText(batPath,
+            "@echo off\r\n" +
+            "timeout /t 2 /nobreak > nul\r\n" +
+            $"move /y \"{tmpPath}\" \"{exePath}\" > nul\r\n" +
+            "del \"%~f0\"\r\n");
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = "cmd",
+            Arguments = $"/c \"{batPath}\"",
+            CreateNoWindow = true,
+            UseShellExecute = false
+        });
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine($"connapse will be updated to v{latestVersion} in a moment.");
+        Console.ResetColor();
+    }
+    else
+    {
+        File.Move(tmpPath, exePath, overwrite: true);
+        // Restore execute permission after overwrite
+        var mode = File.GetUnixFileMode(exePath);
+        File.SetUnixFileMode(exePath,
+            mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine($"Updated to v{latestVersion}. Restart connapse to confirm.");
+        Console.ResetColor();
+    }
+
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
 // Credential helpers
 // ---------------------------------------------------------------------------
 
@@ -1278,6 +1433,77 @@ static void EnsureAuthenticated()
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
+
+static string GetCurrentVersion() =>
+    typeof(Program).Assembly
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+        ?.InformationalVersion.Split('+')[0]   // strip build metadata e.g. +abc123
+        ?? "0.0.0";
+
+static string GetPlatformAssetName()
+{
+    if (OperatingSystem.IsWindows()) return "connapse-win-x64.exe";
+    if (OperatingSystem.IsLinux())   return "connapse-linux-x64";
+    if (OperatingSystem.IsMacOS())
+        return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+            ? "connapse-osx-arm64"
+            : "connapse-osx-x64";
+    return "connapse-linux-x64";
+}
+
+static bool IsGlobalToolInstall()
+{
+    var exePath = Environment.ProcessPath;
+    if (string.IsNullOrEmpty(exePath)) return false;
+    var dotnetToolsDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".dotnet", "tools");
+    return exePath.StartsWith(dotnetToolsDir, StringComparison.OrdinalIgnoreCase);
+}
+
+static bool IsNewer(string latest, string current)
+{
+    if (Version.TryParse(latest, out var latestV) && Version.TryParse(current, out var currentV))
+        return latestV > currentV;
+    return string.Compare(latest, current, StringComparison.Ordinal) > 0;
+}
+
+static async Task CheckForUpdateNotification()
+{
+    try
+    {
+        var checkFile = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".connapse", "last-update-check");
+
+        if (File.Exists(checkFile) &&
+            DateTime.TryParse(File.ReadAllText(checkFile).Trim(), out var lastCheck) &&
+            DateTime.UtcNow - lastCheck < TimeSpan.FromHours(24))
+            return;
+
+        var currentVersion = GetCurrentVersion();
+        using var ghClient = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
+        ghClient.DefaultRequestHeaders.UserAgent.Add(
+            new ProductInfoHeaderValue("connapse-cli", currentVersion));
+
+        var release = await ghClient.GetFromJsonAsync<GitHubRelease>(
+            "https://api.github.com/repos/Destrayon/Connapse/releases/latest",
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Directory.CreateDirectory(Path.GetDirectoryName(checkFile)!);
+        File.WriteAllText(checkFile, DateTime.UtcNow.ToString("O"));
+
+        if (release is null) return;
+        var latestVersion = release.TagName.TrimStart('v');
+        if (IsNewer(latestVersion, currentVersion))
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine($"\n  Note: connapse v{latestVersion} is available. Run 'connapse update' to upgrade.");
+            Console.ResetColor();
+        }
+    }
+    catch { }
+}
 
 // Resolve container name to ID via API
 static async Task<string?> ResolveContainerId(string nameOrId, HttpClient httpClient, JsonSerializerOptions jsonOptions)
@@ -1378,3 +1604,9 @@ record ReindexResult(
     int FailedCount,
     Dictionary<string, int>? ReasonCounts,
     string Message);
+record GitHubRelease(
+    [property: JsonPropertyName("tag_name")] string TagName,
+    [property: JsonPropertyName("assets")]   List<GitHubAsset> Assets);
+record GitHubAsset(
+    [property: JsonPropertyName("name")]                  string Name,
+    [property: JsonPropertyName("browser_download_url")] string BrowserDownloadUrl);

--- a/src/Connapse.Web/Connapse.Web.csproj
+++ b/src/Connapse.Web/Connapse.Web.csproj
@@ -22,6 +22,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
+    <NoWarn>$(NoWarn);ASPDEPR005</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -37,7 +37,7 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
     // Allow any proxy/network — restrict this if your proxy IPs are known
-    options.KnownNetworks.Clear();
+    options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
 });
 


### PR DESCRIPTION
## Summary

- Add `connapse version` — prints the installed version from assembly metadata
- Add `connapse update [--check]` — fetches latest GitHub Release, downloads the platform binary, and replaces the running executable in-place
- Passive background update notification shown once per 24 h after any command (silent on failure)
- Windows binary swap handled via a temp `.bat` script to work around the locked-file limitation
- Detects `.NET` global tool installs and redirects to `dotnet tool update -g Connapse.CLI`
- Bump CLI version `0.2.1 → 0.2.2`; suppress `IL2026`/`IL2072` trimming warnings
- Fix deprecated `KnownNetworks` → `KnownIPNetworks` in `Connapse.Web/Program.cs`

## Test plan

- [ ] `connapse version` prints `connapse v0.2.2`
- [ ] `connapse update --check` shows current vs latest without downloading
- [ ] `connapse update` prompts, downloads, and installs (or prints dotnet-tool message)
- [ ] Running any command when a newer release exists shows the yellow hint (after clearing `~/.connapse/last-update-check`)
- [ ] Build passes with no new errors: `dotnet build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)