### PR TITLE
fix: exclude managed storage from ConnectorWatcherService polling

### DIFF
--- a/src/Connapse.Web/Services/ConnectorWatcherService.cs
+++ b/src/Connapse.Web/Services/ConnectorWatcherService.cs
@@ -677,10 +677,10 @@ public class ConnectorWatcherService : BackgroundService
     }
 
     private static bool IsWatchableConnector(ConnectorType type) =>
-        type is ConnectorType.Filesystem or ConnectorType.S3 or ConnectorType.AzureBlob or ConnectorType.ManagedStorage;
+        type is ConnectorType.Filesystem or ConnectorType.S3 or ConnectorType.AzureBlob;
 
     private static bool IsCloudConnector(ConnectorType type) =>
-        type is ConnectorType.S3 or ConnectorType.AzureBlob or ConnectorType.ManagedStorage;
+        type is ConnectorType.S3 or ConnectorType.AzureBlob;
 
     private static string? GetContentType(string fileName) =>
         Path.GetExtension(fileName).ToLowerInvariant() switch


### PR DESCRIPTION
## Summary
- Removes `ConnectorType.ManagedStorage` from `IsWatchableConnector` and `IsCloudConnector` in `ConnectorWatcherService`
- Managed storage containers are fully handled by the upload endpoint (document creation + ingestion enqueue), so the watcher polling them causes a race condition resulting in `duplicate key value violates unique constraint "idx_documents_container_path"` errors
- External connectors (S3, AzureBlob, Filesystem) are still watched as before

## Test plan
- [x] Upload a file to a managed storage container — verify no duplicate key errors in logs
- [x] Verify external connector containers (S3, Filesystem) still sync correctly
- [x] Verify uploaded files are ingested and persist in the document list

🤖 Generated with [Claude Code](https://claude.com/claude-code)