### PR TITLE
infra: add opengrep.yml with Connapse-specific lint rules

### DIFF
--- a/opengrep.yml
+++ b/opengrep.yml
@@ -1,0 +1,115 @@
+# Connapse-specific OpenGrep rules, picked up automatically by CodeRabbit.
+# See https://docs.coderabbit.ai/tools/opengrep — file lookup order:
+# opengrep.yml > opengrep.yaml > opengrep.config.yml > opengrep.config.yaml > semgrep.yml
+#
+# Conventions enforced here mirror CLAUDE.md. Start narrow; iterate on signal-to-noise.
+
+rules:
+  # ---------------------------------------------------------------------------
+  # 1. Synchronous blocking on Task — CLAUDE.md: "Async all the way (never
+  #    .Result or .Wait())". Deadlocks in Blazor Server and ASP.NET request
+  #    contexts; wastes a thread-pool thread everywhere else.
+  # ---------------------------------------------------------------------------
+  - id: connapse-no-task-sync-blocking
+    patterns:
+      - pattern-either:
+          - pattern: $TASK.Wait()
+          - pattern: $TASK.Wait($TIMEOUT)
+          - pattern: $TASK.GetAwaiter().GetResult()
+    message: |
+      Blocking on Task with .Wait() or .GetAwaiter().GetResult() can deadlock in
+      Blazor Server / ASP.NET request contexts and wastes a thread-pool thread
+      everywhere else. Use `await` instead and propagate async up the call stack.
+      Per CLAUDE.md: "Async all the way (never .Result or .Wait())".
+    languages: [csharp]
+    severity: WARNING
+    paths:
+      include:
+        - "src/**/*.cs"
+      exclude:
+        - "**/bin/**"
+        - "**/obj/**"
+
+  # ---------------------------------------------------------------------------
+  # 2. `dynamic` — CLAUDE.md: "Don't use dynamic". Defeats the type system,
+  #    breaks trimming, and silently masks refactors.
+  # ---------------------------------------------------------------------------
+  - id: connapse-no-dynamic-keyword
+    pattern-regex: '\bdynamic\s+(?!\?)\w+'
+    message: |
+      Avoid the `dynamic` keyword — it defeats static typing, breaks trimming/
+      AOT, and silently masks refactor breaks. Use a concrete type, a record,
+      `JsonElement`/`JsonNode`, or generics instead.
+      Per CLAUDE.md: "Don't use dynamic".
+    languages: [csharp]
+    severity: WARNING
+    paths:
+      include:
+        - "src/**/*.cs"
+      exclude:
+        - "**/bin/**"
+        - "**/obj/**"
+
+  # ---------------------------------------------------------------------------
+  # 3. Raw SQL with string interpolation — SQL injection risk. EF Core ships
+  #    `FromSqlInterpolated` / `ExecuteSqlInterpolated` which parameterize the
+  #    holes safely. CLAUDE.md: "Parameterized SQL queries only".
+  # ---------------------------------------------------------------------------
+  - id: connapse-no-fromsqlraw-interpolation
+    patterns:
+      - pattern-either:
+          - pattern: $DB.FromSqlRaw($"...")
+          - pattern: $DB.ExecuteSqlRaw($"...")
+          - pattern: $DB.ExecuteSqlRawAsync($"...")
+          - pattern: $DB.SqlQueryRaw<$T>($"...")
+    message: |
+      String interpolation in raw SQL is a SQL injection vector — the
+      interpolation happens BEFORE the value reaches EF Core, so it is not
+      parameterized. Use FromSqlInterpolated / ExecuteSqlInterpolated /
+      ExecuteSqlInterpolatedAsync instead — those take FormattableString and
+      parameterize the holes safely.
+      Per CLAUDE.md: "Parameterized SQL queries only (never string interpolation)".
+    languages: [csharp]
+    severity: ERROR
+    paths:
+      include:
+        - "src/**/*.cs"
+      exclude:
+        - "**/bin/**"
+        - "**/obj/**"
+
+  # ---------------------------------------------------------------------------
+  # 4. Interpolated strings in logger calls — loses structured-logging benefits
+  #    and (for user-controlled values) is the cs/log-forging surface. CLAUDE.md
+  #    says wrap user-controlled values with LogSanitizer.Sanitize(...).
+  # ---------------------------------------------------------------------------
+  - id: connapse-logger-interpolation
+    patterns:
+      - pattern-either:
+          - pattern: $LOG.LogTrace($"...")
+          - pattern: $LOG.LogDebug($"...")
+          - pattern: $LOG.LogInformation($"...")
+          - pattern: $LOG.LogWarning($"...")
+          - pattern: $LOG.LogError($"...")
+          - pattern: $LOG.LogCritical($"...")
+    message: |
+      Don't use interpolated strings in logger calls — you lose structured
+      logging (no searchable named fields, no de-duplication of message
+      templates) AND, if any interpolated value is user-controlled, you create
+      a log-forging vector (CodeQL cs/log-forging).
+
+      Use placeholder syntax:
+          _logger.LogInformation("Loaded container {ContainerId}", id);
+
+      For user-controlled values (search queries, request bodies, headers,
+      client-supplied IDs), also wrap with
+          LogSanitizer.Sanitize(value)
+      from Connapse.Core.Utilities.
+    languages: [csharp]
+    severity: WARNING
+    paths:
+      include:
+        - "src/**/*.cs"
+      exclude:
+        - "**/bin/**"
+        - "**/obj/**"

