### PR TITLE
fix(api): reject 0-byte file uploads

### DIFF
--- a/src/Connapse.Web/Endpoints/DocumentsEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/DocumentsEndpoints.cs
@@ -44,6 +44,9 @@ public static class DocumentsEndpoints
             if (files.Count == 0)
                 return Results.BadRequest(new { error = "No files provided" });
 
+            if (files.Any(f => f.Length == 0))
+                return Results.BadRequest(new { error = "File must not be empty" });
+
             // Reject path traversal attempts before normalization
             if (path is not null && PathUtilities.ContainsPathTraversal(path))
                 return Results.BadRequest(new { error = "Path must not contain '..' segments" });

--- a/tests/Connapse.Integration.Tests/IngestionIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/IngestionIntegrationTests.cs
@@ -159,6 +159,27 @@ public class IngestionIntegrationTests : IAsyncLifetime
         }
     }
 
+    [Fact]
+    public async Task Upload_ZeroByteFile_Returns400()
+    {
+        // Arrange: create a 0-byte file upload
+        using var multipart = new MultipartFormDataContent();
+        var emptyContent = new ByteArrayContent(Array.Empty<byte>());
+        emptyContent.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("text/plain");
+        multipart.Add(emptyContent, "files", "empty.txt");
+
+        // Act
+        var response = await _fixture.AdminClient.PostAsync(
+            $"/api/containers/{_containerId}/files", multipart);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOptions);
+        body!.Error.Should().Be("File must not be empty");
+    }
+
+    private record ErrorResponse(string Error);
+
     private async Task<string> UploadDocument(string fileName, string content)
     {
         using var multipart = new MultipartFormDataContent();


### PR DESCRIPTION
## Summary
- Reject 0-byte file uploads with HTTP 400 and error `"File must not be empty"`
- Empty files cause ingestion pipeline failures since there's nothing to parse, chunk, or embed
- Added integration test verifying the rejection

## Test Plan
- [x] `Upload_ZeroByteFile_Returns400` integration test passes
- [x] Full test suite passes (179/179)
- [ ] Manual: upload an empty file via UI → should see 400 error

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)