### PR TITLE
feat(mcp): steer agents toward search_knowledge with precise routing rules

### DIFF
--- a/src/Connapse.Web/Mcp/McpServerConfig.cs
+++ b/src/Connapse.Web/Mcp/McpServerConfig.cs
@@ -8,16 +8,35 @@ namespace Connapse.Web.Mcp;
 public static class McpServerConfig
 {
     /// <summary>
-    /// ServerInstructions delivered to MCP clients on connect. Tells the agent how
-    /// to route across container_list / search_knowledge / list_files / get_document.
+    /// ServerInstructions delivered to MCP clients on connect. Numbered disjoint
+    /// conditional rules — designed for literally-compliant reasoning models
+    /// (e.g., Claude Opus 4.7) per the v2 spec.
     /// </summary>
     public const string McpServerInstructions =
-        "Connapse is a retrieval-augmented knowledge base. For ANY question-answering or " +
-        "research task over container contents, call `search_knowledge` FIRST — it returns " +
-        "the relevant ranked passages directly with citations. " +
-        "Use `list_files` ONLY when the user explicitly asks for a file inventory or names " +
-        "a specific filename to look up. Use `get_document` ONLY after `search_knowledge` " +
-        "returns a `DocumentId` you need to read in full. " +
-        "Enumerating files and reading them one by one to answer content questions will " +
-        "exceed context and produce worse answers than a single `search_knowledge` call.";
+        """
+        Connapse is a retrieval-augmented knowledge base with four primary tools:
+        `container_list`, `search_knowledge`, `list_files`, and `get_document`.
+
+        Routing rules for question-answering:
+
+        1. If the user's question (or the prior conversation) names a specific
+           container, call `search_knowledge` directly on that container.
+           Do NOT call `container_list` first — the container is already known.
+
+        2. Only call `container_list` when the relevant container is genuinely
+           unknown and cannot be inferred from context. After it returns, call
+           `search_knowledge` on the chosen container.
+
+        3. Use `list_files` only for inventory questions ("what files are in X?",
+           "list the docs under /folder"). Never use `list_files` as a substitute
+           for `search_knowledge` when the user is asking about file CONTENT.
+
+        4. Use `get_document` only when `search_knowledge` has returned a specific
+           `DocumentId` you need to read in full, or when the user named an exact
+           file by path.
+
+        Enumerating files and reading them one by one to answer content questions
+        will exceed context and produce worse answers than a single
+        `search_knowledge` call.
+        """;
 }

--- a/src/Connapse.Web/Mcp/McpServerConfig.cs
+++ b/src/Connapse.Web/Mcp/McpServerConfig.cs
@@ -1,0 +1,23 @@
+namespace Connapse.Web.Mcp;
+
+/// <summary>
+/// Centralizes the MCP server configuration strings that Program.cs ships to the
+/// ModelContextProtocol SDK. Extracted here so the routing-rule text can be
+/// regression-tested without lighting up an MCP integration fixture.
+/// </summary>
+public static class McpServerConfig
+{
+    /// <summary>
+    /// ServerInstructions delivered to MCP clients on connect. Tells the agent how
+    /// to route across container_list / search_knowledge / list_files / get_document.
+    /// </summary>
+    public const string McpServerInstructions =
+        "Connapse is a retrieval-augmented knowledge base. For ANY question-answering or " +
+        "research task over container contents, call `search_knowledge` FIRST — it returns " +
+        "the relevant ranked passages directly with citations. " +
+        "Use `list_files` ONLY when the user explicitly asks for a file inventory or names " +
+        "a specific filename to look up. Use `get_document` ONLY after `search_knowledge` " +
+        "returns a `DocumentId` you need to read in full. " +
+        "Enumerating files and reading them one by one to answer content questions will " +
+        "exceed context and produce worse answers than a single `search_knowledge` call.";
+}

--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -54,7 +54,14 @@ public class McpTools
         if (containers.Count == 0)
             return "No containers found.";
 
