### PR TITLE
feat(oauth): capture client IP on DCR for forensics

### DIFF
--- a/src/Connapse.Identity/Data/ConnapseIdentityDbContext.cs
+++ b/src/Connapse.Identity/Data/ConnapseIdentityDbContext.cs
@@ -508,6 +508,10 @@ public class ConnapseIdentityDbContext(DbContextOptions<ConnapseIdentityDbContex
                 .HasMaxLength(16)
                 .IsRequired();
 
+            entity.Property(e => e.RegisteredFromIp)
+                .HasColumnName("registered_from_ip")
+                .HasMaxLength(45);
+
             entity.Property(e => e.CreatedAt)
                 .HasColumnName("created_at")
                 .HasDefaultValueSql("now()");

--- a/src/Connapse.Identity/Data/Entities/OAuthClientEntity.cs
+++ b/src/Connapse.Identity/Data/Entities/OAuthClientEntity.cs
@@ -8,5 +8,6 @@ public class OAuthClientEntity
     public string ClientName { get; set; } = "";
     public string RedirectUris { get; set; } = "[]";
     public string ApplicationType { get; set; } = "native";
+    public string? RegisteredFromIp { get; set; }
     public DateTime CreatedAt { get; set; }
 }

--- a/src/Connapse.Identity/Migrations/20260419194230_AddOAuthClientRegisteredFromIp.Designer.cs
+++ b/src/Connapse.Identity/Migrations/20260419194230_AddOAuthClientRegisteredFromIp.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Connapse.Identity.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Connapse.Identity.Migrations
 {
     [DbContext(typeof(ConnapseIdentityDbContext))]
-    partial class ConnapseIdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419194230_AddOAuthClientRegisteredFromIp")]
+    partial class AddOAuthClientRegisteredFromIp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Connapse.Identity/Migrations/20260419194230_AddOAuthClientRegisteredFromIp.cs
+++ b/src/Connapse.Identity/Migrations/20260419194230_AddOAuthClientRegisteredFromIp.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Connapse.Identity.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOAuthClientRegisteredFromIp : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "registered_from_ip",
+                table: "oauth_clients",
+                type: "character varying(45)",
+                maxLength: 45,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "registered_from_ip",
+                table: "oauth_clients");
+        }
+    }
+}

--- a/src/Connapse.Identity/Services/OAuthClientService.cs
+++ b/src/Connapse.Identity/Services/OAuthClientService.cs
@@ -18,6 +18,7 @@ public class OAuthClientService(
         string clientName,
         List<string> redirectUris,
         string applicationType,
+        string? registeredFromIp = null,
         CancellationToken ct = default)
     {
         ValidateRedirectUris(redirectUris, applicationType);
@@ -30,13 +31,18 @@ public class OAuthClientService(
             ClientName = clientName,
             RedirectUris = JsonSerializer.Serialize(redirectUris),
             ApplicationType = applicationType,
+            RegisteredFromIp = registeredFromIp,
             CreatedAt = DateTime.UtcNow,
         };
 
         dbContext.OAuthClients.Add(entity);
         await dbContext.SaveChangesAsync(ct);
 
-        logger.LogInformation("OAuth client registered: {ClientId} ({ClientName})", clientId, LogSanitizer.Sanitize(clientName));
+        logger.LogInformation(
+            "OAuth client registered: {ClientId} ({ClientName}) from {Ip}",
+            clientId,
+            LogSanitizer.Sanitize(clientName),
+            LogSanitizer.Sanitize(registeredFromIp ?? "unknown"));
 
         return new OAuthClientInfo(clientId, clientName, redirectUris, applicationType);
     }

--- a/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/OAuthEndpoints.cs
@@ -98,6 +98,7 @@ public static class OAuthEndpoints
         // -- Dynamic Client Registration --
 
         app.MapPost("/oauth/register", async (
+            HttpContext ctx,
             [FromBody] ClientRegistrationRequest request,
             [FromServices] OAuthClientService clientService,
             CancellationToken ct) =>
@@ -108,6 +109,7 @@ public static class OAuthEndpoints
                     request.ClientName,
                     request.RedirectUris,
                     request.ApplicationType ?? "web",
+                    ctx.Connection.RemoteIpAddress?.ToString(),
                     ct);
 
                 return Results.Json(new

--- a/tests/Connapse.Identity.Tests/OAuthClientServiceTests.cs
+++ b/tests/Connapse.Identity.Tests/OAuthClientServiceTests.cs
@@ -49,6 +49,32 @@ public class OAuthClientServiceTests
     }
 
     [Fact]
+    public async Task RegisterAsync_WithIp_PersistsIp()
+    {
+        using var db = CreateDbContext();
+        var sut = CreateService(db);
+
+        await sut.RegisterAsync(
+            "Test Client", ["http://127.0.0.1:3000/callback"], "native", "203.0.113.42");
+
+        var entity = await db.OAuthClients.SingleAsync();
+        entity.RegisteredFromIp.Should().Be("203.0.113.42");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_WithoutIp_PersistsNullIp()
+    {
+        using var db = CreateDbContext();
+        var sut = CreateService(db);
+
+        await sut.RegisterAsync(
+            "Test Client", ["http://127.0.0.1:3000/callback"], "native");
+
+        var entity = await db.OAuthClients.SingleAsync();
+        entity.RegisteredFromIp.Should().BeNull();
+    }
+
+    [Fact]
     public async Task RegisterAsync_InvalidRedirectUri_Throws()
     {
         using var db = CreateDbContext();


### PR DESCRIPTION
## Summary

- Adds `registered_from_ip` (nullable, max 45 chars for IPv6) to `oauth_clients` and records the remote IP on `POST /oauth/register`.
- Forensic-only field for the RFC 7591 open DCR endpoint. OAuth 2.1 allows public clients to self-register with `token_endpoint_auth_method=none`, which means anyone on the internet can mint rows here — IP capture gives us something to correlate when investigating suspicious DCR activity or tuning rate limits.
- No change to auth flow, no breaking changes: the service parameter is optional (defaults to `null`), existing callers compile unchanged.

## Changes

- `OAuthClientEntity.RegisteredFromIp` (nullable)
- EF migration `AddOAuthClientRegisteredFromIp`
- `OAuthClientService.RegisterAsync` gains optional `registeredFromIp` parameter
- DCR endpoint passes `HttpContext.Connection.RemoteIpAddress`
- Log line at registration now includes the IP (sanitized)
- Unit tests cover both the IP-captured and null-IP paths

## Test plan

- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet test tests/Connapse.Identity.Tests --filter OAuthClientServiceTests` — 13/13 pass (11 existing + 2 new)
- [ ] Manual: `curl -X POST /oauth/register` after deploy → confirm row has IP