### PR TITLE
refactor: remove dead IngestFromPathAsync from IKnowledgeIngester

### DIFF
--- a/src/Connapse.Core/Interfaces/IKnowledgeIngester.cs
+++ b/src/Connapse.Core/Interfaces/IKnowledgeIngester.cs
@@ -3,6 +3,5 @@ namespace Connapse.Core.Interfaces;
 public interface IKnowledgeIngester
 {
     Task<IngestionResult> IngestAsync(Stream content, IngestionOptions options, CancellationToken ct = default);
-    Task<IngestionResult> IngestFromPathAsync(string path, IngestionOptions options, CancellationToken ct = default);
     IAsyncEnumerable<IngestionProgress> IngestWithProgressAsync(Stream content, IngestionOptions options, CancellationToken ct = default);
 }

--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -289,14 +289,6 @@ public class IngestionPipeline : IKnowledgeIngester
         }
     }
 
-    public Task<IngestionResult> IngestFromPathAsync(
-        string path,
-        IngestionOptions options,
-        CancellationToken ct = default)
-    {
-        throw new NotImplementedException("IngestFromPathAsync will be implemented in Phase 6");
-    }
-
     public async IAsyncEnumerable<IngestionProgress> IngestWithProgressAsync(
         Stream content,
         IngestionOptions options,


### PR DESCRIPTION
## Summary
- Remove `IngestFromPathAsync` method from `IKnowledgeIngester` interface (dead code)
- Remove `NotImplementedException` implementation from `IngestionPipeline`
- Verified no callers exist in the codebase

## Test plan
- [x] `dotnet build` passes (no compile errors from removal)
- [x] `dotnet test` passes — 333 unit tests pass (235 core, 52 ingestion, 46 identity)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)