### PR TITLE
docs: add GitHub Wiki pages (structure, guides, CLI, MCP)

### DIFF
--- a/wiki/CLI-Reference.md
+++ b/wiki/CLI-Reference.md
@@ -1,0 +1,194 @@
+# CLI Reference
+
+The Connapse CLI (`connapse`) provides command-line access to the platform. It authenticates via Personal Access Tokens stored in `~/.connapse/credentials.json`.
+
+## Installation
+
+```bash
+# Option A: .NET Global Tool (requires .NET 10)
+dotnet tool install -g Connapse.CLI
+
+# Option B: Native binary from GitHub Releases (no .NET required)
+# https://github.com/Destrayon/Connapse/releases
+```
+
+## General Commands
+
+### `version`
+
+Show the installed CLI version.
+
+```bash
+connapse version
+connapse --version
+```
+
+### `update`
+
+Update the CLI to the latest release.
+
+```bash
+connapse update            # Download and install the latest version
+connapse update --check    # Check for updates without installing
+```
+
+## Authentication Commands
+
+### `auth login`
+
+Authenticate with a Connapse server. Opens a browser for PKCE-based login by default.
+
+```bash
+connapse auth login [--url <server-url>] [--no-browser]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--url <server-url>` | Server URL (default: `https://localhost:5001` or stored URL) |
+| `--no-browser` | Use email/password prompt instead of browser login |
+
+Credentials are stored in `~/.connapse/credentials.json`.
+
+### `auth logout`
+
+Clear stored credentials and revoke the CLI token on the server.
+
+```bash
+connapse auth logout
+```
+
+### `auth whoami`
+
+Show current identity, server, and connection status.
+
+```bash
+connapse auth whoami
+```
+
+### `auth pat create`
+
+Create a new Personal Access Token.
+
+```bash
+connapse auth pat create <name> [--expires <yyyy-MM-dd>]
+```
+
+| Argument/Flag | Description |
+|---------------|-------------|
+| `<name>` | Name for the token |
+| `--expires <yyyy-MM-dd>` | Optional expiration date |
+
+The token value is shown only once -- copy it immediately.
+
+### `auth pat list`
+
+List all your Personal Access Tokens with status, prefix, and dates.
+
+```bash
+connapse auth pat list
+```
+
+### `auth pat revoke`
+
+Revoke a Personal Access Token by ID.
+
+```bash
+connapse auth pat revoke <id>
+```
+
+| Argument | Description |
+|----------|-------------|
+| `<id>` | PAT ID (GUID format) |
+
+## Container Commands
+
+### `container create`
+
+Create a new container.
+
+```bash
+connapse container create <name> [--description "..."]
+```
+
+| Argument/Flag | Description |
+|---------------|-------------|
+| `<name>` | Container name (lowercase alphanumeric and hyphens) |
+| `--description "..."` | Optional description |
+
+### `container list`
+
+List all containers with document counts.
+
+```bash
+connapse container list
+```
+
+### `container delete`
+
+Delete an empty container.
+
+```bash
+connapse container delete <name>
+```
+
+| Argument | Description |
+|----------|-------------|
+| `<name>` | Container name |
+
+## Upload Command
+
+Upload file(s) to a container. Supports single files or entire directories (recursive).
+
+```bash
+connapse upload <path> --container <name> [--strategy <name>] [--destination <path>]
+```
+
+| Argument/Flag | Description |
+|---------------|-------------|
+| `<path>` | File or directory path to upload |
+| `--container <name>` | **Required.** Target container name |
+| `--strategy <name>` | Chunking strategy: `Semantic` (default), `FixedSize`, or `Recursive` |
+| `--destination <path>` | Destination folder path in the container (default: `/`) |
+
+The legacy alias `ingest` also works in place of `upload`.
+
+## Search Command
+
+Search within a container.
+
+```bash
+connapse search "<query>" --container <name> [--mode <mode>] [--top <n>] [--path <folder>] [--min-score <0.0-1.0>]
+```
+
+| Argument/Flag | Description |
+|---------------|-------------|
+| `"<query>"` | Search query text |
+| `--container <name>` | **Required.** Container to search within |
+| `--mode <mode>` | Search mode: `Semantic`, `Keyword`, or `Hybrid` (default: `Hybrid`) |
+| `--top <n>` | Number of results to return (default: `10`) |
+| `--path <folder>` | Filter results to a folder subtree |
+| `--min-score <0.0-1.0>` | Minimum similarity score threshold |
+
+## Reindex Command
+
+Re-process and re-embed documents in a container.
+
+```bash
+connapse reindex --container <name> [--force] [--no-detect-changes]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--container <name>` | **Required.** Container to reindex |
+| `--force` | Ignore content hashes and reindex all documents |
+| `--no-detect-changes` | Disable automatic settings change detection |
+
+## Configuration
+
+The CLI reads configuration from:
+
+1. `appsettings.json` (optional, in the CLI directory)
+2. Environment variables
+3. Stored credentials at `~/.connapse/credentials.json` (set by `auth login`)
+
+The `ApiBaseUrl` can be set via config, environment variable, or the `--url` flag on `auth login`.

