### PR TITLE
fix: resolve upload duplicate-key errors with generation counter

### DIFF
--- a/src/Connapse.Core/Interfaces/IDocumentStore.cs
+++ b/src/Connapse.Core/Interfaces/IDocumentStore.cs
@@ -2,7 +2,7 @@ namespace Connapse.Core.Interfaces;
 
 public interface IDocumentStore
 {
-    Task<string> StoreAsync(Document document, CancellationToken ct = default);
+    Task<StoreResult> StoreAsync(Document document, CancellationToken ct = default);
     Task<Document?> GetAsync(string documentId, CancellationToken ct = default);
     Task<IReadOnlyList<Document>> ListAsync(Guid containerId, string? pathPrefix = null, int skip = 0, int take = 50, CancellationToken ct = default);
     Task DeleteAsync(string documentId, CancellationToken ct = default);

--- a/src/Connapse.Core/Interfaces/IIngestionQueue.cs
+++ b/src/Connapse.Core/Interfaces/IIngestionQueue.cs
@@ -37,6 +37,31 @@ public interface IIngestionQueue
     /// Gets the current queue depth.
     /// </summary>
     int QueueDepth { get; }
+
+    /// <summary>
+    /// Updates the status of a job (phase, progress, error).
+    /// </summary>
+    void UpdateJobStatus(
+        string jobId,
+        IngestionJobState state,
+        IngestionPhase? currentPhase = null,
+        double percentComplete = 0,
+        string? errorMessage = null);
+
+    /// <summary>
+    /// Gets all job statuses for monitoring and progress broadcasting.
+    /// </summary>
+    IReadOnlyDictionary<string, IngestionJobStatus> GetAllStatuses();
+
+    /// <summary>
+    /// Registers a CancellationTokenSource for a job so it can be cancelled on demand.
+    /// </summary>
+    void RegisterJobCancellation(string jobId, CancellationTokenSource cts);
+
+    /// <summary>
+    /// Removes the CancellationTokenSource for a completed/failed job.
+    /// </summary>
+    void UnregisterJobCancellation(string jobId);
 }
 
 /// <summary>
@@ -47,6 +72,7 @@ public record IngestionJob(
     string DocumentId,
     string Path,
     IngestionOptions Options,
+    int Generation = 0,
     string? BatchId = null);
 
 /// <summary>

