### PR TITLE
refactor: standardize container_delete parameter to containerId

### DIFF
--- a/.claude/state/api-surface.md
+++ b/.claude/state/api-surface.md
@@ -752,7 +752,7 @@ connapse reindex --container <name> [--force] [--no-detect-changes]
 |------|-----------|-------------|
 | `container_create` | `name` (required), `description?` | Create a new container |
 | `container_list` | (none) | List all containers with document counts |
-| `container_delete` | `name` (required) | Delete an empty container |
+| `container_delete` | `containerId` (required) | Delete an empty container |
 | `upload_file` | `containerId` (required), `fileName` (required), `content` (required, base64), `path?`, `strategy?` | Upload file to container |
 | `list_files` | `containerId` (required), `path?` | List files/folders in container |
 | `delete_file` | `containerId` (required), `fileId` (required) | Delete file from container |

--- a/docs/api.md
+++ b/docs/api.md
@@ -728,7 +728,7 @@ Connapse exposes an MCP server for AI agent integration.
 |------|---------------------|----------|-------------|
 | `container_create` | `name` | `description` | Create a new container |
 | `container_list` | — | — | List all containers with document counts |
-| `container_delete` | `name` | — | Delete an empty container |
+| `container_delete` | `containerId` | — | Delete an empty container |
 | `upload_file` | `containerId`, `fileName`, `content` (base64) | `path`, `strategy` | Upload file to container |
 | `list_files` | `containerId` | `path` | List files/folders in container |
 | `delete_file` | `containerId`, `fileId` | — | Delete file from container |

--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -62,20 +62,20 @@ public class McpTools
      Description("Delete a container. MinIO containers must be empty first. Filesystem, S3, and AzureBlob containers just stop being indexed — underlying data is not deleted.")]
     public static async Task<string> ContainerDelete(
         IServiceProvider services,
-        [Description("Container name or ID to delete")] string name,
+        [Description("Container ID or name")] string containerId,
         CancellationToken ct = default)
     {
         var containerStore = services.GetRequiredService<IContainerStore>();
 
-        var containerId = await ResolveContainerIdAsync(name, containerStore, ct);
-        if (containerId is null)
-            return $"Error: Container '{name}' not found.";
+        var resolvedId = await ResolveContainerIdAsync(containerId, containerStore, ct);
+        if (resolvedId is null)
+            return $"Error: Container '{containerId}' not found.";
 
-        var deleted = await containerStore.DeleteAsync(containerId.Value, ct);
+        var deleted = await containerStore.DeleteAsync(resolvedId.Value, ct);
         if (!deleted)
-            return $"Error: Container '{name}' is not empty. Delete all files first.";
+            return $"Error: Container '{containerId}' is not empty. Delete all files first.";
 
-        return $"Container '{name}' deleted.";
+        return $"Container '{containerId}' deleted.";
     }
 
     [McpServerTool(Name = "search_knowledge", Destructive = false),

--- a/src/Connapse.Web/Mcp/README.md
+++ b/src/Connapse.Web/Mcp/README.md
@@ -38,7 +38,7 @@ List all containers with their document counts.
 Delete a container. MinIO containers must be empty first. Filesystem, S3, and AzureBlob containers stop being indexed — underlying data is not deleted.
 
 **Parameters:**
-- `name` (string, required): Container name or ID to delete
+- `containerId` (string, required): Container ID or name
 
 ### 4. upload_file
 


### PR DESCRIPTION
## What
Rename the `container_delete` MCP tool's `name` parameter to `containerId` for consistency with all other MCP tools.

## Why
All other MCP tools (`search_knowledge`, `list_files`, `upload_file`, `delete_file`) use `containerId` for the container identifier. LLM callers pattern-match from these tools and fail on first attempt when `container_delete` expects `name` instead.

## How
- Renamed parameter `name` → `containerId` in `McpTools.ContainerDelete`
- Updated description to match other tools: "Container ID or name"
- Renamed local variable to `resolvedId` to avoid collision with parameter
- Updated docs: MCP README, api.md, api-surface.md

## Test Plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 475 pass (251 core, 46 identity, 52 ingestion, 126 integration)

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)