### PR TITLE
fix: make OAuth flow spec-compliant for MCP clients (enhanced-nav + RFC 8707)

### DIFF
--- a/src/Connapse.Identity/Data/ConnapseIdentityDbContext.cs
+++ b/src/Connapse.Identity/Data/ConnapseIdentityDbContext.cs
@@ -228,6 +228,10 @@ public class ConnapseIdentityDbContext(DbContextOptions<ConnapseIdentityDbContex
                 .HasColumnName("client_id")
                 .HasMaxLength(256);
 
+            entity.Property(e => e.Resource)
+                .HasColumnName("resource")
+                .HasMaxLength(2048);
+
             entity.Property(e => e.CreatedAt)
                 .HasColumnName("created_at")
                 .HasDefaultValueSql("now()");
@@ -553,6 +557,10 @@ public class ConnapseIdentityDbContext(DbContextOptions<ConnapseIdentityDbContex
                 .HasColumnName("scope")
                 .HasMaxLength(1024)
                 .IsRequired();
+
+            entity.Property(e => e.Resource)
+                .HasColumnName("resource")
+                .HasMaxLength(2048);
 
             entity.Property(e => e.CreatedAt)
                 .HasColumnName("created_at")

--- a/src/Connapse.Identity/Data/Entities/OAuthAuthCodeEntity.cs
+++ b/src/Connapse.Identity/Data/Entities/OAuthAuthCodeEntity.cs
@@ -9,6 +9,14 @@ public class OAuthAuthCodeEntity
     public string RedirectUri { get; set; } = "";
     public string CodeChallenge { get; set; } = "";
     public string Scope { get; set; } = "";
+
+    // RFC 8707 resource indicator. Captured at /oauth/authorize and replayed into
+    // the access token's `aud` claim at /oauth/token so the MCP client can verify
+    // the token was issued for the resource it asked for (MCP spec §Token Audience
+    // Binding). Nullable for backwards compatibility with non-MCP OAuth flows that
+    // omit the parameter.
+    public string? Resource { get; set; }
+
     public DateTime CreatedAt { get; set; }
     public DateTime ExpiresAt { get; set; }
     public DateTime? UsedAt { get; set; }

--- a/src/Connapse.Identity/Data/Entities/RefreshTokenEntity.cs
+++ b/src/Connapse.Identity/Data/Entities/RefreshTokenEntity.cs
@@ -9,6 +9,12 @@ public class RefreshTokenEntity
     public DateTime? RevokedAt { get; set; }
     public string? ReplacedByTokenHash { get; set; }
     public string? ClientId { get; set; }
+
+    // RFC 8707 resource indicator carried through the refresh chain so that
+    // refreshed access tokens keep the same `aud` binding the MCP client
+    // originally asked for at /oauth/authorize.
+    public string? Resource { get; set; }
+
     public DateTime CreatedAt { get; set; }
 
     // Navigation properties

--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -180,8 +180,11 @@ public static class IdentityServiceExtensions
                     IssuerSigningKeys = validationKeys,
                     ValidateIssuer = true,
                     ValidIssuer = jwtSettings.Issuer,
-                    ValidateAudience = true,
-                    ValidAudience = jwtSettings.Audience,
+                    // Audience is validated in OnTokenValidated below — that
+                    // handler has access to the current request's scheme+host,
+                    // which is required to accept RFC 8707 resource-bound
+                    // tokens whose `aud` is a URL for this server.
+                    ValidateAudience = false,
                     ValidateLifetime = true,
                     ClockSkew = TimeSpan.FromMinutes(1),
                 };
@@ -197,6 +200,40 @@ public static class IdentityServiceExtensions
                         {
                             context.Token = accessToken;
                         }
+                        return Task.CompletedTask;
+                    },
+                    // RFC 8707 / MCP §Token Audience Binding. Accept two
+                    // audience shapes:
+                    //  1. The static server audience (legacy /api flows that
+                    //     don't use RFC 8707).
+                    //  2. Any absolute-URI audience whose scheme+authority
+                    //     matches the current request — this is the canonical
+                    //     URI form required by RFC 8707 §2, and the only way
+                    //     a multi-tenant deployment can accept resource-bound
+                    //     tokens for whichever prefix the MCP endpoint is
+                    //     mounted under (tenant slug, reverse-proxy prefix).
+                    //     Path is not required to match, because PathBase
+                    //     rewrites happen after authentication.
+                    OnTokenValidated = context =>
+                    {
+                        var token = context.SecurityToken as System.IdentityModel.Tokens.Jwt.JwtSecurityToken;
+                        var audiences = token?.Audiences ?? [];
+                        var request = context.HttpContext.Request;
+
+                        foreach (var audience in audiences)
+                        {
+                            if (string.Equals(audience, jwtSettings.Audience, StringComparison.Ordinal))
+                                return Task.CompletedTask;
+
+                            if (Uri.TryCreate(audience, UriKind.Absolute, out var aud) &&
+                                string.Equals(aud.Scheme, request.Scheme, StringComparison.OrdinalIgnoreCase) &&
+                                string.Equals(aud.Authority, request.Host.Value, StringComparison.OrdinalIgnoreCase))
+                            {
+                                return Task.CompletedTask;
+                            }
+                        }
+
+                        context.Fail("Audience does not match this server.");
                         return Task.CompletedTask;
                     },
                     OnChallenge = context =>

