### PR TITLE
Add MCP Registry metadata for Official Registry listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ appsettings.*.json
 !appsettings.Development.json.template
 secrets.json
 *.pfx
+.mcpregistry_*
 
 # NuGet
 *.nupkg

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/publish .
 
+# MCP Registry ownership verification
+LABEL io.modelcontextprotocol.server.name="io.github.Destrayon/connapse"
+
 ENV ASPNETCORE_ENVIRONMENT=Production
 
 # Install missing native lib needed by Npgsql's GSSAPI/Kerberos probe

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Destrayon/connapse",
+  "title": "Connapse",
+  "description": "Self-hosted knowledge backend for AI agents with hybrid search and MCP tools",
+  "version": "0.3.2",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/destrayon/connapse:v0.3.2",
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://localhost:5001/mcp"
+      }
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/Destrayon/Connapse",
+    "source": "github"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `io.modelcontextprotocol.server.name` label to Dockerfile for OCI ownership verification
- Creates `server.json` with streamable-http transport for the Official MCP Registry
- Adds `.mcpregistry_*` token files to `.gitignore`

Connapse has been published to the [Official MCP Registry](https://registry.modelcontextprotocol.io/) as `io.github.Destrayon/connapse`.

## Test plan
- [x] `mcp-publisher validate` passes
- [x] `mcp-publisher publish` succeeded
- [x] Verified listing via registry API search

🤖 Generated with [Claude Code](https://claude.com/claude-code)