### PR TITLE
fix(mcp): allow list_files at paths without explicit folder records

### DIFF
--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -172,12 +172,12 @@ public class McpTools
 
         var normalizedPath = PathUtilities.NormalizeFolderPath(folderPath);
 
-        // Validate non-root paths exist as folder records
-        if (normalizedPath != "/" && !await folderStore.ExistsAsync(resolvedId.Value, normalizedPath, ct))
-            return $"Error: Folder '{normalizedPath}' not found in this container.";
-
         var folders = await folderStore.ListAsync(resolvedId.Value, parentPath: normalizedPath, take: int.MaxValue, ct: ct);
         var documents = await documentStore.ListAsync(resolvedId.Value, pathPrefix: normalizedPath, take: int.MaxValue, ct: ct);
+
+        // If non-root path has no folder record and no documents, it doesn't exist
+        if (normalizedPath != "/" && folders.Count == 0 && documents.Count == 0)
+            return $"Error: Folder '{normalizedPath}' not found in this container.";
 
         // Collect explicit folder names
         var folderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsListFilesTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsListFilesTests.cs
@@ -68,10 +68,6 @@ public class McpToolsListFilesTests
     [Fact]
     public async Task ListFiles_ShowsFilesAtCorrectLevel()
     {
-        _folderStore
-            .ExistsAsync(ContainerId, "/docs/", Arg.Any<CancellationToken>())
-            .Returns(true);
-
         _documentStore
             .ListAsync(ContainerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(new List<Document>
@@ -132,6 +128,41 @@ public class McpToolsListFilesTests
         // Should only appear once (HashSet deduplication)
         var count = result.Split("[DIR]  research/").Length - 1;
         count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ListFiles_ReturnsFilesAtPathWithoutExplicitFolderRecord()
+    {
+        // Documents exist at /docs/readme.txt but no folder record for /docs/
+        _folderStore
+            .ExistsAsync(ContainerId, "/docs/", Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        _documentStore
+            .ListAsync(ContainerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Document>
+            {
+                MakeDocument("/docs/readme.txt", "readme.txt")
+            });
+
+        var result = await McpTools.ListFiles(_services, ContainerId.ToString(), "/docs/");
+
+        result.Should().Contain("[FILE] readme.txt");
+        result.Should().NotContain("Error");
+    }
+
+    [Fact]
+    public async Task ListFiles_ReturnsErrorForTrulyEmptyNonRootPath()
+    {
+        // No folder record and no documents at /nonexistent/
+        _folderStore
+            .ExistsAsync(ContainerId, "/nonexistent/", Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var result = await McpTools.ListFiles(_services, ContainerId.ToString(), "/nonexistent/");
+
+        result.Should().Contain("Error");
+        result.Should().Contain("/nonexistent/");
     }
 
     [Fact]

--- a/tests/Connapse.Integration.Tests/ContainerIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/ContainerIntegrationTests.cs
@@ -541,6 +541,54 @@ public class ContainerIntegrationTests(SharedWebAppFixture fixture)
         throw new TimeoutException($"Ingestion did not complete within {timeoutSeconds} seconds");
     }
 
+    // ── Path Filtering (Issue #191) ─────────────────────────────────
+
+    [Fact]
+    public async Task ListFiles_WithPathFilter_ReturnsFilesAtPath()
+    {
+        var container = await CreateContainer("path-filter-test");
+
+        // Create folder, then upload file into it
+        await fixture.AdminClient.PostAsJsonAsync(
+            $"/api/containers/{container.Id}/folders",
+            new { Path = "/docs" });
+
+        var docId = await UploadFile(container.Id, "test.md", "Hello from docs folder", path: "/docs");
+        await WaitForIngestionToComplete(container.Id, docId, timeoutSeconds: 60);
+
+        // Verify the document was stored with the right path
+        var docResponse = await fixture.AdminClient.GetAsync(
+            $"/api/containers/{container.Id}/files/{docId}");
+        docResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var doc = await docResponse.Content.ReadFromJsonAsync<DocumentDto>(JsonOptions);
+        doc!.Path.Should().Be("/docs/test.md", "document should be stored with folder path");
+
+        // Act: list files with path filter
+        var response = await fixture.AdminClient.GetAsync(
+            $"/api/containers/{container.Id}/files?path=/docs/&skip=0&take=200");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var paged = await response.Content.ReadFromJsonAsync<PagedResponse<BrowseEntryDto>>(JsonOptions);
+        paged.Should().NotBeNull();
+        paged!.Items.Should().Contain(e => e.Name == "test.md" && !e.IsFolder,
+            "files uploaded to /docs/ should appear when filtering by ?path=/docs/");
+
+        // Also test without trailing slash
+        var response2 = await fixture.AdminClient.GetAsync(
+            $"/api/containers/{container.Id}/files?path=/docs&skip=0&take=200");
+        response2.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var paged2 = await response2.Content.ReadFromJsonAsync<PagedResponse<BrowseEntryDto>>(JsonOptions);
+        paged2.Should().NotBeNull();
+        paged2!.Items.Should().Contain(e => e.Name == "test.md" && !e.IsFolder,
+            "path filter should work with and without trailing slash");
+
+        // Cleanup
+        await fixture.AdminClient.DeleteAsync($"/api/containers/{container.Id}/files/{docId}");
+        await fixture.AdminClient.DeleteAsync($"/api/containers/{container.Id}/folders?path=/docs/&cascade=true");
+        await fixture.AdminClient.DeleteAsync($"/api/containers/{container.Id}");
+    }
+
     // ── DTOs ──────────────────────────────────────────────────────────
 
     private record ContainerDto(


### PR DESCRIPTION
## Summary
- MCP `list_files` tool previously required an explicit folder record before listing files at a non-root path, returning "Folder not found" even when documents existed there
- Moved the existence check after querying documents and folders — now only returns error when the path is truly empty (no folders, no documents)
- Added integration test confirming REST API path filtering works with and without trailing slash

## What changed
- **McpTools.cs**: Replaced pre-query `folderStore.ExistsAsync` gate with post-query emptiness check (`folders.Count == 0 && documents.Count == 0`)
- **McpToolsListFilesTests.cs**: 2 new unit tests (files at path without folder record; truly empty path still errors), removed obsolete `ExistsAsync` mock
- **ContainerIntegrationTests.cs**: 1 new integration test for REST API `?path=` filtering

## Test plan
- [x] 7/7 MCP list_files unit tests pass
- [x] 176/176 integration tests pass
- [x] 522/522 total unit tests pass (340 core + 111 ingestion + 71 identity)

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)