### PR TITLE
feat: add Docker release package and ghcr.io publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write   # needed to create GitHub Releases and upload assets
+  packages: write   # needed to push Docker images to ghcr.io
 
 jobs:
   build-cli:
@@ -105,13 +106,68 @@ jobs:
           fi
           dotnet nuget push nupkgs/*.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json
 
+  build-docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/destrayon/connapse:${{ github.ref_name }}
+            ghcr.io/destrayon/connapse:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  package-release:
+    name: Package release zip
+    runs-on: ubuntu-latest
+    needs: [build-docker]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create release zip
+        run: |
+          mkdir -p dist
+          cp release/docker-compose.yml dist/docker-compose.yml
+          cp release/.env.example dist/.env.example
+          cp release/README.md dist/README.md
+          cd dist
+          zip ../connapse-docker-${{ github.ref_name }}.zip docker-compose.yml .env.example README.md
+
+      - name: Upload release zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: connapse-docker
+          path: connapse-docker-${{ github.ref_name }}.zip
+          retention-days: 1
+
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build-cli, publish-nuget]
+    needs: [build-cli, publish-nuget, package-release]
 
     steps:
-      - name: Download all CLI artifacts
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: connapse-*
@@ -123,10 +179,24 @@ jobs:
         with:
           name: ${{ github.ref_name }}
           body: |
-            ## Installation
+            ## Docker (recommended)
 
-            ### Binary (no .NET required)
-            Download the binary for your platform below and add it to your PATH:
+            Download `connapse-docker-${{ github.ref_name }}.zip`, extract it, then:
+
+            ```bash
+            cp .env.example .env
+            # Edit .env — set passwords, admin credentials, and JWT secret
+            docker compose up -d
+            ```
+
+            Open [http://localhost:5001](http://localhost:5001) and log in with your admin credentials.
+            See `README.md` inside the zip for full setup instructions.
+
+            **Docker image**: `ghcr.io/destrayon/connapse:${{ github.ref_name }}`
+
+            ## CLI binary (no .NET required)
+
+            Download the binary for your platform and add it to your PATH:
             - **Windows**: `connapse-win-x64.exe`
             - **Linux**: `connapse-linux-x64`
             - **macOS (Intel)**: `connapse-osx-x64`
@@ -138,7 +208,7 @@ jobs:
             sudo mv connapse-linux-x64 /usr/local/bin/connapse
             ```
 
-            ### .NET Global Tool (requires .NET 10 SDK)
+            ## .NET Global Tool (requires .NET 10 SDK)
             ```bash
             dotnet tool install -g Connapse.CLI --version ${{ github.ref_name }}
             ```

--- a/release/.env.example
+++ b/release/.env.example
@@ -1,0 +1,32 @@
+# Connapse environment configuration
+# Copy this file to .env and fill in all required values before running docker-compose up.
+
+# --- PostgreSQL -----------------------------------------------------------------
+# Password for the internal Postgres database user.
+# Use a strong random password — this database is not exposed outside Docker.
+POSTGRES_PASSWORD=change_me_postgres
+
+# --- MinIO (internal object storage) --------------------------------------------
+# Credentials for the internal MinIO instance.
+# The MinIO console is not exposed by default; these are used only by Connapse.
+MINIO_ROOT_USER=connapse_minio
+MINIO_ROOT_PASSWORD=change_me_minio
+
+# --- Connapse application -------------------------------------------------------
+# Email and password for the initial admin account created on first startup.
+CONNAPSE_ADMIN_EMAIL=admin@example.com
+CONNAPSE_ADMIN_PASSWORD=change_me_admin
+
+# Secret key used to sign JWT tokens. Must be at least 32 characters.
+# Generate a secure value with: openssl rand -base64 64
+CONNAPSE_JWT_SECRET=change_me_jwt_secret_generate_with_openssl_rand_base64_64
+
+# --- Embedding / Ollama ----------------------------------------------------------
+# Base URL for the Ollama embedding API.
+# If you started Connapse with the --profile with-ollama flag, use the default below.
+# If you run Ollama externally, point this at your Ollama host.
+Knowledge__Embedding__BaseUrl=http://ollama:11434
+
+# --- Image version (optional) ---------------------------------------------------
+# Pin to a specific release tag, e.g. v0.3.0. Defaults to "latest".
+# CONNAPSE_VERSION=latest

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,111 @@
+# Connapse — Quick Start
+
+This directory contains everything you need to run Connapse using Docker Compose.
+No source code or .NET SDK required.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) 24+ with the Compose plugin (`docker compose`)
+- Internet access to pull images from ghcr.io and Docker Hub on first run
+
+## Quick Start
+
+**1. Copy the example environment file and edit it.**
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` in a text editor and set every value marked `change_me_*`.
+Generate a secure JWT secret with:
+
+```bash
+openssl rand -base64 64
+```
+
+**2. Start Connapse.**
+
+```bash
+docker compose up -d
+```
+
+This starts three services: PostgreSQL, MinIO (object storage), and the Connapse web application.
+On first startup, database migrations run automatically and the admin account is created.
+
+**3. Open the browser.**
+
+Navigate to [http://localhost:5001](http://localhost:5001) and log in with the
+`CONNAPSE_ADMIN_EMAIL` and `CONNAPSE_ADMIN_PASSWORD` values you set in `.env`.
+
+**4. Create your first container and upload documents.**
+
+- Click **New Container** and choose a connector type (MinIO is pre-configured).
+- Upload files — Connapse will ingest and embed them automatically.
+- Use the **Search** page to query your knowledge base.
+
+## Optional: Local Ollama (self-hosted embeddings)
+
+If you want to run Ollama locally for embeddings instead of a remote provider:
+
+```bash
+docker compose --profile with-ollama up -d
+```
+
+After Ollama starts, pull a model:
+
+```bash
+docker compose exec ollama ollama pull nomic-embed-text
+```
+
+Then in the Connapse Settings > Embedding page, set the model to `nomic-embed-text`
+and the base URL to `http://ollama:11434` (already the default in `.env.example`).
+
+## Pinning to a specific version
+
+Set `CONNAPSE_VERSION` in your `.env` file:
+
+```bash
+CONNAPSE_VERSION=v0.3.0
+```
+
+Then re-pull and restart:
+
+```bash
+docker compose pull web
+docker compose up -d
+```
+
+## Upgrading
+
+```bash
+docker compose pull web
+docker compose up -d
+```
+
+Migrations run automatically on startup. Your data volumes (`pgdata`, `miniodata`, `appdata`)
+are preserved across upgrades.
+
+## Stopping and removing
+
+```bash
+# Stop without removing data
+docker compose down
+
+# Stop and remove all data volumes (destructive)
+docker compose down -v
+```
+
+## Port reference
+
+| Service   | Host port | Purpose                  |
+|-----------|-----------|--------------------------|
+| web       | 5001      | Connapse web UI and API  |
+
+MinIO and PostgreSQL are only accessible within the internal Docker network.
+
+## Further reading
+
+- [Full project repository](https://github.com/Destrayon/Connapse)
+- [Connectors documentation](https://github.com/Destrayon/Connapse/blob/main/docs/connectors.md)
+- [AWS SSO setup](https://github.com/Destrayon/Connapse/blob/main/docs/aws-sso-setup.md)
+- [Azure identity setup](https://github.com/Destrayon/Connapse/blob/main/docs/azure-identity-setup.md)

--- a/release/docker-compose.yml
+++ b/release/docker-compose.yml
@@ -1,0 +1,100 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_DB: connapse
+      POSTGRES_USER: connapse
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U connapse -d connapse"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - backend
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
+
+  minio:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    volumes:
+      - miniodata:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - backend
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: "0.5"
+
+  ollama:
+    image: ollama/ollama
+    volumes:
+      - ollamadata:/root/.ollama
+    profiles:
+      - with-ollama
+    networks:
+      - backend
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+          cpus: "2.0"
+
+  web:
+    image: ghcr.io/destrayon/connapse:${CONNAPSE_VERSION:-latest}
+    ports:
+      - "5001:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__DefaultConnection: "Host=postgres;Database=connapse;Username=connapse;Password=${POSTGRES_PASSWORD}"
+      Knowledge__Storage__MinIO__Endpoint: "minio:9000"
+      Knowledge__Storage__MinIO__AccessKey: "${MINIO_ROOT_USER}"
+      Knowledge__Storage__MinIO__SecretKey: "${MINIO_ROOT_PASSWORD}"
+      Knowledge__Storage__MinIO__UseSSL: "false"
+      Knowledge__Embedding__BaseUrl: "${Knowledge__Embedding__BaseUrl:-http://ollama:11434}"
+      CONNAPSE_ADMIN_EMAIL: ${CONNAPSE_ADMIN_EMAIL}
+      CONNAPSE_ADMIN_PASSWORD: ${CONNAPSE_ADMIN_PASSWORD}
+      CONNAPSE_JWT_SECRET: ${CONNAPSE_JWT_SECRET}
+    volumes:
+      - appdata:/app/appdata
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    networks:
+      - frontend
+      - backend
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "2.0"
+
+volumes:
+  pgdata:
+  miniodata:
+  ollamadata:
+  appdata:
+
+networks:
+  frontend:
+    driver: bridge
+  backend:
+    driver: bridge
+    internal: true


### PR DESCRIPTION
## Summary
- Add `build-docker` job to release workflow — builds and pushes multi-arch Docker image to `ghcr.io/destrayon/connapse`
- Add `package-release` job — zips production `docker-compose.yml`, `.env.example`, and `README.md` as a release asset
- Production compose uses `ghcr.io` image instead of `build: .`, with no fallback defaults on secrets

## What
- `release/docker-compose.yml` — production compose referencing ghcr.io image
- `release/.env.example` — all env vars with documentation and `change_me_*` placeholders
- `release/README.md` — quick start, Ollama setup, version pinning, upgrading
- `.github/workflows/release.yml` — 2 new jobs + updated release body with Docker instructions

## Why
Users should be able to run Connapse without cloning the source code. `docker compose up` from the release zip starts a working instance.

## Test plan
- [ ] Verify workflow YAML is valid (no syntax errors)
- [ ] Verify `release/docker-compose.yml` passes `docker compose config`
- [ ] Verify `.env.example` covers all variables from dev compose
- [ ] Tag a test release and confirm image pushes to ghcr.io

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)