### PR TITLE
Make ProfileLayout brand logo overridable per deployment

### DIFF
--- a/src/Connapse.Web/Components/Layout/ProfileLayout.razor
+++ b/src/Connapse.Web/Components/Layout/ProfileLayout.razor
@@ -7,7 +7,7 @@
         <div class="top-row ps-3 navbar navbar-dark">
             <div class="container-fluid">
                 <a class="navbar-brand" href="@_backUrl">
-                    <img src="connapse-logo.svg" alt="Connapse" class="navbar-logo" />
+                    <img src="@MenuProvider.LogoUrl" alt="Connapse" class="navbar-logo" />
                 </a>
             </div>
         </div>

--- a/src/Connapse.Web/Services/IProfileMenuProvider.cs
+++ b/src/Connapse.Web/Services/IProfileMenuProvider.cs
@@ -6,4 +6,11 @@ public interface IProfileMenuProvider
 {
     Task<IReadOnlyList<ProfileMenuItem>> GetItemsAsync();
     string BackUrl { get; }
+
+    /// <summary>
+    /// Brand image rendered at the top of the profile sidebar.
+    /// Default: <c>connapse-logo.svg</c>. Downstream apps with their own
+    /// branding (e.g. multi-tenant Cloud) override this.
+    /// </summary>
+    string LogoUrl => "connapse-logo.svg";
 }

--- a/tests/Connapse.Web.Tests/Services/DefaultProfileMenuProviderTests.cs
+++ b/tests/Connapse.Web.Tests/Services/DefaultProfileMenuProviderTests.cs
@@ -27,4 +27,12 @@ public class DefaultProfileMenuProviderTests
 
         provider.BackUrl.Should().Be("/");
     }
+
+    [Fact]
+    public void LogoUrl_IsConnapseLogo()
+    {
+        IProfileMenuProvider provider = new DefaultProfileMenuProvider();
+
+        provider.LogoUrl.Should().Be("connapse-logo.svg");
+    }
 }


### PR DESCRIPTION
Closes #321

## Summary
Adds a `LogoUrl` property to `IProfileMenuProvider` (default `"connapse-logo.svg"`). `ProfileLayout` now renders `MenuProvider.LogoUrl` instead of the literal string, so downstream apps with their own branding can override it.

OSS behavior is unchanged — the default returns the same string the layout used before.

## Why interface change instead of file shadow
Cloud's wwwroot can't shadow `connapse-logo.svg` because Connapse.Web is a web app (not a Razor class library), so static-asset conflict resolution rejects equal-priority duplicates with `error : Conflicting assets with the same target path`. Making the layout's logo source injectable is the cleanest path.

## Test plan
- [x] `dotnet test tests/Connapse.Web.Tests` — 3 unit tests pass (added `LogoUrl_IsConnapseLogo`)
- [x] `dotnet build src/Connapse.Web/Connapse.Web.csproj` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)