-        var text = "TIP: To answer a question, pick the container whose description best matches the topic, then call `search_knowledge(query=\"...\", containerId=\"<name>\")`. Do NOT enumerate files with `list_files` to find an answer — `search_knowledge` returns the relevant passages directly.\n\n";
+        // Conditional TIP: only emit when there's an actual routing decision to make
+        // (i.e., more than one container). For a single container the agent has no
+        // choice; the TIP would be wasted output tokens.
+        var text = "";
+        if (containers.Count > 1)
+        {
+            text = "TIP: Pick the container whose description best matches the topic, then call `search_knowledge(query=\"...\", containerId=\"<name>\")`.\n\n";
+        }
         text += $"Found {containers.Count} container(s):\n\n";
         foreach (var c in containers)
         {

--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -235,7 +235,7 @@ public class McpTools
             .Where(d => string.Equals(PathUtilities.GetParentPath(d.Path), normalizedPath, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
-        var visibleEntries = folderNames.Count + directChildDocs.Count;
+        int visibleEntries = folderNames.Count + directChildDocs.Count;
 
         // Soft-error path: refuse to dump large listings unless agent explicitly opts in.
         // Teaches the agent to reach for `search_knowledge` instead of enumeration.
@@ -248,9 +248,9 @@ public class McpTools
 
         var text = $"TIP: This listing contains {directChildDocs.Count} file(s) and {folderNames.Count} folder(s) at this level but NO file contents. To answer questions about what these files contain, call `search_knowledge(query=\"...\", containerId=\"{containerId}\")` instead — it returns the relevant passages directly without you having to read each file. Use this listing only if the user explicitly asked for an inventory or named a specific filename.\n\n";
         text += $"Contents of {normalizedPath}:\n\n";
-        var hasEntries = false;
-        var rendered = 0;
-        var effectiveLimit = limit ?? int.MaxValue;
+        bool hasEntries = false;
+        int rendered = 0;
+        int effectiveLimit = limit ?? int.MaxValue;
 
         foreach (var folderName in folderNames.OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
         {

--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -253,7 +253,14 @@ public class McpTools
                    $"If you genuinely need the full inventory, retry with `confirmLarge: true`, or paginate with `limit: 25`.";
         }
 
-        var text = $"TIP: This listing contains {directChildDocs.Count} file(s) and {folderNames.Count} folder(s) at this level but NO file contents. To answer questions about what these files contain, call `search_knowledge(query=\"...\", containerId=\"{containerId}\")` instead — it returns the relevant passages directly without you having to read each file. Use this listing only if the user explicitly asked for an inventory or named a specific filename.\n\n";
+        // Conditional TIP: only emit when at the container root with multiple entries —
+        // the case where agent-wandering is the failure mode. Sub-folder listings and
+        // single-entry listings are usually intentional targeting; TIP would be wasted.
+        var text = "";
+        if (normalizedPath == "/" && visibleEntries > 1)
+        {
+            text = $"TIP: This lists folder/file names only — for file contents, call `search_knowledge(query=\"...\", containerId=\"{containerId}\")`.\n\n";
+        }
         text += $"Contents of {normalizedPath}:\n\n";
         bool hasEntries = false;
         int rendered = 0;

--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -43,7 +43,7 @@ public class McpTools
     }
 
     [McpServerTool(Name = "container_list", ReadOnly = true, Idempotent = true),
-     Description("ENTRY POINT for Connapse: lists every container with its description and document count. Call this FIRST when you don't know which container holds the answer — read the descriptions, pick the most relevant container, then call `search_knowledge` with that container's ID or name.")]
+     Description("Lists all containers with their descriptions and document counts. Use to discover what containers exist when the target is unknown; if the user already named a container, call `search_knowledge` on it directly instead.")]
     public static async Task<string> ContainerList(
         IServiceProvider services,
         CancellationToken ct = default)
@@ -97,7 +97,7 @@ public class McpTools
     }
 
     [McpServerTool(Name = "search_knowledge", ReadOnly = true, Idempotent = true),
-     Description("PREFERRED tool for question-answering, research, and any content lookup. Returns the most relevant passages from a container with citations, scores, and document IDs — call this FIRST instead of enumerating files. Default mode is Hybrid (semantic + keyword), which works well without tuning. If the first query returns thin results, refine the query and call again rather than falling back to `list_files`.")]
+     Description("Search a container using semantic, keyword, or hybrid mode (Hybrid is the default and works well without tuning). Returns ranked passages with citations, scores, and document IDs. If the first query returns thin results, refine the query and call again.")]
     public static async Task<string> SearchKnowledge(
         IServiceProvider services,
         [Description("The search query text")] string query,
@@ -178,7 +178,7 @@ public class McpTools
     }
 
     [McpServerTool(Name = "list_files", ReadOnly = true, Idempotent = true),
-     Description("INVENTORY ONLY. DO NOT use this to answer questions about file contents — call `search_knowledge` instead, which returns relevant passages directly. Use `list_files` only when the user explicitly asks for a file inventory, asks what filenames exist, or has named a specific filename they want to find. Returns folder entries and document IDs but NOT file contents. Large containers will return a soft error directing you to `search_knowledge`.")]
+     Description("Lists folder entries and document IDs at a path within a container (does NOT return file contents — for content questions, use `search_knowledge`). Intended for inventory requests such as 'what files exist in X' or when the user named a specific filename. Large listings return a soft error directing you to `search_knowledge`; override with `confirmLarge: true` or paginate with `limit`.")]
     public static async Task<string> ListFiles(
         IServiceProvider services,
         [Description("Container ID or name")] string containerId,
@@ -573,7 +573,7 @@ public class McpTools
     }
 
     [McpServerTool(Name = "get_document", ReadOnly = true, Idempotent = true),
-     Description("Retrieve a single document's FULL text. Use only when `search_knowledge` has returned a specific `DocumentId` you need to read in entirety, or when the user has named an exact file. For question-answering, prefer `search_knowledge` — it returns the relevant passages with citations and is far cheaper in tokens than reading whole documents.")]
+     Description("Retrieve a single document's full text by ID or path. Returns extracted text for binary formats (PDF, DOCX, PPTX). Intended for use after `search_knowledge` returns a `DocumentId` worth reading in entirety, or when the user has named an exact file.")]
     public static async Task<string> GetDocument(
         IServiceProvider services,
         [Description("Container ID or name")] string containerId,

--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -14,6 +14,11 @@ namespace Connapse.Web.Mcp;
 [McpServerToolType]
 public class McpTools
 {
+    // Threshold above which `list_files` returns a soft error steering the agent to
+    // `search_knowledge`. The agent can override with `confirmLarge: true` or paginate with `limit`.
+    internal const int ListFilesSoftLimit = 50;
+
+
     [McpServerTool(Name = "container_create"),
      Description("Create a new container for organizing documents. Use when setting up a new knowledge domain or project.")]
     public static async Task<string> ContainerCreate(
@@ -38,7 +43,7 @@ public class McpTools
     }
 
     [McpServerTool(Name = "container_list", ReadOnly = true, Idempotent = true),
-     Description("List all containers with document counts. Use to discover available knowledge bases before searching.")]
+     Description("ENTRY POINT for Connapse: lists every container with its description and document count. Call this FIRST when you don't know which container holds the answer — read the descriptions, pick the most relevant container, then call `search_knowledge` with that container's ID or name.")]
     public static async Task<string> ContainerList(
         IServiceProvider services,
         CancellationToken ct = default)
@@ -49,7 +54,8 @@ public class McpTools
         if (containers.Count == 0)
             return "No containers found.";
 
-        var text = $"Found {containers.Count} container(s):\n\n";
+        var text = "TIP: To answer a question, pick the container whose description best matches the topic, then call `search_knowledge(query=\"...\", containerId=\"<name>\")`. Do NOT enumerate files with `list_files` to find an answer — `search_knowledge` returns the relevant passages directly.\n\n";
+        text += $"Found {containers.Count} container(s):\n\n";
         foreach (var c in containers)
         {
             text += $"- {c.Name} ({c.DocumentCount} files)";
@@ -91,7 +97,7 @@ public class McpTools
     }
 
     [McpServerTool(Name = "search_knowledge", ReadOnly = true, Idempotent = true),
-     Description("Search a container using semantic, keyword, or hybrid mode. Returns ranked document chunks with scores. Use when answering questions from stored knowledge.")]
+     Description("PREFERRED tool for question-answering, research, and any content lookup. Returns the most relevant passages from a container with citations, scores, and document IDs — call this FIRST instead of enumerating files. Default mode is Hybrid (semantic + keyword), which works well without tuning. If the first query returns thin results, refine the query and call again rather than falling back to `list_files`.")]
     public static async Task<string> SearchKnowledge(
         IServiceProvider services,
         [Description("The search query text")] string query,
@@ -172,11 +178,13 @@ public class McpTools
     }
 
     [McpServerTool(Name = "list_files", ReadOnly = true, Idempotent = true),
-     Description("List files and folders at a path within a container. Use to browse container contents before retrieving documents.")]
+     Description("INVENTORY ONLY. DO NOT use this to answer questions about file contents — call `search_knowledge` instead, which returns relevant passages directly. Use `list_files` only when the user explicitly asks for a file inventory, asks what filenames exist, or has named a specific filename they want to find. Returns folder entries and document IDs but NOT file contents. Large containers will return a soft error directing you to `search_knowledge`.")]
     public static async Task<string> ListFiles(
         IServiceProvider services,
         [Description("Container ID or name")] string containerId,
         [Description("Folder path to list (default: root '/')")] string? path = null,
+        [Description($"Maximum number of entries to return. When set, large listings are truncated instead of returning a soft error. Recommended: 25.")] int? limit = null,
+        [Description("Set to true to confirm you intentionally want the full listing of a large folder. Without this, listings exceeding the soft limit return an error directing you to `search_knowledge`.")] bool? confirmLarge = null,
         CancellationToken ct = default)
     {
         var folderPath = path ?? "/";
@@ -222,27 +230,48 @@ public class McpTools
             }
         }
 
