### PR TITLE
docs: update MCP documentation for all 11 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,23 @@ Connapse includes a Model Context Protocol (MCP) server for integration with Cla
 1. Create an Agent in the Connapse UI (`/admin/agents`) and generate an API key
 2. Configure Claude Desktop to send requests to your Connapse instance with the agent's `X-Api-Key`
 
-The MCP server exposes 7 tools: `container_create`, `container_list`, `container_delete`, `upload_file`, `list_files`, `delete_file`, `search_knowledge`.
+The MCP server exposes **11 tools**:
+
+| Tool | Description |
+|------|-------------|
+| `container_create` | Create a new container for organizing files |
+| `container_list` | List all containers with document counts |
+| `container_delete` | Delete a container |
+| `container_stats` | Get container statistics (documents, chunks, storage, embeddings) |
+| `upload_file` | Upload a single file to a container |
+| `bulk_upload` | Upload up to 100 files in one operation |
+| `list_files` | List files and folders at a path |
+| `get_document` | Retrieve full parsed text content of a document |
+| `delete_file` | Delete a single file from a container |
+| `bulk_delete` | Delete up to 100 files in one operation |
+| `search_knowledge` | Semantic, keyword, or hybrid search within a container |
+
+> **Write guards**: S3 and AzureBlob containers are read-only (synced from source). Filesystem containers respect per-container permission flags. Upload and delete tools will return an error for containers that block writes.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -722,19 +722,42 @@ Connapse exposes an MCP server for AI agent integration.
 
 **Tool list**: `GET /mcp/tools`
 
-### Available Tools
+### Available Tools (11)
 
-| Tool | Required Parameters | Optional | Description |
-|------|---------------------|----------|-------------|
-| `container_create` | `name` | `description` | Create a new container |
+| Tool | Required Parameters | Optional Parameters | Description |
+|------|---------------------|---------------------|-------------|
+| `container_create` | `name` | `description` | Create a new container for organizing files |
 | `container_list` | — | — | List all containers with document counts |
-| `container_delete` | `containerId` | — | Delete an empty container |
-| `upload_file` | `containerId`, `fileName`, `content` (base64) | `path`, `strategy` | Upload file to container |
-| `list_files` | `containerId` | `path` | List files/folders in container |
-| `delete_file` | `containerId`, `fileId` | — | Delete file from container |
-| `search_knowledge` | `query`, `containerId` | `path`, `mode`, `topK`, `minScore` | Search within container |
+| `container_delete` | `containerId` | — | Delete a container (must be empty for MinIO) |
+| `container_stats` | `containerId` | — | Get statistics: document counts by status, chunk count, storage size, embedding model, last indexed time |
+| `upload_file` | `containerId`, `fileName`, + `content` or `textContent` | `path`, `strategy` | Upload a single file (base64 or raw text) |
+| `bulk_upload` | `containerId`, `files` (JSON array) | — | Upload up to 100 files in one operation |
+| `list_files` | `containerId` | `path` | List files and folders at a given path |
+| `get_document` | `containerId`, `fileId` | — | Retrieve full parsed text content by document ID or path |
+| `delete_file` | `containerId`, `fileId` | — | Delete a file and its associated chunks and vectors |
+| `bulk_delete` | `containerId`, `fileIds` (JSON array) | — | Delete up to 100 files in one operation |
+| `search_knowledge` | `query`, `containerId` | `mode`, `topK`, `path`, `minScore` | Semantic, keyword, or hybrid search within a container |
 
-**Note**: `containerId` accepts either a container GUID or container name (resolved automatically).
+**Notes**:
+- `containerId` accepts either a container GUID or container name (resolved automatically).
+- `upload_file` accepts either `content` (base64) for binary files or `textContent` (raw text) for text files — provide one, not both.
+- `bulk_upload` `files` is a JSON array of objects: `{"filename":"name.txt", "content":"...", "encoding":"text|base64", "folderPath":"/optional/"}`.
+- `bulk_delete` `fileIds` is a JSON array of document ID strings: `["id1","id2"]`.
+- `get_document` `fileId` accepts either a document UUID or a virtual path (e.g., `/docs/readme.md`).
+
+### Write Guards
+
+Write operations (`upload_file`, `bulk_upload`, `delete_file`, `bulk_delete`) are subject to container write guards:
+
+| Connector Type | Upload | Delete | Notes |
+|---------------|--------|--------|-------|
+| **MinIO** | Allowed | Allowed | Default connector; full read/write |
+| **InMemory** | Allowed | Allowed | Ephemeral storage |
+| **Filesystem** | Configurable | Configurable | Per-container `allowUpload`/`allowDelete` flags (default: allowed) |
+| **S3** | Blocked | Blocked | Read-only; files are synced from the source bucket |
+| **AzureBlob** | Blocked | Blocked | Read-only; files are synced from the source container |
+
+When a write is blocked, the tool returns an error message explaining why (e.g., "S3 containers are read-only. Files are synced from the source.").
 
 ---
 

--- a/src/Connapse.Web/Mcp/README.md
+++ b/src/Connapse.Web/Mcp/README.md
@@ -15,7 +15,7 @@ All MCP endpoints require authentication. Use one of:
 
 Agent API keys are created in the admin panel under **Agents**.
 