--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -216,8 +216,16 @@ public static class IdentityServiceExtensions
                     //     rewrites happen after authentication.
                     OnTokenValidated = context =>
                     {
-                        var token = context.SecurityToken as System.IdentityModel.Tokens.Jwt.JwtSecurityToken;
-                        var audiences = token?.Audiences ?? [];
+                        // Read audiences from whichever handler validated the
+                        // token — .NET 8+ defaults to JsonWebTokenHandler
+                        // (produces JsonWebToken) but JwtBearer can still be
+                        // configured to use the legacy JwtSecurityTokenHandler.
+                        IEnumerable<string> audiences = context.SecurityToken switch
+                        {
+                            Microsoft.IdentityModel.JsonWebTokens.JsonWebToken j => j.Audiences,
+                            System.IdentityModel.Tokens.Jwt.JwtSecurityToken j => j.Audiences,
+                            _ => [],
+                        };
                         var request = context.HttpContext.Request;
 
                         foreach (var audience in audiences)

--- a/src/Connapse.Identity/Migrations/20260418071015_AddOAuthResourceBinding.Designer.cs
+++ b/src/Connapse.Identity/Migrations/20260418071015_AddOAuthResourceBinding.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Connapse.Identity.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Connapse.Identity.Migrations
 {
     [DbContext(typeof(ConnapseIdentityDbContext))]
-    partial class ConnapseIdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260418071015_AddOAuthResourceBinding")]
+    partial class AddOAuthResourceBinding
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Connapse.Identity/Migrations/20260418071015_AddOAuthResourceBinding.cs
+++ b/src/Connapse.Identity/Migrations/20260418071015_AddOAuthResourceBinding.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Connapse.Identity.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOAuthResourceBinding : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "resource",
+                table: "refresh_tokens",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "resource",
+                table: "oauth_auth_codes",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "resource",
+                table: "refresh_tokens");
+
+            migrationBuilder.DropColumn(
+                name: "resource",
+                table: "oauth_auth_codes");
+        }
+    }
+}

--- a/src/Connapse.Identity/Services/ITokenService.cs
+++ b/src/Connapse.Identity/Services/ITokenService.cs
@@ -5,8 +5,8 @@ namespace Connapse.Identity.Services;
 
 public interface ITokenService
 {
-    string GenerateAccessToken(IEnumerable<Claim> claims);
-    Task<TokenResponse> GenerateTokenPairAsync(IEnumerable<Claim> claims, Guid userId, CancellationToken cancellationToken = default);
+    string GenerateAccessToken(IEnumerable<Claim> claims, string? audience = null);
+    Task<TokenResponse> GenerateTokenPairAsync(IEnumerable<Claim> claims, Guid userId, string? audience = null, CancellationToken cancellationToken = default);
     Task<TokenResponse?> RefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default);
     ClaimsPrincipal? ValidateToken(string token);
 }

