### PR TITLE
feat: add container_stats MCP tool

### DIFF
--- a/src/Connapse.Core/Interfaces/IDocumentStore.cs
+++ b/src/Connapse.Core/Interfaces/IDocumentStore.cs
@@ -8,4 +8,5 @@ public interface IDocumentStore
     Task DeleteAsync(string documentId, CancellationToken ct = default);
     Task<bool> ExistsByPathAsync(Guid containerId, string path, CancellationToken ct = default);
     Task<Document?> GetByPathAsync(Guid containerId, string path, CancellationToken ct = default);
+    Task<ContainerStats> GetContainerStatsAsync(Guid containerId, CancellationToken ct = default);
 }

--- a/src/Connapse.Core/Models/StorageModels.cs
+++ b/src/Connapse.Core/Models/StorageModels.cs
@@ -43,6 +43,15 @@ public record Document(
     DateTime CreatedAt,
     Dictionary<string, string> Metadata);
 
+public record ContainerStats(
+    int DocumentCount,
+    int ReadyCount,
+    int ProcessingCount,
+    int FailedCount,
+    long TotalChunks,
+    long TotalSizeBytes,
+    DateTime? LastIndexedAt);
+
 public record VectorSearchResult(
     string Id,
     float Score,

--- a/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
+++ b/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
@@ -147,6 +147,39 @@ public class PostgresDocumentStore : IDocumentStore
         return entity is null ? null : MapToModel(entity);
     }
 
