### PR TITLE
fix: Replace stale project names and URLs

### DIFF
--- a/PUBLIC_RELEASE_PREP.md
+++ b/PUBLIC_RELEASE_PREP.md
@@ -96,7 +96,7 @@ MINIO_ROOT_PASSWORD=change_me_strong_password
 Current README is 13 lines. Expand to include:
 
 ```markdown
-# AIKnowledgePlatform
+# Connapse
 
 > Open-source AI-powered knowledge management platform. Transform documents into searchable knowledge for AI agents.
 
@@ -121,8 +121,8 @@ Current README is 13 lines. Expand to include:
 ### Run with Docker
 \`\`\`bash
 # Clone and start
-git clone https://github.com/yourusername/AIKnowledgePlatform.git
-cd AIKnowledgePlatform
+git clone https://github.com/Destrayon/Connapse.git
+cd Connapse
 docker-compose up -d
 
 # Access UI
@@ -135,7 +135,7 @@ open http://localhost:5001
 docker-compose up -d postgres minio
 
 # Run web app
-dotnet run --project src/AIKnowledge.Web
+dotnet run --project src/Connapse.Web
 
 # Run tests
 dotnet test
@@ -178,7 +178,7 @@ dotnet test
 
 ## Commercial Hosting
 
-While AIKnowledgePlatform is open source and free to self-host, we will offer a **managed cloud service** for teams who want:
+While Connapse is open source and free to self-host, we will offer a **managed cloud service** for teams who want:
 - Zero-ops deployment
 - Automatic backups & scaling
 - Enterprise support
@@ -197,8 +197,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 ## Support
 
 - 📖 [Documentation](docs/)
-- 🐛 [Issue Tracker](https://github.com/yourusername/AIKnowledgePlatform/issues)
-- 💬 [Discussions](https://github.com/yourusername/AIKnowledgePlatform/discussions)
+- 🐛 [Issue Tracker](https://github.com/Destrayon/Connapse/issues)
+- 💬 [Discussions](https://github.com/Destrayon/Connapse/discussions)
 \`\`\`
 ```
 

--- a/docs/GITHUB_SETUP.md
+++ b/docs/GITHUB_SETUP.md
@@ -190,7 +190,7 @@ main
 
 **After pushing to GitHub**, update the badge URLs in [README.md](../README.md):
 
-Replace `yourusername` with your actual GitHub username/organization:
+The badge URLs in README.md already use the correct repository path (`Destrayon/Connapse`):
 ```markdown
 [![Build](https://img.shields.io/github/actions/workflow/status/Destrayon/Connapse/ci.yml?branch=main&label=build)](https://github.com/Destrayon/Connapse/actions)
 [![Tests](https://img.shields.io/badge/tests-171%20passing-success)](https://github.com/Destrayon/Connapse/actions)
@@ -268,25 +268,9 @@ After completing the manual configuration:
 
 ## 📝 Notes
 
-### About "yourusername" Placeholders
+### Repository URLs
 
-The following files contain `yourusername` placeholders that need to be replaced with your actual GitHub username or organization name:
-
-1. **README.md** - Badge URLs, repository links
-2. **.github/ISSUE_TEMPLATE/config.yml** - Contact links
-3. **docs/GITHUB_SETUP.md** (this file) - Example URLs
-
-You can use find-and-replace to update all occurrences:
-
-```bash
-# Linux/macOS
-find . -type f -name "*.md" -o -name "*.yml" | xargs sed -i 's/yourusername/ACTUAL_USERNAME/g'
-
-# Windows (PowerShell)
-Get-ChildItem -Recurse -Include *.md,*.yml | ForEach-Object {
-    (Get-Content $_.FullName) -replace 'yourusername', 'ACTUAL_USERNAME' | Set-Content $_.FullName
-}
-```
+All repository URLs and badge paths use `Destrayon/Connapse`. If you fork this repository, update these references to match your fork's path.
 
 ### Why These Settings Matter
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-ConnapsePlatform is a .NET 10 Blazor WebApp that transforms uploaded documents into searchable knowledge for AI agents. This document describes the system architecture, design patterns, and data flow.
+Connapse is a .NET 10 Blazor WebApp that transforms uploaded documents into searchable knowledge for AI agents. This document describes the system architecture, design patterns, and data flow.
 
 ## System Overview
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-This guide covers deploying ConnapsePlatform in various environments.
+This guide covers deploying Connapse in various environments.
 
 ## Table of Contents
 
@@ -15,7 +15,7 @@ This guide covers deploying ConnapsePlatform in various environments.
 
 ## Quick Start (Docker Compose)
 
-The fastest way to run ConnapsePlatform with all dependencies.
+The fastest way to run Connapse with all dependencies.
 
 ### Prerequisites
 
@@ -28,8 +28,8 @@ The fastest way to run ConnapsePlatform with all dependencies.
 
 1. **Clone the repository**:
 ```bash
-git clone https://github.com/yourorg/ConnapsePlatform.git
-cd ConnapsePlatform
+git clone https://github.com/Destrayon/Connapse.git
+cd Connapse
 ```
 
 2. **Create environment file**:

--- a/src/Connapse.Web/Components/Pages/FileBrowser.razor
+++ b/src/Connapse.Web/Components/Pages/FileBrowser.razor
@@ -20,7 +20,7 @@
 @inject AuthenticationStateProvider AuthStateProvider
 @implements IAsyncDisposable
 
-<PageTitle>@(container?.Name ?? "Files") - AIKnowledge</PageTitle>
+<PageTitle>@(container?.Name ?? "Files") - Connapse</PageTitle>
 
 @* Header *@
 <div class="browser-header">


### PR DESCRIPTION
## Summary
- Replaced all remaining `AIKnowledge`/`AIKnowledgePlatform`/`ConnapsePlatform` references with `Connapse`
- Fixed clone URLs from `yourorg/ConnapsePlatform` to `Destrayon/Connapse`
- Removed outdated `yourusername` placeholder section from GITHUB_SETUP.md

## What
5 files had stale project names or placeholder URLs from before the rename to Connapse.

## Why
Stale references confuse users and hurt credibility. All public-facing names and URLs should consistently use the current project name.

## How
Simple find-and-replace across docs and one Blazor PageTitle.

Closes #134

## Test plan
- [ ] Verify `FileBrowser.razor` page title renders correctly
- [ ] Check all updated URLs resolve properly
- [ ] Markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)