### PR TITLE
feat: add GET /api/v1/auth/me endpoint

### DIFF
--- a/src/Connapse.Core/Models/AuthModels.cs
+++ b/src/Connapse.Core/Models/AuthModels.cs
@@ -40,6 +40,13 @@ public record UserListItem(
     DateTime CreatedAt,
     DateTime? LastLoginAt);
 
+public record MeResponse(
+    Guid Id,
+    string Email,
+    string? DisplayName,
+    IReadOnlyList<string> Roles,
+    DateTime CreatedAt);
+
 public record AssignRolesRequest(IReadOnlyList<string> Roles);
 
 public record CreateAgentRequest(string Name, string? Description = null);

--- a/src/Connapse.Web/Endpoints/AuthEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/AuthEndpoints.cs
@@ -84,6 +84,33 @@ public static class AuthEndpoints
         .WithDescription("Exchange a refresh token for a new JWT access token and refresh token")
         .AllowAnonymous();
 
+        // GET /api/v1/auth/me — return identity for the currently authenticated caller
+        group.MapGet("/me", async (
+            HttpContext httpContext,
+            [FromServices] UserManager<ConnapseUser> userManager,
+            CancellationToken ct) =>
+        {
+            var userId = GetUserId(httpContext);
+            if (userId is null)
+                return Results.Unauthorized();
+
+            var user = await userManager.FindByIdAsync(userId.Value.ToString());
+            if (user is null)
+                return Results.Unauthorized();
+
+            var roles = await userManager.GetRolesAsync(user);
+
+            return Results.Ok(new MeResponse(
+                user.Id,
+                user.Email ?? "",
+                user.DisplayName,
+                roles.ToList(),
+                user.CreatedAt));
+        })
+        .WithName("GetMe")
+        .WithDescription("Return the authenticated caller's identity (id, email, display name, roles).")
+        .RequireAuthorization();
+
         // GET /api/v1/auth/pats — list the authenticated user's PATs
         group.MapGet("/pats", async (
             HttpContext httpContext,


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/auth/me` returning the authenticated caller's identity (`id`, `email`, `displayName`, `roles`, `createdAt`)
- Adds `MeResponse` DTO in `Connapse.Core/Models/AuthModels.cs`
- Endpoint reads `NameIdentifier` claim from the access token, calls `UserManager.FindByIdAsync`, returns the user and their roles

## Motivation

The OAuth/PKCE browser login flow returns only `access_token` + `refresh_token` — no identity. CLI tools need a way to display "Email: alice@example.com" in `auth whoami` output without caching identity in local credential files.

## Security notes

- Uses `.RequireAuthorization()` — any authenticated principal can call it, but only sees their own identity

## Test plan

- [ ] Manual: `curl -H "Authorization: Bearer $TOKEN" https://.../api/v1/auth/me` returns the caller's identity
- [ ] Manual: unauthenticated call returns 401
- [ ] Manual: expired token returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new authenticated endpoint that allows users to retrieve their complete current account profile information and personal details. This includes their unique identifier, email address, display name, the full list of all their assigned roles, and the exact date their account was originally created and registered in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->