-        var text = $"Contents of {normalizedPath}:\n\n";
+        // Direct-child files (the only docs that actually render at this level)
+        var directChildDocs = documents
+            .Where(d => string.Equals(PathUtilities.GetParentPath(d.Path), normalizedPath, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var visibleEntries = folderNames.Count + directChildDocs.Count;
+
+        // Soft-error path: refuse to dump large listings unless agent explicitly opts in.
+        // Teaches the agent to reach for `search_knowledge` instead of enumeration.
+        if (visibleEntries > ListFilesSoftLimit && confirmLarge != true && !limit.HasValue)
+        {
+            return $"Error: '{normalizedPath}' contains {visibleEntries} entries, which exceeds the soft listing limit of {ListFilesSoftLimit}. " +
+                   $"For question-answering, call `search_knowledge(query=\"...\", containerId=\"{containerId}\")` instead — it returns the relevant passages directly. " +
+                   $"If you genuinely need the full inventory, retry with `confirmLarge: true`, or paginate with `limit: 25`.";
+        }
+
+        var text = $"TIP: This listing contains {directChildDocs.Count} file(s) and {folderNames.Count} folder(s) at this level but NO file contents. To answer questions about what these files contain, call `search_knowledge(query=\"...\", containerId=\"{containerId}\")` instead — it returns the relevant passages directly without you having to read each file. Use this listing only if the user explicitly asked for an inventory or named a specific filename.\n\n";
+        text += $"Contents of {normalizedPath}:\n\n";
         var hasEntries = false;
+        var rendered = 0;
+        var effectiveLimit = limit ?? int.MaxValue;
 
         foreach (var folderName in folderNames.OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
         {
+            if (rendered >= effectiveLimit) break;
             text += $"[DIR]  {folderName}/\n";
             hasEntries = true;
+            rendered++;
         }
 
-        foreach (var doc in documents)
+        foreach (var doc in directChildDocs)
         {
-            var docParent = PathUtilities.GetParentPath(doc.Path);
-            if (!string.Equals(docParent, normalizedPath, StringComparison.OrdinalIgnoreCase))
-                continue;
-
+            if (rendered >= effectiveLimit) break;
             text += $"[FILE] {doc.FileName} ({doc.SizeBytes:N0} bytes) ID: {doc.Id}\n";
             hasEntries = true;
+            rendered++;
         }
 
         if (!hasEntries)
             text += "(empty)\n";
+        else if (rendered < visibleEntries)
+            text += $"\n... {visibleEntries - rendered} more entries truncated (limit={effectiveLimit}). Call `search_knowledge` for content questions, or re-run with a higher `limit`.";
 
         return text.TrimEnd();
     }
@@ -544,7 +573,7 @@ public class McpTools
     }
 
     [McpServerTool(Name = "get_document", ReadOnly = true, Idempotent = true),
-     Description("Retrieve a document's full text by ID or path. Returns extracted text for binary formats (PDF, DOCX, PPTX).")]
+     Description("Retrieve a single document's FULL text. Use only when `search_knowledge` has returned a specific `DocumentId` you need to read in entirety, or when the user has named an exact file. For question-answering, prefer `search_knowledge` — it returns the relevant passages with citations and is far cheaper in tokens than reading whole documents.")]
     public static async Task<string> GetDocument(
         IServiceProvider services,
         [Description("Container ID or name")] string containerId,

--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -194,6 +194,13 @@ public class McpTools
         [Description("Set to true to confirm you intentionally want the full listing of a large folder. Without this, listings exceeding the soft limit return an error directing you to `search_knowledge`.")] bool? confirmLarge = null,
         CancellationToken ct = default)
     {
+        // Validate `limit` upfront. A non-positive value would otherwise bypass the
+        // soft-error guard (`!limit.HasValue` is false when limit is set) and the
+        // rendering loop would short-circuit at `rendered >= effectiveLimit`,
+        // producing misleading "(empty)" output for non-empty folders.
+        if (limit.HasValue && limit.Value <= 0)
+            return "Error: 'limit' must be greater than 0.";
+
         var folderPath = path ?? "/";
 
         var containerStore = services.GetRequiredService<IContainerStore>();

--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -97,6 +97,15 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
         .GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?.InformationalVersion
         ?? "0.0.0";
     options.ServerInfo = new() { Name = "Connapse", Version = assemblyVersion };
+    options.ServerInstructions =
+        "Connapse is a retrieval-augmented knowledge base. For ANY question-answering or " +
+        "research task over container contents, call `search_knowledge` FIRST — it returns " +
+        "the relevant ranked passages directly with citations. " +
+        "Use `list_files` ONLY when the user explicitly asks for a file inventory or names " +
+        "a specific filename to look up. Use `get_document` ONLY after `search_knowledge` " +
+        "returns a `DocumentId` you need to read in full. " +
+        "Enumerating files and reading them one by one to answer content questions will " +
+        "exceed context and produce worse answers than a single `search_knowledge` call.";
 })
 .WithHttpTransport()
 .WithToolsFromAssembly()

