### PR TITLE
feat: add manual re-embed button to embedding settings

### DIFF
--- a/src/Connapse.Web/Components/Settings/EmbeddingSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/EmbeddingSettingsTab.razor
@@ -114,6 +114,27 @@
             </button>
         </div>
 
+        <div class="col-12 mt-3">
+            <hr />
+            <h6>Re-Embedding</h6>
+            <p class="text-muted small mb-2">
+                Re-embed all documents using the current embedding model and settings.
+                Useful after changing the model, dimensions, or if embeddings need to be refreshed.
+            </p>
+            <button type="button" class="btn btn-outline-warning" @onclick="StartManualReEmbed" disabled="@isReEmbedding">
+                @if (isReEmbedding)
+                {
+                    <span class="spinner-border spinner-border-sm me-1" role="status"></span>
+                    <span>Starting...</span>
+                }
+                else
+                {
+                    <span class="bi-arrow-repeat me-1"></span>
+                    <span>Re-Embed All Documents</span>
+                }
+            </button>
+        </div>
+
         @if (!string.IsNullOrEmpty(testMessage))
         {
             <div class="col-12 mt-3">
@@ -274,6 +295,38 @@
         }
 
         StateHasChanged();
+    }
+
+    private async Task StartManualReEmbed()
+    {
+        isReEmbedding = true;
+        StateHasChanged();
+
+        try
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await using var scope = ScopeFactory.CreateAsyncScope();
+                    var reindexService = scope.ServiceProvider.GetRequiredService<IReindexService>();
+                    await reindexService.ReindexAsync(new ReindexOptions
+                    {
+                        Force = true
+                    }, CancellationToken.None);
+                }
+                catch { /* Reindex is best-effort; errors logged by ReindexService */ }
+            });
+
+            reEmbedStarted = true;
+            queueDepth = IngestionQueue.QueueDepth;
+        }
+        catch { /* Best-effort */ }
+        finally
+        {
+            isReEmbedding = false;
+            StateHasChanged();
+        }
     }
 
     private async Task StartReEmbed()


### PR DESCRIPTION
## Summary
- Adds an always-visible "Re-Embed All Documents" button to the Embedding settings tab
- Triggers a force re-embed of all documents using the current embedding model/settings
- Reuses existing `IReindexService` with `Force = true` and shows the in-progress banner with queue depth

## Test plan
- [x] Open Settings > Embedding tab and verify the "Re-Embed All Documents" button is visible
- [x] Click the button and confirm the spinner appears briefly, then the "re-embedding in progress" banner shows
- [x] Verify documents are re-queued for embedding (check queue depth or ingestion logs)
- [ ] Confirm the legacy vector banner still works independently when changing models

🤖 Generated with [Claude Code](https://claude.com/claude-code)