--- a/opengrep.yml
+++ b/opengrep.yml
@@ -1,21 +1,31 @@
 # Connapse-specific OpenGrep rules, picked up automatically by CodeRabbit.
 # See https://docs.coderabbit.ai/tools/opengrep — file lookup order:
-# opengrep.yml > opengrep.yaml > opengrep.config.yml > opengrep.config.yaml > semgrep.yml
+#   opengrep.yml > opengrep.yaml > opengrep.config.yml > opengrep.config.yaml > semgrep.yml
 #
-# Conventions enforced here mirror CLAUDE.md. Start narrow; iterate on signal-to-noise.
+# Conventions enforced here mirror CLAUDE.md. Severity uses the legacy
+# ERROR/WARNING names (Semgrep maps ERROR → HIGH, WARNING → MEDIUM).
+#
+# Note: the open-source Semgrep CLI's C# parser (<= 1.163) chokes on C# 12+
+# primary constructors (`PartialParsing` errors) and may under-report inside
+# those files. OpenGrep, which CodeRabbit uses, ships an upgraded C# 14
+# parser, so this gap shows up in local dry-runs but not in CodeRabbit's
+# reviews.
 
 rules:
   # ---------------------------------------------------------------------------
   # 1. Synchronous blocking on Task — CLAUDE.md: "Async all the way (never
   #    .Result or .Wait())". Deadlocks in Blazor Server and ASP.NET request
   #    contexts; wastes a thread-pool thread everywhere else.
+  #
+  #    We deliberately do NOT match the bare `.Result` accessor — too many
+  #    unrelated types have a `.Result` property (search results, parser
+  #    results, etc.). The two patterns below are unambiguous to Task.
   # ---------------------------------------------------------------------------
   - id: connapse-no-task-sync-blocking
-    patterns:
-      - pattern-either:
-          - pattern: $TASK.Wait()
-          - pattern: $TASK.Wait($TIMEOUT)
-          - pattern: $TASK.GetAwaiter().GetResult()
+    pattern-either:
+      - pattern: $TASK.Wait()
+      - pattern: $TASK.Wait($TIMEOUT)
+      - pattern: $TASK.GetAwaiter().GetResult()
     message: |
       Blocking on Task with .Wait() or .GetAwaiter().GetResult() can deadlock in
       Blazor Server / ASP.NET request contexts and wastes a thread-pool thread
@@ -23,6 +33,11 @@ rules:
       Per CLAUDE.md: "Async all the way (never .Result or .Wait())".
     languages: [csharp]
     severity: WARNING
+    metadata:
+      category: best-practice
+      technology: [csharp, dotnet, async]
+      references:
+        - https://learn.microsoft.com/en-us/dotnet/csharp/asynchronous-programming/
     paths:
       include:
         - "src/**/*.cs"