+    public async Task<ContainerStats> GetContainerStatsAsync(Guid containerId, CancellationToken ct = default)
+    {
+        await using var context = await _factory.CreateDbContextAsync(ct);
+
+        var stats = await context.Documents
+            .AsNoTracking()
+            .Where(d => d.ContainerId == containerId)
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                DocumentCount = g.Count(),
+                ReadyCount = g.Count(d => d.Status == "Ready"),
+                ProcessingCount = g.Count(d => d.Status == "Processing" || d.Status == "Pending" || d.Status == "Queued"),
+                FailedCount = g.Count(d => d.Status == "Failed"),
+                TotalChunks = g.Sum(d => (long)d.ChunkCount),
+                TotalSizeBytes = g.Sum(d => d.SizeBytes),
+                LastIndexedAt = g.Max(d => d.LastIndexedAt)
+            })
+            .FirstOrDefaultAsync(ct);
+
+        if (stats is null)
+            return new ContainerStats(0, 0, 0, 0, 0, 0, null);
+
+        return new ContainerStats(
+            stats.DocumentCount,
+            stats.ReadyCount,
+            stats.ProcessingCount,
+            stats.FailedCount,
+            stats.TotalChunks,
+            stats.TotalSizeBytes,
+            stats.LastIndexedAt);
+    }
+
     private static Document MapToModel(DocumentEntity entity)
     {
         var metadata = new Dictionary<string, string>(entity.Metadata ?? new());

--- a/src/Connapse.Storage/Vectors/VectorModelDiscovery.cs
+++ b/src/Connapse.Storage/Vectors/VectorModelDiscovery.cs
@@ -18,7 +18,7 @@ public class VectorModelDiscovery(
     /// Returns information about each distinct embedding model in the store,
     /// optionally filtered by container.
     /// </summary>
-    public async Task<IReadOnlyList<EmbeddingModelInfo>> GetModelsAsync(
+    public virtual async Task<IReadOnlyList<EmbeddingModelInfo>> GetModelsAsync(
         Guid? containerId = null, CancellationToken ct = default)
     {
         await using var context = await contextFactory.CreateDbContextAsync(ct);

--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -1,6 +1,7 @@
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
+using Connapse.Storage.Vectors;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
@@ -457,6 +458,66 @@ public class McpTools
     };
 
     private static bool IsTextNative(string extension) => TextExtensions.Contains(extension);
+
+    [McpServerTool(Name = "container_stats", Destructive = false),
+     Description("Get statistics for a container: document counts by status, chunk count, storage size, embedding model, and last indexed time.")]
+    public static async Task<string> ContainerStats(
+        IServiceProvider services,
+        [Description("Container ID or name")] string containerId,
+        CancellationToken ct = default)
+    {
+        var containerStore = services.GetRequiredService<IContainerStore>();
+        var resolvedId = await ResolveContainerIdAsync(containerId, containerStore, ct);
+        if (resolvedId is null)
+            return $"Error: Container '{containerId}' not found.";
+
+        var container = await containerStore.GetAsync(resolvedId.Value, ct);
+        if (container is null)
+            return $"Error: Container '{containerId}' not found.";
+
+        var documentStore = services.GetRequiredService<IDocumentStore>();
+        var stats = await documentStore.GetContainerStatsAsync(resolvedId.Value, ct);
+
+        var modelDiscovery = services.GetRequiredService<VectorModelDiscovery>();
+        var models = await modelDiscovery.GetModelsAsync(resolvedId.Value, ct);
+
+        var text = $"Container: {container.Name}\n";
+        text += $"Type: {container.ConnectorType}\n";
+
+        // Status breakdown only when there are non-ready documents
+        if (stats.ProcessingCount > 0 || stats.FailedCount > 0)
+            text += $"Documents: {stats.DocumentCount} ({stats.ReadyCount} ready, {stats.ProcessingCount} processing, {stats.FailedCount} failed)\n";
+        else
+            text += $"Documents: {stats.DocumentCount}\n";
+
+        text += $"Chunks: {stats.TotalChunks:N0}\n";
+        text += $"Storage: {FormatBytes(stats.TotalSizeBytes)}\n";
+
+        if (models.Count > 0)
+        {
+            var primary = models[0];
+            text += $"Embedding model: {primary.ModelId} ({primary.Dimensions} dims, {primary.VectorCount:N0} vectors)\n";
+        }
+        else
+        {
+            text += "Embedding model: none\n";
+        }
+
+        text += stats.LastIndexedAt.HasValue
+            ? $"Last indexed: {stats.LastIndexedAt.Value:u}\n"
+            : "Last indexed: never\n";
+        text += $"Created: {container.CreatedAt:u}";
+
+        return text;
+    }
+
+    private static string FormatBytes(long bytes) => bytes switch
+    {
+        < 1024 => $"{bytes} B",
+        < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
+        < 1024 * 1024 * 1024 => $"{bytes / (1024.0 * 1024):F1} MB",
+        _ => $"{bytes / (1024.0 * 1024 * 1024):F1} GB"
+    };
 
     // Helpers
     private static async Task<Guid?> ResolveContainerIdAsync(string nameOrId, IContainerStore store, CancellationToken ct)

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsContainerStatsTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsContainerStatsTests.cs
@@ -1,0 +1,134 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Data;
+using Connapse.Storage.Vectors;
+using Connapse.Web.Mcp;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Connapse.Core.Tests.Mcp;
+
+[Trait("Category", "Unit")]
+public class McpToolsContainerStatsTests
+{
+    private static readonly Guid ContainerId = Guid.NewGuid();
+
+    private readonly IContainerStore _containerStore;
+    private readonly IDocumentStore _documentStore;
+    private readonly VectorModelDiscovery _modelDiscovery;
+    private readonly IServiceProvider _services;
+
+    public McpToolsContainerStatsTests()
+    {
+        _containerStore = Substitute.For<IContainerStore>();
+        _documentStore = Substitute.For<IDocumentStore>();
+        _modelDiscovery = Substitute.ForPartsOf<VectorModelDiscovery>(
+            Substitute.For<IDbContextFactory<KnowledgeDbContext>>(),
+            Substitute.For<ILogger<VectorModelDiscovery>>());
+
+        _containerStore
+            .GetAsync(ContainerId, Arg.Any<CancellationToken>())
+            .Returns(MakeContainer());
+
+        _documentStore
+            .GetContainerStatsAsync(ContainerId, Arg.Any<CancellationToken>())
+            .Returns(new ContainerStats(10, 8, 1, 1, 250, 1_048_576, new DateTime(2026, 3, 5, 14, 0, 0, DateTimeKind.Utc)));
+
+        _modelDiscovery
+            .GetModelsAsync(ContainerId, Arg.Any<CancellationToken>())
+            .Returns(new List<EmbeddingModelInfo>
+            {
+                new("text-embedding-3-small", 1536, 240)
+            });
+
+        var services = Substitute.For<IServiceProvider>();
+        services.GetService(typeof(IContainerStore)).Returns(_containerStore);
+        services.GetService(typeof(IDocumentStore)).Returns(_documentStore);
+        services.GetService(typeof(VectorModelDiscovery)).Returns(_modelDiscovery);
+        _services = services;
+    }
+
+    [Fact]
+    public async Task ContainerStats_ReturnsFormattedStats()
+    {
+        var result = await McpTools.ContainerStats(_services, ContainerId.ToString());
+
+        result.Should().Contain("Container: test-container");
+        result.Should().Contain("Type: MinIO");
+        result.Should().Contain("Documents: 10 (8 ready, 1 processing, 1 failed)");
+        result.Should().Contain("Chunks: 250");
+        result.Should().Contain("Storage: 1.0 MB");
+        result.Should().Contain("Embedding model: text-embedding-3-small (1536 dims, 240 vectors)");
+        result.Should().Contain("Last indexed: 2026-03-05");
+    }
+
+    [Fact]
+    public async Task ContainerStats_AllReady_OmitsStatusBreakdown()
+    {
+        _documentStore
+            .GetContainerStatsAsync(ContainerId, Arg.Any<CancellationToken>())
+            .Returns(new ContainerStats(5, 5, 0, 0, 100, 512, null));
+
+        _modelDiscovery
+            .GetModelsAsync(ContainerId, Arg.Any<CancellationToken>())
+            .Returns(new List<EmbeddingModelInfo>());
+
+        var result = await McpTools.ContainerStats(_services, ContainerId.ToString());
+
+        result.Should().Contain("Documents: 5");
+        result.Should().NotContain("ready");
+        result.Should().Contain("Embedding model: none");
+        result.Should().Contain("Last indexed: never");
+    }
+
+    [Fact]
+    public async Task ContainerStats_ContainerNotFound_ReturnsError()
+    {
+        var result = await McpTools.ContainerStats(_services, "nonexistent");
+
+        result.Should().StartWith("Error:");
+        result.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task ContainerStats_ResolvesByName()
+    {
+        _containerStore
+            .GetByNameAsync("test-container", Arg.Any<CancellationToken>())
+            .Returns(MakeContainer());
+
+        var result = await McpTools.ContainerStats(_services, "test-container");
+
+        result.Should().Contain("Container: test-container");
+    }
+
+    [Fact]
+    public async Task ContainerStats_EmptyContainer_ReturnsZeros()
+    {
+        _documentStore
+            .GetContainerStatsAsync(ContainerId, Arg.Any<CancellationToken>())
+            .Returns(new ContainerStats(0, 0, 0, 0, 0, 0, null));
+
+        _modelDiscovery
+            .GetModelsAsync(ContainerId, Arg.Any<CancellationToken>())
+            .Returns(new List<EmbeddingModelInfo>());
+
+        var result = await McpTools.ContainerStats(_services, ContainerId.ToString());
+
+        result.Should().Contain("Documents: 0");
+        result.Should().Contain("Chunks: 0");
+        result.Should().Contain("Storage: 0 B");
+        result.Should().Contain("Embedding model: none");
+        result.Should().Contain("Last indexed: never");
+    }
+
+    private static Container MakeContainer() => new(
+        Id: ContainerId.ToString(),
+        Name: "test-container",
+        Description: "A test container",
+        ConnectorType: ConnectorType.MinIO,
+        CreatedAt: new DateTime(2026, 2, 28, 10, 0, 0, DateTimeKind.Utc),
+        UpdatedAt: new DateTime(2026, 3, 5, 14, 0, 0, DateTimeKind.Utc));
+}


### PR DESCRIPTION
## What
Adds a `container_stats` MCP tool that returns compact, agent-friendly statistics for a container.

## Why
Agents need to understand what's in a container before searching — document count, ingestion status, storage size, and embedding model. Without this, they fly blind.

## How
- **`ContainerStats` record** in Core — holds aggregate metrics (doc count, status breakdown, chunks, bytes, last indexed)
- **`GetContainerStatsAsync`** on `IDocumentStore` — single EF `GroupBy` aggregate query (no loading all documents)
- **`container_stats` MCP tool** — resolves container by ID or name, composes stats + model discovery, returns flat key-value text (~50 tokens)
- **`FormatBytes` helper** — human-readable byte formatting (B/KB/MB/GB)
- **5 unit tests** covering: full stats, all-ready shorthand, empty container, name resolution, not-found error

### Output format (designed for minimal agent context usage)
```
Container: my-knowledge-base
Type: Filesystem
Documents: 46 (42 ready, 3 processing, 1 failed)
Chunks: 1,284
Storage: 12.5 MB
Embedding model: text-embedding-3-small (1536 dims, 1,200 vectors)
Last indexed: 2026-03-05T14:23:00Z
Created: 2026-02-28T10:00:00Z
```

Closes #74

## Test plan
- [x] 5 new unit tests pass
- [x] All 493 tests pass (269 core + 46 identity + 52 ingestion + 126 integration)
- [x] Build: 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)