### PR TITLE
fix: improve keyword search to find exact term matches

### DIFF
--- a/src/Connapse.Search/Keyword/KeywordSearchService.cs
+++ b/src/Connapse.Search/Keyword/KeywordSearchService.cs
@@ -36,8 +36,16 @@ public class KeywordSearchService
             return [];
         }
 
-        // Sanitize query for tsquery (replace special characters, handle phrases)
-        var tsQuery = SanitizeQuery(query);
+        // Build an OR-joined tsquery so any matching term produces results.
+        // plainto_tsquery uses AND (all terms required), which misses chunks
+        // that contain only some of the query terms.
+        var tsQuery = BuildOrQuery(query);
+
+        if (string.IsNullOrEmpty(tsQuery))
+        {
+            _logger.LogWarning("Query '{Query}' produced no searchable terms", query);
+            return [];
+        }
 
         // Build WHERE clause for filters
         // Use {N} format consistently for EF Core's SqlQueryRaw parameterization
@@ -76,23 +84,24 @@ public class KeywordSearchService
 
         var whereClause = string.Join(" AND ", whereClauses);
 
-        // Use ts_rank for relevance scoring
-        // ts_rank returns a float4 score based on TF-IDF-like ranking
-        // Note: all parameters use {N} format for SqlQueryRaw
+        // Use ts_rank for relevance scoring with to_tsquery (OR-joined terms).
+        // Chunks matching more terms rank higher naturally via ts_rank.
+        // The tsQuery string is already a valid tsquery expression (e.g. 'term1' | 'term2'),
+        // so we use to_tsquery which accepts pre-formatted tsquery syntax.
         var sql = @$"
             SELECT
                 c.id as ChunkId,
                 c.document_id as DocumentId,
                 c.content as Content,
                 c.chunk_index as ChunkIndex,
-                ts_rank(c.search_vector, plainto_tsquery('english', {{{0}}})) as Rank,
+                ts_rank(c.search_vector, to_tsquery('english', {{{0}}})) as Rank,
                 d.file_name as FileName,
                 d.content_type as ContentType,
                 d.container_id as ContainerId
             FROM chunks c
             INNER JOIN documents d ON c.document_id = d.id
             WHERE {whereClause}
-              AND c.search_vector @@ plainto_tsquery('english', {{{0}}})
+              AND c.search_vector @@ to_tsquery('english', {{{0}}})
             ORDER BY Rank DESC
             LIMIT {{{topKIdx}}}";
 
@@ -142,19 +151,53 @@ public class KeywordSearchService
     }
 
     /// <summary>
-    /// Sanitizes user query for safe use with tsquery.
-    /// Removes special characters that could break the query.
+    /// Builds an OR-joined tsquery expression from user input.
+    /// Each term is sanitized and joined with '|' (OR) so that chunks
+    /// containing any of the query terms are returned. Chunks matching
+    /// more terms will rank higher via ts_rank.
     /// </summary>