--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -97,15 +97,7 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
         .GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?.InformationalVersion
         ?? "0.0.0";
     options.ServerInfo = new() { Name = "Connapse", Version = assemblyVersion };
-    options.ServerInstructions =
-        "Connapse is a retrieval-augmented knowledge base. For ANY question-answering or " +
-        "research task over container contents, call `search_knowledge` FIRST — it returns " +
-        "the relevant ranked passages directly with citations. " +
-        "Use `list_files` ONLY when the user explicitly asks for a file inventory or names " +
-        "a specific filename to look up. Use `get_document` ONLY after `search_knowledge` " +
-        "returns a `DocumentId` you need to read in full. " +
-        "Enumerating files and reading them one by one to answer content questions will " +
-        "exceed context and produce worse answers than a single `search_knowledge` call.";
+    options.ServerInstructions = Connapse.Web.Mcp.McpServerConfig.McpServerInstructions;
 })
 .WithHttpTransport()
 .WithToolsFromAssembly()

--- a/tests/Connapse.Core.Tests/Mcp/McpServerConfigTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpServerConfigTests.cs
@@ -16,4 +16,19 @@ public class McpServerConfigTests
         McpServerConfig.McpServerInstructions.Should().NotBeNullOrWhiteSpace();
         McpServerConfig.McpServerInstructions.Should().Contain("search_knowledge");
     }