-## Available Tools (8)
+## Available Tools (11)
 
 Tools are defined in `McpTools.cs` using `[McpServerTool]` attributes and are auto-discovered by the SDK.
 
@@ -35,23 +35,39 @@ List all containers with their document counts.
 
 ### 3. container_delete
 
-Delete a container. MinIO containers must be empty first. Filesystem, S3, and AzureBlob containers stop being indexed — underlying data is not deleted.
+Delete a container. MinIO containers must be empty first. Filesystem, S3, and AzureBlob containers just stop being indexed — underlying data is not deleted.
 
 **Parameters:**
 - `containerId` (string, required): Container ID or name
 
-### 4. upload_file
+### 4. container_stats
 
-Upload a file to a container. The file will be parsed, chunked, embedded, and made searchable.
+Get statistics for a container: document counts by status, chunk count, storage size, embedding model, and last indexed time.
 
 **Parameters:**
 - `containerId` (string, required): Container ID or name
-- `content` (string, required): Base64-encoded file content
+
+### 5. upload_file
+
+Upload a file to a container. The file will be parsed, chunked, embedded, and made searchable. Provide either `content` (base64) or `textContent` (raw text), not both.
+
+**Parameters:**
+- `containerId` (string, required): Container ID or name
+- `content` (string, optional): Base64-encoded file content. For binary files (PDF, DOCX, images). Mutually exclusive with `textContent`.
+- `textContent` (string, optional): Raw text content for text-based files (Markdown, TXT, CSV, JSON, etc.). Mutually exclusive with `content`.
 - `fileName` (string, required): Original file name with extension
 - `path` (string, optional): Destination folder path (e.g., `/docs/2026/`). Default: `/`
 - `strategy` (string, optional): Chunking strategy: `Semantic`, `FixedSize`, or `Recursive`. Default: `Semantic`
 
-### 5. list_files
+### 6. bulk_upload
+
+Upload multiple files to a container in one operation. Each file is parsed, chunked, embedded, and made searchable. Returns per-file results.
+
+**Parameters:**
+- `containerId` (string, required): Container ID or name
+- `files` (string, required): JSON array of file objects. Each object: `{"filename":"name.txt", "content":"...", "encoding":"text|base64", "folderPath":"/optional/"}`. Max 100 files.
+
+### 7. list_files
 
 List files and folders in a container at a given path.
 
@@ -59,15 +75,7 @@ List files and folders in a container at a given path.
 - `containerId` (string, required): Container ID or name
 - `path` (string, optional): Folder path to list. Default: root `/`
 
-### 6. delete_file
-
-Delete a file from a container. This also deletes all associated chunks and vectors.
-
-**Parameters:**
-- `containerId` (string, required): Container ID or name
-- `fileId` (string, required): File (document) ID to delete
-
-### 7. get_document
+### 8. get_document
 
 Retrieve the full text content of a document by ID or path. For text files the original content is returned; for binary formats (PDF, DOCX, PPTX) the extracted text is returned.
 
@@ -75,7 +83,23 @@ Retrieve the full text content of a document by ID or path. For text files the o
 - `containerId` (string, required): Container ID or name
 - `fileId` (string, required): Document ID (UUID) or virtual path (e.g., `/docs/readme.md`)
 
-### 8. search_knowledge
+### 9. delete_file
+
+Delete a file from a container. This also deletes all associated chunks and vectors.
+
+**Parameters:**
+- `containerId` (string, required): Container ID or name
+- `fileId` (string, required): File (document) ID to delete
+
+### 10. bulk_delete
+
+Delete multiple files from a container in one operation. Returns per-file results.
+
+**Parameters:**
+- `containerId` (string, required): Container ID or name
+- `fileIds` (string, required): JSON array of file (document) IDs to delete, e.g. `["id1","id2"]`. Max 100.
+
+### 11. search_knowledge
 
 Search within a container using semantic, keyword, or hybrid search. Returns relevant document chunks with scores.
 
@@ -86,6 +110,14 @@ Search within a container using semantic, keyword, or hybrid search. Returns rel
 - `topK` (integer, optional): Number of results to return. Default: `10`
 - `path` (string, optional): Filter results to a folder subtree (e.g., `/docs/`)
 - `minScore` (number, optional): Minimum similarity score threshold (0.0-1.0). Defaults to server setting.
+
+## Write Guards
+
+Write operations (`upload_file`, `bulk_upload`, `delete_file`, `bulk_delete`) are subject to container write guards:
+
+- **MinIO / InMemory**: Full read/write access.
+- **Filesystem**: Per-container `allowUpload` / `allowDelete` permission flags (default: allowed). Configurable in the connector config.
+- **S3 / AzureBlob**: Read-only. These containers are synced from the source and do not allow uploads or deletes through MCP. The tools return an error explaining why.
 
 ## Using with Claude Desktop
 


### PR DESCRIPTION
## Summary
- Updates `README.md` to reference 11 MCP tools (was 7) with full tool table
- Updates `docs/api.md` MCP section with all 11 tools, parameters, and write guard behavior
- Updates `src/Connapse.Web/Mcp/README.md` with all 11 tools and write guard documentation
- All tool names and parameters verified against `McpTools.cs` implementation

## Test plan
- [x] `dotnet test` — 646 tests pass
- [x] Verify tool names match between all 3 doc files
- [x] Verify parameter names match the code in `McpTools.cs`

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)