### PR TITLE
fix: pin System.Security.Cryptography.Xml to 10.0.6 (CVE)

### DIFF
--- a/src/Connapse.Storage/Connapse.Storage.csproj
+++ b/src/Connapse.Storage/Connapse.Storage.csproj
@@ -17,6 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />


### PR DESCRIPTION
## Summary
- `dotnet list package --vulnerable --include-transitive` reports `System.Security.Cryptography.Xml` 9.0.0 with two high-severity advisories ([GHSA-37gx-xxp4-5rgx](https://github.com/advisories/GHSA-37gx-xxp4-5rgx), [GHSA-w3x6-4m5h-cxqf](https://github.com/advisories/GHSA-w3x6-4m5h-cxqf)).
- It is pulled in transitively via `Microsoft.EntityFrameworkCore.Design` → `Microsoft.Build.Tasks.Core` → `System.Security.Cryptography.Xml`. Design-time only, never shipped at runtime — but the NU1903 warning still fires on restore.
- Pin an explicit `System.Security.Cryptography.Xml` 10.0.6 reference in `Connapse.Storage` with `PrivateAssets="all"` to override the transitive and keep it design-time-only.

## Why 10.0.6
Latest stable on the `net10.0` line (project targets `net10.0`). Both advisories are fixed in 9.0.1+.

## Test plan
- [x] `dotnet list package --vulnerable --include-transitive` reports no vulnerabilities in any project
- [x] `dotnet build` succeeds with 0 warnings / 0 errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies with a new cryptographic library package to enhance the technical foundation of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->