### PR TITLE
refactor: remove fake SearchStreamAsync that buffers before yielding

### DIFF
--- a/src/Connapse.Core/Interfaces/IKnowledgeSearch.cs
+++ b/src/Connapse.Core/Interfaces/IKnowledgeSearch.cs
@@ -3,5 +3,4 @@ namespace Connapse.Core.Interfaces;
 public interface IKnowledgeSearch
 {
     Task<SearchResult> SearchAsync(string query, SearchOptions options, CancellationToken ct = default);
-    IAsyncEnumerable<SearchHit> SearchStreamAsync(string query, SearchOptions options, CancellationToken ct = default);
 }

--- a/src/Connapse.Search/Hybrid/HybridSearchService.cs
+++ b/src/Connapse.Search/Hybrid/HybridSearchService.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Search.Keyword;
@@ -187,26 +186,4 @@ public class HybridSearchService : IKnowledgeSearch
         return combinedHits;
     }
 
-    /// <summary>
-    /// Streams search results as they become available.
-    /// </summary>
-    public async IAsyncEnumerable<SearchHit> SearchStreamAsync(
-        string query,
-        SearchOptions options,
-        [EnumeratorCancellation] CancellationToken ct = default)
-    {
-        // For now, stream results from the batch search
-        // In a future enhancement, this could stream results as they're found
-        var result = await SearchAsync(query, options, ct);
-
-        foreach (var hit in result.Hits)
-        {
-            if (ct.IsCancellationRequested)
-            {
-                yield break;
-            }
-
-            yield return hit;
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- Remove `SearchStreamAsync` from `IKnowledgeSearch` interface (was buffering the entire result set via `SearchAsync` before yielding individual hits, providing no streaming benefit and presenting a misleading API contract)
- Remove the implementation from `HybridSearchService`, including the now-unused `System.Runtime.CompilerServices` import
- No callers needed updating — `SearchStreamAsync` had zero call sites outside the interface/implementation

## Test plan
- [x] `dotnet build` passes (0 errors, 0 warnings)
- [x] `dotnet test --filter Category=Unit` passes (274 tests: 177 Core + 46 Identity + 51 Ingestion)
- [x] Verified no remaining references to `SearchStreamAsync` in `.cs` files

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)