+
+    [Fact]
+    public void McpServerInstructions_ContainsKeyRoutingPhrases()
+    {
+        // These phrases are the substantive routing directives. Future copyedits
+        // are fine as long as these directives survive — see the v2 design doc
+        // (docs/superpowers/specs/2026-05-23-mcp-agent-steering-v2-design.md)
+        // for why each one matters.
+        var instructions = McpServerConfig.McpServerInstructions;
+
+        instructions.Should().Contain("Routing rules");
+        instructions.Should().Contain("call `search_knowledge` directly");
+        instructions.Should().Contain("Do NOT call `container_list` first");
+        instructions.Should().Contain("Never use `list_files` as a substitute");
+    }
 }

--- a/tests/Connapse.Core.Tests/Mcp/McpServerConfigTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpServerConfigTests.cs
@@ -1,0 +1,19 @@
+using Connapse.Web.Mcp;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Mcp;
+
+/// <summary>
+/// Regression net for the MCP ServerInstructions string. Asserts the load-bearing
+/// routing-rule phrases survive future copyedits, without locking the exact text.
+/// </summary>
+[Trait("Category", "Unit")]
+public class McpServerConfigTests
+{
+    [Fact]
+    public void McpServerInstructions_IsNonEmptyAndMentionsSearchKnowledge()
+    {
+        McpServerConfig.McpServerInstructions.Should().NotBeNullOrWhiteSpace();
+        McpServerConfig.McpServerInstructions.Should().Contain("search_knowledge");
+    }
+}

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsContainerListTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsContainerListTests.cs
@@ -34,7 +34,24 @@ public class McpToolsContainerListTests
     }
 
     [Fact]
