### PR TITLE
Fix create-tickets skill adding needs-triage to triaged issues

### DIFF
--- a/.claude/skills/create-tickets/SKILL.md
+++ b/.claude/skills/create-tickets/SKILL.md
@@ -54,13 +54,18 @@ For each issue, determine all metadata:
 - Good: "Add multi-prefix OR-clause to cloud scope search"
 - Bad: "Cloud scope search improvements"
 
-### Labels (always include `needs-triage` plus one type and one or more area labels)
+### Labels (one type, one or more area labels, and a size label)
 
 **Type labels** (exactly one):
 `type: feature`, `type: bug`, `type: enhancement`, `type: refactor`, `type: docs`, `type: test`, `type: infrastructure`
 
 **Area labels** (one or more):
 `area: core`, `area: web-ui`, `area: api`, `area: cli`, `area: mcp`, `area: ingestion`, `area: search`, `area: database`, `area: storage`, `area: identity`, `area: agents`
+
+**Size labels** (exactly one):
+`size/XS`, `size/S`, `size/M`, `size/L`, `size/XL`
+
+**Do NOT add `needs-triage`** — issues created by this skill are fully triaged at creation time.
 
 ### Priority
 - `P0-Critical`: Blocking users or breaking core functionality
@@ -137,9 +142,9 @@ gh issue create \
 BODY_CONTENT
 ISSUE_EOF
 )" \
-  --label "needs-triage" \
   --label "type: feature" \
   --label "area: storage" \
+  --label "size/S" \
   --milestone "v0.4.0"
 ```
 


### PR DESCRIPTION
## Summary
- Remove `needs-triage` label from the create-tickets skill — issues it creates are already fully triaged with type, area, priority, size, and milestone labels
- Add explicit size label (`size/XS`–`size/XL`) guidance to prevent the `size/size/` prefix duplication that was occurring

## Test plan
- [x] Run `/create-tickets` on a test discussion and verify no `needs-triage` label is added
- [x] Verify size labels use `size/S` format, not `size/size/S`

🤖 Generated with [Claude Code](https://claude.com/claude-code)