### PR TITLE
refactor: remove reflection-based MinIO settings extraction

### DIFF
--- a/src/Connapse.Storage/ConnectionTesters/MinioConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/MinioConnectionTester.cs
@@ -160,14 +160,8 @@ public class MinioConnectionTester : IConnectionTester
         if (settings is FileSystem.MinioOptions opts)
             return (opts.Endpoint, opts.AccessKey, opts.SecretKey, opts.BucketName, opts.UseSSL);
 
-        // Reflection fallback for arbitrary DTOs
-        var type = settings.GetType();
-        var endpoint = (type.GetProperty("MinioEndpoint") ?? type.GetProperty("Endpoint"))?.GetValue(settings)?.ToString();
-        var accessKey = (type.GetProperty("MinioAccessKey") ?? type.GetProperty("AccessKey"))?.GetValue(settings)?.ToString();
-        var secretKey = (type.GetProperty("MinioSecretKey") ?? type.GetProperty("SecretKey"))?.GetValue(settings)?.ToString();
-        var bucketName = (type.GetProperty("MinioBucketName") ?? type.GetProperty("BucketName"))?.GetValue(settings)?.ToString();
-        var useSSL = (type.GetProperty("MinioUseSSL") ?? type.GetProperty("UseSSL"))?.GetValue(settings) as bool? ?? false;
-
-        return (endpoint, accessKey, secretKey, bucketName, useSSL);
+        throw new ArgumentException(
+            $"Settings must be of type {nameof(FileSystem.MinioOptions)}, but received {settings.GetType().Name}.",
+            nameof(settings));
     }
 }


### PR DESCRIPTION
## Summary
- Remove fragile reflection-based `ExtractMinioSettings` fallback from `MinioConnectionTester`
- Only accept typed `MinioOptions` — throw `ArgumentException` for other types
- Eliminates silent null returns on property mismatch that caused confusing errors

## Test plan
- [x] `dotnet build src/Connapse.Storage/Connapse.Storage.csproj` passes
- [x] `dotnet test tests/Connapse.Core.Tests` passes (233 tests)
- [x] `dotnet test tests/Connapse.Identity.Tests` passes (46 tests)
- [x] `dotnet test tests/Connapse.Ingestion.Tests` passes (52 tests)
- [x] MinIO connection test still works with properly typed settings

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)