### PR TITLE
feat: include document IDs in MCP list_files output

### DIFF
--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -210,7 +210,7 @@ public class McpTools
             if (!string.Equals(docParent, normalizedPath, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            text += $"[FILE] {doc.FileName} ({doc.SizeBytes:N0} bytes)\n";
+            text += $"[FILE] {doc.FileName} ({doc.SizeBytes:N0} bytes) ID: {doc.Id}\n";
             hasEntries = true;
         }
 

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsListFilesTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsListFilesTests.cs
@@ -130,6 +130,23 @@ public class McpToolsListFilesTests
         count.Should().Be(1);
     }
 
+    [Fact]
+    public async Task ListFiles_IncludesDocumentIdInFileEntries()
+    {
+        var docId = Guid.NewGuid();
+        _documentStore
+            .ListAsync(ContainerId, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Document>
+            {
+                MakeDocument("/notes.md", "notes.md", docId)
+            });
+
+        var result = await McpTools.ListFiles(_services, ContainerId.ToString(), "/");
+
+        result.Should().Contain($"ID: {docId}");
+        result.Should().Contain($"[FILE] notes.md (1,024 bytes) ID: {docId}");
+    }
+
     private static Container MakeContainer() => new(
         Id: ContainerId.ToString(),
         Name: "test",
@@ -138,8 +155,8 @@ public class McpToolsListFilesTests
         CreatedAt: DateTime.UtcNow,
         UpdatedAt: DateTime.UtcNow);
 
-    private static Document MakeDocument(string path, string fileName) => new(
-        Id: Guid.NewGuid().ToString(),
+    private static Document MakeDocument(string path, string fileName, Guid? id = null) => new(
+        Id: (id ?? Guid.NewGuid()).ToString(),
         ContainerId: ContainerId.ToString(),
         FileName: fileName,
         ContentType: "application/octet-stream",


### PR DESCRIPTION
## What
Adds document ID to each file entry in the `list_files` MCP tool output.

## Why
Agents that call `list_files` had no way to get document IDs needed for `delete_file` or `get_document` without tracking state from prior `upload_file` calls. This makes the MCP surface self-discoverable.

## How
- Changed format from `[FILE] name (size)` to `[FILE] name (size) ID: <uuid>` in `McpTools.ListFiles`
- Added test `ListFiles_IncludesDocumentIdInFileEntries`

Closes #97

## Test Plan
- [x] New test verifies ID appears in output
- [x] All 486 tests pass (262 core, 46 identity, 52 ingestion, 126 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)