### PR TITLE
chore: enable Playwright plugin in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,7 @@
     "superpowers@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,
     "csharp-lsp@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true
+    "skill-creator@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary
- Adds the `playwright@claude-plugins-official` plugin to `.claude/settings.json`

## Test plan
- [x] Verify settings.json is valid JSON
- [x] Confirm Playwright plugin loads in Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)