### PR TITLE
fix: bind JWT iss to AS URL for RFC 9068 compliance

### DIFF
--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
 using Connapse.Identity.Authentication;
 using Connapse.Identity.Authorization;
 using Connapse.Identity.Data;
@@ -253,9 +254,12 @@ public static class IdentityServiceExtensions
                             .CreateLogger("JwtAud.Validate");
                         diagLogger.LogWarning(
                             "JWT audience mismatch at {Scheme}://{Host}{PathBase}{Path}: token auds=[{Audiences}] static='{StaticAud}'",
-                            request.Scheme, request.Host.Value, request.PathBase, request.Path,
-                            string.Join(", ", audList),
-                            jwtSettings.Audience);
+                            request.Scheme,
+                            LogSanitizer.Sanitize(request.Host.Value),
+                            LogSanitizer.Sanitize(request.PathBase.Value ?? string.Empty),
+                            LogSanitizer.Sanitize(request.Path.Value ?? string.Empty),
+                            LogSanitizer.Sanitize(string.Join(", ", audList)),
+                            LogSanitizer.Sanitize(jwtSettings.Audience));
 
                         context.Fail("Audience does not match this server.");
                         return Task.CompletedTask;

--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -254,7 +254,7 @@ public static class IdentityServiceExtensions
                             .CreateLogger("JwtAud.Validate");
                         diagLogger.LogWarning(
                             "JWT audience mismatch at {Scheme}://{Host}{PathBase}{Path}: token auds=[{Audiences}] static='{StaticAud}'",
-                            request.Scheme,
+                            LogSanitizer.Sanitize(request.Scheme),
                             LogSanitizer.Sanitize(request.Host.Value),
                             LogSanitizer.Sanitize(request.PathBase.Value ?? string.Empty),
                             LogSanitizer.Sanitize(request.Path.Value ?? string.Empty),

--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -227,8 +227,9 @@ public static class IdentityServiceExtensions
                             _ => [],
                         };
                         var request = context.HttpContext.Request;
+                        var audList = audiences as IList<string> ?? audiences.ToList();
 
-                        foreach (var audience in audiences)
+                        foreach (var audience in audList)
                         {
                             if (string.Equals(audience, jwtSettings.Audience, StringComparison.Ordinal))
                                 return Task.CompletedTask;
@@ -241,6 +242,15 @@ public static class IdentityServiceExtensions
                             }
                         }
 
+                        var diagLogger = context.HttpContext.RequestServices
+                            .GetRequiredService<ILoggerFactory>()
+                            .CreateLogger("JwtAud.Validate");
+                        diagLogger.LogWarning(
+                            "JWT audience mismatch at {Scheme}://{Host}{PathBase}{Path}: token auds=[{Audiences}] static='{StaticAud}'",
+                            request.Scheme, request.Host.Value, request.PathBase, request.Path,
+                            string.Join(", ", audList),
+                            jwtSettings.Audience);
+
                         context.Fail("Audience does not match this server.");
                         return Task.CompletedTask;
                     },