--- a/wiki/Deployment-Guide.md
+++ b/wiki/Deployment-Guide.md
@@ -1,0 +1,126 @@
+# Deployment Guide
+
+## Services
+
+Connapse runs as a set of Docker containers orchestrated by Docker Compose.
+
+| Service | Image | Purpose | Default Port |
+|---------|-------|---------|-------------|
+| `web` | Custom (Dockerfile) | Connapse application (Blazor Server + API + MCP) | 5001 (mapped to container 8080) |
+| `postgres` | `pgvector/pgvector:pg17` | PostgreSQL 17 with pgvector extension | Internal only |
+| `minio` | `minio/minio` | S3-compatible object storage for files | Internal only (console: 9001) |
+| `ollama` | `ollama/ollama` | Local LLM/embedding inference (optional, requires `--profile with-ollama`) | Internal only |
+
+### Networks
+
+- **frontend** -- Bridge network; exposes the web service to the host
+- **backend** -- Internal bridge network; database, MinIO, and Ollama are not exposed to the host
+
+## Environment Variables
+
+### Required
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `CONNAPSE_ADMIN_EMAIL` | Admin account email (seeded on first run) | `admin@example.com` |
+| `CONNAPSE_ADMIN_PASSWORD` | Admin account password | `YourSecurePassword123!` |
+| `CONNAPSE_JWT_SECRET` | JWT signing secret (HS256). **Must be set in production.** | Output of `openssl rand -base64 64` |
+
+> **Note:** `CONNAPSE_JWT_SECRET` can also be set via `Identity__Jwt__Secret`.
+
+### Optional
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ASPNETCORE_ENVIRONMENT` | `Production` | ASP.NET Core environment |
+| `POSTGRES_PASSWORD` | `connapse_dev` | PostgreSQL password |
+| `MINIO_ROOT_USER` | `connapse_dev` | MinIO root username |
+| `MINIO_ROOT_PASSWORD` | `connapse_dev_secret` | MinIO root password |
+| `ConnectionStrings__DefaultConnection` | (set in compose) | Full PostgreSQL connection string |
+| `Knowledge__Storage__MinIO__Endpoint` | `minio:9000` | MinIO endpoint |
+| `Knowledge__Storage__MinIO__AccessKey` | (from MINIO_ROOT_USER) | MinIO access key |
+| `Knowledge__Storage__MinIO__SecretKey` | (from MINIO_ROOT_PASSWORD) | MinIO secret key |
+| `Knowledge__Storage__MinIO__UseSSL` | `false` | MinIO SSL toggle |
+| `Knowledge__Embedding__BaseUrl` | `http://ollama:11434` | Ollama embedding endpoint |
+
+### Cloud Identity (Optional)
+
+| Variable | Description |
+|----------|-------------|
+| `Identity__AzureAd__ClientId` | Azure AD application client ID |
+| `Identity__AzureAd__TenantId` | Azure AD tenant ID |
+| `Identity__AzureAd__ClientSecret` | Azure AD client secret |
+| `Identity__AwsSso__IssuerUrl` | AWS IAM Identity Center issuer URL |
+| `Identity__AwsSso__Region` | AWS region for SSO |
+
+## Volumes
+
+| Volume | Mount Point | Purpose |
+|--------|-------------|---------|
+| `pgdata` | `/var/lib/postgresql/data` | PostgreSQL database files |
+| `miniodata` | `/data` | MinIO object storage |
+| `ollamadata` | `/root/.ollama` | Ollama model cache |
+| `appdata` | `/app/appdata` | Application data (filesystem connector roots, DataProtection keys) |
+
+## Resource Limits
+
+Default resource limits from docker-compose.yml:
+
+| Service | Memory | CPUs |
+|---------|--------|------|
+| postgres | 512 MB | 1.0 |
+| minio | 256 MB | 0.5 |
+| ollama | 4 GB | 2.0 |
+| web | 1 GB | 2.0 |
+
+Adjust these in `docker-compose.yml` under `deploy.resources.limits` based on your workload.
+
+## Production Hardening
+
+1. **Set a strong JWT secret** -- Use `openssl rand -base64 64` and set via `CONNAPSE_JWT_SECRET` or `Identity__Jwt__Secret`. Never use the default.
+
+2. **Change default passwords** -- Set `POSTGRES_PASSWORD`, `MINIO_ROOT_USER`, and `MINIO_ROOT_PASSWORD` to strong, unique values.
+
+3. **Use a `.env` file** -- Store secrets in a `.env` file (not committed to version control) rather than exporting them in your shell.
+
+4. **Enable HTTPS** -- Place a reverse proxy (nginx, Caddy, Traefik) in front of the `web` service to terminate TLS. The web service listens on HTTP internally (port 8080).
+
+5. **Restrict network exposure** -- By default, only port 5001 is exposed. Keep the backend network internal. Do not expose PostgreSQL or MinIO ports to the host in production.
+
+6. **Set `ASPNETCORE_ENVIRONMENT=Production`** -- This is the default in docker-compose.yml. Ensures detailed errors are not exposed.
+
+7. **Rate limiting** -- Built-in ASP.NET Core rate limiting middleware is enabled with per-user and per-IP policies.
+
+## Backup and Restore
+
+### Database
+
+```bash
+# Backup
+docker-compose exec postgres pg_dump -U connapse connapse > backup.sql
+
+# Restore
+docker-compose exec -T postgres psql -U connapse connapse < backup.sql
+```
+
+### MinIO (Object Storage)
+
+```bash
+# Backup the MinIO volume
+docker run --rm -v connapse_miniodata:/data -v $(pwd):/backup alpine \
+  tar czf /backup/minio-backup.tar.gz -C /data .
+
+# Restore
+docker run --rm -v connapse_miniodata:/data -v $(pwd):/backup alpine \
+  tar xzf /backup/minio-backup.tar.gz -C /data
+```
+
+### Full Backup
+
+Back up both the `pgdata` and `miniodata` Docker volumes together for a consistent snapshot. Stop services first if consistency is critical:
+
+```bash
+docker-compose stop
+# Back up volumes...
+docker-compose start
+```

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,113 @@
+# Getting Started
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
+- (Optional) [.NET 10 SDK](https://dotnet.microsoft.com/download) for development or CLI installation via `dotnet tool`
+- (Optional) [Ollama](https://ollama.ai/) for local embeddings and LLM
+
+## Quick Start with Docker Compose
+
+```bash
+# Clone the repository
+git clone https://github.com/Destrayon/Connapse.git
+cd Connapse
+
+# Set required environment variables (or create a .env file)
+export CONNAPSE_ADMIN_EMAIL=admin@example.com
+export CONNAPSE_ADMIN_PASSWORD=YourSecurePassword123!
+export Identity__Jwt__Secret=$(openssl rand -base64 64)
+
+# Start all services (PostgreSQL, MinIO, Web App)
+docker-compose up -d
+```
+
+The application will be available at **http://localhost:5001**.
+
+### What happens on first run
+
+1. Docker images are pulled (~2-5 minutes)
+2. PostgreSQL initializes with the pgvector extension and runs EF Core migrations
+3. MinIO buckets are created
+4. The admin account is seeded from environment variables
+5. The web application starts
+
+### Including Ollama
+
+To start with the optional Ollama service for local embeddings:
+
+```bash
+docker-compose --profile with-ollama up -d
+```
+
+## First Walkthrough
+
+### 1. Log in to the Web UI
+
+Open http://localhost:5001 and log in with the admin email and password you set above.
+
+### 2. Configure Embeddings
+
+Navigate to **Settings** and configure your embedding provider. If using Ollama, set the base URL to `http://ollama:11434` (already configured in Docker Compose) and pull an embedding model (e.g., `nomic-embed-text`).
+
+### 3. Create a Container
+
+From the **Home** page, click **Create Container**. Give it a name (lowercase, alphanumeric, hyphens allowed) and an optional description.
+
+### 4. Upload Files
+
+Click into your container and upload files. Supported formats include PDF, DOCX, PPTX, Markdown, plain text, CSV, JSON, XML, and YAML. Files are parsed, chunked, embedded, and indexed in the background.
+
+### 5. Search Your Knowledge
+
+Use the **Search** page to query your container. Choose a search mode:
+
+- **Semantic** -- Vector similarity search using embeddings
+- **Keyword** -- Full-text search using PostgreSQL tsvector
+- **Hybrid** -- Both combined with Reciprocal Rank Fusion (recommended)
+
+### Using the CLI
+
+Install the CLI and authenticate:
+
+```bash
+# Install via .NET global tool (requires .NET 10)
+dotnet tool install -g Connapse.CLI
+
+# Or download a native binary from GitHub Releases
+# https://github.com/Destrayon/Connapse/releases
+
+# Authenticate (opens browser)
+connapse auth login --url http://localhost:5001
+
+# Create a container
+connapse container create my-project --description "My knowledge base"
+
+# Upload files
+connapse upload ./documents --container my-project
+
+# Search
+connapse search "your query" --container my-project
+```
+
+See [[CLI Reference]] for the full command reference.
+
+### Using with Claude Desktop (MCP)
+
+See [[MCP Integration]] for setup instructions.
+
+## Development Setup
+
+```bash
+# Start infrastructure only
+docker-compose up -d postgres minio
+
+# Run the web app locally
+dotnet run --project src/Connapse.Web
+
+# Run all tests
+dotnet test
+
+# Run just unit tests
+dotnet test --filter "Category=Unit"
+```

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,34 @@
+# Connapse
+
+**Open-source AI-powered knowledge management platform. Transform documents into searchable knowledge for AI agents.**
+
+Connapse provides container-based document organization, hybrid search (vector + keyword), multi-format ingestion, and four access surfaces: Web UI, REST API, CLI, and MCP server.
+
+## Key Features
+
+- **Container-Based Organization** -- Isolated projects with S3-like folder hierarchies
+- **5 Connector Types** -- MinIO (default), Filesystem (live watch), S3, Azure Blob, InMemory (ephemeral)
+- **Hybrid Search** -- Vector similarity + keyword full-text with Reciprocal Rank Fusion and cross-model support
+- **Multi-Format Ingestion** -- PDF, Office documents (DOCX, PPTX), Markdown, plain text, CSV, JSON, XML, YAML
+- **Real-Time Processing** -- Background ingestion with live progress updates via SignalR
+- **Multi-Provider AI** -- Embeddings (Ollama, OpenAI, Azure OpenAI) + LLM (Ollama, OpenAI, Azure OpenAI, Anthropic)
+- **Three-Tier Auth** -- Cookie sessions, Personal Access Tokens, and JWT with role-based access control
+- **Cloud Identity** -- AWS IAM Identity Center (device auth) + Azure AD (OAuth2+PKCE)
+- **MCP Server** -- Claude Desktop integration with 8 tools for container and document management
+- **Fully Dockerized** -- PostgreSQL + pgvector, MinIO, optional Ollama
+
+## Wiki Pages
+
+- [[Getting Started]] -- Prerequisites, Docker Compose quickstart, first walkthrough
+- [[Deployment Guide]] -- Services, environment variables, volumes, production hardening
+- [[CLI Reference]] -- Full command reference with all flags and options
+- [[MCP Integration]] -- MCP tools, parameters, and Claude Desktop configuration
+
+## Links
+
+- [Source Code](https://github.com/Destrayon/Connapse)
+- [API Reference](https://github.com/Destrayon/Connapse/blob/main/docs/api.md)
+- [Architecture Guide](https://github.com/Destrayon/Connapse/blob/main/docs/architecture.md)
+- [Connectors Guide](https://github.com/Destrayon/Connapse/blob/main/docs/connectors.md)
+- [Security Policy](https://github.com/Destrayon/Connapse/blob/main/SECURITY.md)
+- [Contributing](https://github.com/Destrayon/Connapse/blob/main/CONTRIBUTING.md)

--- a/wiki/MCP-Integration.md
+++ b/wiki/MCP-Integration.md
@@ -1,0 +1,143 @@
+# MCP Integration
+
+Connapse includes a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for integration with Claude Desktop and other MCP-compatible clients.
+
+## Setup
+
+### 1. Create an Agent
+
+1. Log in to the Connapse Web UI as an admin
+2. Navigate to **Admin > Agents** (`/admin/agents`)
+3. Create a new agent and generate an API key
+4. Copy the API key -- it is shown only once
+
+### 2. Configure Claude Desktop
+
+Add the following to your Claude Desktop configuration file:
+
+**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "connapse": {
+      "url": "http://localhost:5001/mcp",
+      "headers": {
+        "X-Api-Key": "YOUR_AGENT_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Replace `YOUR_AGENT_API_KEY` with the API key generated in step 1. Adjust the URL if your Connapse instance runs on a different host or port.
+
+### 3. Restart Claude Desktop
+
+After saving the configuration, restart Claude Desktop. The Connapse tools will appear in the tools menu.
+
+## Available Tools
+
+### `container_create`
+
+Create a new container for organizing files.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Container name (lowercase alphanumeric and hyphens, 2-128 chars) |
+| `description` | string | No | Optional description for the container |
+
+### `container_list`
+
+List all containers with their document counts. No parameters.
+
+### `container_delete`
+
+Delete a container. MinIO containers must be empty first. Filesystem, S3, and AzureBlob containers just stop being indexed -- underlying data is not deleted.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `containerId` | string | Yes | Container ID or name |
+
+### `search_knowledge`
+
+Search within a container using semantic, keyword, or hybrid search. Returns relevant document chunks with scores.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | The search query text |
+| `containerId` | string | Yes | Container ID or name to search within |
+| `mode` | string | No | Search mode: `Semantic`, `Keyword`, or `Hybrid` (default: `Hybrid`) |
+| `topK` | int | No | Number of results to return (default: 10) |
+| `path` | string | No | Filter results to a folder subtree (e.g., `/docs/`) |
+| `minScore` | float | No | Minimum similarity score floor, 0.0-1.0 (default: from server settings) |
+
+### `list_files`
+
+List files and folders in a container at a given path.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `containerId` | string | Yes | Container ID or name |
+| `path` | string | No | Folder path to list (default: root `/`) |
+
+### `upload_file`
+
+Upload a file to a container. The file will be parsed, chunked, embedded, and made searchable.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `containerId` | string | Yes | Container ID or name |
+| `content` | string | Yes | Base64-encoded file content |
+| `fileName` | string | Yes | Original file name with extension |
+| `path` | string | No | Destination folder path (e.g., `/docs/2026/`) |
+| `strategy` | string | No | Chunking strategy: `Semantic` (default), `FixedSize`, or `Recursive` |
+
+### `delete_file`
+
+Delete a file from a container. Also deletes all associated chunks and vectors.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `containerId` | string | Yes | Container ID or name |
+| `fileId` | string | Yes | File (document) ID to delete |
+
+### `get_document`
+
+Retrieve the full text content of a document by ID or path. For text files the original content is returned; for binary formats (PDF, DOCX, PPTX) the extracted text is returned.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `containerId` | string | Yes | Container ID or name |
+| `fileId` | string | Yes | Document ID (UUID) or virtual path (e.g., `/docs/readme.md`) |
+
+### `container_stats`
+
+Get statistics for a container: document counts by status, chunk count, storage size, embedding model, and last indexed time.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `containerId` | string | Yes | Container ID or name |
+
+## Authentication
+
+The MCP server uses agent API key authentication via the `X-Api-Key` header. Agent identities are managed separately from user accounts -- create them in the admin UI under **Admin > Agents**.
+
+Agents have the `Agent` role, which grants read and write access to containers, documents, and search. Admin-only operations (user management, settings) are not available to agents.
+
+## Supported File Formats
+
+Files uploaded via the `upload_file` tool support the same formats as the Web UI and REST API:
+
+- **Text:** `.txt`, `.md`, `.markdown`, `.csv`, `.log`, `.json`, `.xml`, `.yaml`, `.yml`
+- **Binary (parsed):** `.pdf`, `.docx`, `.pptx`
+
+## Container Resolution
+
+All tools that accept a `containerId` parameter accept either:
+
+- A container **ID** (UUID format)
+- A container **name** (lowercase string)
+
+The tool resolves names to IDs automatically.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,1 @@
+[Repository](https://github.com/Destrayon/Connapse) | [Issues](https://github.com/Destrayon/Connapse/issues) | [Discussions](https://github.com/Destrayon/Connapse/discussions) | [Project Board](https://github.com/users/Destrayon/projects/3) | [License (MIT)](https://github.com/Destrayon/Connapse/blob/main/LICENSE)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,14 @@
+**Connapse Wiki**
+
+- [[Home]]
+- [[Getting Started]]
+- [[Deployment Guide]]
+- [[CLI Reference]]
+- [[MCP Integration]]
+
+**Resources**
+
+- [Source Code](https://github.com/Destrayon/Connapse)
+- [Issues](https://github.com/Destrayon/Connapse/issues)
+- [Discussions](https://github.com/Destrayon/Connapse/discussions)
+- [Releases](https://github.com/Destrayon/Connapse/releases)


### PR DESCRIPTION
## Summary
- Set up GitHub Wiki structure with Home, Sidebar, and Footer
- Add Getting Started and Deployment Guide pages
- Add CLI Reference and MCP Integration pages sourced from actual code

## What
- `wiki/Home.md` — project overview, feature highlights, navigation
- `wiki/_Sidebar.md` / `wiki/_Footer.md` — wiki navigation structure
- `wiki/Getting-Started.md` — prerequisites, Docker Compose quickstart, first walkthrough
- `wiki/Deployment-Guide.md` — services table, env vars, volumes, hardening, backup/restore
- `wiki/CLI-Reference.md` — full command reference extracted from `Program.cs`
- `wiki/MCP-Integration.md` — all 9 MCP tools with parameters from `McpTools.cs`, Claude Desktop config

## Why
User-facing documentation hub. Wiki pages are task-oriented and concise, while `/docs/` remains the developer/architecture reference.

## Test plan
- [ ] Review all wiki pages render correctly in GitHub markdown preview
- [ ] Verify CLI commands match `src/Connapse.CLI/Program.cs`
- [ ] Verify MCP tools match `src/Connapse.Web/Mcp/McpTools.cs`
- [ ] After merge, copy `wiki/` files to the wiki repo (`Connapse.wiki.git`)

Closes #52, Closes #53, Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)