### PR TITLE
feat: add /api/v1/info server edition endpoint

### DIFF
--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -284,6 +284,16 @@ app.MapRazorComponents<App>()
 // Used by integration tests to replace Task.Delay(2000) startup waits.
 app.MapGet("/health", () => Results.Ok());
 
+// Server info — lets CLI detect whether it's talking to Cloud or self-hosted
+app.MapGet("/api/v1/info", () => Results.Json(new
+{
+    edition = "self-hosted",
+    version = typeof(Program).Assembly
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+        ?.InformationalVersion ?? "0.0.0",
+    features = new[] { "mcp", "connectors", "agents" },
+})).AllowAnonymous();
+
 // Map API endpoints — antiforgery is disabled for all API routes because they
 // authenticate via JWT / PAT bearer tokens, not browser form submissions.
 var api = app.MapGroup("").DisableAntiforgery()

--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -292,7 +292,7 @@ app.MapGet("/api/v1/info", () => Results.Json(new
         .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
         ?.InformationalVersion ?? "0.0.0",
     features = new[] { "mcp", "connectors", "agents" },
-})).AllowAnonymous();
+})).AllowAnonymous().RequireRateLimiting(RateLimitingExtensions.ApiPolicy);
 
 // Map API endpoints — antiforgery is disabled for all API routes because they
 // authenticate via JWT / PAT bearer tokens, not browser form submissions.


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/info` anonymous endpoint that returns server edition metadata
- Returns `edition` ("self-hosted"), `version` (from assembly), and `features` array
- Enables CLI to detect server capabilities and adapt behavior accordingly

## Test Plan

- [ ] `curl http://localhost:5000/api/v1/info` returns `{"edition":"self-hosted","version":"...","features":["mcp","connectors","agents"]}`
- [ ] Endpoint is anonymous (no auth required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/api/v1/info` API endpoint that provides server information including edition type, application version, and available features. This endpoint is publicly accessible and includes rate limiting protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->