### PR TITLE
fix(auth): use scheme-aware cookie Secure flag for HTTP/HTTPS support

### DIFF
--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -124,7 +124,7 @@ public static class IdentityServiceExtensions
                 options.SlidingExpiration = true;
                 options.Cookie.HttpOnly = true;
                 options.Cookie.SameSite = SameSiteMode.Strict;
-                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+                options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
 
                 // For API/MCP endpoints, return 401 instead of redirecting to login
                 options.Events.OnRedirectToLogin = context =>

--- a/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
@@ -50,7 +50,7 @@ public static class CloudIdentityEndpoints
             var cookieOptions = new CookieOptions
             {
                 HttpOnly = true,
-                Secure = true,
+                Secure = httpContext.Request.IsHttps,
                 SameSite = SameSiteMode.Lax,
                 MaxAge = TimeSpan.FromMinutes(10),
                 Path = "/api/v1/auth/cloud/azure"


### PR DESCRIPTION
## Summary
- Changes `CookieSecurePolicy.Always` to `CookieSecurePolicy.SameAsRequest` for the session cookie in `IdentityServiceExtensions.cs`
- Changes hardcoded `Secure = true` to `Secure = httpContext.Request.IsHttps` for Azure OAuth cookies in `CloudIdentityEndpoints.cs`
- Fixes login failures on `http://localhost` while preserving Secure cookies on HTTPS deployments

Closes #187

## Test Plan
- [ ] Verify login works on `http://localhost`
- [ ] Verify login works on `https://localhost`
- [ ] Verify Azure OAuth flow sets Secure cookie only on HTTPS
- [ ] All 682 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)