### PR TITLE
fix: make OAuth PRM spec-compliant for MCP clients

### DIFF
--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -139,9 +139,7 @@ public static class IdentityServiceExtensions
                     if (context.Request.Path.StartsWithSegments("/mcp"))
                     {
                         context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-                        var baseUrl = $"{context.Request.Scheme}://{context.Request.Host}";
-                        context.Response.Headers.WWWAuthenticate =
-                            $"Bearer resource_metadata=\"{baseUrl}/.well-known/oauth-protected-resource\"";
+                        context.Response.Headers.WWWAuthenticate = BuildMcpChallenge(context.HttpContext);
                         return Task.CompletedTask;
                     }
 
@@ -205,9 +203,7 @@ public static class IdentityServiceExtensions
                     {
                         if (context.Request.Path.StartsWithSegments("/mcp"))
                         {
-                            var baseUrl = $"{context.Request.Scheme}://{context.Request.Host}";
-                            context.Response.Headers.WWWAuthenticate =
-                                $"Bearer resource_metadata=\"{baseUrl}/.well-known/oauth-protected-resource\"";
+                            context.Response.Headers.WWWAuthenticate = BuildMcpChallenge(context.HttpContext);
                             context.HandleResponse();
                             context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                         }
@@ -246,6 +242,20 @@ public static class IdentityServiceExtensions
                 policy.Requirements.Add(new ScopeRequirement("agent:ingest")));
 
         return services;
+    }
+
+    // Builds the WWW-Authenticate challenge that 401 responses return for /mcp.
+    // RFC 9728 §3.1: the resource metadata URL for a protected resource at
+    // "/foo/mcp" is "/.well-known/oauth-protected-resource/foo/mcp". Using the
+    // request's PathBase+Path preserves any prefix a host has mounted the MCP
+    // endpoint under (e.g. a tenant slug inserted upstream by a rewrite
+    // middleware), without the submodule having to know the prefix exists.
+    private static string BuildMcpChallenge(HttpContext context)
+    {
+        var request = context.Request;
+        var baseUrl = $"{request.Scheme}://{request.Host}";
+        var resourcePath = request.PathBase.Add(request.Path).ToString();
+        return $"Bearer resource_metadata=\"{baseUrl}/.well-known/oauth-protected-resource{resourcePath}\"";
     }
 
     private static void EnsureJwtSecret(IConfiguration configuration)

--- a/src/Connapse.Web/Components/Pages/Auth/OAuthAuthorize.razor
+++ b/src/Connapse.Web/Components/Pages/Auth/OAuthAuthorize.razor
@@ -241,11 +241,19 @@
             return false;
         }
 
