### PR TITLE
feat(api): add GET /api/containers/{id}/stats endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -404,6 +404,36 @@ All container endpoints require authentication. RBAC rules:
 
 ---
 
+### Get Container Stats
+
+**Endpoint**: `GET /api/containers/{id}/stats`
+
+**Auth**: Viewer minimum
+
+**Response** (200 OK):
+```json
+{
+  "containerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "containerName": "my-project",
+  "connectorType": "MinIO",
+  "documents": {
+    "total": 42,
+    "ready": 40,
+    "processing": 1,
+    "failed": 1
+  },
+  "totalChunks": 1200,
+  "totalSizeBytes": 52428800,
+  "embeddingModels": [
+    { "modelId": "nomic-embed-text", "dimensions": 768, "vectorCount": 1200 }
+  ],
+  "lastIndexedAt": "2026-03-09T10:00:00Z",
+  "createdAt": "2026-02-26T10:00:00Z"
+}
+```
+
+---
+
 ## Container Files API
 
 ### Upload Files

--- a/src/Connapse.Web/Endpoints/ContainersEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/ContainersEndpoints.cs
@@ -5,6 +5,7 @@ using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
 using Connapse.Storage.ConnectionTesters;
 using Connapse.Storage.Connectors;
+using Connapse.Storage.Vectors;
 using Connapse.Web.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -141,6 +142,49 @@ public static class ContainersEndpoints
         .WithName("DeleteContainer")
         .WithDescription("Delete a container. MinIO containers must be empty first. Filesystem, S3, and AzureBlob containers just stop being indexed — the underlying data is not deleted.")
         .RequireAuthorization("RequireEditor");
+
+        // GET /api/containers/{containerId}/stats - Get container statistics
+        group.MapGet("/{containerId:guid}/stats", async (
+            Guid containerId,
+            [FromServices] IContainerStore containerStore,
+            [FromServices] IDocumentStore documentStore,
+            [FromServices] VectorModelDiscovery modelDiscovery,
+            CancellationToken ct) =>
+        {
+            var container = await containerStore.GetAsync(containerId, ct);
+            if (container is null)
+                return Results.NotFound(new { error = $"Container {containerId} not found" });
+
+            var stats = await documentStore.GetContainerStatsAsync(containerId, ct);
+            var models = await modelDiscovery.GetModelsAsync(containerId, ct);
+
+            return Results.Ok(new
+            {
+                containerId = container.Id,
+                containerName = container.Name,
+                connectorType = container.ConnectorType.ToString(),
+                documents = new
+                {
+                    total = stats.DocumentCount,
+                    ready = stats.ReadyCount,
+                    processing = stats.ProcessingCount,
+                    failed = stats.FailedCount
+                },
+                totalChunks = stats.TotalChunks,
+                totalSizeBytes = stats.TotalSizeBytes,
+                embeddingModels = models.Select(m => new
+                {
+                    modelId = m.ModelId,
+                    dimensions = m.Dimensions,
+                    vectorCount = m.VectorCount
+                }),
+                lastIndexedAt = stats.LastIndexedAt,
+                createdAt = container.CreatedAt
+            });
+        })
+        .WithName("GetContainerStats")
+        .WithDescription("Get statistics for a container: document counts by status, chunk count, storage size, embedding models, last indexed time")
+        .RequireAuthorization("RequireViewer");
 
         // GET /api/containers/{containerId}/settings - Get container settings overrides
         group.MapGet("/{containerId:guid}/settings", async (


### PR DESCRIPTION
## Summary
- Adds `GET /api/containers/{id}/stats` endpoint returning document counts by status, chunk count, storage size, embedding model info, and last indexed time
- Uses existing `IDocumentStore.GetContainerStatsAsync` and `VectorModelDiscovery.GetModelsAsync`
- Requires `RequireViewer` authorization policy
- Documented in `docs/api.md`

## What
Mirrors the MCP `container_stats` tool data as a REST endpoint, unblocking #137 (CLI container stats command).

## Why
REST API parity with MCP tools — CLI and external integrations need the same data.

## How
Single endpoint in `ContainersEndpoints.cs` following existing patterns. No new services or models needed.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)