--- a/src/Connapse.Identity/Services/JwtTokenService.cs
+++ b/src/Connapse.Identity/Services/JwtTokenService.cs
@@ -17,14 +17,14 @@ public class JwtTokenService(
     ConnapseIdentityDbContext dbContext,
     ILogger<JwtTokenService> logger) : ITokenService
 {
-    public string GenerateAccessToken(IEnumerable<Claim> claims)
+    public string GenerateAccessToken(IEnumerable<Claim> claims, string? audience = null)
     {
         var settings = jwtSettings.CurrentValue;
         var credentials = GetSigningCredentials(settings);
 
         var token = new JwtSecurityToken(
             issuer: settings.Issuer,
-            audience: settings.Audience,
+            audience: audience ?? settings.Audience,
             claims: claims,
             expires: DateTime.UtcNow.AddMinutes(settings.AccessTokenLifetimeMinutes),
             signingCredentials: credentials);
@@ -35,11 +35,12 @@ public class JwtTokenService(
     public async Task<TokenResponse> GenerateTokenPairAsync(
         IEnumerable<Claim> claims,
         Guid userId,
+        string? audience = null,
         CancellationToken cancellationToken = default)
     {
         var settings = jwtSettings.CurrentValue;
 
-        var accessToken = GenerateAccessToken(claims);
+        var accessToken = GenerateAccessToken(claims, audience);
         var refreshToken = GenerateRefreshToken();
         var refreshTokenHash = ComputeSha256Hash(refreshToken);
 
@@ -119,12 +120,18 @@ public class JwtTokenService(
             claims.Add(new Claim(ClaimTypes.Role, role));
         }
 
-        var accessToken = GenerateAccessToken(claims);
+        // Carry the RFC 8707 resource binding through the refresh chain so the
+        // new access token keeps the same `aud` the MCP client originally asked
+        // for. Without this, refreshed tokens would fall back to the static
+        // server audience and the MCP client would reject them.
+        var accessToken = GenerateAccessToken(claims, existingToken.Resource);
 
         var newRefreshTokenEntity = new RefreshTokenEntity
         {
             UserId = existingToken.UserId,
             TokenHash = newRefreshTokenHash,
+            ClientId = existingToken.ClientId,
+            Resource = existingToken.Resource,
             ExpiresAt = DateTime.UtcNow.AddDays(settings.RefreshTokenLifetimeDays),
             CreatedAt = DateTime.UtcNow,
         };

--- a/src/Connapse.Identity/Services/JwtTokenService.cs
+++ b/src/Connapse.Identity/Services/JwtTokenService.cs
@@ -155,8 +155,13 @@ public class JwtTokenService(
             IssuerSigningKeys = GetValidationKeys(settings),
             ValidateIssuer = true,
             ValidIssuer = settings.Issuer,
-            ValidateAudience = true,
-            ValidAudience = settings.Audience,
+            // Audience is not validated here — this helper is standalone
+            // and has no HTTP request context, so it can't apply the
+            // RFC 8707 canonical-URI scheme+authority check that the
+            // JwtBearer middleware performs for API/MCP requests. Callers
+            // that need per-deployment audience checks must go through
+            // the auth pipeline.
+            ValidateAudience = false,
             ValidateLifetime = true,
             ClockSkew = TimeSpan.FromMinutes(1),
         };

--- a/src/Connapse.Identity/Services/OAuthAuthCodeService.cs
+++ b/src/Connapse.Identity/Services/OAuthAuthCodeService.cs
@@ -20,6 +20,7 @@ public class OAuthAuthCodeService(
         string codeChallenge,
         string redirectUri,
         string scope,
+        string? resource = null,
         CancellationToken ct = default)
     {
         var rawCode = GenerateCode();
@@ -33,6 +34,7 @@ public class OAuthAuthCodeService(
             CodeChallenge = codeChallenge,
             RedirectUri = redirectUri,
             Scope = scope,
+            Resource = resource,
             CreatedAt = DateTime.UtcNow,
             ExpiresAt = DateTime.UtcNow.Add(CodeExpiry),
         };
@@ -101,7 +103,7 @@ public class OAuthAuthCodeService(
 
         logger.LogInformation("OAuth code exchange succeeded for user {UserId}, client {ClientId}", entity.UserId, LogSanitizer.Sanitize(clientId));
 
-        return new OAuthCodeExchangeResult(entity.UserId, entity.Scope, entity.User.Email ?? entity.User.UserName ?? "");
+        return new OAuthCodeExchangeResult(entity.UserId, entity.Scope, entity.User.Email ?? entity.User.UserName ?? "", entity.Resource);
     }
 
     private static string GenerateCode()
@@ -123,4 +125,4 @@ public class OAuthAuthCodeService(
     }
 }
 
-public record OAuthCodeExchangeResult(Guid UserId, string Scope, string UserEmail);
+public record OAuthCodeExchangeResult(Guid UserId, string Scope, string UserEmail, string? Resource);

--- a/src/Connapse.Web/Components/Pages/Auth/OAuthAuthorize.razor
+++ b/src/Connapse.Web/Components/Pages/Auth/OAuthAuthorize.razor
@@ -64,7 +64,15 @@
             <strong>Settings &rsaquo; Access Tokens</strong>.
         </p>
 
-        <form method="post" @formname="oauth-authorize" data-enhance="true">
+        @* No data-enhance: the post redirects to a cross-origin OAuth client
+           callback (e.g. claude.ai). Blazor enhanced nav wraps forceLoad
+           redirects in /_framework/opaque-redirect, which re-encodes the target
+           URL through a DataProtection token — that extra hop mangles the
+           cross-origin callback for strict OAuth clients. A plain form POST
+           lets NavigationManager.NavigateTo(..., forceLoad: true) emit a real
+           302 Location header to the external redirect_uri, as OAuth 2.1
+           expects. *@
+        <form method="post" @formname="oauth-authorize">
             <AntiforgeryToken />
             <input type="hidden" name="Form.ResponseType" value="@ResponseType" />
             <input type="hidden" name="Form.ClientId" value="@ClientId" />

--- a/src/Connapse.Web/Components/Pages/Auth/OAuthAuthorize.razor
+++ b/src/Connapse.Web/Components/Pages/Auth/OAuthAuthorize.razor
@@ -208,7 +208,8 @@
         var effectiveScope = string.IsNullOrWhiteSpace(Scope) ? "knowledge:read knowledge:write" : Scope;
 
         var rawCode = await OAuthAuthCodeService.CreateAsync(
-            userId, ClientId!, CodeChallenge!, RedirectUri!, effectiveScope);
+            userId, ClientId!, CodeChallenge!, RedirectUri!, effectiveScope,
+            string.IsNullOrWhiteSpace(Resource) ? null : Resource);
 
         var callbackUrl = string.IsNullOrWhiteSpace(State)
             ? $"{RedirectUri}?code={Uri.EscapeDataString(rawCode)}"

--- a/src/Connapse.Web/Endpoints/AuthEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/AuthEndpoints.cs
@@ -43,7 +43,7 @@ public static class AuthEndpoints
 
             var roles = await userManager.GetRolesAsync(user);
             var claims = BuildClaims(user, roles);
-            var tokenResponse = await tokenService.GenerateTokenPairAsync(claims, user.Id, ct);
+            var tokenResponse = await tokenService.GenerateTokenPairAsync(claims, user.Id, cancellationToken: ct);
 
             user.LastLoginAt = DateTime.UtcNow;
             await userManager.UpdateAsync(user);

--- a/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
@@ -230,9 +230,12 @@ public static class OAuthEndpoints
         // RFC 8707: an incoming `resource` at refresh time must match what the
         // original token was bound to. Clients may omit it to request the same
         // resource (common with MCP clients that only send it at authorize).
+        // If the client sends a resource but the stored token isn't bound to
+        // one (pre-migration or legacy /api flow), reject — otherwise we'd
+        // silently issue a token with the static audience, which is exactly
+        // the mismatch strict clients discard.
         if (!string.IsNullOrWhiteSpace(resourceParam) &&
-            oldRefreshEntity?.Resource is not null &&
-            !string.Equals(resourceParam, oldRefreshEntity.Resource, StringComparison.Ordinal))
+            !string.Equals(resourceParam, oldRefreshEntity?.Resource, StringComparison.Ordinal))
         {
             return Results.Json(new { error = "invalid_target" }, statusCode: 400);
         }

--- a/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
@@ -84,9 +84,9 @@ public static class OAuthEndpoints
             return grantType switch
             {
                 "authorization_code" => await HandleAuthorizationCodeGrant(
-                    form, authCodeService, tokenService, userManager, dbContext, ct),
+                    ctx, form, authCodeService, tokenService, userManager, dbContext, ct),
                 "refresh_token" => await HandleRefreshTokenGrant(
-                    form, tokenService, dbContext, ct),
+                    ctx, form, tokenService, dbContext, ct),
                 _ => Results.Json(new { error = "unsupported_grant_type" }, statusCode: 400),
             };
         })
