### PR TITLE
feat: show truncated vs total match count in MCP search output

### DIFF
--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -127,7 +127,10 @@ public class McpTools
         if (result.Hits.Count == 0)
             return "No results found.";
 
-        var resultText = $"Found {result.TotalMatches} result(s) in {result.Duration.TotalMilliseconds:F0}ms (mode: {parsedMode}):\n\n";
+        var countSummary = result.Hits.Count < result.TotalMatches
+            ? $"Showing {result.Hits.Count} of {result.TotalMatches} matching chunk(s)"
+            : $"Found {result.TotalMatches} result(s)";
+        var resultText = $"{countSummary} in {result.Duration.TotalMilliseconds:F0}ms (mode: {parsedMode}):\n\n";
         for (var i = 0; i < result.Hits.Count; i++)
         {
             var hit = result.Hits[i];

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsSearchKnowledgeTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsSearchKnowledgeTests.cs
@@ -150,6 +150,44 @@ public class McpToolsSearchKnowledgeTests
         result.Should().Contain("Chunk: 0");
     }
 
+    [Fact]
+    public async Task SearchKnowledge_TruncatedResults_ShowsTotalMatchCount()
+    {
+        var hits = new List<SearchHit>
+        {
+            new("c1", "d1", "First", 0.9f, new Dictionary<string, string>
+            {
+                { "fileName", "a.txt" }, { "path", "/a.txt" }, { "chunkIndex", "0" }
+            })
+        };
+        _searchService.SearchAsync(Arg.Any<string>(), Arg.Any<SearchOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SearchResult(hits, 15, TimeSpan.FromMilliseconds(5)));
+
+        var result = await McpTools.SearchKnowledge(
+            _services, "query", ContainerId.ToString());
+
+        result.Should().Contain("Showing 1 of 15 matching chunk(s)");
+    }
+
+    [Fact]
+    public async Task SearchKnowledge_AllResultsReturned_ShowsFoundCount()
+    {
+        var hits = new List<SearchHit>
+        {
+            new("c1", "d1", "First", 0.9f, new Dictionary<string, string>
+            {
+                { "fileName", "a.txt" }, { "path", "/a.txt" }, { "chunkIndex", "0" }
+            })
+        };
+        _searchService.SearchAsync(Arg.Any<string>(), Arg.Any<SearchOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SearchResult(hits, 1, TimeSpan.FromMilliseconds(5)));
+
+        var result = await McpTools.SearchKnowledge(
+            _services, "query", ContainerId.ToString());
+
+        result.Should().Contain("Found 1 result(s)");
+    }
+
     private static Container MakeContainer() => new(
         Id: ContainerId.ToString(),
         Name: "test",


### PR DESCRIPTION
## What
When `topK` returns fewer results than `TotalMatches`, the MCP search summary now reads **"Showing 10 of 23 matching chunk(s)"** instead of "Found 23 result(s)". When all matches fit within topK, it still shows "Found N result(s)".

## Why
LLM callers need to know when search results are truncated so they can decide whether to increase `topK` or refine their query.

## How
- 2-line change in `McpTools.SearchKnowledge` to conditionally format the summary line
- 2 new unit tests for truncated vs non-truncated cases

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)