### PR TITLE
fix(api): return 404 for nonexistent settings category

### DIFF
--- a/.claude/skills/release-gatekeeper/references/api-surface.md
+++ b/.claude/skills/release-gatekeeper/references/api-surface.md
@@ -28,7 +28,7 @@ These shapes were verified in live testing and differ from what you might assume
 - **Search hits** have `fileName` inside `metadata` object: `hit.metadata.fileName` (not `hit.fileName`).
 - **Container create** returns HTTP **201** with `{id, name, description, ...}`.
 - **Container delete** returns HTTP **204** (empty). Delete of non-empty container returns **400** with error message.
-- **Nonexistent settings category** returns **400** (not 404).
+- **Nonexistent settings category** returns **404** with descriptive error message.
 
 ## REST API Endpoints
 

--- a/src/Connapse.Web/Endpoints/SettingsEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/SettingsEndpoints.cs
@@ -43,7 +43,7 @@ public static class SettingsEndpoints
                 "upload" => Results.Ok(await GetSettingsAsync<UploadSettings>(categoryLower, settingsStore, serviceProvider, ct)),
                 "awssso" => Results.Ok(await GetSettingsAsync<AwsSsoSettings>(categoryLower, settingsStore, serviceProvider, ct)),
                 "azuread" => Results.Ok(await GetSettingsAsync<AzureAdSettings>(categoryLower, settingsStore, serviceProvider, ct)),
-                _ => Results.BadRequest(new { error = $"Unknown category: {category}" })
+                _ => Results.NotFound(new { error = $"Unknown settings category: {category}" })
             };
         })
         .WithName("GetSettings")
@@ -97,7 +97,7 @@ public static class SettingsEndpoints
                         if (azureAd != null) await settingsStore.SaveAsync(categoryLower, azureAd, ct);
                         break;
                     default:
-                        return Results.BadRequest(new { error = $"Unknown category: {category}" });
+                        return Results.NotFound(new { error = $"Unknown settings category: {category}" });
                 }
 
                 // When embedding settings change, reconcile partial IVFFlat indexes

--- a/tests/Connapse.Integration.Tests/SettingsIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SettingsIntegrationTests.cs
@@ -136,4 +136,24 @@ public class SettingsIntegrationTests(SharedWebAppFixture fixture)
         await fixture.AdminClient.PutAsJsonAsync("/api/settings/embedding", originalEmbedding);
         await fixture.AdminClient.PutAsJsonAsync("/api/settings/chunking", originalChunking);
     }
+
+    [Fact]
+    public async Task GetSettings_UnknownCategory_Returns404()
+    {
+        // Act
+        var response = await fixture.AdminClient.GetAsync("/api/settings/nonexistent");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UpdateSettings_UnknownCategory_Returns404()
+    {
+        // Act
+        var response = await fixture.AdminClient.PutAsJsonAsync("/api/settings/nonexistent", new { foo = "bar" });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
 }


### PR DESCRIPTION
## Summary
- Changed `GET /api/settings/{category}` and `PUT /api/settings/{category}` to return **404 Not Found** (was 400 Bad Request) for unknown categories
- Added 2 integration tests verifying the new behavior
- Updated release gatekeeper API surface reference

## Test Plan
- [x] `dotnet test` — 178/178 pass
- [ ] Manual: `GET /api/settings/nonexistent` returns 404

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)