### PR TITLE
feat: include scores and metadata in MCP search results

### DIFF
--- a/src/Connapse.Search/Keyword/KeywordSearchService.cs
+++ b/src/Connapse.Search/Keyword/KeywordSearchService.cs
@@ -80,7 +80,8 @@ public class KeywordSearchService
                     32) as Rank,
                 d.file_name as FileName,
                 d.content_type as ContentType,
-                d.container_id as ContainerId
+                d.container_id as ContainerId,
+                d.path as Path
             FROM chunks c
             INNER JOIN documents d ON c.document_id = d.id
             WHERE {whereClause}
@@ -105,7 +106,8 @@ public class KeywordSearchService
                     { "contentType", r.ContentType ?? "" },
                     { "containerId", r.ContainerId.ToString() },
                     { "chunkIndex", r.ChunkIndex.ToString() },
-                    { "rawRank", r.Rank.ToString("F6") }
+                    { "rawRank", r.Rank.ToString("F6") },
+                    { "path", r.Path }
                 }))
             .ToList();
 
@@ -126,5 +128,6 @@ public class KeywordSearchService
         float Rank,
         string FileName,
         string? ContentType,
-        Guid ContainerId);
+        Guid ContainerId,
+        string Path);
 }

--- a/src/Connapse.Storage/Vectors/PgVectorStore.cs
+++ b/src/Connapse.Storage/Vectors/PgVectorStore.cs
@@ -198,7 +198,8 @@ public class PgVectorStore : IVectorStore
                 c.content as ""Content"",
                 c.chunk_index as ""ChunkIndex"",
                 d.file_name as ""FileName"",
-                d.content_type as ""ContentType""
+                d.content_type as ""ContentType"",
+                d.path as ""Path""
             FROM chunk_vectors cv
             INNER JOIN chunks c ON cv.chunk_id = c.id
             INNER JOIN documents d ON cv.document_id = d.id
@@ -222,7 +223,8 @@ public class PgVectorStore : IVectorStore
                 { "fileName", r.FileName },
                 { "contentType", r.ContentType ?? "" },
                 { "content", r.Content },
-                { "chunkIndex", r.ChunkIndex.ToString() }
+                { "chunkIndex", r.ChunkIndex.ToString() },
+                { "path", r.Path }
             }
         )).ToList();
 
@@ -243,7 +245,8 @@ public class PgVectorStore : IVectorStore
         string Content,
         int ChunkIndex,
         string FileName,
-        string? ContentType);
+        string? ContentType,
+        string Path);
 
     public async Task DeleteAsync(string id, CancellationToken ct = default)
     {

--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -109,22 +109,39 @@ public class McpTools
             effectiveMinScore = (float)searchSettings.CurrentValue.MinimumScore;
         }
 
+        Dictionary<string, string>? filters = null;
+        if (!string.IsNullOrWhiteSpace(path))
+            filters = new Dictionary<string, string> { ["pathPrefix"] = path };
+
         var options = new SearchOptions(
             Mode: parsedMode,
             TopK: effectiveTopK,
             MinScore: effectiveMinScore,
-            ContainerId: resolvedId.Value.ToString());
+            ContainerId: resolvedId.Value.ToString(),
+            Filters: filters);
 
         var searchService = services.GetRequiredService<IKnowledgeSearch>();
         var result = await searchService.SearchAsync(query, options, ct);
 
