### PR TITLE
fix: make Ollama accessible from Docker containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
 
   ollama:
     image: ollama/ollama
+    environment:
+      OLLAMA_HOST: "0.0.0.0"
     volumes:
       - ollamadata:/root/.ollama
     profiles:

--- a/release/docker-compose.yml
+++ b/release/docker-compose.yml
@@ -43,6 +43,8 @@ services:
 
   ollama:
     image: ollama/ollama
+    environment:
+      OLLAMA_HOST: "0.0.0.0"
     volumes:
       - ollamadata:/root/.ollama
     profiles:

--- a/src/Connapse.Core/Models/SettingsModels.cs
+++ b/src/Connapse.Core/Models/SettingsModels.cs
@@ -22,8 +22,10 @@ public record EmbeddingSettings
 
     /// <summary>
     /// Base URL for Ollama embedding service.
+    /// Defaults come from appsettings.json or environment variables — no hardcoded default
+    /// so that Docker deployments can override via Knowledge__Embedding__BaseUrl.
     /// </summary>
-    public string? BaseUrl { get; set; } = "http://localhost:11434";
+    public string? BaseUrl { get; set; }
 
     /// <summary>
     /// API key — legacy shared field, kept for backward compatibility.
@@ -192,8 +194,10 @@ public record LlmSettings
 
     /// <summary>
     /// Base URL for Ollama LLM service.
+    /// Defaults come from appsettings.json or environment variables — no hardcoded default
+    /// so that Docker deployments can override via Knowledge__Llm__BaseUrl.
     /// </summary>
-    public string? BaseUrl { get; set; } = "http://localhost:11434";
+    public string? BaseUrl { get; set; }
 
     /// <summary>
     /// API key — legacy shared field, kept for backward compatibility.

--- a/src/Connapse.Web/Components/Settings/EmbeddingSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/EmbeddingSettingsTab.razor
@@ -26,7 +26,7 @@
 
             <div class="col-md-6">
                 <label class="form-label">Base URL</label>
-                <InputText @bind-Value="localSettings.BaseUrl" class="form-control" placeholder="http://localhost:11434" />
+                <InputText @bind-Value="localSettings.BaseUrl" class="form-control" placeholder="e.g. http://ollama:11434 (Docker) or http://localhost:11434 (local)" />
             </div>
         }
         else if (IsOpenAi)
@@ -234,8 +234,7 @@
                     localSettings.Model = "nomic-embed-text";
                 if (localSettings.Dimensions == 1536 || localSettings.Dimensions == 3072)
                     localSettings.Dimensions = 768;
-                if (string.IsNullOrWhiteSpace(localSettings.BaseUrl))
-                    localSettings.BaseUrl = "http://localhost:11434";
+                // BaseUrl comes from config (appsettings / env var) — don't hardcode a default
                 if (localSettings.BatchSize == 64)
                     localSettings.BatchSize = 16;
                 break;

--- a/src/Connapse.Web/Components/Settings/LlmSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/LlmSettingsTab.razor
@@ -25,7 +25,7 @@
 
             <div class="col-md-6">
                 <label class="form-label">Base URL</label>
-                <InputText @bind-Value="localSettings.BaseUrl" class="form-control" placeholder="http://localhost:11434" />
+                <InputText @bind-Value="localSettings.BaseUrl" class="form-control" placeholder="e.g. http://ollama:11434 (Docker) or http://localhost:11434 (local)" />
             </div>
         }
         else if (IsOpenAi)
@@ -183,8 +183,7 @@
             default:
                 if (localSettings.Model is "gpt-4o" or "claude-sonnet-4-20250514")
                     localSettings.Model = "llama3.2";
-                if (string.IsNullOrWhiteSpace(localSettings.BaseUrl))
-                    localSettings.BaseUrl = "http://localhost:11434";
+                // BaseUrl comes from config (appsettings / env var) — don't hardcode a default
                 if (localSettings.MaxTokens == 4096)
                     localSettings.MaxTokens = 2000;
                 break;


### PR DESCRIPTION
## Summary
- Set `OLLAMA_HOST=0.0.0.0` in both docker-compose files so Ollama listens on all interfaces (not just loopback)
- Removed hardcoded `http://localhost:11434` defaults from `EmbeddingSettings.BaseUrl` and `LlmSettings.BaseUrl` — value now comes from config layer (appsettings.json for local dev, env var for Docker)
- Removed hardcoded localhost fallback in UI provider-switch logic and updated placeholder text to show both Docker and local examples

## What was happening
Ollama binds to `127.0.0.1` by default inside its container, making it unreachable from the `web` container even on the same Docker network. Additionally, the C# model defaults and UI hardcoded `localhost:11434`, which got saved to the DB and overrode the Docker Compose env var (`http://ollama:11434`).

## Test plan
- [x] All 646 tests pass
- [x] Deploy with `--profile with-ollama` and verify embedding connection test succeeds with `http://ollama:11434`
- [x] Verify local dev (`dotnet run`) still works with `http://localhost:11434` from appsettings.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)