-    public async Task ContainerList_OutputBeginsWithTipPointingAtSearchKnowledge()
+    public async Task ContainerList_SingleContainerReturnsNoTip()
+    {
+        _containerStore
+            .ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Container>
+            {
+                MakeContainer("only-one", "The only container", 7)
+            });
+
+        var result = await McpTools.ContainerList(_services);
+
+        result.Should().NotStartWith("TIP:");
+        result.Should().StartWith("Found 1 container(s):");
+        result.Should().Contain("- only-one (7 files) — The only container");
+    }
+
+    [Fact]
+    public async Task ContainerList_MultipleContainersBeginWithTrimmedTip()
     {
         _containerStore
             .ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
@@ -48,6 +65,12 @@ public class McpToolsContainerListTests
 
         result.Should().StartWith("TIP:");
         result.Should().Contain("search_knowledge");
+        result.Should().Contain("Pick the container whose description best matches the topic");
+
+        // Trimmed TIP should NOT contain the v1 "Do NOT enumerate files" phrasing —
+        // ServerInstructions Rule 3 covers that now.
+        result.Should().NotContain("Do NOT enumerate files");
+
         result.Should().Contain("- docs (12 files) — Product documentation");
         result.Should().Contain("- research (5 files) — Customer research");
     }

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsContainerListTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsContainerListTests.cs
@@ -1,0 +1,63 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Web.Mcp;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Connapse.Core.Tests.Mcp;
+
+[Trait("Category", "Unit")]
+public class McpToolsContainerListTests
+{
+    private readonly IContainerStore _containerStore;
+    private readonly IServiceProvider _services;
+
+    public McpToolsContainerListTests()
+    {
+        _containerStore = Substitute.For<IContainerStore>();
+
+        var services = Substitute.For<IServiceProvider>();
+        services.GetService(typeof(IContainerStore)).Returns(_containerStore);
+        _services = services;
+    }
+
+    [Fact]
+    public async Task ContainerList_EmptyReturnsPlainMessageWithoutTip()
+    {
+        _containerStore
+            .ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Container>());
+
+        var result = await McpTools.ContainerList(_services);
+
+        result.Should().Be("No containers found.");
+    }
+
+    [Fact]
+    public async Task ContainerList_OutputBeginsWithTipPointingAtSearchKnowledge()
+    {
+        _containerStore
+            .ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Container>
+            {
+                MakeContainer("docs", "Product documentation", 12),
+                MakeContainer("research", "Customer research", 5)
+            });
+
+        var result = await McpTools.ContainerList(_services);
+
+        result.Should().StartWith("TIP:");
+        result.Should().Contain("search_knowledge");
+        result.Should().Contain("- docs (12 files) — Product documentation");
+        result.Should().Contain("- research (5 files) — Customer research");
+    }
+
+    private static Container MakeContainer(string name, string description, int docCount) => new(
+        Id: Guid.NewGuid().ToString(),
+        Name: name,
+        Description: description,
+        ConnectorType: ConnectorType.ManagedStorage,
+        CreatedAt: DateTime.UtcNow,
+        UpdatedAt: DateTime.UtcNow,
+        DocumentCount: docCount);
+}

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsListFilesTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsListFilesTests.cs
@@ -182,6 +182,79 @@ public class McpToolsListFilesTests
         result.Should().Contain($"[FILE] notes.md (1,024 bytes) ID: {docId}");
     }
 
