### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,28 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@1c30734416d9b05948ccd7f4b3cf60baada87e9e
+        with:
+          mode: validate


### PR DESCRIPTION
This repo already has enough skill metadata to validate in CI.

A couple of repo-specific details I checked first:
- Open-source, self-hosted knowledge backend for AI agents — hybrid search (vector + keyword), MCP server, 5 connectors, Docker-ready
- .NET Global Tool (requires .NET 10)
- Connapse includes a Model Context Protocol (MCP) server for integration with Claude and any MCP client

This adds one workflow for `.` and leaves the runtime code alone.
It only runs the schema and trust checks for the skill metadata in validate mode.

If you would rather place the workflow under a different filename or point it at a different skill directory, I can adjust the branch.