-        var resultText = $"Found {result.TotalMatches} results in {result.Duration.TotalMilliseconds:F0}ms:\n\n";
-        foreach (var hit in result.Hits)
+        if (result.Hits.Count == 0)
+            return "No results found.";
+
+        var resultText = $"Found {result.TotalMatches} result(s) in {result.Duration.TotalMilliseconds:F0}ms (mode: {parsedMode}):\n\n";
+        for (var i = 0; i < result.Hits.Count; i++)
         {
-            resultText += $"Content: {hit.Content}\n";
-            if (hit.Metadata.TryGetValue("FileName", out var fileName))
-                resultText += $"File: {fileName}\n";
-            resultText += "\n";
+            var hit = result.Hits[i];
+            var meta = hit.Metadata;
+            meta.TryGetValue("fileName", out var fileName);
+            meta.TryGetValue("path", out var docPath);
+            meta.TryGetValue("chunkIndex", out var chunkIndex);
+
+            resultText += $"--- Result {i + 1} ---\n";
+            resultText += $"Score: {hit.Score:F3}\n";
+            resultText += $"File: {fileName ?? "unknown"}\n";
+            resultText += $"Path: {docPath ?? "/"}\n";
+            resultText += $"Chunk: {chunkIndex ?? "0"}\n";
+            resultText += $"DocumentId: {hit.DocumentId}\n";
+            resultText += $"Content:\n{hit.Content}\n\n";
         }
 
         return resultText.TrimEnd();

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsSearchKnowledgeTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsSearchKnowledgeTests.cs
@@ -1,0 +1,161 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Web.Mcp;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Connapse.Core.Tests.Mcp;
+
+[Trait("Category", "Unit")]
+public class McpToolsSearchKnowledgeTests
+{
+    private static readonly Guid ContainerId = Guid.NewGuid();
+
+    private readonly IContainerStore _containerStore;
+    private readonly IKnowledgeSearch _searchService;
+    private readonly IOptionsMonitor<SearchSettings> _searchSettings;
+    private readonly IServiceProvider _services;
+
+    public McpToolsSearchKnowledgeTests()
+    {
+        _containerStore = Substitute.For<IContainerStore>();
+        _searchService = Substitute.For<IKnowledgeSearch>();
+        _searchSettings = Substitute.For<IOptionsMonitor<SearchSettings>>();
+        _searchSettings.CurrentValue.Returns(new SearchSettings());
+
+        _containerStore
+            .GetAsync(ContainerId, Arg.Any<CancellationToken>())
+            .Returns(MakeContainer());
+
+        var services = Substitute.For<IServiceProvider>();
+        services.GetService(typeof(IContainerStore)).Returns(_containerStore);
+        services.GetService(typeof(IKnowledgeSearch)).Returns(_searchService);
+        services.GetService(typeof(IOptionsMonitor<SearchSettings>)).Returns(_searchSettings);
+        _services = services;
+    }
+
+    [Fact]
+    public async Task SearchKnowledge_ReturnsScoreAndMetadata()
+    {
+        var hits = new List<SearchHit>
+        {
+            new("chunk-1", "doc-1", "Hello world", 0.847f, new Dictionary<string, string>
+            {
+                { "fileName", "report.pdf" },
+                { "path", "/docs/report.pdf" },
+                { "chunkIndex", "2" }
+            })
+        };
+        var searchResult = new SearchResult(hits, 1, TimeSpan.FromMilliseconds(42));
+        _searchService.SearchAsync("test query", Arg.Any<SearchOptions>(), Arg.Any<CancellationToken>())
+            .Returns(searchResult);
+
+        var result = await McpTools.SearchKnowledge(
+            _services, "test query", ContainerId.ToString());
+
+        result.Should().Contain("Score: 0.847");
+        result.Should().Contain("File: report.pdf");
+        result.Should().Contain("Path: /docs/report.pdf");
+        result.Should().Contain("Chunk: 2");
+        result.Should().Contain("DocumentId: doc-1");
+        result.Should().Contain("Hello world");
+    }
+
+    [Fact]
+    public async Task SearchKnowledge_NoResults_ReturnsNoResultsMessage()
+    {
+        var searchResult = new SearchResult([], 0, TimeSpan.FromMilliseconds(10));
+        _searchService.SearchAsync(Arg.Any<string>(), Arg.Any<SearchOptions>(), Arg.Any<CancellationToken>())
+            .Returns(searchResult);
+
+        var result = await McpTools.SearchKnowledge(
+            _services, "no match", ContainerId.ToString());
+
+        result.Should().Be("No results found.");
+    }
+
+    [Fact]
+    public async Task SearchKnowledge_MultipleResults_NumberedCorrectly()
+    {
+        var hits = new List<SearchHit>
+        {
+            new("c1", "d1", "First", 0.9f, new Dictionary<string, string>
+            {
+                { "fileName", "a.txt" }, { "path", "/a.txt" }, { "chunkIndex", "0" }
+            }),
+            new("c2", "d2", "Second", 0.7f, new Dictionary<string, string>
+            {
+                { "fileName", "b.txt" }, { "path", "/b.txt" }, { "chunkIndex", "1" }
+            })
+        };
+        _searchService.SearchAsync(Arg.Any<string>(), Arg.Any<SearchOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SearchResult(hits, 2, TimeSpan.FromMilliseconds(5)));
+
+        var result = await McpTools.SearchKnowledge(
+            _services, "query", ContainerId.ToString());
+
+        result.Should().Contain("--- Result 1 ---");
+        result.Should().Contain("--- Result 2 ---");
+        result.Should().Contain("Score: 0.900");
+        result.Should().Contain("Score: 0.700");
+    }
+
+    [Fact]
+    public async Task SearchKnowledge_PathFilterWiredToOptions()
+    {
+        _searchService.SearchAsync(Arg.Any<string>(), Arg.Any<SearchOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SearchResult([], 0, TimeSpan.FromMilliseconds(1)));
+
+        await McpTools.SearchKnowledge(
+            _services, "query", ContainerId.ToString(), path: "/docs/");
+
+        await _searchService.Received(1).SearchAsync(
+            "query",
+            Arg.Is<SearchOptions>(o =>
+                o.Filters != null &&
+                o.Filters.ContainsKey("pathPrefix") &&
+                o.Filters["pathPrefix"] == "/docs/"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchKnowledge_ContainerNotFound_ReturnsError()
+    {
+        var unknownId = Guid.NewGuid();
+
+        var result = await McpTools.SearchKnowledge(
+            _services, "query", unknownId.ToString());
+
+        result.Should().StartWith("Error:");
+        result.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task SearchKnowledge_MissingMetadata_ShowsFallbacks()
+    {
+        var hits = new List<SearchHit>
+        {
+            new("chunk-1", "doc-1", "content", 0.5f, new Dictionary<string, string>())
+        };
+        _searchService.SearchAsync(Arg.Any<string>(), Arg.Any<SearchOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SearchResult(hits, 1, TimeSpan.FromMilliseconds(1)));
+
+        var result = await McpTools.SearchKnowledge(
+            _services, "query", ContainerId.ToString());
+
+        result.Should().Contain("File: unknown");
+        result.Should().Contain("Path: /");
+        result.Should().Contain("Chunk: 0");
+    }
+
+    private static Container MakeContainer() => new(
+        Id: ContainerId.ToString(),
+        Name: "test",
+        Description: null,
+        ConnectorType: ConnectorType.MinIO,
+        IsEphemeral: false,
+        CreatedAt: DateTime.UtcNow,
+        UpdatedAt: DateTime.UtcNow);
+}


### PR DESCRIPTION
## What
Enhances the `search_knowledge` MCP tool to return structured, agent-friendly results with relevance scores and source metadata.

## Why
Agents consuming MCP search results had no way to assess result confidence or trace results back to source documents. The tool was also silently dropping file names due to a casing bug and ignoring the `path` filter parameter.

## How
- Reformatted MCP search output with Score, File, Path, Chunk, DocumentId per result
- Added `d.path` to both vector (`PgVectorStore`) and keyword (`KeywordSearchService`) SQL queries via existing JOINs — no N+1 lookups
- Fixed `"FileName"` → `"fileName"` metadata key casing (was silently failing for every result)
- Wired the `path` parameter into `SearchOptions.Filters["pathPrefix"]` (was declared but never used)
- Added 6 unit tests covering formatting, path filter wiring, empty results, and fallbacks

## Test Plan
- [x] 351 unit tests pass (253 Core + 46 Identity + 52 Ingestion)
- [x] Manual: search via MCP tool and verify score/metadata appear
- [x] Manual: search with `path` parameter and verify filtering works

Closes #72