### PR TITLE
docs(api): fix agent enable/disable endpoint path

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -298,7 +298,7 @@ Agents are non-human identities (CI/CD pipelines, automation scripts) that authe
 
 ### Enable/Disable Agent
 
-**Endpoint**: `PUT /api/v1/agents/{id}/status`
+**Endpoint**: `PUT /api/v1/agents/{id}/active`
 
 **Request Body**:
 ```json


### PR DESCRIPTION
## Summary

- Fix incorrect endpoint path in agent enable/disable docs: `/api/v1/agents/{id}/status` → `/api/v1/agents/{id}/active`

Closes #190

## Test plan
- [x] Verified actual endpoint in `AgentEndpoints.cs:85` is `PUT /{id:guid}/active`
- [x] Single-line docs correction, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)