### PR TITLE
fix: create intermediate folders for nested folder paths

### DIFF
--- a/src/Connapse.Storage/Folders/PostgresFolderStore.cs
+++ b/src/Connapse.Storage/Folders/PostgresFolderStore.cs
@@ -24,6 +24,34 @@ public class PostgresFolderStore(
         if (exists)
             throw new InvalidOperationException($"Folder '{normalizedPath}' already exists in this container.");
 
+        // Build list of all ancestor paths that need to exist (mkdir -p behavior)
+        var segments = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var ancestorPaths = new List<string>();
+        for (var i = 1; i < segments.Length; i++)
+        {
+            ancestorPaths.Add("/" + string.Join("/", segments.Take(i)) + "/");
+        }
+
+        if (ancestorPaths.Count > 0)
+        {
+            var existingPaths = await context.Folders
+                .Where(f => f.ContainerId == containerId && ancestorPaths.Contains(f.Path))
+                .Select(f => f.Path)
+                .ToListAsync(ct);
+
+            var now = DateTime.UtcNow;
+            foreach (var ancestor in ancestorPaths.Where(a => !existingPaths.Contains(a)))
+            {
+                context.Folders.Add(new FolderEntity
+                {
+                    Id = Guid.NewGuid(),
+                    ContainerId = containerId,
+                    Path = ancestor,
+                    CreatedAt = now
+                });
+            }
+        }
+
         var entity = new FolderEntity
         {
             Id = Guid.NewGuid(),


### PR DESCRIPTION
## Summary
- When creating a folder with a nested path like `/test1/test2/`, only the leaf folder record was persisted in the database
- The file browser tree filters to immediate children at each level, so the orphaned nested folder was invisible in the UI despite existing in storage
- `PostgresFolderStore.CreateAsync` now ensures all ancestor folders exist automatically (`mkdir -p` behavior)

## Test plan
- [x] Create a nested folder like `/test1/test2` — both `/test1/` and `/test1/test2/` should appear in the tree
- [x] Create a folder with a single name (no nesting) — still works as before
- [x] Create a nested folder where the parent already exists — no duplicate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)