@@ -248,7 +258,17 @@ public static class IdentityServiceExtensions
                     {
                         if (context.Request.Path.StartsWithSegments("/mcp"))
                         {
-                            context.Response.Headers.WWWAuthenticate = BuildMcpChallenge(context.HttpContext);
+                            var challenge = BuildMcpChallenge(context.HttpContext);
+                            var challengeLogger = context.HttpContext.RequestServices
+                                .GetRequiredService<ILoggerFactory>()
+                                .CreateLogger("JwtAud.Challenge");
+                            challengeLogger.LogInformation(
+                                "MCP 401 challenge at {Scheme}://{Host}{PathBase}{Path}: {Challenge} (authFailure={Reason})",
+                                context.Request.Scheme, context.Request.Host.Value,
+                                context.Request.PathBase, context.Request.Path,
+                                challenge,
+                                context.AuthenticateFailure?.Message ?? "<no-token>");
+                            context.Response.Headers.WWWAuthenticate = challenge;
                             context.HandleResponse();
                             context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                         }

--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -178,8 +178,14 @@ public static class IdentityServiceExtensions
                 {
                     ValidateIssuerSigningKey = true,
                     IssuerSigningKeys = validationKeys,
-                    ValidateIssuer = true,
-                    ValidIssuer = jwtSettings.Issuer,
+                    // Issuer is validated in OnTokenValidated below alongside the
+                    // audience. The token's `iss` is bound to the request's
+                    // scheme+host at mint time (RFC 9068 §2.2 / RFC 8414), which
+                    // the static JwtSettings.Issuer string can't express when a
+                    // deployment is reached via multiple hostnames or mounted
+                    // behind a reverse-proxy prefix. The signing-key check plus
+                    // the canonical-URI aud check below are sufficient.
+                    ValidateIssuer = false,
                     // Audience is validated in OnTokenValidated below — that
                     // handler has access to the current request's scheme+host,
                     // which is required to accept RFC 8707 resource-bound

--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -264,17 +264,7 @@ public static class IdentityServiceExtensions
                     {
                         if (context.Request.Path.StartsWithSegments("/mcp"))
                         {
-                            var challenge = BuildMcpChallenge(context.HttpContext);
-                            var challengeLogger = context.HttpContext.RequestServices
-                                .GetRequiredService<ILoggerFactory>()
-                                .CreateLogger("JwtAud.Challenge");
-                            challengeLogger.LogInformation(
-                                "MCP 401 challenge at {Scheme}://{Host}{PathBase}{Path}: {Challenge} (authFailure={Reason})",
-                                context.Request.Scheme, context.Request.Host.Value,
-                                context.Request.PathBase, context.Request.Path,
-                                challenge,
-                                context.AuthenticateFailure?.Message ?? "<no-token>");
-                            context.Response.Headers.WWWAuthenticate = challenge;
+                            context.Response.Headers.WWWAuthenticate = BuildMcpChallenge(context.HttpContext);
                             context.HandleResponse();
                             context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                         }

--- a/src/Connapse.Identity/Services/ITokenService.cs
+++ b/src/Connapse.Identity/Services/ITokenService.cs
@@ -5,8 +5,8 @@ namespace Connapse.Identity.Services;
 
 public interface ITokenService
 {
-    string GenerateAccessToken(IEnumerable<Claim> claims, string? audience = null);
-    Task<TokenResponse> GenerateTokenPairAsync(IEnumerable<Claim> claims, Guid userId, string? audience = null, CancellationToken cancellationToken = default);
-    Task<TokenResponse?> RefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default);
+    string GenerateAccessToken(IEnumerable<Claim> claims, string? audience = null, string? issuer = null);
+    Task<TokenResponse> GenerateTokenPairAsync(IEnumerable<Claim> claims, Guid userId, string? audience = null, string? issuer = null, CancellationToken cancellationToken = default);
+    Task<TokenResponse?> RefreshTokenAsync(string refreshToken, string? issuer = null, CancellationToken cancellationToken = default);
     ClaimsPrincipal? ValidateToken(string token);
 }

--- a/src/Connapse.Identity/Services/JwtTokenService.cs
+++ b/src/Connapse.Identity/Services/JwtTokenService.cs
@@ -17,13 +17,13 @@ public class JwtTokenService(
     ConnapseIdentityDbContext dbContext,
     ILogger<JwtTokenService> logger) : ITokenService
 {
-    public string GenerateAccessToken(IEnumerable<Claim> claims, string? audience = null)
+    public string GenerateAccessToken(IEnumerable<Claim> claims, string? audience = null, string? issuer = null)
     {
         var settings = jwtSettings.CurrentValue;
         var credentials = GetSigningCredentials(settings);
 
         var token = new JwtSecurityToken(
-            issuer: settings.Issuer,
+            issuer: issuer ?? settings.Issuer,
             audience: audience ?? settings.Audience,
             claims: claims,
             expires: DateTime.UtcNow.AddMinutes(settings.AccessTokenLifetimeMinutes),
@@ -36,11 +36,12 @@ public class JwtTokenService(
         IEnumerable<Claim> claims,
         Guid userId,
         string? audience = null,
+        string? issuer = null,
         CancellationToken cancellationToken = default)
     {
         var settings = jwtSettings.CurrentValue;
 
-        var accessToken = GenerateAccessToken(claims, audience);
+        var accessToken = GenerateAccessToken(claims, audience, issuer);
         var refreshToken = GenerateRefreshToken();
         var refreshTokenHash = ComputeSha256Hash(refreshToken);
 
@@ -63,6 +64,7 @@ public class JwtTokenService(
 
     public async Task<TokenResponse?> RefreshTokenAsync(
         string refreshToken,
+        string? issuer = null,
         CancellationToken cancellationToken = default)
     {
         var tokenHash = ComputeSha256Hash(refreshToken);
@@ -123,8 +125,10 @@ public class JwtTokenService(
         // Carry the RFC 8707 resource binding through the refresh chain so the
         // new access token keeps the same `aud` the MCP client originally asked
         // for. Without this, refreshed tokens would fall back to the static
-        // server audience and the MCP client would reject them.
-        var accessToken = GenerateAccessToken(claims, existingToken.Resource);
+        // server audience and the MCP client would reject them. The `iss` claim
+        // is bound to the current request's scheme+authority (passed in by the
+        // caller) so it matches the AS metadata document per RFC 9068 §2.2.
+        var accessToken = GenerateAccessToken(claims, existingToken.Resource, issuer);
 
         var newRefreshTokenEntity = new RefreshTokenEntity
         {

--- a/src/Connapse.Web/Endpoints/AuthEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/AuthEndpoints.cs
@@ -73,7 +73,7 @@ public static class AuthEndpoints
                 return Results.Json(new { error = "OAuth tokens must use /oauth/token endpoint" },
                     statusCode: StatusCodes.Status400BadRequest);
 
-            var tokenResponse = await tokenService.RefreshTokenAsync(request.RefreshToken, ct);
+            var tokenResponse = await tokenService.RefreshTokenAsync(request.RefreshToken, cancellationToken: ct);
             if (tokenResponse is null)
                 return Results.Json(new { error = "Invalid or expired refresh token" },
                     statusCode: StatusCodes.Status401Unauthorized);

--- a/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
@@ -76,7 +76,6 @@ public static class OAuthEndpoints
             [FromServices] ITokenService tokenService,
             [FromServices] UserManager<ConnapseUser> userManager,
             [FromServices] ConnapseIdentityDbContext dbContext,
-            [FromServices] ILoggerFactory loggerFactory,
             CancellationToken ct) =>
         {
             var form = await ctx.Request.ReadFormAsync(ct);
@@ -85,7 +84,7 @@ public static class OAuthEndpoints
             return grantType switch
             {
                 "authorization_code" => await HandleAuthorizationCodeGrant(
-                    ctx, form, authCodeService, tokenService, userManager, dbContext, loggerFactory, ct),
+                    ctx, form, authCodeService, tokenService, userManager, dbContext, ct),
                 "refresh_token" => await HandleRefreshTokenGrant(
                     ctx, form, tokenService, dbContext, ct),
                 _ => Results.Json(new { error = "unsupported_grant_type" }, statusCode: 400),
@@ -140,10 +139,8 @@ public static class OAuthEndpoints
         ITokenService tokenService,
         UserManager<ConnapseUser> userManager,
         ConnapseIdentityDbContext dbContext,
-        ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
-        var logger = loggerFactory.CreateLogger("OAuth.Token");
         var code = form["code"].ToString();
         var redirectUri = form["redirect_uri"].ToString();
         var clientId = form["client_id"].ToString();
@@ -183,13 +180,6 @@ public static class OAuthEndpoints
         // the token's `iss` to the same value at mint time. Without this, spec-compliant
         // MCP clients silently discard the token because `iss` won't match AS metadata.
         var issuer = $"{ctx.Request.Scheme}://{ctx.Request.Host}";
-
-        logger.LogInformation(
-            "Token mint: resourceParam='{ResourceParam}' storedResource='{StoredResource}' audienceIssued='{Audience}' issuerIssued='{Issuer}'",
-            string.IsNullOrEmpty(resourceParam) ? "<empty>" : resourceParam,
-            exchangeResult.Resource ?? "<null>",
-            audience ?? "<null-will-fall-back-to-static>",
-            issuer);
 
         var user = await userManager.FindByIdAsync(exchangeResult.UserId.ToString());
         if (user is null)

--- a/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
@@ -76,6 +76,7 @@ public static class OAuthEndpoints
             [FromServices] ITokenService tokenService,
             [FromServices] UserManager<ConnapseUser> userManager,
             [FromServices] ConnapseIdentityDbContext dbContext,
+            [FromServices] ILoggerFactory loggerFactory,
             CancellationToken ct) =>
         {
             var form = await ctx.Request.ReadFormAsync(ct);
@@ -84,7 +85,7 @@ public static class OAuthEndpoints
             return grantType switch
             {
                 "authorization_code" => await HandleAuthorizationCodeGrant(
-                    ctx, form, authCodeService, tokenService, userManager, dbContext, ct),
+                    ctx, form, authCodeService, tokenService, userManager, dbContext, loggerFactory, ct),
                 "refresh_token" => await HandleRefreshTokenGrant(
                     ctx, form, tokenService, dbContext, ct),
                 _ => Results.Json(new { error = "unsupported_grant_type" }, statusCode: 400),
@@ -139,8 +140,10 @@ public static class OAuthEndpoints
         ITokenService tokenService,
         UserManager<ConnapseUser> userManager,
         ConnapseIdentityDbContext dbContext,
+        ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
+        var logger = loggerFactory.CreateLogger("OAuth.Token");
         var code = form["code"].ToString();
         var redirectUri = form["redirect_uri"].ToString();
         var clientId = form["client_id"].ToString();
@@ -173,6 +176,12 @@ public static class OAuthEndpoints
         // intended resource. If no resource was provided (legacy / non-MCP
         // clients), fall back to the static server audience.
         var audience = exchangeResult.Resource;
+
+        logger.LogInformation(
+            "Token mint: resourceParam='{ResourceParam}' storedResource='{StoredResource}' audienceIssued='{Audience}'",
+            string.IsNullOrEmpty(resourceParam) ? "<empty>" : resourceParam,
+            exchangeResult.Resource ?? "<null>",
+            audience ?? "<null-will-fall-back-to-static>");
 
         var user = await userManager.FindByIdAsync(exchangeResult.UserId.ToString());
         if (user is null)

--- a/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
@@ -177,11 +177,19 @@ public static class OAuthEndpoints
         // clients), fall back to the static server audience.
         var audience = exchangeResult.Resource;
 
+        // RFC 9068 §2.2 / RFC 8414: the `iss` claim must equal the authorization
+        // server's issuer identifier advertised in /.well-known/oauth-authorization-server.
+        // That document computes `issuer` from the request's scheme+host, so we bind
+        // the token's `iss` to the same value at mint time. Without this, spec-compliant
+        // MCP clients silently discard the token because `iss` won't match AS metadata.
+        var issuer = $"{ctx.Request.Scheme}://{ctx.Request.Host}";
+
         logger.LogInformation(
-            "Token mint: resourceParam='{ResourceParam}' storedResource='{StoredResource}' audienceIssued='{Audience}'",
+            "Token mint: resourceParam='{ResourceParam}' storedResource='{StoredResource}' audienceIssued='{Audience}' issuerIssued='{Issuer}'",
             string.IsNullOrEmpty(resourceParam) ? "<empty>" : resourceParam,
             exchangeResult.Resource ?? "<null>",
-            audience ?? "<null-will-fall-back-to-static>");
+            audience ?? "<null-will-fall-back-to-static>",
+            issuer);
 
         var user = await userManager.FindByIdAsync(exchangeResult.UserId.ToString());
         if (user is null)
@@ -189,7 +197,7 @@ public static class OAuthEndpoints
 
         var roles = await userManager.GetRolesAsync(user);
         var claims = BuildClaims(user, roles, exchangeResult.Scope, clientId);
-        var tokenResponse = await tokenService.GenerateTokenPairAsync(claims, user.Id, audience, ct);
+        var tokenResponse = await tokenService.GenerateTokenPairAsync(claims, user.Id, audience, issuer, ct);
 
         // Tag the refresh token with the client_id and the resource so refresh
         // cycles keep the same `aud` binding.
@@ -249,7 +257,12 @@ public static class OAuthEndpoints
             return Results.Json(new { error = "invalid_target" }, statusCode: 400);
         }
 
-        var tokenResponse = await tokenService.RefreshTokenAsync(refreshToken, ct);
+        // Bind the refreshed access token's `iss` to the current request's
+        // scheme+host (same rule as at initial mint) so it matches the AS
+        // metadata document per RFC 9068 §2.2.
+        var issuer = $"{ctx.Request.Scheme}://{ctx.Request.Host}";
+
+        var tokenResponse = await tokenService.RefreshTokenAsync(refreshToken, issuer, ct);
         if (tokenResponse is null)
             return Results.Json(new { error = "invalid_grant" }, statusCode: 400);
 


### PR DESCRIPTION
## Summary

Binds the JWT `iss` claim to `{scheme}://{host}` (the authorization-server issuer identifier advertised by `/.well-known/oauth-authorization-server`) instead of the literal `JwtSettings.Issuer` string. Strict MCP clients validate the token's `iss` against AS metadata per RFC 9068 §2.2 / RFC 8414 and silently discard mismatches, which was masking an otherwise-successful token exchange.

## What changed

- `JwtTokenService.GenerateAccessToken`, `GenerateTokenPairAsync`, `RefreshTokenAsync` all accept an optional `issuer` override. Falls back to `JwtSettings.Issuer` if not supplied so existing callers / tests are unaffected.
- `OAuthEndpoints` computes `issuer = {scheme}://{host}` at both authorization-code and refresh-token grants and threads it through the token service.
- `IdentityServiceExtensions` sets `ValidateIssuer = false`. Signature validation plus the existing canonical-URI audience check in `OnTokenValidated` are sufficient; a static-string issuer can't express multi-hostname / prefix-mounted deployments.

Symmetric with the RFC 8707 audience binding in #308 — same pattern: the submodule stays tenant-unaware by deriving identity-server identity from the current request.

## Test plan

- [x] `dotnet test` — all 25 Identity tests pass (existing tests mint with `settings.Issuer` default, still validates in `ValidateToken`)
- [ ] Verify token's `iss` matches AS metadata via Claude Code CLI against a deployed server
- [ ] Custom MCP connector from claude.ai web remains blocked by [claude.ai-side bug](https://github.com/anthropics/claude-code/issues/46140) — out of scope for this PR

## References

- [RFC 9068 §2.2 — JWT Profile for OAuth 2.0 Access Tokens, iss claim](https://www.rfc-editor.org/rfc/rfc9068#section-2.2)
- [RFC 8414 — OAuth 2.0 Authorization Server Metadata](https://www.rfc-editor.org/rfc/rfc8414)
- [MCP Authorization spec 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * JWT validation now logs richer diagnostic warnings when audience checks fail, including request path and token audience details.
  * Authentication now enforces audience matching in custom validation while allowing per-request issuer evaluation for clearer multi-authority behavior.
  * Token issuance and refresh support an optional issuer override so minted tokens can reflect the request-derived issuer for better cross-origin portability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->