+    [Fact]
+    public async Task ListFiles_OutputBeginsWithTipPointingAtSearchKnowledge()
+    {
+        _documentStore
+            .ListAsync(ContainerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Document>
+            {
+                MakeDocument("/notes.md", "notes.md")
+            });
+
+        var result = await McpTools.ListFiles(_services, ContainerId.ToString(), "/");
+
+        result.Should().StartWith("TIP:");
+        result.Should().Contain("search_knowledge");
+    }
+
+    [Fact]
+    public async Task ListFiles_LargeListingReturnsSoftErrorByDefault()
+    {
+        var docs = Enumerable.Range(0, McpTools.ListFilesSoftLimit + 5)
+            .Select(i => MakeDocument($"/file{i}.txt", $"file{i}.txt"))
+            .ToList();
+
+        _documentStore
+            .ListAsync(ContainerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(docs);
+
+        var result = await McpTools.ListFiles(_services, ContainerId.ToString(), "/");
+
+        result.Should().StartWith("Error:");
+        result.Should().Contain("search_knowledge");
+        result.Should().Contain("confirmLarge");
+        result.Should().NotContain("[FILE]");
+    }
+
+    [Fact]
+    public async Task ListFiles_ConfirmLargeBypassesSoftError()
+    {
+        var docs = Enumerable.Range(0, McpTools.ListFilesSoftLimit + 5)
+            .Select(i => MakeDocument($"/file{i}.txt", $"file{i}.txt"))
+            .ToList();
+
+        _documentStore
+            .ListAsync(ContainerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(docs);
+
+        var result = await McpTools.ListFiles(_services, ContainerId.ToString(), "/", limit: null, confirmLarge: true);
+
+        result.Should().NotStartWith("Error:");
+        result.Should().Contain("[FILE] file0.txt");
+        result.Should().Contain($"[FILE] file{McpTools.ListFilesSoftLimit + 4}.txt");
+    }
+
+    [Fact]
+    public async Task ListFiles_LimitTruncatesLargeListing()
+    {
+        var docs = Enumerable.Range(0, McpTools.ListFilesSoftLimit + 5)
+            .Select(i => MakeDocument($"/file{i:D3}.txt", $"file{i:D3}.txt"))
+            .ToList();
+
+        _documentStore
+            .ListAsync(ContainerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(docs);
+
+        var result = await McpTools.ListFiles(_services, ContainerId.ToString(), "/", limit: 5);
+
+        result.Should().NotStartWith("Error:");
+        result.Should().Contain("[FILE] file000.txt");
+        result.Should().Contain("[FILE] file004.txt");
+        result.Should().NotContain("[FILE] file005.txt");
+        result.Should().Contain("more entries truncated");
+    }
+
     private static Container MakeContainer() => new(
         Id: ContainerId.ToString(),
         Name: "test",

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsListFilesTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsListFilesTests.cs
@@ -241,6 +241,31 @@ public class McpToolsListFilesTests
         result.Should().Contain("[FILE] install.md");
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public async Task ListFiles_NonPositiveLimitReturnsValidationError(int badLimit)
+    {
+        // limit <= 0 would otherwise bypass the soft-error path (limit.HasValue is true)
+        // and render every entry as truncated, producing misleading "(empty)" output
+        // for non-empty folders. Guard upfront.
+        var docs = Enumerable.Range(0, McpTools.ListFilesSoftLimit + 5)
+            .Select(i => MakeDocument($"/file{i}.txt", $"file{i}.txt"))
+            .ToList();
+
+        _documentStore
+            .ListAsync(ContainerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(docs);
+
+        var result = await McpTools.ListFiles(_services, ContainerId.ToString(), "/", limit: badLimit);
+
+        result.Should().StartWith("Error:");
+        result.Should().Contain("limit");
+        result.Should().NotContain("[FILE]");
+        result.Should().NotContain("(empty)");
+    }
+
     [Fact]
     public async Task ListFiles_LargeListingReturnsSoftErrorByDefault()
     {

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsListFilesTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsListFilesTests.cs
@@ -183,8 +183,32 @@ public class McpToolsListFilesTests
     }
 
     [Fact]
-    public async Task ListFiles_OutputBeginsWithTipPointingAtSearchKnowledge()
+    public async Task ListFiles_RootWithMultipleEntriesBeginsWithTrimmedTip()
     {
+        // Two direct-child files at root — TIP must emit (path == "/" and entries > 1)
+        _documentStore
+            .ListAsync(ContainerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Document>
+            {
+                MakeDocument("/notes.md", "notes.md"),
+                MakeDocument("/readme.md", "readme.md")
+            });
+
+        var result = await McpTools.ListFiles(_services, ContainerId.ToString(), "/");
+
+        result.Should().StartWith("TIP:");
+        result.Should().Contain("search_knowledge");
+        result.Should().Contain("folder/file names only");
+
+        // Trimmed TIP should NOT contain the v1 phrasings that ServerInstructions now covers.
+        result.Should().NotContain("Use this listing only if the user explicitly asked");
+        result.Should().NotContain("contains 2 file(s) and 0 folder(s)");
+    }
+
+    [Fact]
+    public async Task ListFiles_SingleEntryRootListingHasNoTip()
+    {
+        // Single direct-child at root — no routing decision to nudge
         _documentStore
             .ListAsync(ContainerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(new List<Document>
@@ -194,8 +218,27 @@ public class McpToolsListFilesTests
 
         var result = await McpTools.ListFiles(_services, ContainerId.ToString(), "/");
 
-        result.Should().StartWith("TIP:");
-        result.Should().Contain("search_knowledge");
+        result.Should().NotStartWith("TIP:");
+        result.Should().Contain("[FILE] notes.md");
+    }
+
+    [Fact]
+    public async Task ListFiles_SubFolderListingHasNoTip()
+    {
+        // Multi-entry listing at a sub-folder — already targeted, no need to re-route
+        _documentStore
+            .ListAsync(ContainerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Document>
+            {
+                MakeDocument("/docs/readme.md", "readme.md"),
+                MakeDocument("/docs/install.md", "install.md")
+            });
+
+        var result = await McpTools.ListFiles(_services, ContainerId.ToString(), "/docs/");
+
+        result.Should().NotStartWith("TIP:");
+        result.Should().Contain("[FILE] readme.md");
+        result.Should().Contain("[FILE] install.md");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Two-phase MCP agent-steering intervention to reduce `list_files` enumeration when `search_knowledge` is the right tool for content questions.

### v1 (commits 65c9c27 + 7e51675)
Prescriptive `ServerInstructions` + tool description rewrites: "call `search_knowledge` FIRST", "ENTRY POINT", "INVENTORY ONLY", "DO NOT enumerate files" imperatives. Benchmark verdict was net-positive on Claude Haiku 4.5 and Sonnet 4.6, but produced a documented failure mode on Opus 4.7: literal compliance to *competing* "FIRST" imperatives (one in `ServerInstructions`, one in the `container_list` description) collapsed `search_knowledge` adoption to zero on the `qa_factoid` bucket and inflated MCP call count by +41%.

### v2 (commits 9538f69 + a11825b + a834cb9 + 901dcc9 + 1d43e2c)
Restructured the intervention based on literature (Faghih et al. EMNLP 2025 on description-driven tool substitution; Anthropic's Opus 4.7 prompting guide on literal compliance) along three axes:

1. **`ServerInstructions` becomes the single source of routing voice** — four numbered scope-explicit conditional rules instead of unconditional imperatives. Re-licenses `search_knowledge` as the primary path when the container is already known (Rule 1), explicitly preventing the Opus literal-compliance chain.
2. **Tool `[Description]` attributes** rewritten as neutral functional text (one minimal disambiguation cue each, no routing imperatives).
3. **Inline TIPs in `container_list` and `list_files` output** are now conditional — emit only when an actual routing decision exists at the response. Trimmed from ~60-80 words to ~20-25.

The `list_files` soft-error path (when entries > 50 without `confirmLarge`) deliberately retains its routing imperative — that's a contextual policy refusal at the moment of violation, consistent with the v2 principle of "disambiguate output, don't re-teach routing."

### Out of scope
- Per-model description shipping
- `defer_loading` / Tool Search infrastructure (Connapse has 4 primary MCP tools, not dozens)
- Server-side per-MCP-tool-call telemetry
- Benchmark harness session-limit-detection fix
- Judge calibration
- Re-running the v1 benchmark (a v2 benchmark would validate the conditional-phrasing prediction)

### Design/plan docs
v2 spec and implementation plan live locally at `docs/superpowers/specs/2026-05-23-mcp-agent-steering-v2-design.md` and `docs/superpowers/plans/2026-05-23-mcp-agent-steering-v2.md` (not committed; happy to share).

## Test plan

- [x] All 683 unit tests pass (`dotnet test --filter "Category=Unit"`)
- [ ] Integration tests pass with Docker (`dotnet test --filter "Category=Integration"`)

## Follow-up validation (separate work)

The v2 benchmark should confirm:
- Opus `qa_factoid` `right_tool_first_rate` ≥ v1's +15.2pp
- Opus `qa_factoid` `mean_mcp_call_count` delta < +0.30 (v1 had +0.67)
- Opus `qa_factoid` `search_knowledge` adoption rate > 0 (v1 collapsed to 0)
- Haiku `qa_demo_realistic` `right_tool_first_rate` ≥ v1's +16.7pp (softer phrasing must not flatten)

Closes #324


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional parameters to file listing controls: `limit` to truncate results and `confirmLarge` to override size constraints.
  * Introduced conditional guidance tips for large folder inventories, redirecting to search when appropriate.

* **Improvements**
  * Refined tool descriptions to clarify agent workflows: container selection followed by search, then file inventory retrieval.
  * Enhanced file listing behavior with soft-limit enforcement and clearer truncation messaging.
  * Configured MCP server routing instructions for improved agent decision-making.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Destrayon/Connapse/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->