-        // RFC 8707: validate resource parameter matches this server
+        // RFC 8707: the `resource` parameter is the canonical URI of the
+        // protected resource the client intends to access. For MCP that is
+        // the MCP endpoint URL (e.g. https://host/mcp or https://host/<prefix>/mcp),
+        // not the bare origin — matching the `resource` claim we advertise in
+        // /.well-known/oauth-protected-resource. Validate by comparing
+        // scheme+authority so any path served by this host is accepted;
+        // rejecting on path equality would break as soon as the endpoint is
+        // mounted under any prefix (tenant slug, reverse-proxy path, etc.).
         if (!string.IsNullOrWhiteSpace(Resource))
         {
-            var baseUrl = $"{HttpContext.Request.Scheme}://{HttpContext.Request.Host}";
-            if (!string.Equals(Resource.TrimEnd('/'), baseUrl.TrimEnd('/'), StringComparison.OrdinalIgnoreCase))
+            if (!Uri.TryCreate(Resource, UriKind.Absolute, out var resourceUri) ||
+                !string.Equals(resourceUri.Scheme, HttpContext.Request.Scheme, StringComparison.OrdinalIgnoreCase) ||
+                !string.Equals(resourceUri.Authority, HttpContext.Request.Host.Value, StringComparison.OrdinalIgnoreCase))
             {
                 error = "The resource parameter does not match this server.";
                 return false;

--- a/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
@@ -16,17 +16,20 @@ public static class OAuthEndpoints
     {
         // -- Discovery --
 
+        // RFC 9728 §3.1: the Protected Resource Metadata discovery URL for a
+        // resource whose identifier is "https://host/foo/bar" is
+        // "https://host/.well-known/oauth-protected-resource/foo/bar". The
+        // catch-all route below echoes whichever path the client used to
+        // discover the metadata back into the "resource" claim, which RFC 9728
+        // §3.3 requires to equal the protected resource's identifier. Strict
+        // MCP clients (Claude Code among them) reject the document when this
+        // doesn't match the URL they are trying to reach, which is why the
+        // bare endpoint alone is not sufficient for multi-path deployments.
         app.MapGet("/.well-known/oauth-protected-resource", (HttpContext ctx) =>
-        {
-            var baseUrl = GetBaseUrl(ctx);
-            return Results.Json(new
-            {
-                resource = baseUrl,
-                authorization_servers = new[] { baseUrl },
-                scopes_supported = new[] { "knowledge:read", "knowledge:write" },
-                bearer_methods_supported = new[] { "header" },
-            });
-        }).AllowAnonymous();
+            BuildProtectedResourceMetadata(ctx, resourcePath: null)).AllowAnonymous();
+
+        app.MapGet("/.well-known/oauth-protected-resource/{**resourcePath}", (HttpContext ctx, string resourcePath) =>
+            BuildProtectedResourceMetadata(ctx, resourcePath)).AllowAnonymous();
 
         app.MapGet("/.well-known/oauth-authorization-server", (HttpContext ctx) =>
         {
@@ -251,6 +254,23 @@ public static class OAuthEndpoints
     {
         var request = ctx.Request;
         return $"{request.Scheme}://{request.Host}";
+    }
+
+    private static IResult BuildProtectedResourceMetadata(HttpContext ctx, string? resourcePath)
+    {
+        var baseUrl = GetBaseUrl(ctx);
+        var normalizedPath = string.IsNullOrEmpty(resourcePath)
+            ? string.Empty
+            : "/" + resourcePath.TrimStart('/');
+        var resource = baseUrl + normalizedPath;
+
+        return Results.Json(new
+        {
+            resource,
+            authorization_servers = new[] { baseUrl },
+            scopes_supported = new[] { "knowledge:read", "knowledge:write" },
+            bearer_methods_supported = new[] { "header" },
+        });
     }
 
     // OAuth 2.1 requires application/x-www-form-urlencoded (RFC 6749 §3.2)

--- a/tests/Connapse.Integration.Tests/OAuthEndpointTests.cs
+++ b/tests/Connapse.Integration.Tests/OAuthEndpointTests.cs
@@ -25,6 +25,32 @@ public class OAuthEndpointTests(SharedWebAppFixture fixture)
         json.RootElement.GetProperty("scopes_supported").GetArrayLength().Should().Be(2);
     }
 
+    /// <summary>
+    /// RFC 9728 §3.1: clients may discover PRM by inserting
+    /// "/.well-known/oauth-protected-resource" between host and path. RFC 9728
+    /// §3.3 then requires the "resource" claim in the document to equal the
+    /// protected resource identifier. Strict MCP clients (Claude Code among
+    /// them) reject the document if this doesn't match the URL they are
+    /// actually trying to access.
+    /// </summary>
+    [Theory]
+    [InlineData("/mcp")]
+    [InlineData("/khastra/mcp")]
+    [InlineData("/some/deep/nested/path")]
+    public async Task ProtectedResourceMetadata_PathSuffixed_ResourceMatchesRequestedPath(string resourcePath)
+    {
+        using var client = fixture.Factory.CreateClient();
+
+        var response = await client.GetAsync($"/.well-known/oauth-protected-resource{resourcePath}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadFromJsonAsync<JsonDocument>();
+        var resource = json!.RootElement.GetProperty("resource").GetString();
+        resource.Should().NotBeNullOrWhiteSpace();
+        resource.Should().EndWith(resourcePath, "the resource claim must equal the URL the client discovered metadata for");
+        json.RootElement.GetProperty("authorization_servers").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
     [Fact]
     public async Task AuthorizationServerMetadata_ReturnsValidJson()
     {
@@ -165,6 +191,10 @@ public class OAuthEndpointTests(SharedWebAppFixture fixture)
         var wwwAuth = response.Headers.WwwAuthenticate.ToString();
         wwwAuth.Should().Contain("Bearer");
         wwwAuth.Should().Contain("resource_metadata");
-        wwwAuth.Should().Contain(".well-known/oauth-protected-resource");
+        // The challenge must point at the path-suffixed PRM URL for the
+        // actual resource (/mcp), not the bare /.well-known endpoint. This is
+        // what lets strict MCP clients resolve metadata whose "resource"
+        // claim matches the URL they are trying to access.
+        wwwAuth.Should().Contain(".well-known/oauth-protected-resource/mcp");
     }
 }


### PR DESCRIPTION
## Summary
- PRM `resource` claim now matches the canonical URI of the protected resource per RFC 9728 §3.3 — previously returned just the origin (e.g. `https://host`) which strict MCP clients (Claude Code) reject when the client is accessing `https://host/mcp`.
- Add path-suffixed PRM route `/.well-known/oauth-protected-resource/{**resourcePath}` per RFC 9728 §3.1 so clients that discover metadata via the suffixed URL get a document whose `resource` matches the URL they requested.
- `/mcp` 401 WWW-Authenticate challenge now points at the suffixed PRM URL and derives the resource path from `PathBase + Path` so deployments that mount the endpoint under a prefix upstream (e.g. a rewrite middleware that inserts a tenant slug) keep working without the submodule needing to know the prefix exists.

## Why
Claude Code (and any other MCP client that validates RFC 9728 §3.3) silently drops the Protected Resource Metadata document when `resource` doesn't equal the URL it discovered it for. That killed the OAuth handshake before token exchange could even start, surfacing in the Claude Code UI as "Failed to connect" with no useful server-side signal (the request completed successfully with a 401 + correct challenge; the client just wouldn't proceed).

## Test plan
- [x] `dotnet build src/Connapse.Web` — clean
- [x] `dotnet test tests/Connapse.Integration.Tests --filter OAuthEndpointTests` — 11/11 passing, including 3 new theory cases covering `/mcp`, `/khastra/mcp`, and nested paths
- [x] Tightened `McpEndpoint_NoAuth_Returns401WithWwwAuthenticate` to assert the challenge points at `.well-known/oauth-protected-resource/mcp`, not just the bare endpoint
- [ ] Manual verification against Claude Code VSCode after the downstream deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth challenge headers now include resource metadata URLs that reflect the incoming request path/mount.
  * Resource parameter validation tightened to require a valid absolute URI matching the request scheme and authority.

* **New Features**
  * Protected resource metadata discovery supports path-based resource identifiers.

* **Tests**
  * Added integration test verifying path-suffixed protected resource metadata responses and updated expectations for WWW-Authenticate challenge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->