### PR TITLE
fix: route file deletes through connector for correct prefix scoping

### DIFF
--- a/src/Connapse.Web/Components/Pages/FileBrowser.razor
+++ b/src/Connapse.Web/Components/Pages/FileBrowser.razor
@@ -8,7 +8,6 @@
 @inject IContainerStore ContainerStore
 @inject IDocumentStore DocumentStore
 @inject IFolderStore FolderStore
-@inject IKnowledgeFileSystem FileSystem
 @inject IConnectorFactory ConnectorFactory
 @inject IIngestionQueue IngestionQueue
 @inject IContainerSettingsResolver SettingsResolver
@@ -1228,15 +1227,10 @@
         {
             if (!string.IsNullOrEmpty(entry.Path))
             {
-                if (container?.ConnectorType == ConnectorType.Filesystem)
+                if (container is not null)
                 {
-                    // entry.Path is a virtual path (/subfolder/file.pdf); connector resolves it to absolute
-                    var fsConnector = (FilesystemConnector)ConnectorFactory.Create(container);
-                    await fsConnector.DeleteFileAsync(entry.Path.TrimStart('/'));
-                }
-                else
-                {
-                    await FileSystem.DeleteAsync(entry.Path);
+                    var connector = ConnectorFactory.Create(container);
+                    await connector.DeleteFileAsync(entry.Path.TrimStart('/'));
                 }
             }
         }
@@ -1284,14 +1278,18 @@
 
             await FolderStore.DeleteAsync(containerId, normalizedPath);
 
-            foreach (var doc in docs)
+            if (container is not null)
             {
-                try
+                var connector = ConnectorFactory.Create(container);
+                foreach (var doc in docs)
                 {
-                    if (!string.IsNullOrEmpty(doc.Path))
-                        await FileSystem.DeleteAsync(doc.Path);
+                    try
+                    {
+                        if (!string.IsNullOrEmpty(doc.Path))
+                            await connector.DeleteFileAsync(doc.Path.TrimStart('/'));
+                    }
+                    catch { /* File already deleted or not found */ }
                 }
-                catch { /* File already deleted or not found */ }
             }
         }
     }

--- a/src/Connapse.Web/Endpoints/DocumentsEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/DocumentsEndpoints.cs
@@ -21,7 +21,6 @@ public static class DocumentsEndpoints
             [FromForm] string? path,
             [FromForm] ChunkingStrategy? strategy,
             [FromServices] IContainerStore containerStore,
-            [FromServices] IKnowledgeFileSystem fileSystem,
             [FromServices] IConnectorFactory connectorFactory,
             [FromServices] IIngestionQueue queue,
             [FromServices] IAuditLogger auditLogger,
@@ -266,7 +265,7 @@ public static class DocumentsEndpoints
             string fileId,
             [FromServices] IContainerStore containerStore,
             [FromServices] IDocumentStore documentStore,
-            [FromServices] IKnowledgeFileSystem fileSystem,
+            [FromServices] IConnectorFactory connectorFactory,
             [FromServices] IIngestionQueue ingestionQueue,
             [FromServices] IAuditLogger auditLogger,
             [FromServices] ICloudScopeService cloudScopeService,
@@ -293,11 +292,15 @@ public static class DocumentsEndpoints
             // Delete from database (cascades to chunks and vectors)
             await documentStore.DeleteAsync(fileId, ct);
 
-            // Delete file from storage (best effort)
+            // Delete file from storage (best effort) — use the connector so
+            // the correct prefix / root path is applied.
             try
             {
                 if (!string.IsNullOrEmpty(document.Path))
-                    await fileSystem.DeleteAsync(document.Path, ct);
+                {
+                    var connector = connectorFactory.Create(container);
+                    await connector.DeleteFileAsync(document.Path.TrimStart('/'), ct);
+                }
             }
             catch { /* File already deleted or not found */ }
 

--- a/src/Connapse.Web/Endpoints/FoldersEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/FoldersEndpoints.cs
@@ -74,7 +74,7 @@ public static class FoldersEndpoints
             [FromServices] IContainerStore containerStore,
             [FromServices] IFolderStore folderStore,
             [FromServices] IDocumentStore documentStore,
-            [FromServices] IKnowledgeFileSystem fileSystem,
+            [FromServices] IConnectorFactory connectorFactory,
             [FromServices] IIngestionQueue ingestionQueue,
             [FromServices] ICloudScopeService cloudScopeService,
             CancellationToken ct) =>
@@ -120,10 +120,12 @@ public static class FoldersEndpoints
             if (!deleted)
                 return Results.BadRequest(new { error = "Folder is not empty. Use cascade=true to delete contents." });
 
-            // Clean up file storage (best effort)
+            // Clean up file storage (best effort) — use the connector so
+            // the correct prefix / root path is applied.
+            var connector = connectorFactory.Create(container);
             foreach (var filePath in filePaths)
             {
-                try { await fileSystem.DeleteAsync(filePath, ct); }
+                try { await connector.DeleteFileAsync(filePath.TrimStart('/'), ct); }
                 catch { /* File already deleted or not found */ }
             }
 

--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -338,9 +338,13 @@ public class McpTools
         var storageDeleteFailed = false;
         try
         {
-            var fileSystem = services.GetRequiredService<IKnowledgeFileSystem>();
             if (!string.IsNullOrEmpty(document.Path))
-                await fileSystem.DeleteAsync(document.Path, ct);
+            {
+                var container = await containerStore.GetAsync(resolvedId.Value, ct);
+                var connectorFactory = services.GetRequiredService<IConnectorFactory>();
+                var connector = connectorFactory.Create(container!);
+                await connector.DeleteFileAsync(document.Path.TrimStart('/'), ct);
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
Follow-up to #121. Delete operations were still using the global `IKnowledgeFileSystem` instead of the connector, so deletes would target the wrong S3 key (missing `{containerId}/` prefix).

- **DocumentsEndpoints**: delete handler now uses `IConnectorFactory` instead of `IKnowledgeFileSystem`
- **FoldersEndpoints**: cascade delete now uses connector
- **McpTools**: `delete_file` now uses connector
- **FileBrowser.razor**: single file and folder deletes now use connector, removed unused `IKnowledgeFileSystem` inject

## Test plan
- [ ] Upload a file to a MinIO container, then delete it — verify the S3 object is actually removed
- [ ] Delete a folder with files — verify backing S3 objects are cleaned up
- [ ] Delete via MCP `delete_file` tool — verify correct S3 key is targeted

🤖 Generated with [Claude Code](https://claude.com/claude-code)