### PR TITLE
fix(cli): scope SSL certificate bypass to localhost only

### DIFF
--- a/src/Connapse.CLI/Program.cs
+++ b/src/Connapse.CLI/Program.cs
@@ -25,10 +25,14 @@ var credentials = LoadCredentials();
 if (credentials?.ApiBaseUrl is not null)
     apiBaseUrl = credentials.ApiBaseUrl;
 
-// Create HttpClient with SSL bypass for localhost
+// Create HttpClient with SSL bypass scoped to localhost only
+var serverUri = new Uri(apiBaseUrl);
+var isLocalhost = serverUri.Host is "localhost" or "127.0.0.1" or "::1";
 var handler = new HttpClientHandler
 {
-    ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true
+    ServerCertificateCustomValidationCallback = isLocalhost
+        ? (message, cert, chain, errors) => true
+        : null
 };
 var httpClient = new HttpClient(handler)
 {


### PR DESCRIPTION
## Summary
- SSL certificate validation bypass now only applies to `localhost`, `127.0.0.1`, and `::1`
- Remote server connections use standard certificate validation
- Parses the configured `apiBaseUrl` and checks the hostname before setting the callback

## Test plan
- [x] `dotnet test` — 646 tests pass
- [x] Verify CLI connects to localhost without SSL errors
- [x] Verify CLI validates certificates for remote URLs

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)