### PR TITLE
fix(cli): fix PAT list deserialization in trimmed binary

### DIFF
--- a/src/Connapse.CLI/Program.cs
+++ b/src/Connapse.CLI/Program.cs
@@ -44,7 +44,11 @@ var httpClient = new HttpClient(handler)
 if (credentials?.ApiKey is not null)
     httpClient.DefaultRequestHeaders.Add("X-Api-Key", credentials.ApiKey);
 
-var jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+var jsonOptions = new JsonSerializerOptions
+{
+    PropertyNameCaseInsensitive = true,
+    TypeInfoResolver = CliJsonContext.Default
+};
 
 if (args.Length == 0)
 {
@@ -1637,9 +1641,9 @@ static async Task<int> HandleUpdate(string[] args)
     GitHubRelease? release;
     try
     {
-        release = await ghClient.GetFromJsonAsync<GitHubRelease>(
+        release = await ghClient.GetFromJsonAsync(
             "https://api.github.com/repos/Destrayon/Connapse/releases/latest",
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            CliJsonContext.Default.GitHubRelease);
     }
     catch (Exception ex)
     {
@@ -1832,8 +1836,7 @@ static CliCredentials? LoadCredentials()
     try
     {
         var json = File.ReadAllText(path);
-        return JsonSerializer.Deserialize<CliCredentials>(json,
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize(json, CliJsonContext.Default.CliCredentials);
     }
     catch
     {
@@ -1845,7 +1848,7 @@ static void SaveCredentials(CliCredentials credentials)
 {
     var path = GetCredentialsPath();
     Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-    var json = JsonSerializer.Serialize(credentials, new JsonSerializerOptions { WriteIndented = true });
+    var json = JsonSerializer.Serialize(credentials, CliJsonContext.Default.CliCredentials);
     File.WriteAllText(path, json);
 }
 
@@ -1916,9 +1919,9 @@ static async Task CheckForUpdateNotification()
         ghClient.DefaultRequestHeaders.UserAgent.Add(
             new ProductInfoHeaderValue("connapse-cli", currentVersion));
 
-        var release = await ghClient.GetFromJsonAsync<GitHubRelease>(
+        var release = await ghClient.GetFromJsonAsync(
             "https://api.github.com/repos/Destrayon/Connapse/releases/latest",
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            CliJsonContext.Default.GitHubRelease);
 
         Directory.CreateDirectory(Path.GetDirectoryName(checkFile)!);
         File.WriteAllText(checkFile, DateTime.UtcNow.ToString("O"));
@@ -2041,3 +2044,21 @@ record GitHubRelease(
 record GitHubAsset(
     [property: JsonPropertyName("name")]                  string Name,
     [property: JsonPropertyName("browser_download_url")] string BrowserDownloadUrl);
+
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(List<PatListItem>))]
+[JsonSerializable(typeof(PatListItem))]
+[JsonSerializable(typeof(PatCreateResponse))]
+[JsonSerializable(typeof(PagedContainerResponse))]
+[JsonSerializable(typeof(ContainerInfo))]
+[JsonSerializable(typeof(List<ContainerInfo>))]
+[JsonSerializable(typeof(SearchResult))]
+[JsonSerializable(typeof(SearchHit))]
+[JsonSerializable(typeof(ReindexResult))]
+[JsonSerializable(typeof(TokenResponse))]
+[JsonSerializable(typeof(CliExchangeResponse))]
+[JsonSerializable(typeof(CliCredentials))]
+[JsonSerializable(typeof(GitHubRelease))]
+[JsonSerializable(typeof(GitHubAsset))]
+[JsonSerializable(typeof(JsonDocument))]
+internal partial class CliJsonContext : JsonSerializerContext { }


### PR DESCRIPTION
## Summary
- Add `CliJsonContext` source-generated JSON serializer context with `[JsonSerializable]` for all 15 CLI DTO types
- Wire `jsonOptions` to use `CliJsonContext.Default` as `TypeInfoResolver`, making all deserialization trim-safe
- Update standalone `GetFromJsonAsync`/`Deserialize`/`Serialize` calls in `HandleUpdate`, `CheckForUpdateNotification`, `LoadCredentials`, and `SaveCredentials` to use the source-generated context directly

## What / Why / How
**What:** `connapse auth pat list` (and other record-deserializing commands) fail in the published trimmed binary with `NotSupportedException: Deserialization of types without a parameterless constructor`.

**Why:** `PublishTrimmed=true` strips constructor metadata from positional record types. Despite `JsonSerializerIsReflectionEnabledByDefault=true`, the IL trimmer removes enough metadata that `System.Text.Json` can't find parameterized constructors at runtime.

**How:** System.Text.Json source generation (`JsonSerializerContext`) generates serialization code at compile time, eliminating reflection dependency for deserialization. Anonymous-type `Serialize` calls continue using reflection (preserved by the existing `JsonSerializerIsReflectionEnabledByDefault` flag).

## Test plan
- [x] `dotnet test` — 682 tests pass (0 failures)
- [x] `dotnet publish` trimmed binary, run `auth pat list` — works (was: `NotSupportedException`)
- [x] Published binary `container list` — works
- [x] Published binary `update --check` — works
- [x] Confirmed old v0.3.2-alpha binary still reproduces the bug

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)