-    private static string SanitizeQuery(string query)
+    internal static string BuildOrQuery(string query)
     {
-        // Remove characters that have special meaning in tsquery
-        // Keep alphanumeric, spaces, and common punctuation
-        var sanitized = new string(query
-            .Where(c => char.IsLetterOrDigit(c) || char.IsWhiteSpace(c) || c == '-' || c == '_')
+        // Split on whitespace, sanitize each term, filter empties
+        var terms = query
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
+            .Select(SanitizeTerm)
+            .Where(t => !string.IsNullOrEmpty(t))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (terms.Count == 0)
+            return string.Empty;
+
+        // Join with OR operator for to_tsquery syntax
+        return string.Join(" | ", terms);
+    }
+
+    /// <summary>
+    /// Sanitizes a single term for safe use in a tsquery expression.
+    /// Strips characters that are not valid in tsquery lexemes.
+    /// </summary>
+    internal static string SanitizeTerm(string term)
+    {
+        // Strip leading/trailing dots and other punctuation that PostgreSQL
+        // FTS would discard (e.g. ".NET" -> "NET", "C#" -> "C", "node.js" -> "node.js")
+        // Keep internal dots/hyphens as they can form compound lexemes
+        var sanitized = new string(term
+            .Where(c => char.IsLetterOrDigit(c) || c == '-' || c == '_' || c == '.')
             .ToArray());
 
-        // Collapse multiple spaces
-        return string.Join(" ", sanitized.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+        // Trim leading/trailing dots and hyphens (not valid at boundaries in tsquery)
+        sanitized = sanitized.Trim('.', '-', '_');
+
+        // Reject if empty or only special chars remain
+        if (string.IsNullOrEmpty(sanitized))
+            return string.Empty;
+
+        // Escape any single quotes (defense in depth — to_tsquery is parameterized,
+        // but the term flows through the 'english' dictionary as a lexeme)
+        sanitized = sanitized.Replace("'", "");
+
+        return sanitized;
     }
 
     // DTO for raw SQL query result

--- a/tests/Connapse.Core.Tests/Search/KeywordSearchQueryTests.cs
+++ b/tests/Connapse.Core.Tests/Search/KeywordSearchQueryTests.cs
@@ -1,0 +1,134 @@
+using Connapse.Search.Keyword;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Search;
+
+/// <summary>
+/// Tests for KeywordSearchService query building logic.
+/// Validates that multi-term queries use OR joining and terms are sanitized correctly.
+/// </summary>
+public class KeywordSearchQueryTests
+{
+    [Fact]
+    public void BuildOrQuery_SingleTerm_ReturnsTerm()
+    {
+        var result = KeywordSearchService.BuildOrQuery("Jellyfin");
+
+        result.Should().Be("Jellyfin");
+    }
+
+    [Fact]
+    public void BuildOrQuery_MultipleTerms_JoinsWithOr()
+    {
+        var result = KeywordSearchService.BuildOrQuery("Jellyfin Bitwarden");
+
+        result.Should().Be("Jellyfin | Bitwarden");
+    }
+
+    [Fact]
+    public void BuildOrQuery_ThreeTerms_JoinsAllWithOr()
+    {
+        var result = KeywordSearchService.BuildOrQuery("Jellyfin Bitwarden NET");
+
+        result.Should().Be("Jellyfin | Bitwarden | NET");
+    }
+
+    [Fact]
+    public void BuildOrQuery_DotNetTerm_StripsLeadingDot()
+    {
+        // ".NET" should become "NET" (leading dot stripped)
+        var result = KeywordSearchService.BuildOrQuery(".NET framework");
+
+        result.Should().Be("NET | framework");
+    }
+
+    [Fact]
+    public void BuildOrQuery_EmptyQuery_ReturnsEmpty()
+    {
+        var result = KeywordSearchService.BuildOrQuery("   ");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildOrQuery_SpecialCharactersOnly_ReturnsEmpty()
+    {
+        var result = KeywordSearchService.BuildOrQuery("!@#$%^&*()");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildOrQuery_DuplicateTerms_Deduplicates()
+    {
+        var result = KeywordSearchService.BuildOrQuery("test Test TEST");
+
+        // Should deduplicate case-insensitively
+        result.Should().Be("test");
+    }
+
+    [Fact]
+    public void BuildOrQuery_ExtraWhitespace_HandledCorrectly()
+    {
+        var result = KeywordSearchService.BuildOrQuery("  hello   world  ");
+
+        result.Should().Be("hello | world");
+    }
+
+    [Fact]
+    public void BuildOrQuery_HyphenatedTerm_PreservesHyphen()
+    {
+        var result = KeywordSearchService.BuildOrQuery("real-time updates");
+
+        result.Should().Be("real-time | updates");
+    }
+
+    [Fact]
+    public void BuildOrQuery_InternalDots_Preserved()
+    {
+        // "node.js" has internal dot which may form a compound lexeme
+        var result = KeywordSearchService.BuildOrQuery("node.js setup");
+
+        result.Should().Be("node.js | setup");
+    }
+
+    [Fact]
+    public void SanitizeTerm_LeadingTrailingDots_Stripped()
+    {
+        var result = KeywordSearchService.SanitizeTerm("..NET..");
+
+        result.Should().Be("NET");
+    }
+
+    [Fact]
+    public void SanitizeTerm_SpecialCharsRemoved()
+    {
+        var result = KeywordSearchService.SanitizeTerm("C#");
+
+        result.Should().Be("C");
+    }
+
+    [Fact]
+    public void SanitizeTerm_SingleQuotesRemoved()
+    {
+        var result = KeywordSearchService.SanitizeTerm("it's");
+
+        result.Should().Be("its");
+    }
+
+    [Fact]
+    public void SanitizeTerm_EmptyInput_ReturnsEmpty()
+    {
+        var result = KeywordSearchService.SanitizeTerm("!!!");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SanitizeTerm_Underscore_Preserved()
+    {
+        var result = KeywordSearchService.SanitizeTerm("my_variable");
+
+        result.Should().Be("my_variable");
+    }
+}


### PR DESCRIPTION
## Summary
- Switch keyword search from `plainto_tsquery` (AND) to `to_tsquery` with OR-joined terms
- Multi-word queries now match chunks containing **any** of the search terms (not all)
- Chunks matching more terms rank higher naturally via `ts_rank`
- Fix `SanitizeQuery` stripping dots from terms like ".NET" -- now handled per-term
- Add 15 unit tests for query building and term sanitization

## What changed
- `plainto_tsquery('english', ...)` replaced with `to_tsquery('english', ...)` using OR (`|`) between terms
- `SanitizeQuery` replaced with `BuildOrQuery` + `SanitizeTerm` (per-term sanitization, OR joining)
- Internal dots preserved (e.g. `node.js`), boundary dots stripped (e.g. `.NET` -> `NET`)

## Why
`plainto_tsquery` requires ALL terms to match in a single chunk. A query like "Jellyfin Bitwarden .NET" would only return chunks containing all three terms. This caused keyword search to miss documents where exact terms were present but not all in the same chunk.

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (481 tests: 255 core, 46 identity, 52 ingestion, 128 integration)
- [x] Multi-word keyword searches return documents containing those terms
- [x] Existing search behavior not regressed

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)