### PR TITLE
fix(ingestion): clear stale error message when file succeeds

### DIFF
--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -234,6 +234,7 @@ public class IngestionPipeline : IKnowledgeIngester
             // Update document status
             documentEntity.ChunkCount = chunks.Count;
             documentEntity.Status = "Ready";
+            documentEntity.ErrorMessage = null;
             documentEntity.LastIndexedAt = DateTime.UtcNow;
 
             await _context.SaveChangesAsync(ct);

--- a/src/Connapse.Web/Components/Pages/FileBrowser.razor
+++ b/src/Connapse.Web/Components/Pages/FileBrowser.razor
@@ -398,7 +398,8 @@
                     <span class="detail-value">@model</span>
                 </div>
             }
-            @if (selectedFile.Metadata.TryGetValue("ErrorMessage", out var error) && !string.IsNullOrEmpty(error))
+            @if (selectedFile.Metadata.TryGetValue("ErrorMessage", out var error) && !string.IsNullOrEmpty(error)
+                && selectedFile.Metadata.GetValueOrDefault("Status") is "Failed" or "Error")
             {
                 <div class="detail-row">
                     <span class="detail-label">Error</span>


### PR DESCRIPTION
## Summary
- **Bug:** File detail panel showed an error message even when the file status was "Ready", if the file had previously failed ingestion
- **Root cause:** `IngestionPipeline` set `Status = "Ready"` on success but never cleared the old `ErrorMessage` from a prior failure
- **Fix:** Clear `ErrorMessage = null` when status becomes Ready, and guard the UI to only render the error section when status is `Failed` or `Error`

## Test plan
- [x] Ingest a file that fails (e.g. unsupported format), verify error shows in detail panel
- [x] Re-ingest the same file successfully, verify error no longer appears in detail panel
- [x] Verify existing error display still works for files currently in Failed/Error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)