@@ -31,11 +46,21 @@ rules:
         - "**/obj/**"
 
   # ---------------------------------------------------------------------------
-  # 2. `dynamic` — CLAUDE.md: "Don't use dynamic". Defeats the type system,
-  #    breaks trimming, and silently masks refactors.
+  # 2. `dynamic` keyword — CLAUDE.md: "Don't use dynamic". Defeats the type
+  #    system, breaks trimming/AOT, and silently masks refactors.
+  #
+  #    Uses AST-form patterns (not a regex) so we don't false-positive on
+  #    comments like "// dynamic JSON support" or identifiers like
+  #    `EnableDynamicJson`.
   # ---------------------------------------------------------------------------
   - id: connapse-no-dynamic-keyword
-    pattern-regex: '\bdynamic\s+(?!\?)\w+'
+    pattern-either:
+      - pattern: |
+          dynamic $X = $E;
+      - pattern: |
+          dynamic $M(...) { ... }
+      - pattern: |
+          dynamic $M(...) => $E;
     message: |
       Avoid the `dynamic` keyword — it defeats static typing, breaks trimming/
       AOT, and silently masks refactor breaks. Use a concrete type, a record,
@@ -43,6 +68,9 @@ rules:
       Per CLAUDE.md: "Don't use dynamic".
     languages: [csharp]
     severity: WARNING
+    metadata:
+      category: best-practice
+      technology: [csharp, dotnet]
     paths:
       include:
         - "src/**/*.cs"
@@ -56,12 +84,11 @@ rules:
   #    holes safely. CLAUDE.md: "Parameterized SQL queries only".
   # ---------------------------------------------------------------------------
   - id: connapse-no-fromsqlraw-interpolation
-    patterns:
-      - pattern-either:
-          - pattern: $DB.FromSqlRaw($"...")
-          - pattern: $DB.ExecuteSqlRaw($"...")
-          - pattern: $DB.ExecuteSqlRawAsync($"...")
-          - pattern: $DB.SqlQueryRaw<$T>($"...")
+    pattern-either:
+      - pattern: $DB.FromSqlRaw($"...")
+      - pattern: $DB.ExecuteSqlRaw($"...")
+      - pattern: $DB.ExecuteSqlRawAsync($"...")
+      - pattern: $DB.SqlQueryRaw<$T>($"...")
     message: |
       String interpolation in raw SQL is a SQL injection vector — the
       interpolation happens BEFORE the value reaches EF Core, so it is not
@@ -71,6 +98,15 @@ rules:
       Per CLAUDE.md: "Parameterized SQL queries only (never string interpolation)".
     languages: [csharp]
     severity: ERROR
+    metadata:
+      category: security
+      technology: [csharp, efcore, sql]
+      cwe:
+        - "CWE-89: Improper Neutralization of Special Elements used in an SQL Command"
+      owasp:
+        - "A03:2021 - Injection"
+      references:
+        - https://learn.microsoft.com/en-us/ef/core/querying/sql-queries#passing-parameters
     paths:
       include:
         - "src/**/*.cs"
@@ -79,19 +115,20 @@ rules:
         - "**/obj/**"
 
   # ---------------------------------------------------------------------------
-  # 4. Interpolated strings in logger calls — loses structured-logging benefits
-  #    and (for user-controlled values) is the cs/log-forging surface. CLAUDE.md
-  #    says wrap user-controlled values with LogSanitizer.Sanitize(...).
+  # 4. Interpolated strings in logger calls — loses structured-logging
+  #    benefits (no searchable named fields, no de-duplication of message
+  #    templates) AND, for user-controlled values, is the cs/log-forging
+  #    surface. CLAUDE.md says wrap user-controlled values with
+  #    LogSanitizer.Sanitize(...) from Connapse.Core.Utilities.
   # ---------------------------------------------------------------------------
   - id: connapse-logger-interpolation
