### PR TITLE
fix: repair PR auto-labeling workflows

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,7 +2,7 @@ name: PR Branch Labeler
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -12,7 +12,7 @@ jobs:
   label-size:
     runs-on: ubuntu-latest
     steps:
-      - uses: pascalgn/size-label-action@v0.5.4
+      - uses: pascalgn/size-label-action@v0.5.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILES_TO_IGNORE: >
@@ -27,11 +27,11 @@ jobs:
         with:
           sizes: >
             {
-              "0": "size/XS",
-              "50": "size/S",
-              "150": "size/M",
-              "300": "size/L",
-              "500": "size/XL"
+              "0": "XS",
+              "50": "S",
+              "150": "M",
+              "300": "L",
+              "500": "XL"
             }
 
   warn-large:


### PR DESCRIPTION
## Summary
- Fix `pr-size.yml`: remove redundant `size/` prefix from label values — `pascalgn/size-label-action` prepends `size/` automatically, causing labels like `size/size/XS` to be created instead of `size/XS`
- Bump `pascalgn/size-label-action` from v0.5.4 to v0.5.5 (latest)
- Fix `pr-labeler.yml`: add `synchronize` and `reopened` trigger types so branch-based labels are re-applied when commits are pushed to an existing PR

Also cleaned up the bogus `size/size/XL` and `size/size/S` labels that were previously created by the bug.

## Test plan
- [ ] Create a test PR from a `fix/` branch and verify `type: bug` label is applied
- [ ] Verify `size/XS` (or appropriate tier) label is applied — not `size/size/XS`
- [ ] Push an additional commit to the PR and verify labels are re-evaluated
- [ ] Check workflow run logs in Actions tab confirm success

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)