### PR TITLE
fix: update LICENSE copyright to Connapse Contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 AIKnowledgePlatform Contributors
+Copyright (c) 2026 Connapse Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Updates LICENSE copyright from "AIKnowledgePlatform Contributors" to "Connapse Contributors"
- Verified remaining old-name references are only in `PUBLIC_RELEASE_PREP.md` (covered by #134)

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)