### PR TITLE
chore: standardize JWT secret to Identity__Jwt__Secret only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       Knowledge__Embedding__BaseUrl: "http://ollama:11434"
       CONNAPSE_ADMIN_EMAIL: ${CONNAPSE_ADMIN_EMAIL:-}
       CONNAPSE_ADMIN_PASSWORD: ${CONNAPSE_ADMIN_PASSWORD:-}
-      CONNAPSE_JWT_SECRET: ${CONNAPSE_JWT_SECRET:-}
+      Identity__Jwt__Secret: ${Identity__Jwt__Secret:-}
     volumes:
       - appdata:/app/appdata
     depends_on:

--- a/release/.env.example
+++ b/release/.env.example
@@ -19,7 +19,7 @@ CONNAPSE_ADMIN_PASSWORD=change_me_admin
 
 # Secret key used to sign JWT tokens. Must be at least 32 characters.
 # Generate a secure value with: openssl rand -base64 64
-CONNAPSE_JWT_SECRET=change_me_jwt_secret_generate_with_openssl_rand_base64_64
+Identity__Jwt__Secret=change_me_jwt_secret_generate_with_openssl_rand_base64_64
 
 # --- Embedding / Ollama ----------------------------------------------------------
 # Base URL for the Ollama embedding API.

--- a/release/docker-compose.yml
+++ b/release/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       Knowledge__Embedding__BaseUrl: "${Knowledge__Embedding__BaseUrl:-http://ollama:11434}"
       CONNAPSE_ADMIN_EMAIL: ${CONNAPSE_ADMIN_EMAIL}
       CONNAPSE_ADMIN_PASSWORD: ${CONNAPSE_ADMIN_PASSWORD}
-      CONNAPSE_JWT_SECRET: ${CONNAPSE_JWT_SECRET}
+      Identity__Jwt__Secret: ${Identity__Jwt__Secret}
     volumes:
       - appdata:/app/appdata
     depends_on:

--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -83,9 +83,8 @@ public static class IdentityServiceExtensions
             ?? new JwtSettings();
 
         var jwtSecret = jwtSettings.Secret
-            ?? configuration["CONNAPSE_JWT_SECRET"]
             ?? throw new InvalidOperationException(
-                "JWT secret not configured. Set CONNAPSE_JWT_SECRET environment variable.");
+                "JWT secret not configured. Set Identity__Jwt__Secret environment variable.");
 
         services.AddAuthentication(options =>
             {
@@ -223,7 +222,7 @@ public static class IdentityServiceExtensions
 
     private static void EnsureJwtSecret(IConfiguration configuration)
     {
-        var secret = configuration["Identity:Jwt:Secret"] ?? configuration["CONNAPSE_JWT_SECRET"];
+        var secret = configuration["Identity:Jwt:Secret"];
 
         if (!string.IsNullOrWhiteSpace(secret))
             return;
@@ -251,6 +250,6 @@ public static class IdentityServiceExtensions
         configuration["Identity:Jwt:Secret"] = newSecret;
 
         // We can't use ILogger here since we're in a static method during startup
-        Console.WriteLine($"WARNING: Auto-generated JWT secret. Set CONNAPSE_JWT_SECRET for production use. Secret stored at: {secretPath}");
+        Console.WriteLine($"WARNING: Auto-generated JWT secret. Set Identity__Jwt__Secret for production use. Secret stored at: {secretPath}");
     }
 }

--- a/src/Connapse.Identity/Services/JwtTokenService.cs
+++ b/src/Connapse.Identity/Services/JwtTokenService.cs
@@ -178,7 +178,7 @@ public class JwtTokenService(
     {
         var secret = settings.Secret
             ?? throw new InvalidOperationException(
-                "JWT secret is not configured. Set CONNAPSE_JWT_SECRET environment variable or Identity:Jwt:Secret in configuration.");
+                "JWT secret is not configured. Set Identity__Jwt__Secret environment variable.");
 
         return new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
     }


### PR DESCRIPTION
## Summary
- Remove `CONNAPSE_JWT_SECRET` fallback from `IdentityServiceExtensions.cs` — `Identity:Jwt:Secret` (via `JwtSettings.Secret`) is now the sole source
- Update all error messages and warnings to reference `Identity__Jwt__Secret`
- Update `docker-compose.yml`, `release/docker-compose.yml`, and `release/.env.example` to use `Identity__Jwt__Secret`

## What / Why / How
**What**: Standardize JWT secret configuration to a single env var name
**Why**: Two names (`CONNAPSE_JWT_SECRET` + `Identity__Jwt__Secret`) for the same secret adds confusion
**How**: Remove the custom fallback, keep only the .NET-convention `__` separator approach

Closes #117

## Test plan
- [x] `dotnet test` — all 646 tests pass (306 core, 71 identity, 111 ingestion, 158 integration)
- [x] `grep -r CONNAPSE_JWT_SECRET` returns zero matches
- [ ] Verify Docker Compose starts correctly with `Identity__Jwt__Secret` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)