### PR TITLE
fix: sanitize user query in search/reindex logs (cs/log-forging)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ The standalone [connapse-cli](https://github.com/Destrayon/connapse-cli) is an a
 - Parameterized SQL queries only (never string interpolation)
 - Don't use `var` for primitive types
 - Don't use `dynamic`
+- When logging user-controlled values (search queries, request bodies, headers, client-supplied IDs), wrap them with `LogSanitizer.Sanitize(...)` from `Connapse.Core.Utilities` to prevent CodeQL `cs/log-forging` alerts
 
 ## Commit Messages
 

--- a/src/Connapse.Ingestion/Reindex/ReindexService.cs
+++ b/src/Connapse.Ingestion/Reindex/ReindexService.cs
@@ -95,7 +95,7 @@ public class ReindexService : IReindexService
     {
         _logger.LogInformation(
             "Starting reindex operation: ContainerId={ContainerId}, Force={Force}, DetectSettingsChanges={DetectSettingsChanges}",
-            options.ContainerId,
+            Sanitize(options.ContainerId?.ToString()),
             options.Force,
             options.DetectSettingsChanges);
 

--- a/src/Connapse.Search/Hybrid/HybridSearchService.cs
+++ b/src/Connapse.Search/Hybrid/HybridSearchService.cs
@@ -6,6 +6,7 @@ using Connapse.Search.Vector;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using static Connapse.Core.Utilities.LogSanitizer;
 
 namespace Connapse.Search.Hybrid;
 
@@ -80,7 +81,7 @@ public class HybridSearchService : IKnowledgeSearch
         _logger.LogInformation(
             "Starting {Mode} search for query: '{Query}' (topK={TopK})",
             mode,
-            query,
+            Sanitize(query),
             options.TopK);
 
         // Create a scope to get search services

--- a/src/Connapse.Search/Keyword/KeywordSearchService.cs
+++ b/src/Connapse.Search/Keyword/KeywordSearchService.cs
@@ -2,6 +2,7 @@ using Connapse.Core;
 using Connapse.Storage.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using static Connapse.Core.Utilities.LogSanitizer;
 
 namespace Connapse.Search.Keyword;
 
@@ -113,7 +114,7 @@ public class KeywordSearchService
 
         _logger.LogInformation(
             "Keyword search for query '{Query}' returned {Count} results (topK={TopK})",
-            query,
+            Sanitize(query),
             hits.Count,
             options.TopK);
 

--- a/src/Connapse.Search/Vector/VectorSearchService.cs
+++ b/src/Connapse.Search/Vector/VectorSearchService.cs
@@ -2,6 +2,7 @@ using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using static Connapse.Core.Utilities.LogSanitizer;
 
 namespace Connapse.Search.Vector;
 
@@ -87,7 +88,7 @@ public class VectorSearchService
 
         _logger.LogInformation(
             "Vector search for query '{Query}' returned {Count} results (topK={TopK}, minScore={MinScore})",
-            query,
+            Sanitize(query),
             hits.Count,
             options.TopK,
             options.MinScore);


### PR DESCRIPTION
## Summary
- Closes the 4 open CodeQL `cs/log-forging` alerts (#48, #49, #50, #51) by routing user-controlled values through the existing `LogSanitizer.Sanitize` helper before they reach `_logger.LogInformation`.
- Touched files: `VectorSearchService`, `HybridSearchService`, `KeywordSearchService`, `ReindexService`.

## Why
CodeQL flagged user-supplied search queries (and the reindex `ContainerId`) as untrusted values flowing into log entries, where embedded CR/LF could be used to forge log lines. The repo already has `Connapse.Core.Utilities.LogSanitizer` for exactly this — it was just not wired into these four call sites.

## How
- Added `using static Connapse.Core.Utilities.LogSanitizer;` to the three search services (Reindex already had it).
- Wrapped the offending log arguments with `Sanitize(...)`. For `ReindexService` the value is `Guid?`, so it's stringified first (`options.ContainerId?.ToString()`).
- Verified `Connapse.Search` and `Connapse.Ingestion` both build clean (0 warnings, 0 errors).

## Test plan
- [ ] CI build passes
- [ ] CodeQL re-run closes alerts #48-#51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by sanitizing sensitive information in system log messages to better protect user data privacy across search and indexing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->