@@ -133,6 +133,7 @@ public static class OAuthEndpoints
     }
 
     private static async Task<IResult> HandleAuthorizationCodeGrant(
+        HttpContext ctx,
         IFormCollection form,
         OAuthAuthCodeService authCodeService,
         ITokenService tokenService,
@@ -144,6 +145,7 @@ public static class OAuthEndpoints
         var redirectUri = form["redirect_uri"].ToString();
         var clientId = form["client_id"].ToString();
         var codeVerifier = form["code_verifier"].ToString();
+        var resourceParam = form["resource"].ToString();
 
         if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(redirectUri) ||
             string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(codeVerifier))
@@ -155,21 +157,40 @@ public static class OAuthEndpoints
         if (exchangeResult is null)
             return Results.Json(new { error = "invalid_grant" }, statusCode: 400);
 
+        // RFC 8707 §2 / MCP §Token Audience Binding: if the client included a
+        // `resource` parameter at the token endpoint, it MUST match the value
+        // it presented at the authorization endpoint. Mismatches mean the
+        // client is requesting a token for a different audience than the user
+        // consented to — reject as invalid_target.
+        if (!string.IsNullOrWhiteSpace(resourceParam) &&
+            !string.Equals(resourceParam, exchangeResult.Resource, StringComparison.Ordinal))
+        {
+            return Results.Json(new { error = "invalid_target" }, statusCode: 400);
+        }
+
+        // Bind the access token's `aud` claim to the resource the client asked
+        // for so that MCP clients can verify the token was issued for their
+        // intended resource. If no resource was provided (legacy / non-MCP
+        // clients), fall back to the static server audience.
+        var audience = exchangeResult.Resource;
+
         var user = await userManager.FindByIdAsync(exchangeResult.UserId.ToString());
         if (user is null)
             return Results.Json(new { error = "invalid_grant" }, statusCode: 400);
 
         var roles = await userManager.GetRolesAsync(user);
         var claims = BuildClaims(user, roles, exchangeResult.Scope, clientId);
