### PR TITLE
fix(cli): support --help and -h flags for all commands

### DIFF
--- a/src/Connapse.CLI/Program.cs
+++ b/src/Connapse.CLI/Program.cs
@@ -1644,6 +1644,12 @@ static int HandleVersion()
 
 static async Task<int> HandleUpdate(string[] args)
 {
+    if (IsSubcommandHelp(args))
+    {
+        Console.WriteLine("Usage: connapse update [--check] [--pre]");
+        return 0;
+    }
+
     var checkOnly = args.Contains("--check");
     var includePre = args.Contains("--pre");
     var currentVersion = GetCurrentVersion();

--- a/tests/Connapse.Core.Tests/Cli/CliHelpTests.cs
+++ b/tests/Connapse.Core.Tests/Cli/CliHelpTests.cs
@@ -21,9 +21,10 @@ public class CliHelpTests
         };
 
         using var process = Process.Start(psi)!;
-        var stdout = await process.StandardOutput.ReadToEndAsync();
-        var stderr = await process.StandardError.ReadToEndAsync();
-        await process.WaitForExitAsync();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var stdout = await process.StandardOutput.ReadToEndAsync(cts.Token);
+        var stderr = await process.StandardError.ReadToEndAsync(cts.Token);
+        await process.WaitForExitAsync(cts.Token);
 
         return (process.ExitCode, stdout + stderr);
     }
@@ -62,5 +63,15 @@ public class CliHelpTests
 
         exitCode.Should().Be(0);
         output.Should().Contain("container create");
+    }
+
+    [Fact]
+    public async Task Update_Help_Shows_Usage_Without_Network_Call()
+    {
+        var (exitCode, output) = await RunCliAsync("update", "--help");
+
+        exitCode.Should().Be(0);
+        output.Should().Contain("connapse update");
+        output.Should().NotContain("Current version:");
     }
 }


### PR DESCRIPTION
## Summary
- `connapse --help` / `-h` / `help` now shows full usage text with exit code 0
- All subcommands (`auth`, `container`, `files`, `upload`, `search`, `reindex`, `update`) support `--help` and `-h`
- Explicit help requests return exit 0; missing subcommand args still return exit 1

Closes #229

## What
Running `connapse --help` returned "Unknown command" with exit code 1. Standard CLI convention is for `--help` to display usage information.

## Why
`--help` is the universal way users discover CLI commands. Returning "Unknown command" breaks user expectations and was flagged during release validation.

## How
- Added `"help" or "--help" or "-h"` to the root command switch
- Added `IsHelpFlag`, `IsSubcommandHelp`, and `NeedsSubcommandUsage` helpers
- Each handler now checks for help flags and shows its usage text
- 5 process-level tests verify root and subcommand help behavior

## Test plan
- [x] `connapse --help` shows usage (exit 0)
- [x] `connapse -h` shows usage (exit 0)
- [x] `connapse auth --help` shows auth subcommands (exit 0)
- [x] `connapse container -h` shows container subcommands (exit 0)
- [x] `connapse update --help` shows update usage without making network call (exit 0)
- [x] All 755 tests pass (366 Core + 71 Identity + 132 Ingestion + 186 Integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)