### PR TITLE
fix(cli): resolve containers by name via direct lookup

### DIFF
--- a/src/Connapse.CLI/Program.cs
+++ b/src/Connapse.CLI/Program.cs
@@ -1946,14 +1946,11 @@ static async Task<string?> ResolveContainerId(string nameOrId, HttpClient httpCl
         return nameOrId;
 
     // Otherwise resolve by name
-    var response = await httpClient.GetAsync("/api/containers");
+    var response = await httpClient.GetAsync($"/api/containers/by-name/{Uri.EscapeDataString(nameOrId.ToLowerInvariant())}");
     if (!response.IsSuccessStatusCode) return null;
 
-    var containers = await response.Content.ReadFromJsonAsync<List<ContainerInfo>>(jsonOptions);
-    var match = containers?.FirstOrDefault(c =>
-        c.Name.Equals(nameOrId, StringComparison.OrdinalIgnoreCase));
-
-    return match?.Id;
+    var container = await response.Content.ReadFromJsonAsync<ContainerInfo>(jsonOptions);
+    return container?.Id;
 }
 
 static string? GetOption(string[] args, string option)

--- a/src/Connapse.Web/Endpoints/AuthEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/AuthEndpoints.cs
@@ -167,20 +167,22 @@ public static class AuthEndpoints
 
         // GET /api/v1/auth/users — list users (Admin only, paginated)
         group.MapGet("/users", async (
-            [FromQuery] int skip,
-            [FromQuery] int take,
+            [FromQuery] int? skip,
+            [FromQuery] int? take,
             [FromServices] ConnapseIdentityDbContext dbContext,
             CancellationToken ct) =>
         {
-            var validationError = PaginationValidator.Validate(skip, take);
+            var effectiveSkip = skip ?? 0;
+            var effectiveTake = take ?? 50;
+            var validationError = PaginationValidator.Validate(effectiveSkip, effectiveTake);
             if (validationError is not null) return validationError;
 
             var totalCount = await dbContext.Users.CountAsync(ct);
 
             var users = await dbContext.Users
                 .OrderBy(u => u.CreatedAt)
-                .Skip(skip)
-                .Take(take)
+                .Skip(effectiveSkip)
+                .Take(effectiveTake)
                 .ToListAsync(ct);
 
             var userIds = users.Select(u => u.Id).ToList();
@@ -207,7 +209,7 @@ public static class AuthEndpoints
                 u.CreatedAt,
                 u.LastLoginAt)).ToList();
 
-            return Results.Ok(new PagedResponse<UserListItem>(items, totalCount, skip + take < totalCount));
+            return Results.Ok(new PagedResponse<UserListItem>(items, totalCount, effectiveSkip + effectiveTake < totalCount));
         })
         .WithName("ListUsers")
         .WithDescription("List users with pagination (?skip=0&take=50) (Admin only)")

--- a/src/Connapse.Web/Endpoints/ContainersEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/ContainersEndpoints.cs
@@ -75,17 +75,19 @@ public static class ContainersEndpoints
 
         // GET /api/containers - List containers (paginated)
         group.MapGet("/", async (
-            [FromQuery] int skip,
-            [FromQuery] int take,
+            [FromQuery] int? skip,
+            [FromQuery] int? take,
             [FromServices] IContainerStore containerStore,
             CancellationToken ct) =>
         {
-            var validationError = PaginationValidator.Validate(skip, take);
+            var effectiveSkip = skip ?? 0;
+            var effectiveTake = take ?? 50;
+            var validationError = PaginationValidator.Validate(effectiveSkip, effectiveTake);
             if (validationError is not null) return validationError;
 
-            var containers = await containerStore.ListAsync(skip, take + 1, ct);
-            var hasMore = containers.Count > take;
-            var items = hasMore ? containers.Take(take).ToList() : containers;
+            var containers = await containerStore.ListAsync(effectiveSkip, effectiveTake + 1, ct);
+            var hasMore = containers.Count > effectiveTake;
+            var items = hasMore ? containers.Take(effectiveTake).ToList() : containers;
 
             return Results.Ok(new PagedResponse<Container>(items, items.Count, hasMore));
         })
@@ -106,6 +108,21 @@ public static class ContainersEndpoints
         })
         .WithName("GetContainer")
         .WithDescription("Get a specific container by ID")
+        .RequireAuthorization("RequireViewer");
+
+        // GET /api/containers/by-name/{name} - Resolve container by name
+        group.MapGet("/by-name/{name}", async (
+            string name,
+            [FromServices] IContainerStore containerStore,
+            CancellationToken ct) =>
+        {
+            var container = await containerStore.GetByNameAsync(name.ToLowerInvariant(), ct);
+            return container is not null
+                ? Results.Ok(container)
+                : Results.NotFound(new { error = $"Container '{name}' not found" });
+        })
+        .WithName("GetContainerByName")
+        .WithDescription("Get a specific container by name")
         .RequireAuthorization("RequireViewer");
 
         // DELETE /api/containers/{containerId} - Delete container (must be empty for storage-backed connectors; Filesystem containers just stop being watched)

--- a/src/Connapse.Web/Endpoints/DocumentsEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/DocumentsEndpoints.cs
@@ -115,15 +115,17 @@ public static class DocumentsEndpoints
             HttpContext httpContext,
             Guid containerId,
             [FromQuery] string? path,
-            [FromQuery] int skip,
-            [FromQuery] int take,
+            [FromQuery] int? skip,
+            [FromQuery] int? take,
             [FromServices] IContainerStore containerStore,
             [FromServices] IDocumentStore documentStore,
             [FromServices] IFolderStore folderStore,
             [FromServices] ICloudScopeService cloudScopeService,
             CancellationToken ct) =>
         {
-            var validationError = PaginationValidator.Validate(skip, take);
+            var effectiveSkip = skip ?? 0;
+            var effectiveTake = take ?? 50;
+            var validationError = PaginationValidator.Validate(effectiveSkip, effectiveTake);
             if (validationError is not null) return validationError;
 
             var container = await containerStore.GetAsync(containerId, ct);
@@ -200,8 +202,8 @@ public static class DocumentsEndpoints
 
             // Paginate the combined, sorted result
             var totalCount = entries.Count;
-            var paged = entries.Skip(skip).Take(take).ToList();
-            var hasMore = skip + take < totalCount;
+            var paged = entries.Skip(effectiveSkip).Take(effectiveTake).ToList();
+            var hasMore = effectiveSkip + effectiveTake < totalCount;
 
             return Results.Ok(new PagedResponse<BrowseEntry>(paged, totalCount, hasMore));
         })


### PR DESCRIPTION
## Summary
- **CLI `ResolveContainerId` was broken** — called `GET /api/containers` without `skip`/`take` params, which defaulted to `take=0` and got rejected by `PaginationValidator`. Also tried to deserialize the paged response as a flat list.
- **Added `GET /api/containers/by-name/{name}`** — direct O(1) database lookup via `IContainerStore.GetByNameAsync()`, replacing the list-and-filter approach.
- **Made `skip`/`take` nullable with defaults** on all 3 paginated endpoints (containers, documents, users) so omitting pagination params returns results instead of 400.

## Test plan
- [ ] `connapse container delete my-container` resolves by name correctly
- [ ] `connapse search "query" --container my-container` resolves by name correctly
- [ ] `GET /api/containers` without params returns first 50 containers
- [ ] `GET /api/containers?take=0` still returns 400
- [ ] `GET /api/containers/by-name/my-container` returns the container
- [ ] `GET /api/containers/by-name/nonexistent` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)