### PR TITLE
fix(cli): version comparison treats pre-release as newer than stable

### DIFF
--- a/src/Connapse.CLI/Program.cs
+++ b/src/Connapse.CLI/Program.cs
@@ -1926,10 +1926,32 @@ static bool IsGlobalToolInstall()
 
 static bool IsNewer(string latest, string current)
 {
-    if (NuGetVersion.TryParse(latest, out var latestV) && NuGetVersion.TryParse(current, out var currentV))
-        return latestV > currentV;
+    try
+    {
+        if (NuGetVersion.TryParse(latest, out var latestV) && NuGetVersion.TryParse(current, out var currentV))
+            return latestV > currentV;
+    }
+    catch { /* NuGet.Versioning assembly may be unavailable in trimmed builds */ }
+
+    // Fallback: strip pre-release suffix and compare base versions, then treat
+    // pre-release as older than the same base version (per SemVer 2.0).
+    var latestBase = StripPreRelease(latest);
+    var currentBase = StripPreRelease(current);
+
+    if (Version.TryParse(latestBase, out var lv) && Version.TryParse(currentBase, out var cv))
+    {
+        if (lv != cv) return lv > cv;
+        // Same base version: release (no suffix) is newer than pre-release (has suffix)
+        var latestIsPre = latest.Contains('-');
+        var currentIsPre = current.Contains('-');
+        return !latestIsPre && currentIsPre;
+    }
+
     return string.Compare(latest, current, StringComparison.Ordinal) > 0;
 }
+
+static string StripPreRelease(string version) =>
+    version.Contains('-') ? version[..version.IndexOf('-')] : version;
 
 static async Task<GitHubRelease?> GetLatestReleaseAsync(HttpClient ghClient, bool includePre)
 {

--- a/src/Connapse.CLI/trimmer-roots.xml
+++ b/src/Connapse.CLI/trimmer-roots.xml
@@ -3,4 +3,6 @@
   <assembly fullname="System.Text.Json" preserve="all" />
   <!-- Preserve Microsoft.Extensions.Configuration JSON provider -->
   <assembly fullname="Microsoft.Extensions.Configuration.Json" preserve="all" />
+  <!-- Preserve NuGet.Versioning for SemVer comparison in update command -->
+  <assembly fullname="NuGet.Versioning" preserve="all" />
 </linker>


### PR DESCRIPTION
## Summary
- `connapse update` incorrectly says "already up to date" when running a pre-release build (e.g. `v0.3.2-alpha.2`) and a stable release (`v0.3.2`) is available
- Root cause: `System.Version.TryParse` can't parse SemVer pre-release suffixes, falling through to ordinal string comparison where `"0.3.2" < "0.3.2-alpha.2"` (shorter string sorts first)
- Adds SemVer-aware fallback that strips pre-release suffixes before comparing base versions, then correctly treats stable as newer than pre-release of the same base
- Preserves `NuGet.Versioning` in trimmer roots for self-contained binary builds

Closes #243

## Test plan
- [ ] Verify `IsNewer("0.3.2", "0.3.2-alpha.2")` returns `true`
- [ ] Verify `IsNewer("0.3.2-alpha.2", "0.3.2")` returns `false`
- [ ] Verify `IsNewer("0.4.0", "0.3.2-alpha.2")` returns `true`
- [ ] Verify `IsNewer("0.3.2", "0.3.2")` returns `false`
- [ ] Build self-contained trimmed binary and verify update check works

🤖 Generated with [Claude Code](https://claude.com/claude-code)