-    patterns:
-      - pattern-either:
-          - pattern: $LOG.LogTrace($"...")
-          - pattern: $LOG.LogDebug($"...")
-          - pattern: $LOG.LogInformation($"...")
-          - pattern: $LOG.LogWarning($"...")
-          - pattern: $LOG.LogError($"...")
-          - pattern: $LOG.LogCritical($"...")
+    pattern-either:
+      - pattern: $LOG.LogTrace($"...")
+      - pattern: $LOG.LogDebug($"...")
+      - pattern: $LOG.LogInformation($"...")
+      - pattern: $LOG.LogWarning($"...")
+      - pattern: $LOG.LogError($"...")
+      - pattern: $LOG.LogCritical($"...")
     message: |
       Don't use interpolated strings in logger calls — you lose structured
       logging (no searchable named fields, no de-duplication of message
@@ -107,6 +144,13 @@ rules:
       from Connapse.Core.Utilities.
     languages: [csharp]
     severity: WARNING
+    metadata:
+      category: best-practice
+      technology: [csharp, logging]
+      cwe:
+        - "CWE-117: Improper Output Neutralization for Logs"
+      references:
+        - https://learn.microsoft.com/en-us/dotnet/core/extensions/logging?tabs=command-line#log-message-template
     paths:
       include:
         - "src/**/*.cs"


### PR DESCRIPTION
Closes #326

## What

Adds a starter `opengrep.yml` at the repo root so CodeRabbit applies Connapse-specific static-analysis rules on PRs. Today CodeRabbit falls back to its built-in profile, which doesn't know our conventions.

CodeRabbit auto-picks up the file — per [their docs](https://docs.coderabbit.ai/tools/opengrep), the lookup order is `opengrep.yml` → `opengrep.yaml` → `opengrep.config.yml` → `opengrep.config.yaml` → `semgrep.yml`. No `.coderabbit.yaml` wiring needed.

## Why

Several [CLAUDE.md](CLAUDE.md) conventions are easy to violate by accident and not caught by the compiler or existing CodeQL pack:

| CLAUDE.md rule | Rule id |
|---|---|
| "Async all the way (never `.Result` or `.Wait()`)" | `connapse-no-task-sync-blocking` |
| "Don't use `dynamic`" | `connapse-no-dynamic-keyword` |
| "Parameterized SQL queries only (never string interpolation)" | `connapse-no-fromsqlraw-interpolation` |
| "wrap user-controlled values with `LogSanitizer.Sanitize(...)`" | `connapse-logger-interpolation` |

## How

- `connapse-no-task-sync-blocking` — **WARN**. Matches `$T.Wait()`, `$T.Wait($MS)`, `$T.GetAwaiter().GetResult()`. Deliberately excludes the bare `.Result` accessor (too many false positives on `SearchResult.Result`, parser `.Result`, etc.); the two patterns we do match are unambiguous.
- `connapse-no-dynamic-keyword` — **WARN**. Regex-based: `\bdynamic\s+(?!\?)\w+`. Catches `dynamic foo = ...`, `public dynamic Bar(...)`, etc.
- `connapse-no-fromsqlraw-interpolation` — **ERROR**. SQL injection risk. Matches the `Raw` family of EF Core methods called with an interpolated string `$"..."`. Suggests `FromSqlInterpolated`/`ExecuteSqlInterpolated` as the safe analogue.
- `connapse-logger-interpolation` — **WARN**. Matches `LogTrace`/`LogDebug`/`LogInformation`/`LogWarning`/`LogError`/`LogCritical` called with `$"..."`. Costs structured-logging fields and creates cs/log-forging surface for user-controlled values.

All rules scope to `src/**/*.cs` and exclude `bin/`/`obj/`. Test code is excluded from the sync-blocking rule (legit sync use in test setup).

## Out of scope

- Replacing CodeQL — opengrep.yml is additive.
- Style rules that need type inference (e.g. "no `var` for primitives") — OpenGrep is syntactic. Use a Roslyn analyzer if we want that later.
- A `.coderabbit.yaml` overall-profile tweak — separate ticket if/when we want it.

## Test plan

- [x] YAML parses cleanly
- [x] File path matches CodeRabbit's documented lookup order (`opengrep.yml` at root)
- [ ] After merge, the next PR shows CodeRabbit picking up the ruleset in its review comment
- [ ] Optional follow-up: run `opengrep --config opengrep.yml src/` locally once a CLI is available, tune patterns based on findings