--- a/src/Connapse.Core/Models/IngestionModels.cs
+++ b/src/Connapse.Core/Models/IngestionModels.cs
@@ -7,7 +7,8 @@ public record IngestionOptions(
     string? ContainerId = null,
     string? Path = null,
     ChunkingStrategy Strategy = ChunkingStrategy.Semantic,
-    Dictionary<string, string>? Metadata = null);
+    Dictionary<string, string>? Metadata = null,
+    int Generation = 0);
 
 public record IngestionResult(
     string DocumentId,

--- a/src/Connapse.Core/Models/StorageModels.cs
+++ b/src/Connapse.Core/Models/StorageModels.cs
@@ -43,6 +43,8 @@ public record Document(
     DateTime CreatedAt,
     Dictionary<string, string> Metadata);
 
+public record StoreResult(string DocumentId, int Generation);
+
 public record ContainerStats(
     int DocumentCount,
     int ReadyCount,

--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -4,6 +4,7 @@ using Connapse.Storage.Data;
 using Connapse.Storage.Data.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+
 using Microsoft.Extensions.Options;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -116,9 +117,24 @@ public class IngestionPipeline : IKnowledgeIngester
                 ? cId
                 : Guid.Empty;
 
-            // Check if document already exists (e.g., during reindex)
+            // Check if document already exists (created eagerly by UploadService)
             documentEntity = await _context.Documents.FindAsync([documentId], ct);
             bool isReindex = documentEntity is not null;
+
+            // Generation check: skip stale jobs early (before any expensive work)
+            int jobGeneration = options.Generation;
+            if (isReindex && !await IsCurrentGenerationAsync(documentId, jobGeneration, ct))
+            {
+                _logger.LogInformation(
+                    "Skipping stale job for document {DocumentId}: job generation {JobGen} != current generation",
+                    documentId, jobGeneration);
+                return new IngestionResult(
+                    DocumentId: documentId.ToString(),
+                    ChunkCount: 0,
+                    Duration: stopwatch.Elapsed,
+                    Warnings: ["Stale job skipped — document was re-uploaded"]);
+            }
+
             if (documentEntity != null)
             {
                 // Update existing document for reindex
@@ -157,7 +173,7 @@ public class IngestionPipeline : IKnowledgeIngester
             if (isReindex)
             {
                 await _context.Chunks
-                    .Where(c => c.DocumentId == documentId)
+                    .Where(c => c.DocumentId == documentEntity.Id)
                     .ExecuteDeleteAsync(ct);
             }
 
@@ -197,6 +213,35 @@ public class IngestionPipeline : IKnowledgeIngester
                 embeddings = await _embeddingProvider.EmbedBatchAsync(chunkContents, ct);
             }
 
+            // Second generation check: the document may have been re-uploaded during the
+            // expensive embedding call. If so, skip chunk insertion — the newer job will handle it.
+            if (!await IsCurrentGenerationAsync(documentEntity.Id, jobGeneration, ct))
+            {
+                _logger.LogInformation(
+                    "Document {DocumentId} was re-uploaded during ingestion (generation changed) — skipping chunk insertion",
+                    documentEntity.Id);
+                return new IngestionResult(
+                    DocumentId: documentEntity.Id.ToString(),
+                    ChunkCount: 0,
+                    Duration: stopwatch.Elapsed,
+                    Warnings: ["Document was re-uploaded during ingestion"]);
+            }
+
+            // Also verify the row still exists (handles deletion during ingestion)
+            var docStillExists = await _context.Documents
+                .AnyAsync(d => d.Id == documentEntity.Id, ct);
+            if (!docStillExists)
+            {
+                _logger.LogWarning(
+                    "Document {DocumentId} was deleted during ingestion — skipping chunk insertion",
+                    documentEntity.Id);
+                return new IngestionResult(
+                    DocumentId: documentEntity.Id.ToString(),
+                    ChunkCount: 0,
+                    Duration: stopwatch.Elapsed,
+                    Warnings: ["Document was deleted during ingestion"]);
+            }
+
             // Stage all chunk entities and vector items, then flush in two SaveChangesAsync calls
             // (one inside UpsertBatchAsync for chunks+vectors, one for the document status update).
             var vectorItems = new List<(string Id, float[] Vector, Dictionary<string, string> Metadata)>(chunks.Count);
@@ -209,7 +254,7 @@ public class IngestionPipeline : IKnowledgeIngester
                 _context.Chunks.Add(new ChunkEntity
                 {
                     Id = chunkId,
-                    DocumentId = documentId,
+                    DocumentId = documentEntity.Id,
                     ContainerId = containerId,
                     Content = chunkInfo.Content,
                     ChunkIndex = chunkInfo.ChunkIndex,
@@ -221,7 +266,7 @@ public class IngestionPipeline : IKnowledgeIngester
 
                 vectorItems.Add((chunkId.ToString(), embeddings[i], new Dictionary<string, string>(chunkInfo.Metadata)
                 {
-                    ["documentId"] = documentId.ToString(),
+                    ["documentId"] = documentEntity.Id.ToString(),
                     ["containerId"] = containerId.ToString(),
                     ["modelId"] = embedSettings.Model,
                     ["ChunkIndex"] = chunkInfo.ChunkIndex.ToString()
@@ -358,6 +403,19 @@ public class IngestionPipeline : IKnowledgeIngester
         }
 
         return await strategy.ChunkAsync(parsedDocument, settings, ct);
+    }
+
+    private async Task<bool> IsCurrentGenerationAsync(Guid documentId, int jobGeneration, CancellationToken ct)
+    {
+        if (jobGeneration == 0)
+            return true;
+
+        int currentGen = await _context.Documents
+            .Where(d => d.Id == documentId)
+            .Select(d => d.Generation)
+            .FirstOrDefaultAsync(ct);
+
+        return currentGen == jobGeneration;
     }
 
     private static async Task<string> ComputeContentHashAsync(Stream content, CancellationToken ct)

--- a/src/Connapse.Ingestion/Pipeline/IngestionWorker.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionWorker.cs
@@ -76,21 +76,17 @@ public class IngestionWorker : BackgroundService
                     job.DocumentId);
 
                 // Update status to Processing
-                if (_queue is IngestionQueue queue)
-                {
-                    queue.UpdateJobStatus(
-                        job.JobId,
-                        IngestionJobState.Processing,
-                        IngestionPhase.Parsing,
-                        0);
-                }
+                _queue.UpdateJobStatus(
+                    job.JobId,
+                    IngestionJobState.Processing,
+                    IngestionPhase.Parsing,
+                    0);
 
                 // Create a per-job CTS linked with the application stopping token
                 // so the job can be individually cancelled (e.g., on document delete)
                 using var jobCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
 
-                if (_queue is IngestionQueue q)
-                    q.RegisterJobCancellation(job.JobId, jobCts);
+                _queue.RegisterJobCancellation(job.JobId, jobCts);
 
                 IngestionResult result;
                 try
@@ -99,30 +95,26 @@ public class IngestionWorker : BackgroundService
                 }
                 finally
                 {
-                    if (_queue is IngestionQueue q2)
-                        q2.UnregisterJobCancellation(job.JobId);
+                    _queue.UnregisterJobCancellation(job.JobId);
                 }
 
                 // Update final status
-                if (_queue is IngestionQueue queue2)
+                if (result.Warnings.Any(w => w.Contains("failed", StringComparison.OrdinalIgnoreCase)))
                 {
-                    if (result.Warnings.Any(w => w.Contains("failed", StringComparison.OrdinalIgnoreCase)))
-                    {
-                        queue2.UpdateJobStatus(
-                            job.JobId,
-                            IngestionJobState.Failed,
-                            IngestionPhase.Complete,
-                            100,
-                            string.Join("; ", result.Warnings));
-                    }
-                    else
-                    {
-                        queue2.UpdateJobStatus(
-                            job.JobId,
-                            IngestionJobState.Completed,
-                            IngestionPhase.Complete,
-                            100);
-                    }
+                    _queue.UpdateJobStatus(
+                        job.JobId,
+                        IngestionJobState.Failed,
+                        IngestionPhase.Complete,
+                        100,
+                        string.Join("; ", result.Warnings));
+                }
+                else
+                {
+                    _queue.UpdateJobStatus(
+                        job.JobId,
+                        IngestionJobState.Completed,
+                        IngestionPhase.Complete,
+                        100);
                 }
 
                 _logger.LogInformation(

--- a/src/Connapse.Storage/Data/Entities/DocumentEntity.cs
+++ b/src/Connapse.Storage/Data/Entities/DocumentEntity.cs
@@ -10,6 +10,7 @@ public class DocumentEntity
     public string ContentHash { get; set; } = string.Empty;
     public long SizeBytes { get; set; }
     public int ChunkCount { get; set; }
+    public int Generation { get; set; } = 1;
     public string Status { get; set; } = "Pending";
     public string? ErrorMessage { get; set; }
     public DateTime CreatedAt { get; set; }

--- a/src/Connapse.Storage/Data/KnowledgeDbContext.cs
+++ b/src/Connapse.Storage/Data/KnowledgeDbContext.cs
@@ -146,6 +146,10 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
                 .HasColumnName("chunk_count")
                 .HasDefaultValue(0);
 
+            entity.Property(e => e.Generation)
+                .HasColumnName("generation")
+                .HasDefaultValue(1);
+
             entity.Property(e => e.Status)
                 .HasColumnName("status")
                 .IsRequired()

--- a/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
+++ b/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
@@ -4,6 +4,9 @@ using Connapse.Storage.Data;
 using Connapse.Storage.Data.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Npgsql;
+using NpgsqlTypes;
+using System.Text.Json;
 using static Connapse.Core.Utilities.LogSanitizer;
 
 namespace Connapse.Storage.Documents;
@@ -26,38 +29,72 @@ public class PostgresDocumentStore : IDocumentStore
         _logger = logger;
     }
 
-    public async Task<string> StoreAsync(Document document, CancellationToken ct = default)
+    public async Task<StoreResult> StoreAsync(Document document, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(document);
 
         await using var context = await _factory.CreateDbContextAsync(ct);
 
-        var entity = new DocumentEntity
-        {
-            Id = string.IsNullOrEmpty(document.Id) ? Guid.NewGuid() : Guid.Parse(document.Id),
-            ContainerId = Guid.Parse(document.ContainerId),
-            FileName = document.FileName,
-            ContentType = document.ContentType,
-            Path = document.Path,
-            ContentHash = string.Empty,
-            SizeBytes = document.SizeBytes,
-            ChunkCount = 0,
-            Status = "Pending",
-            CreatedAt = document.CreatedAt,
-            Metadata = document.Metadata ?? new Dictionary<string, string>()
-        };
+        var docId = string.IsNullOrEmpty(document.Id) ? Guid.NewGuid() : Guid.Parse(document.Id);
+        var containerId = Guid.Parse(document.ContainerId);
+        var metadata = document.Metadata ?? new Dictionary<string, string>();
 
-        context.Documents.Add(entity);
-        await context.SaveChangesAsync(ct);
+        // Atomic upsert: INSERT ... ON CONFLICT (container_id, path) DO UPDATE.
+        // On conflict, increments generation so stale ingestion jobs can detect they're outdated.
+        // Returns the winning row's id and generation.
+        var conn = context.Database.GetDbConnection();
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO documents (id, container_id, file_name, content_type, path, content_hash, size_bytes, chunk_count, generation, status, created_at, metadata)
+            VALUES (@id, @cid, @fname, @ctype, @path, @hash, @size, 0, 1, 'Pending', @created, @meta::jsonb)
+            ON CONFLICT (container_id, path) DO UPDATE SET
+                file_name    = EXCLUDED.file_name,
+                content_type = EXCLUDED.content_type,
+                content_hash = EXCLUDED.content_hash,
+                size_bytes   = EXCLUDED.size_bytes,
+                generation   = documents.generation + 1,
+                status       = 'Pending',
+                metadata     = EXCLUDED.metadata
+            RETURNING id, generation
+            """;
+
+        var p = cmd.Parameters;
+        p.Add(new NpgsqlParameter("id", docId));
+        p.Add(new NpgsqlParameter("cid", containerId));
+        p.Add(new NpgsqlParameter("fname", document.FileName));
+        p.Add(new NpgsqlParameter("ctype", document.ContentType));
+        p.Add(new NpgsqlParameter("path", document.Path));
+        p.Add(new NpgsqlParameter("hash", string.Empty));
+        p.Add(new NpgsqlParameter("size", document.SizeBytes));
+        p.Add(new NpgsqlParameter("created", document.CreatedAt));
+        p.Add(new NpgsqlParameter("meta", NpgsqlTypes.NpgsqlDbType.Jsonb) { Value = JsonSerializer.Serialize(metadata) });
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        await reader.ReadAsync(ct);
+        var winnerId = reader.GetGuid(0);
+        int generation = reader.GetInt32(1);
+
+        // Close reader before running EF commands on the same connection
+        await reader.CloseAsync();
+
+        // If an existing row was updated (not our new id), purge its stale chunks.
+        if (winnerId != docId)
+        {
+            await context.Chunks
+                .Where(c => c.DocumentId == winnerId)
+                .ExecuteDeleteAsync(ct);
+        }
 
         _logger.LogInformation(
-            "Stored document {DocumentId} ({FileName}, {SizeBytes} bytes) in container {ContainerId}",
-            entity.Id,
-            entity.FileName,
-            entity.SizeBytes,
-            entity.ContainerId);
+            "Stored document {DocumentId} gen={Generation} ({FileName}, {SizeBytes} bytes) in container {ContainerId}",
+            winnerId,
+            generation,
+            document.FileName,
+            document.SizeBytes,
+            containerId);
 
-        return entity.Id.ToString();
+        return new StoreResult(winnerId.ToString(), generation);
     }
 
     public async Task<Document?> GetAsync(string documentId, CancellationToken ct = default)

--- a/src/Connapse.Storage/Migrations/20260407030140_AddDocumentGeneration.Designer.cs
+++ b/src/Connapse.Storage/Migrations/20260407030140_AddDocumentGeneration.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Connapse.Storage.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -15,9 +16,11 @@ using Pgvector;
 namespace Connapse.Storage.Migrations
 {
     [DbContext(typeof(KnowledgeDbContext))]
-    partial class KnowledgeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260407030140_AddDocumentGeneration")]
+    partial class AddDocumentGeneration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Connapse.Storage/Migrations/20260407030140_AddDocumentGeneration.cs
+++ b/src/Connapse.Storage/Migrations/20260407030140_AddDocumentGeneration.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Connapse.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDocumentGeneration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "generation",
+                table: "documents",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "generation",
+                table: "documents");
+        }
+    }
+}

--- a/src/Connapse.Web/Services/IngestionProgressBroadcaster.cs
+++ b/src/Connapse.Web/Services/IngestionProgressBroadcaster.cs
@@ -1,6 +1,5 @@
 using Connapse.Core;
 using Connapse.Core.Interfaces;
-using Connapse.Ingestion.Pipeline;
 using Connapse.Web.Hubs;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Hosting;
@@ -41,50 +40,47 @@ public class IngestionProgressBroadcaster : BackgroundService
             try
             {
                 // Get all current job statuses
-                if (_queue is IngestionQueue queue)
+                var allStatuses = _queue.GetAllStatuses();
+
+                foreach (var (jobId, status) in allStatuses)
                 {
-                    var allStatuses = queue.GetAllStatuses();
-
-                    foreach (var (jobId, status) in allStatuses)
+                    // Only broadcast if status has changed or hasn't been broadcast recently
+                    if (ShouldBroadcast(jobId, status))
                     {
-                        // Only broadcast if status has changed or hasn't been broadcast recently
-                        if (ShouldBroadcast(jobId, status))
-                        {
-                            // Broadcast to job-specific group
-                            var progressUpdate = new IngestionProgressUpdate(
-                                JobId: jobId,
-                                DocumentId: status.DocumentId,
-                                ContainerId: status.ContainerId,
-                                State: status.State.ToString(),
-                                CurrentPhase: status.CurrentPhase?.ToString(),
-                                PercentComplete: status.PercentComplete,
-                                ErrorMessage: status.ErrorMessage,
-                                StartedAt: status.StartedAt,
-                                CompletedAt: status.CompletedAt);
+                        // Broadcast to job-specific group
+                        var progressUpdate = new IngestionProgressUpdate(
+                            JobId: jobId,
+                            DocumentId: status.DocumentId,
+                            ContainerId: status.ContainerId,
+                            State: status.State.ToString(),
+                            CurrentPhase: status.CurrentPhase?.ToString(),
+                            PercentComplete: status.PercentComplete,
+                            ErrorMessage: status.ErrorMessage,
+                            StartedAt: status.StartedAt,
+                            CompletedAt: status.CompletedAt);
 
-                            await _hubContext.Clients.Group(jobId).SendAsync(
-                                "IngestionProgress",
-                                progressUpdate,
-                                stoppingToken);
+                        await _hubContext.Clients.Group(jobId).SendAsync(
+                            "IngestionProgress",
+                            progressUpdate,
+                            stoppingToken);
 
-                            // Also notify in-process subscribers (Blazor Server components)
-                            _notifier.Notify(progressUpdate);
+                        // Also notify in-process subscribers (Blazor Server components)
+                        _notifier.Notify(progressUpdate);
 
-                            _lastBroadcast[jobId] = DateTime.UtcNow;
-                        }
+                        _lastBroadcast[jobId] = DateTime.UtcNow;
                     }
+                }
 
-                    // Clean up old broadcast tracking (jobs completed > 5 minutes ago)
-                    var cutoff = DateTime.UtcNow.AddMinutes(-5);
-                    var oldJobs = _lastBroadcast
-                        .Where(kvp => !allStatuses.ContainsKey(kvp.Key) || kvp.Value < cutoff)
-                        .Select(kvp => kvp.Key)
-                        .ToList();
+                // Clean up old broadcast tracking (jobs completed > 5 minutes ago)
+                var cutoff = DateTime.UtcNow.AddMinutes(-5);
+                var oldJobs = _lastBroadcast
+                    .Where(kvp => !allStatuses.ContainsKey(kvp.Key) || kvp.Value < cutoff)
+                    .Select(kvp => kvp.Key)
+                    .ToList();
 
-                    foreach (var jobId in oldJobs)
-                    {
-                        _lastBroadcast.Remove(jobId);
-                    }
+                foreach (var jobId in oldJobs)
+                {
+                    _lastBroadcast.Remove(jobId);
                 }
 
                 // Wait 500ms before next poll

--- a/src/Connapse.Web/Services/UploadService.cs
+++ b/src/Connapse.Web/Services/UploadService.cs
@@ -10,6 +10,7 @@ public class UploadService : IUploadService
     private readonly IConnectorFactory _connectorFactory;
     private readonly IFolderStore _folderStore;
     private readonly IIngestionQueue _ingestionQueue;
+    private readonly IDocumentStore _documentStore;
     private readonly IFileTypeValidator _fileTypeValidator;
     private readonly ICloudScopeService _cloudScopeService;
     private readonly IAuditLogger _auditLogger;
@@ -35,6 +36,7 @@ public class UploadService : IUploadService
         IConnectorFactory connectorFactory,
         IFolderStore folderStore,
         IIngestionQueue ingestionQueue,
+        IDocumentStore documentStore,
         IFileTypeValidator fileTypeValidator,
         ICloudScopeService cloudScopeService,
         IAuditLogger auditLogger)
@@ -43,6 +45,7 @@ public class UploadService : IUploadService
         _connectorFactory = connectorFactory;
         _folderStore = folderStore;
         _ingestionQueue = ingestionQueue;
+        _documentStore = documentStore;
         _fileTypeValidator = fileTypeValidator;
         _cloudScopeService = cloudScopeService;
         _auditLogger = auditLogger;
@@ -190,19 +193,45 @@ public class UploadService : IUploadService
         // Resolve job path
         var jobPath = connector.ResolveJobPath(relativePath);
 
+        // Cancel any in-flight ingestion for an existing document at the same path.
+        var existingDoc = await _documentStore.GetByPathAsync(request.ContainerId, virtualFilePath, ct);
+        if (existingDoc is not null)
+            await _ingestionQueue.CancelJobForDocumentAsync(existingDoc.Id);
+
+        // Eagerly create/update the document row. The upsert atomically increments
+        // the generation counter, so any in-flight job for a prior generation will
+        // detect it's stale and skip chunk insertion.
+        var storeResult = await _documentStore.StoreAsync(new Document(
+            documentId,
+            request.ContainerId.ToString(),
+            request.FileName,
+            contentType,
+            virtualFilePath,
+            request.Content.CanSeek ? request.Content.Length : 0,
+            DateTime.UtcNow,
+            new Dictionary<string, string>
+            {
+                ["OriginalFileName"] = request.FileName,
+                ["UploadedAt"] = DateTime.UtcNow.ToString("O"),
+                ["IngestedVia"] = request.IngestedVia
+            }), ct);
+
+        // Use the winning document ID (may differ from our generated one if upsert hit an existing row)
+        var winnerDocId = storeResult.DocumentId;
+
         // Parse strategy
         var strategy = ChunkingStrategy.Semantic;
         if (request.Strategy is not null &&
             Enum.TryParse<ChunkingStrategy>(request.Strategy, true, out var parsed))
             strategy = parsed;
 
-        // Build and enqueue ingestion job
+        // Build and enqueue ingestion job with the current generation
         var job = new IngestionJob(
             JobId: jobId,
-            DocumentId: documentId,
+            DocumentId: winnerDocId,
             Path: jobPath,
             Options: new IngestionOptions(
-                DocumentId: documentId,
+                DocumentId: winnerDocId,
                 FileName: request.FileName,
                 ContentType: contentType,
                 ContainerId: request.ContainerId.ToString(),
@@ -213,16 +242,18 @@ public class UploadService : IUploadService
                     ["OriginalFileName"] = request.FileName,
                     ["UploadedAt"] = DateTime.UtcNow.ToString("O"),
                     ["IngestedVia"] = request.IngestedVia
-                }),
+                },
+                Generation: storeResult.Generation),
+            Generation: storeResult.Generation,
             BatchId: batchId);
 
         await _ingestionQueue.EnqueueAsync(job, ct);
 
         // Audit log
-        await _auditLogger.LogAsync("doc.uploaded", "document", documentId,
+        await _auditLogger.LogAsync("doc.uploaded", "document", winnerDocId,
             new { FileName = request.FileName, ContainerId = request.ContainerId, Via = request.IngestedVia }, ct);
 
-        return new UploadResult(true, documentId, jobId);
+        return new UploadResult(true, winnerDocId, jobId);
     }
 
     private static string InferContentType(string fileName)

--- a/tests/Connapse.Core.Tests/Services/UploadServiceTests.cs
+++ b/tests/Connapse.Core.Tests/Services/UploadServiceTests.cs
@@ -18,6 +18,7 @@ public class UploadServiceTests
     private readonly IConnector _connector = Substitute.For<IConnector>();
     private readonly IFolderStore _folderStore = Substitute.For<IFolderStore>();
     private readonly IIngestionQueue _ingestionQueue = Substitute.For<IIngestionQueue>();
+    private readonly IDocumentStore _documentStore = Substitute.For<IDocumentStore>();
     private readonly IFileTypeValidator _fileTypeValidator = Substitute.For<IFileTypeValidator>();
     private readonly ICloudScopeService _cloudScopeService = Substitute.For<ICloudScopeService>();
     private readonly IAuditLogger _auditLogger = Substitute.For<IAuditLogger>();
@@ -34,10 +35,12 @@ public class UploadServiceTests
         _fileTypeValidator.IsSupported(Arg.Any<string>()).Returns(true);
         _fileTypeValidator.SupportedExtensions.Returns(new HashSet<string> { ".txt", ".pdf", ".md" });
         _folderStore.ExistsAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        _documentStore.StoreAsync(Arg.Any<Document>(), Arg.Any<CancellationToken>())
+            .Returns(ci => new StoreResult(Guid.NewGuid().ToString(), 1));
 
         _sut = new UploadService(
             _containerStore, _connectorFactory, _folderStore,
-            _ingestionQueue, _fileTypeValidator, _cloudScopeService, _auditLogger);
+            _ingestionQueue, _documentStore, _fileTypeValidator, _cloudScopeService, _auditLogger);
     }
 
     private UploadRequest MakeRequest(


### PR DESCRIPTION
## What

Eliminates all duplicate-key (23505) and FK-violation (23503) errors during concurrent uploads, re-uploads, and deletes by adding a **generation counter** to documents — a pattern used by LlamaIndex, LangChain, and Azure AI Search.

## Why

The original approach tried to handle concurrent upload races via exception catching (stale-row fallback lookups, `DbUpdateException` recovery). This was fragile — each fix exposed a new race window. The generation counter makes the system **self-healing**: even if cancellation races or misses, stale jobs harmlessly self-terminate.

## How

- **`DocumentEntity.Generation`** — monotonically increasing integer (default 1), incremented atomically via `INSERT...ON CONFLICT DO UPDATE SET generation = documents.generation + 1`
- **`StoreAsync` returns `StoreResult(DocumentId, Generation)`** — callers get the winning row's ID and current generation
- **`IngestionJob` + `IngestionOptions` carry `Generation`** — `0` means "skip check" (reindex/watcher/sync), non-zero triggers stale detection
- **Two generation checks in `IngestionPipeline`:**
  1. At start — before parsing/chunking/embedding (skips immediately)
  2. Before chunk insertion — catches re-uploads during long embedding calls
- **Removed** fallback/recovery code (stale-row lookup by path, `DbUpdateException` catch, `IsDuplicatePathConflict`)
- **Progress interface promotion** — `UpdateJobStatus`, `GetAllStatuses`, `RegisterJobCancellation`, `UnregisterJobCancellation` moved from concrete `IngestionQueue` to `IIngestionQueue` interface

## Test plan

- [x] Upload a file — ingests successfully with `gen=1`
- [x] Delete mid-ingestion — worker logs cancellation, no FK violations
- [x] Re-upload while ingesting — old job skipped (generation mismatch), new job completes
- [x] Rapid re-uploads — no 23505 errors, only latest version ingested
- [x] All 584 unit tests pass

Closes #295