### PR TITLE
Add raw text upload to MCP upload_file tool

### DIFF
--- a/docs/plans/2026-03-08-mcp-text-upload-design.md
+++ b/docs/plans/2026-03-08-mcp-text-upload-design.md
@@ -1,0 +1,36 @@
+# MCP upload_file: Raw Text Content Parameter
+
+**Date:** 2026-03-08
+**Status:** Approved
+
+## Problem
+
+The MCP `upload_file` tool requires Base64-encoded content for all files. For text-based files (Markdown, JSON, CSV, etc.), this adds unnecessary friction in agent workflows — agents must encode plain text to Base64 before uploading.
+
+## Solution
+
+Add an optional `textContent` parameter to `upload_file`, mutually exclusive with the existing `content` (Base64) parameter.
+
+## Parameter Changes
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `containerId` | string | yes | Container ID or name (unchanged) |
+| `content` | string | no* | Base64-encoded file content. For binary files (PDF, DOCX, images). Mutually exclusive with textContent. |
+| `textContent` | string | no* | Raw text content for text-based files (Markdown, TXT, CSV, JSON, etc.). Mutually exclusive with content. |
+| `fileName` | string | yes | Original file name with extension (unchanged) |
+| `path` | string | no | Destination folder path (unchanged) |
+| `strategy` | string | no | Chunking strategy (unchanged) |
+
+*Exactly one of `content` or `textContent` must be provided.
+
+## Validation
+
+- Both provided: error `"Provide either 'content' or 'textContent', not both."`
+- Neither provided: error `"Provide either 'content' (base64) or 'textContent' (raw text)."`
+- `textContent` provided: encode to UTF-8 bytes, wrap in MemoryStream
+- `content` provided: Base64 decode (existing behavior)
+
+## Scope
+
+Only [McpTools.cs](../../src/Connapse.Web/Mcp/McpTools.cs) `UploadFile` method changes. No restrictions on file extension when using `textContent`. All downstream processing (storage, ingestion, chunking, embedding) is unchanged.

--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -225,29 +225,46 @@ public class McpTools
     }
 
     [McpServerTool(Name = "upload_file"),
-     Description("Upload a file to a container. The file will be parsed, chunked, embedded, and made searchable.")]
+     Description("Upload a file to a container. The file will be parsed, chunked, embedded, and made searchable. Provide either 'content' (base64) or 'textContent' (raw text), not both.")]
     public static async Task<string> UploadFile(
         IServiceProvider services,
         [Description("Container ID or name")] string containerId,
-        [Description("Base64-encoded file content")] string content,
-        [Description("Original file name with extension")] string fileName,
+        [Description("Base64-encoded file content. For binary files (PDF, DOCX, images). Mutually exclusive with textContent.")] string? content = null,
+        [Description("Raw text content for text-based files (Markdown, TXT, CSV, JSON, etc.). Mutually exclusive with content.")] string? textContent = null,
+        [Description("Original file name with extension")] string fileName = "",
         [Description("Destination folder path (e.g., '/docs/2026/')")] string? path = null,
         [Description("Chunking strategy: Semantic, FixedSize, or Recursive. Default: Semantic")] string? strategy = null,
         CancellationToken ct = default)
     {
+        if (string.IsNullOrEmpty(fileName))
+            return "Error: 'fileName' is required.";
+
+        if (content is not null && textContent is not null)
+            return "Error: Provide either 'content' or 'textContent', not both.";
+
+        if (content is null && textContent is null)
+            return "Error: Provide either 'content' (base64) or 'textContent' (raw text).";
+
         var containerStore = services.GetRequiredService<IContainerStore>();
         var resolvedId = await ResolveContainerIdAsync(containerId, containerStore, ct);
         if (resolvedId is null)
             return $"Error: Container '{containerId}' not found.";
 
         byte[] fileBytes;
-        try
+        if (textContent is not null)
         {
-            fileBytes = Convert.FromBase64String(content);
+            fileBytes = System.Text.Encoding.UTF8.GetBytes(textContent);
         }
-        catch
+        else
         {
-            return "Error: 'content' must be valid base64-encoded data.";
+            try
+            {
+                fileBytes = Convert.FromBase64String(content!);
+            }
+            catch
+            {
+                return "Error: 'content' must be valid base64-encoded data.";
+            }
         }
 
         var parsedStrategy = Enum.TryParse<ChunkingStrategy>(strategy, ignoreCase: true, out var s)


### PR DESCRIPTION
## Summary
- Adds `textContent` parameter to MCP `upload_file` tool for raw text uploads (Markdown, TXT, CSV, JSON, etc.)
- `textContent` and `content` (base64) are mutually exclusive — clear error if both or neither provided
- Eliminates Base64 encoding friction for agent workflows uploading text-based files

## What changed
- `content` parameter changed from required to optional
- New `textContent` parameter: raw UTF-8 text, encoded to bytes internally
- Validation: exactly one of `content` or `textContent` must be provided
- `fileName` made optional at signature level with explicit validation (required by C# since `content` is now optional)

## Test plan
- [ ] Upload a text file via MCP using `textContent` — verify file is stored and ingested
- [ ] Upload a binary file via MCP using `content` (base64) — verify existing flow still works
- [ ] Provide both `content` and `textContent` — verify error message
- [ ] Provide neither — verify error message
- [ ] Omit `fileName` — verify error message

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)