### PR TITLE
docs: Document container write guard behavior

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -471,6 +471,7 @@ Upload one or more files into a container.
 - Files stream directly to MinIO (not buffered in memory)
 - Ingestion is asynchronous — track progress via SignalR or poll the file endpoint
 - Duplicate filenames in the same folder auto-increment: `file (1).pdf`, `file (2).pdf`
+- **Write guard**: S3 and AzureBlob containers block uploads (read-only). Filesystem containers respect the `allowUpload` flag. Returns `400` with `{ "error": "write_denied" }` when blocked. See [connectors.md — Write Guards](connectors.md#write-guards).
 
 ---
 
@@ -540,6 +541,8 @@ Returns whether the file needs reindexing and the reason.
 
 Cascade deletes chunks, vectors, and removes the file from MinIO.
 
+**Write guard**: S3 and AzureBlob containers block deletes. Filesystem containers respect the `allowDelete` flag. Returns `400` with `{ "error": "write_denied" }` when blocked. See [connectors.md — Write Guards](connectors.md#write-guards).
+
 **Response** (204 No Content)
 
 ---
@@ -555,6 +558,8 @@ Cascade deletes chunks, vectors, and removes the file from MinIO.
 { "path": "/docs/2026/" }
 ```
 
+**Write guard**: S3 and AzureBlob containers block folder creation. Filesystem containers respect the `allowCreateFolder` flag. Returns `400` with `{ "error": "write_denied" }` when blocked.
+
 **Response** (200 OK): Returns `Folder` object.
 
 ---
@@ -564,6 +569,8 @@ Cascade deletes chunks, vectors, and removes the file from MinIO.
 **Endpoint**: `DELETE /api/containers/{id}/folders?path=/docs/2026/`
 
 Cascade deletes all nested files, subfolders, chunks, vectors, and MinIO objects.
+
+**Write guard**: S3 and AzureBlob containers block folder deletion. Filesystem containers respect the `allowDelete` flag. Returns `400` with `{ "error": "write_denied" }` when blocked.
 
 **Response** (204 No Content)
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -188,6 +188,61 @@ POST /api/containers/test-connection
 
 ---
 
+## Write Guards
+
+Write operations (upload, delete, create folder) are subject to **container write guards** enforced by `ContainerWriteGuard`. This applies consistently across both the REST API and MCP tools.
+
+### Permissions by Connector Type
+
+| Connector Type | Upload | Delete | Create Folder | Notes |
+|---------------|--------|--------|---------------|-------|
+| **MinIO** | Allowed | Allowed | Allowed | Default connector; full read/write |
+| **InMemory** | Allowed | Allowed | Allowed | Ephemeral storage |
+| **Filesystem** | Configurable | Configurable | Configurable | Per-container flags (default: allowed) |
+| **S3** | Blocked | Blocked | Blocked | Read-only; files are synced from the source bucket |
+| **AzureBlob** | Blocked | Blocked | Blocked | Read-only; files are synced from the source container |
+
+### Filesystem Permission Flags
+
+Filesystem containers support three per-container permission flags in their connector config:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `allowUpload` | `true` | Allow uploading files through the API/UI |
+| `allowDelete` | `true` | Allow deleting files through the API/UI |
+| `allowCreateFolder` | `true` | Allow creating folders through the API/UI |
+
+Set these to `false` to make a Filesystem container partially or fully read-only:
+
+```json
+{
+  "rootPath": "C:\\Documents\\Knowledge",
+  "allowUpload": false,
+  "allowDelete": false,
+  "allowCreateFolder": false
+}
+```
+
+### Error Responses
+
+When a write operation is blocked:
+
+- **REST API**: Returns `400 Bad Request` with `{ "error": "write_denied", "message": "..." }`
+- **MCP**: Returns an error message as plain text (e.g., `"Error: S3 containers are read-only. Files are synced from the source."`)
+
+### Affected Endpoints
+
+| Endpoint | Operation |
+|----------|-----------|
+| `POST /api/containers/{id}/files` | Upload |
+| `DELETE /api/containers/{id}/files/{fileId}` | Delete |
+| `POST /api/containers/{id}/folders` | CreateFolder |
+| `DELETE /api/containers/{id}/folders` | Delete |
+| MCP `upload_file` / `bulk_upload` | Upload |
+| MCP `delete_file` / `bulk_delete` | Delete |
+
+---
+
 ## Per-Container Settings
 
 Each container can override global settings for chunking, embedding, search, and upload.


### PR DESCRIPTION
## Summary
- Added comprehensive "Write Guards" section to `docs/connectors.md` covering permissions by connector type, Filesystem permission flags, error responses, and all affected endpoints
- Added inline write guard notes to `docs/api.md` for Upload Files, Delete File, Create Folder, and Delete Folder endpoints with cross-references

## What
Documents the `ContainerWriteGuard` enforcement behavior that applies to both REST API and MCP tools — which connector types are read-only, how Filesystem per-container flags work, and what error responses look like.

## Why
Write guard behavior was implemented but undocumented in the REST API sections and connectors guide, making it hard for users to understand why write operations fail on certain container types.

## How
Pure documentation changes to `docs/connectors.md` and `docs/api.md`.

Closes #136

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Cross-reference links resolve properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)