### PR TITLE
fix(auth): reject empty X-Api-Key with 401 instead of cookie fallback

### DIFF
--- a/src/Connapse.Identity/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/src/Connapse.Identity/Authentication/ApiKeyAuthenticationHandler.cs
@@ -19,6 +19,12 @@ public class ApiKeyAuthenticationHandler(
     IServiceProvider serviceProvider)
     : AuthenticationHandler<ApiKeyAuthenticationOptions>(options, logger, encoder)
 {
+    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+    {
+        Response.StatusCode = 401;
+        return Task.CompletedTask;
+    }
+
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
         if (!Request.Headers.TryGetValue(ApiKeyAuthenticationOptions.HeaderName, out var apiKeyHeader))

--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -101,7 +101,9 @@ public static class IdentityServiceExtensions
             {
                 options.ForwardDefaultSelector = context =>
                 {
-                    // Check for API key header
+                    // Check for API key header — if the header is present (even empty),
+                    // route to ApiKey scheme so it rejects invalid keys with 401 instead
+                    // of falling through to cookie auth.
                     if (context.Request.Headers.ContainsKey(ApiKeyAuthenticationOptions.HeaderName))
                         return ApiKeyAuthenticationOptions.SchemeName;
 
@@ -126,11 +128,14 @@ public static class IdentityServiceExtensions
                 options.Cookie.SameSite = SameSiteMode.Strict;
                 options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
 
-                // For API/MCP endpoints, return 401 instead of redirecting to login
+                // For API/MCP endpoints, return 401 instead of redirecting to login.
+                // Also reject requests that explicitly sent an X-Api-Key header
+                // (even empty) — they intended API key auth, not cookie fallback.
                 options.Events.OnRedirectToLogin = context =>
                 {
                     if (context.Request.Path.StartsWithSegments("/api") ||
-                        context.Request.Path.StartsWithSegments("/mcp"))
+                        context.Request.Path.StartsWithSegments("/mcp") ||
+                        context.Request.Headers.ContainsKey(ApiKeyAuthenticationOptions.HeaderName))
                     {
                         context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                         return Task.CompletedTask;

--- a/tests/Connapse.Integration.Tests/PatIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/PatIntegrationTests.cs
@@ -216,4 +216,28 @@ public class PatIntegrationTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
+
+    // ── Empty / whitespace API key ───────────────────────────────────────
+
+    [Fact]
+    public async Task EmptyApiKey_Returns401()
+    {
+        using var client = _fixture.Factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Api-Key", "");
+
+        var response = await client.GetAsync("/api/containers?skip=0&take=50");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task WhitespaceApiKey_Returns401()
+    {
+        using var client = _fixture.Factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Api-Key", "   ");
+
+        var response = await client.GetAsync("/api/containers?skip=0&take=50");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
 }


### PR DESCRIPTION
## Summary
- Empty or whitespace-only `X-Api-Key` headers now return 401 instead of falling through to cookie authentication
- Added `HandleChallengeAsync` to `ApiKeyAuthenticationHandler` so the ApiKey scheme never redirects
- Updated cookie `OnRedirectToLogin` to also return 401 when `X-Api-Key` header is present
- Added integration tests for empty and whitespace API key rejection

## Why
The ApiKey handler already rejects empty keys with `AuthenticateResult.Fail`, but the challenge falls through to the Cookie scheme's `DefaultChallengeScheme`. If the client has a valid session cookie, cookie auth can silently authenticate the request — returning 200 instead of 401. This is incorrect: when a client explicitly sends an `X-Api-Key` header, they intend API key auth, and failure should be final.

## How
Defense-in-depth across two layers:
1. `ApiKeyAuthenticationHandler.HandleChallengeAsync` — returns 401 directly when the ApiKey scheme is challenged
2. Cookie `OnRedirectToLogin` — checks for `X-Api-Key` header presence alongside the existing `/api` and `/mcp` path checks

Closes #224

## Test plan
- [ ] `EmptyApiKey_Returns401` — empty `X-Api-Key` header returns 401
- [ ] `WhitespaceApiKey_Returns401` — whitespace-only `X-Api-Key` header returns 401
- [ ] Existing PAT tests continue to pass (valid PAT → 200, revoked PAT → 401)
- [ ] All 564 unit tests pass (`dotnet test --filter "Category!=Integration"`)
- [ ] Integration tests pass with Docker (not available locally, needs CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)