-        var tokenResponse = await tokenService.GenerateTokenPairAsync(claims, user.Id, ct);
+        var tokenResponse = await tokenService.GenerateTokenPairAsync(claims, user.Id, audience, ct);
 
-        // Tag the refresh token with the client_id
+        // Tag the refresh token with the client_id and the resource so refresh
+        // cycles keep the same `aud` binding.
         var refreshTokenHash = ComputeSha256Hex(tokenResponse.RefreshToken);
         var refreshEntity = await dbContext.RefreshTokens
             .FirstOrDefaultAsync(r => r.TokenHash == refreshTokenHash, ct);
         if (refreshEntity is not null)
         {
             refreshEntity.ClientId = clientId;
+            refreshEntity.Resource = exchangeResult.Resource;
             await dbContext.SaveChangesAsync(ct);
         }
 
@@ -184,6 +205,7 @@ public static class OAuthEndpoints
     }
 
     private static async Task<IResult> HandleRefreshTokenGrant(
+        HttpContext ctx,
         IFormCollection form,
         ITokenService tokenService,
         ConnapseIdentityDbContext dbContext,
@@ -191,10 +213,11 @@ public static class OAuthEndpoints
     {
         var refreshToken = form["refresh_token"].ToString();
         var clientId = form["client_id"].ToString();
+        var resourceParam = form["resource"].ToString();
         if (string.IsNullOrEmpty(refreshToken))
             return Results.Json(new { error = "invalid_request" }, statusCode: 400);
 
-        // Look up the old refresh token to validate client_id and propagate it
+        // Look up the old refresh token to validate client_id/resource and propagate them
         var oldTokenHash = ComputeSha256Hex(refreshToken);
         var oldRefreshEntity = await dbContext.RefreshTokens
             .FirstOrDefaultAsync(r => r.TokenHash == oldTokenHash, ct);
@@ -204,11 +227,22 @@ public static class OAuthEndpoints
             return Results.Json(new { error = "invalid_grant" }, statusCode: 400);
         }
 
+        // RFC 8707: an incoming `resource` at refresh time must match what the
+        // original token was bound to. Clients may omit it to request the same
+        // resource (common with MCP clients that only send it at authorize).
+        if (!string.IsNullOrWhiteSpace(resourceParam) &&
+            oldRefreshEntity?.Resource is not null &&
+            !string.Equals(resourceParam, oldRefreshEntity.Resource, StringComparison.Ordinal))
+        {
+            return Results.Json(new { error = "invalid_target" }, statusCode: 400);
+        }
+
         var tokenResponse = await tokenService.RefreshTokenAsync(refreshToken, ct);
         if (tokenResponse is null)
             return Results.Json(new { error = "invalid_grant" }, statusCode: 400);
 
-        // Tag the new refresh token with client_id
+        // Tag the new refresh token with client_id (Resource is already
+        // carried forward inside JwtTokenService.RefreshTokenAsync).
         if (!string.IsNullOrEmpty(clientId))
         {
             var newTokenHash = ComputeSha256Hex(tokenResponse.RefreshToken);


### PR DESCRIPTION
## Summary

Two related fixes that together unblock claude.ai / Claude Desktop custom MCP connectors against Connapse:

1. **Blazor enhanced-nav on the consent form** — `data-enhance` wrapped the cross-origin `redirect_uri` in `/_framework/opaque-redirect?url=<token>`, which OAuth 2.1 clients don't follow.
2. **Missing RFC 8707 resource binding** — token `aud` defaulted to the static server audience, so spec-compliant MCP clients (per MCP auth spec 2025-06-18 §Token Audience Binding) silently discarded the access token and restarted the auth flow.

### 1. Enhanced-nav fix (`OAuthAuthorize.razor`)

Removed `data-enhance="true"` from the consent form. The form's submit handler calls `NavigationManager.NavigateTo(redirectUri, forceLoad: true)` which needs to surface as a real HTTP 302 with a `Location` header. With enhanced nav, Blazor intercepts the response and emits `blazor-enhanced-nav-redirect-location: _framework/opaque-redirect?url=<DataProtection-token>` — a same-origin SPA hop that mangles cross-origin OAuth callbacks.

### 2. RFC 8707 resource binding

Per MCP auth spec 2025-06-18:
> MCP servers MUST validate that access tokens presented to them were issued specifically for them.
> MCP clients MUST implement and use the `resource` parameter as defined in RFC 8707.

Implementation:
- `resource` parameter captured at `/oauth/authorize`, persisted on the auth code row (new `oauth_auth_codes.resource` column).
- At `/oauth/token` (authorization_code grant), the stored `resource` is used as the JWT `aud` claim. If the client re-sends `resource` at token exchange, it must match the one bound to the code (else `invalid_target`).
- `resource` carried onto the refresh token row (new `refresh_tokens.resource` column) so refreshed access tokens keep the same audience. Refresh exchange validates any resubmitted `resource` the same way.
- Token validation accepts either the static server audience (legacy `/api` flows) **or** an absolute-URI audience whose scheme+authority matches the current request — one signing key serves both REST API and MCP.

### Observed behavior (before fix #2)

After applying fix #1 alone, the consent → callback → token exchange completes cleanly, but claude.ai never calls `/mcp` — it restarts the full OAuth flow because its client-side audience check rejects the issued token. That's the behavior the spec text quoted above mandates: a valid-looking token gets discarded because its `aud` doesn't match the resource the client asked for.

## Migration

`20260418071015_AddOAuthResourceBinding` adds `resource VARCHAR(2048) NULL` to both `oauth_auth_codes` and `refresh_tokens`. Backfill not required — existing sessions keep working via the static-audience path.

## Test plan

- [ ] Connect claude.ai custom MCP connector → consent → verify the client lands on `<client>/api/mcp/auth_callback?code=...&state=...`, completes token exchange, then successfully hits `/mcp`.
- [ ] Decoded access token has `aud` equal to the canonical MCP URL the client advertised in `resource`, not the static server audience.
- [ ] Refresh exchange issues a new access token with the same `aud`.
- [ ] Legacy `/api/v1/auth/token` flow still works (no `resource` → static audience).
- [ ] Deny flow still returns `error=access_denied`.
