### PR TITLE
feat: configurable summary settings (Enabled + prompt overrides + LlmModel + MaxInputTokens)

### DIFF
--- a/docs/agent/container-summaries-qa.md
+++ b/docs/agent/container-summaries-qa.md
@@ -17,3 +17,36 @@ Verify that the auto-generated container summary biases an MCP-connected agent t
 2. **Out-of-scope test.** Ask the agent something the container should NOT route to. Expected: agent does not route based on the summary's "Does not cover…" section.
 
 3. **Query-term lift.** Compare agent query terms with/without summary. Agent should use phrases from the "Query hints" section more often when summary is present.
+
+## v2 — Configurable settings scenarios
+
+### Scenario: Toggle enable/disable
+
+1. Go to `/settings` → Summary tab
+2. Confirm "Enable summary generation" checkbox is unchecked (opt-in default)
+3. Upload a document to any container — verify no per-doc summary generated (DB: `documents.summary IS NULL` for the new row)
+4. Check the box, click "Save Summary Settings"
+5. Upload a document — verify per-doc summary IS generated within ingestion latency
+
+### Scenario: Per-doc prompt override (fixes Qwen 3 script-bleed)
+
+1. With Ollama + qwen3:14b configured and enabled, upload an engineering-flavored document and verify the summary may contain a Chinese character (`流程` etc.)
+2. Go to `/settings` → Summary tab → "Per-document system prompt" textarea
+3. Append "Respond entirely in English. /no_think" to the end of the default text
+4. Save
+5. Upload a fresh engineering document — verify the summary is entirely in English with no thinking preamble
+
+### Scenario: Per-container override via FileBrowser
+
+1. Open a specific container at `/{slug}/files`
+2. Click the Settings tab
+3. In the Summary Generation section: enable, set LLM Model to a non-default
+4. Click Save
+5. Upload a document to THIS container — verify the per-doc summary uses the override model (check the `documents.summary` or LLM provider logs)
+6. Upload a document to a DIFFERENT container — verify it uses the global model (not the per-container override)
+
+### Scenario: "Restore default" link behavior
+
+1. Edit the per-doc prompt textarea
+2. Click "Restore default" — verify the textarea repopulates with the in-code default text
+3. Save — verify no override is stored (DB JSON for that container has `summary.perDocSystemPrompt: null` or the field absent)

--- a/src/Connapse.Core/Interfaces/IContainerSummarizer.cs
+++ b/src/Connapse.Core/Interfaces/IContainerSummarizer.cs
@@ -18,5 +18,6 @@ public interface IContainerSummarizer
     Task<ContainerSummarizationResult> GenerateAsync(
         string containerName,
         IReadOnlyList<DocumentWithSummary> docs,
+        SummarySettings settings,
         CancellationToken ct = default);
 }

--- a/src/Connapse.Core/Interfaces/IPerDocSummarizer.cs
+++ b/src/Connapse.Core/Interfaces/IPerDocSummarizer.cs
@@ -7,6 +7,7 @@ public interface IPerDocSummarizer
         string docText,
         string? mimeType,
         string fileName,
+        SummarySettings settings,
         CancellationToken ct = default);
 }
 

--- a/src/Connapse.Core/Models/LlmCompletionOptions.cs
+++ b/src/Connapse.Core/Models/LlmCompletionOptions.cs
@@ -2,8 +2,9 @@ namespace Connapse.Core;
 
 /// <summary>
 /// Per-call overrides for LLM completion requests.
-/// When null/default, providers read from LlmSettings.
+/// When null/default, providers read from LlmSettings (constructor-injected).
 /// </summary>
 public record LlmCompletionOptions(
     float? Temperature = null,
-    int? MaxTokens = null);
+    int? MaxTokens = null,
+    string? Model = null);

--- a/src/Connapse.Core/Models/SettingsModels.cs
+++ b/src/Connapse.Core/Models/SettingsModels.cs
@@ -343,10 +343,6 @@ public record UploadSettings
 }
 
 /// <summary>
-/// Per-container summary generation settings.
-/// All fields are optional — null means fall back to the instance-level LlmSettings default.
-/// </summary>
-/// <summary>
 /// Container/document summary generation settings.
 /// Resolution hierarchy (highest wins):
 ///   per-container SettingsOverridesJson.summary

--- a/src/Connapse.Core/Models/SettingsModels.cs
+++ b/src/Connapse.Core/Models/SettingsModels.cs
@@ -346,55 +346,53 @@ public record UploadSettings
 /// Per-container summary generation settings.
 /// All fields are optional — null means fall back to the instance-level LlmSettings default.
 /// </summary>
+/// <summary>
+/// Container/document summary generation settings.
+/// Resolution hierarchy (highest wins):
+///   per-container SettingsOverridesJson.summary
+///   → global DB settings table, key="Summary"
+///   → property-initializer defaults below (Enabled=false, others=null)
+/// </summary>
 public record SummarySettings
 {
     /// <summary>
-    /// Override the LLM provider for summary generation (Anthropic / OpenAI / AzureOpenAI / Ollama).
-    /// Null uses the instance-level LlmSettings.Provider value.
+    /// Master toggle. When false, both per-doc summaries and container rollups
+    /// skip with reason "summaries_disabled" and no LLM call is made.
+    /// Default: false (opt-in).
+    /// </summary>
+    public bool Enabled { get; init; } = false;
+
+    /// <summary>
+    /// LLM provider for summary generation (Ollama / OpenAI / AzureOpenAI / Anthropic).
+    /// Null = inherit from instance-level LlmSettings.Provider via SummaryLlmResolver.
     /// </summary>
     public string? LlmProvider { get; init; }
 
     /// <summary>
-    /// Override the model identifier (e.g. "claude-haiku-4-5", "gpt-4.1-nano").
-    /// Ignored in v1; only <see cref="LlmProvider"/> is currently honored.
-    /// Model-level override is deferred to v2.
+    /// Model identifier for summary generation (e.g. "qwen3:14b", "claude-haiku-4-5").
+    /// Null = inherit from instance-level LlmSettings.Model. Wired via
+    /// LlmCompletionOptions.Model per-call override (no provider re-construction).
     /// </summary>
     public string? LlmModel { get; init; }
 
     /// <summary>
-    /// Optional full system-prompt replacement for container roll-up summarization.
-    /// Reserved for future use.
+    /// Override for the per-document system prompt. Null/empty = use
+    /// SummaryPrompts.PerDocSystemPrompt. When non-null, the stored string IS
+    /// the prompt sent to the LLM — no concatenation, no automatic prefixing.
     /// </summary>
-    public string? PromptOverride { get; init; }
+    public string? PerDocSystemPrompt { get; init; }
 
     /// <summary>
-    /// Cap on the number of input tokens fed to the LLM per document summary.
-    /// Reserved for future use.
+    /// Override for the container-rollup system prompt. Same semantics as
+    /// PerDocSystemPrompt; falls back to SummaryPrompts.ContainerRollupSystemPrompt.
+    /// </summary>
+    public string? ContainerRollupSystemPrompt { get; init; }
+
+    /// <summary>
+    /// Max input tokens fed to the per-document LLM call. Null = use default (5_000).
+    /// Maps to characters via a 4-char/token heuristic at the truncation site
+    /// in PerDocSummarizer (replaces the hardcoded MaxInputCharacters = 20_000).
     /// </summary>
     public int? MaxInputTokens { get; init; }
-
-    /// <summary>
-    /// Target output tokens per document summary (default: 100).
-    /// Reserved for future use.
-    /// </summary>
-    public int? PerDocTargetTokens { get; init; }
-
-    /// <summary>
-    /// Target output tokens for the container roll-up summary (default: 500).
-    /// Reserved for future use.
-    /// </summary>
-    public int? ContainerTargetTokens { get; init; }
-
-    /// <summary>
-    /// Dirty-event count threshold before triggering a summary (default: 25).
-    /// Reserved for future use.
-    /// </summary>
-    public int? DebounceCount { get; init; }
-
-    /// <summary>
-    /// Dirty-event time threshold in seconds before triggering a summary (default: 21600 = 6h).
-    /// Reserved for future use.
-    /// </summary>
-    public int? DebounceSeconds { get; init; }
 }
 

--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -31,6 +31,7 @@ public class IngestionPipeline : IKnowledgeIngester
     private readonly EmbeddingCache _embeddingCache;
     private readonly IPerDocSummarizer _summarizer;
     private readonly IContainerSummaryQueue _dirtyQueue;
+    private readonly IContainerSettingsResolver _settingsResolver;
     private readonly ILogger<IngestionPipeline> _logger;
 
     // Metadata keys for tracking indexing settings
@@ -57,6 +58,7 @@ public class IngestionPipeline : IKnowledgeIngester
     /// <param name="embeddingCache">Cache used to retrieve or compute embeddings to avoid redundant work.</param>
     /// <param name="summarizer">Per-document summarizer called after chunks and vectors are persisted.</param>
     /// <param name="dirtyQueue">Queue for posting container summary dirty events.</param>
+    /// <param name="settingsResolver">Resolves per-container settings (chunking, embedding, summary, etc.).</param>
     /// <param name="logger">Logger used for recording pipeline diagnostics and errors.</param>
     public IngestionPipeline(
         KnowledgeDbContext context,
@@ -70,6 +72,7 @@ public class IngestionPipeline : IKnowledgeIngester
         EmbeddingCache embeddingCache,
         IPerDocSummarizer summarizer,
         IContainerSummaryQueue dirtyQueue,
+        IContainerSettingsResolver settingsResolver,
         ILogger<IngestionPipeline> logger)
     {
         _context = context;
@@ -83,6 +86,7 @@ public class IngestionPipeline : IKnowledgeIngester
         _embeddingCache = embeddingCache;
         _summarizer = summarizer;
         _dirtyQueue = dirtyQueue;
+        _settingsResolver = settingsResolver;
         _logger = logger;
     }
 
@@ -374,11 +378,14 @@ public class IngestionPipeline : IKnowledgeIngester
             // Generate per-document summary — non-fatal; ingestion succeeds regardless.
             try
             {
+                SummarySettings summarySettings = await _settingsResolver.GetSummarySettingsAsync(containerId, ct);
+
                 PerDocSummarizationResult summaryResult = await _summarizer.GenerateAsync(
                     documentId: documentEntity.Id.ToString(),
                     docText: parsedDocument.Content,
                     mimeType: options.ContentType,
                     fileName: options.FileName ?? "",
+                    settings: summarySettings,
                     ct: ct);
 
                 if (summaryResult.Skipped)

--- a/src/Connapse.Ingestion/Summarization/ContainerSummarizer.cs
+++ b/src/Connapse.Ingestion/Summarization/ContainerSummarizer.cs
@@ -1,3 +1,4 @@
+using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.Llm;
 
@@ -13,8 +14,12 @@ public sealed class ContainerSummarizer(
     public async Task<ContainerSummarizationResult> GenerateAsync(
         string containerName,
         IReadOnlyList<DocumentWithSummary> docs,
+        SummarySettings settings,
         CancellationToken ct = default)
     {
+        if (!settings.Enabled)
+            return new ContainerSummarizationResult(true, SkipReason: "summaries_disabled");
+
         if (llmProvider is null)
             return new ContainerSummarizationResult(true, SkipReason: "no_provider_configured");
 
@@ -49,15 +54,22 @@ public sealed class ContainerSummarizer(
             totalDocs: docs.Count,
             isClustered: isClustered,
             summaries: renderedSummaries);
-        string systemPrompt = SummaryPrompts.ContainerRollupSystemPrompt;
+
+        string systemPrompt = !string.IsNullOrWhiteSpace(settings.ContainerRollupSystemPrompt)
+            ? settings.ContainerRollupSystemPrompt
+            : SummaryPrompts.ContainerRollupSystemPrompt;
 
         int inputTokens = tokenCounter.CountTokens(systemPrompt) + tokenCounter.CountTokens(userMsg);
 
+        LlmCompletionOptions? options = settings.LlmModel is null
+            ? null
+            : new LlmCompletionOptions(Model: settings.LlmModel);
+
         string responseText = await llmProvider.CompleteAsync(
-            systemPrompt, userMsg, options: null, ct);
+            systemPrompt, userMsg, options, ct);
 
         int outputTokens = tokenCounter.CountTokens(responseText);
-        string model = llmProvider.ModelId;
+        string model = settings.LlmModel ?? llmProvider.ModelId;
 
         return new ContainerSummarizationResult(
             Skipped: false,

--- a/src/Connapse.Ingestion/Summarization/ContainerSummaryWorker.cs
+++ b/src/Connapse.Ingestion/Summarization/ContainerSummaryWorker.cs
@@ -138,6 +138,15 @@ public sealed class ContainerSummaryWorker(
                     scope.ServiceProvider.GetRequiredService<IContainerSettingsResolver>();
                 SummarySettings summarySettings = await settingsResolver.GetSummarySettingsAsync(containerId, ct);
 
+                // Enabled gate — short-circuit before fetching docs / constructing summarizer.
+                if (!summarySettings.Enabled)
+                {
+                    logger.LogInformation(
+                        "ContainerRollupSkipped {ContainerId} reason=summaries_disabled",
+                        LogSanitizer.Sanitize(containerId.ToString()));
+                    return;
+                }
+
                 SummaryLlmResolver llmResolver = scope.ServiceProvider.GetRequiredService<SummaryLlmResolver>();
                 ILlmProvider? llmProvider = llmResolver.Resolve(summarySettings);
 
@@ -170,7 +179,7 @@ public sealed class ContainerSummaryWorker(
                     await embeddingProvider.GetSummaryEmbeddingsAsync(withSummaries, ct);
 
                 ContainerSummarizationResult result = await summarizer.GenerateAsync(
-                    container.Name, docsWithEmbeddings, ct);
+                    container.Name, docsWithEmbeddings, summarySettings, ct);
 
                 if (result.Skipped)
                 {

--- a/src/Connapse.Ingestion/Summarization/PerDocSummarizer.cs
+++ b/src/Connapse.Ingestion/Summarization/PerDocSummarizer.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-using System.Text;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;

--- a/src/Connapse.Ingestion/Summarization/PerDocSummarizer.cs
+++ b/src/Connapse.Ingestion/Summarization/PerDocSummarizer.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
 using Connapse.Storage.Llm;
@@ -9,47 +12,52 @@ public sealed class PerDocSummarizer(
     IDocumentStore docStore,
     ITokenCounter tokenCounter) : IPerDocSummarizer
 {
-    private const int MaxInputCharacters = 20_000; // ~5K tokens — configurable later
+    private const int DefaultMaxInputTokens = 5_000;
 
     public async Task<PerDocSummarizationResult> GenerateAsync(
         string documentId,
         string docText,
         string? mimeType,
         string fileName,
+        SummarySettings settings,
         CancellationToken ct = default)
     {
+        if (!settings.Enabled)
+            return new PerDocSummarizationResult(Skipped: true, SkipReason: "summaries_disabled");
+
         if (llmProvider is null)
-        {
             return new PerDocSummarizationResult(Skipped: true, SkipReason: "no_provider_configured");
-        }
 
         if (string.IsNullOrWhiteSpace(docText))
-        {
             return new PerDocSummarizationResult(Skipped: true, SkipReason: "extraction_empty");
-        }
 
         string contentHash = HexHash.Sha256(docText);
 
         Connapse.Core.Document? existing = await docStore.GetAsync(documentId, ct);
         if (existing?.SummaryContentHash == contentHash)
-        {
             return new PerDocSummarizationResult(Skipped: true, SkipReason: "content_hash_match");
-        }
 
-        string truncated = docText.Length > MaxInputCharacters
-            ? docText[..MaxInputCharacters]
-            : docText;
+        int maxTokens = settings.MaxInputTokens ?? DefaultMaxInputTokens;
+        int maxChars = maxTokens * 4;
+        string truncated = docText.Length > maxChars ? docText[..maxChars] : docText;
+
+        string systemPrompt = !string.IsNullOrWhiteSpace(settings.PerDocSystemPrompt)
+            ? settings.PerDocSystemPrompt
+            : SummaryPrompts.PerDocSystemPrompt;
 
         string userMessage = SummaryPrompts.RenderPerDocUserMessage(fileName, mimeType, truncated);
-        string systemPrompt = SummaryPrompts.PerDocSystemPrompt;
 
         int inputTokens = tokenCounter.CountTokens(systemPrompt) + tokenCounter.CountTokens(userMessage);
 
+        LlmCompletionOptions? options = settings.LlmModel is null
+            ? null
+            : new LlmCompletionOptions(Model: settings.LlmModel);
+
         string responseText = await llmProvider.CompleteAsync(
-            systemPrompt, userMessage, options: null, ct);
+            systemPrompt, userMessage, options, ct);
 
         int outputTokens = tokenCounter.CountTokens(responseText);
-        string model = llmProvider.ModelId;
+        string model = settings.LlmModel ?? llmProvider.ModelId;
 
         DateTime now = DateTime.UtcNow;
         await docStore.UpdateSummaryAsync(documentId, responseText, now, contentHash, ct);
@@ -61,5 +69,4 @@ public sealed class PerDocSummarizer(
             OutputTokens: outputTokens,
             Model: model);
     }
-
 }

--- a/src/Connapse.Storage/Llm/AnthropicLlmProvider.cs
+++ b/src/Connapse.Storage/Llm/AnthropicLlmProvider.cs
@@ -96,14 +96,15 @@ public class AnthropicLlmProvider : ILlmProvider
         }
     }
 
-    private MessageCreateParams BuildParams(
+    internal MessageCreateParams BuildParams(
         string systemPrompt, string userPrompt, LlmCompletionOptions? options)
     {
         var temperature = options?.Temperature ?? (float)_settings.Temperature;
+        var model = options?.Model ?? _settings.Model;
 
         var parameters = new MessageCreateParams
         {
-            Model = _settings.Model,
+            Model = model,
             MaxTokens = options?.MaxTokens ?? _settings.MaxTokens,
             Temperature = temperature,
             Messages =

--- a/src/Connapse.Storage/Llm/AzureOpenAiLlmProvider.cs
+++ b/src/Connapse.Storage/Llm/AzureOpenAiLlmProvider.cs
@@ -14,7 +14,7 @@ namespace Connapse.Storage.Llm;
 /// </summary>
 public class AzureOpenAiLlmProvider : ILlmProvider
 {
-    private readonly ChatClient _client;
+    private readonly AzureOpenAIClient _client;
     private readonly ILogger<AzureOpenAiLlmProvider> _logger;
     private readonly LlmSettings _settings;
 
@@ -35,13 +35,8 @@ public class AzureOpenAiLlmProvider : ILlmProvider
             throw new InvalidOperationException(
                 "Azure OpenAI API key is required. Configure it in Settings > LLM > API Key.");
 
-        var deploymentName = !string.IsNullOrWhiteSpace(_settings.AzureDeploymentName)
-            ? _settings.AzureDeploymentName
-            : _settings.Model;
-
         var credential = new ApiKeyCredential(apiKey);
-        var azureClient = new AzureOpenAIClient(new Uri(endpoint), credential);
-        _client = azureClient.GetChatClient(deploymentName);
+        _client = new AzureOpenAIClient(new Uri(endpoint), credential);
     }
 
     public string Provider => "AzureOpenAI";
@@ -49,19 +44,31 @@ public class AzureOpenAiLlmProvider : ILlmProvider
         ? _settings.AzureDeploymentName
         : _settings.Model;
 
+    /// <summary>
+    /// Resolves the Azure deployment name to use for a request. Per-request
+    /// <see cref="LlmCompletionOptions.Model"/> overrides the configured
+    /// <see cref="LlmSettings.AzureDeploymentName"/>, falling back to
+    /// <see cref="LlmSettings.Model"/>. Callers using the override are
+    /// responsible for ensuring the named deployment exists on the Azure resource.
+    /// </summary>
+    internal string ResolveModel(LlmCompletionOptions? options)
+        => options?.Model ?? _settings.AzureDeploymentName ?? _settings.Model;
+
     public async Task<string> CompleteAsync(
         string systemPrompt,
         string userPrompt,
         LlmCompletionOptions? options = null,
         CancellationToken ct = default)
     {
+        var deployment = ResolveModel(options);
+        var chatClient = _client.GetChatClient(deployment);
         var messages = BuildMessages(systemPrompt, userPrompt);
         var chatOptions = BuildOptions(options);
 
         try
         {
             ClientResult<ChatCompletion> result =
-                await _client.CompleteChatAsync(messages, chatOptions, ct);
+                await chatClient.CompleteChatAsync(messages, chatOptions, ct);
 
             var text = result.Value.Content[0].Text;
             _logger.LogDebug("Azure OpenAI completion: {TokenCount} chars", text.Length);
@@ -72,7 +79,7 @@ public class AzureOpenAiLlmProvider : ILlmProvider
             _logger.LogError(ex, "Azure OpenAI chat completion failed (status {Status})", ex.Status);
             throw new InvalidOperationException(
                 $"Azure OpenAI chat completion failed (HTTP {ex.Status}): {ex.Message}. " +
-                $"Verify your endpoint, API key, and deployment '{ModelId}' are correct.", ex);
+                $"Verify your endpoint, API key, and deployment '{deployment}' are correct.", ex);
         }
     }
 
@@ -82,19 +89,22 @@ public class AzureOpenAiLlmProvider : ILlmProvider
         LlmCompletionOptions? options = null,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
+        var deployment = ResolveModel(options);
+        var chatClient = _client.GetChatClient(deployment);
         var messages = BuildMessages(systemPrompt, userPrompt);
         var chatOptions = BuildOptions(options);
 
         AsyncCollectionResult<StreamingChatCompletionUpdate> updates;
         try
         {
-            updates = _client.CompleteChatStreamingAsync(messages, chatOptions, ct);
+            updates = chatClient.CompleteChatStreamingAsync(messages, chatOptions, ct);
         }
         catch (ClientResultException ex)
         {
             _logger.LogError(ex, "Azure OpenAI streaming failed (status {Status})", ex.Status);
             throw new InvalidOperationException(
-                $"Azure OpenAI streaming failed (HTTP {ex.Status}): {ex.Message}.", ex);
+                $"Azure OpenAI streaming failed (HTTP {ex.Status}): {ex.Message}. " +
+                $"Verify your endpoint, API key, and deployment '{deployment}' are correct.", ex);
         }
 
         await foreach (var update in updates)

--- a/src/Connapse.Storage/Llm/OllamaLlmProvider.cs
+++ b/src/Connapse.Storage/Llm/OllamaLlmProvider.cs
@@ -42,7 +42,8 @@ public class OllamaLlmProvider : ILlmProvider
         LlmCompletionOptions? options = null,
         CancellationToken ct = default)
     {
-        var request = BuildRequest(systemPrompt, userPrompt, options, stream: false);
+        var resolvedModel = ResolveModel(options);
+        var request = BuildRequest(systemPrompt, userPrompt, options, resolvedModel, stream: false);
 
         try
         {
@@ -62,7 +63,7 @@ public class OllamaLlmProvider : ILlmProvider
             _logger.LogError(ex, "Failed to connect to Ollama at {BaseUrl}", _httpClient.BaseAddress);
             throw new InvalidOperationException(
                 $"Failed to connect to Ollama at {_httpClient.BaseAddress}. " +
-                $"Ensure Ollama is running and the model '{_settings.Model}' is available.", ex);
+                $"Ensure Ollama is running and the model '{resolvedModel}' is available.", ex);
         }
     }
 
@@ -72,7 +73,8 @@ public class OllamaLlmProvider : ILlmProvider
         LlmCompletionOptions? options = null,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
-        var request = BuildRequest(systemPrompt, userPrompt, options, stream: true);
+        var resolvedModel = ResolveModel(options);
+        var request = BuildRequest(systemPrompt, userPrompt, options, resolvedModel, stream: true);
 
         HttpResponseMessage response;
         try
@@ -91,7 +93,7 @@ public class OllamaLlmProvider : ILlmProvider
             _logger.LogError(ex, "Failed to connect to Ollama at {BaseUrl}", _httpClient.BaseAddress);
             throw new InvalidOperationException(
                 $"Failed to connect to Ollama at {_httpClient.BaseAddress}. " +
-                $"Ensure Ollama is running and the model '{_settings.Model}' is available.", ex);
+                $"Ensure Ollama is running and the model '{resolvedModel}' is available.", ex);
         }
 
         await using var stream = await response.Content.ReadAsStreamAsync(ct);
@@ -128,7 +130,7 @@ public class OllamaLlmProvider : ILlmProvider
 
     private OllamaChatRequest BuildRequest(
         string systemPrompt, string userPrompt,
-        LlmCompletionOptions? options, bool stream)
+        LlmCompletionOptions? options, string resolvedModel, bool stream)
     {
         var messages = new List<OllamaChatMessage>();
 
@@ -139,7 +141,7 @@ public class OllamaLlmProvider : ILlmProvider
 
         return new OllamaChatRequest
         {
-            Model = _settings.Model,
+            Model = resolvedModel,
             Messages = messages,
             Stream = stream,
             Options = new OllamaChatOptions
@@ -148,6 +150,11 @@ public class OllamaLlmProvider : ILlmProvider
                 NumPredict = options?.MaxTokens ?? _settings.MaxTokens
             }
         };
+    }
+
+    internal string ResolveModel(LlmCompletionOptions? options)
+    {
+        return options?.Model ?? _settings.Model;
     }
 
     // DTOs for Ollama /api/chat

--- a/src/Connapse.Storage/Llm/OpenAiLlmProvider.cs
+++ b/src/Connapse.Storage/Llm/OpenAiLlmProvider.cs
@@ -100,7 +100,7 @@ public class OpenAiLlmProvider : ILlmProvider
         {
             _logger.LogError(ex, "OpenAI streaming failed (status {Status})", ex.Status);
             throw new InvalidOperationException(
-                $"OpenAI streaming failed (HTTP {ex.Status}): {ex.Message}.", ex);
+                $"OpenAI streaming failed (HTTP {ex.Status}): {ex.Message}. Verify your API key and model '{model}' are correct.", ex);
         }
 
         await foreach (var update in updates)

--- a/src/Connapse.Storage/Llm/OpenAiLlmProvider.cs
+++ b/src/Connapse.Storage/Llm/OpenAiLlmProvider.cs
@@ -15,7 +15,7 @@ namespace Connapse.Storage.Llm;
 /// </summary>
 public class OpenAiLlmProvider : ILlmProvider
 {
-    private readonly ChatClient _client;
+    private readonly OpenAIClient _client;
     private readonly ILogger<OpenAiLlmProvider> _logger;
     private readonly LlmSettings _settings;
 
@@ -37,17 +37,19 @@ public class OpenAiLlmProvider : ILlmProvider
         if (!string.IsNullOrWhiteSpace(baseUrl) && baseUrl != "http://localhost:11434")
         {
             var options = new OpenAIClientOptions { Endpoint = new Uri(baseUrl) };
-            var client = new OpenAIClient(credential, options);
-            _client = client.GetChatClient(_settings.Model);
+            _client = new OpenAIClient(credential, options);
         }
         else
         {
-            _client = new ChatClient(_settings.Model, credential);
+            _client = new OpenAIClient(credential);
         }
     }
 
     public string Provider => "OpenAI";
     public string ModelId => _settings.Model;
+
+    internal string ResolveModel(LlmCompletionOptions? options)
+        => options?.Model ?? _settings.Model;
 
     public async Task<string> CompleteAsync(
         string systemPrompt,
@@ -55,13 +57,15 @@ public class OpenAiLlmProvider : ILlmProvider
         LlmCompletionOptions? options = null,
         CancellationToken ct = default)
     {
+        var model = ResolveModel(options);
+        var chatClient = _client.GetChatClient(model);
         var messages = BuildMessages(systemPrompt, userPrompt);
         var chatOptions = BuildOptions(options);
 
         try
         {
             ClientResult<ChatCompletion> result =
-                await _client.CompleteChatAsync(messages, chatOptions, ct);
+                await chatClient.CompleteChatAsync(messages, chatOptions, ct);
 
             var text = result.Value.Content[0].Text;
             _logger.LogDebug("OpenAI completion: {TokenCount} chars", text.Length);
@@ -72,7 +76,7 @@ public class OpenAiLlmProvider : ILlmProvider
             _logger.LogError(ex, "OpenAI chat completion failed (status {Status})", ex.Status);
             throw new InvalidOperationException(
                 $"OpenAI chat completion failed (HTTP {ex.Status}): {ex.Message}. " +
-                $"Verify your API key and model '{_settings.Model}' are correct.", ex);
+                $"Verify your API key and model '{model}' are correct.", ex);
         }
     }
 
@@ -82,13 +86,15 @@ public class OpenAiLlmProvider : ILlmProvider
         LlmCompletionOptions? options = null,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
+        var model = ResolveModel(options);
+        var chatClient = _client.GetChatClient(model);
         var messages = BuildMessages(systemPrompt, userPrompt);
         var chatOptions = BuildOptions(options);
 
         AsyncCollectionResult<StreamingChatCompletionUpdate> updates;
         try
         {
-            updates = _client.CompleteChatStreamingAsync(messages, chatOptions, ct);
+            updates = chatClient.CompleteChatStreamingAsync(messages, chatOptions, ct);
         }
         catch (ClientResultException ex)
         {

--- a/src/Connapse.Web/Components/Pages/FileBrowser.razor
+++ b/src/Connapse.Web/Components/Pages/FileBrowser.razor
@@ -5,7 +5,9 @@
 @using Connapse.Core.Interfaces
 @using Connapse.Core.Utilities
 @using Connapse.Storage.Connectors
+@using Microsoft.Extensions.Options
 @inject IContainerStore ContainerStore
+@inject IOptionsMonitor<LlmSettings> LlmOptions
 @inject IDocumentStore DocumentStore
 @inject IFolderStore FolderStore
 @inject IKnowledgeFileSystem FileSystem
@@ -156,6 +158,13 @@
                             <input type="number" class="form-control form-control-sm" placeholder="Global default (@globalTopK)" @bind="settingsTopK" min="1" max="100" />
                         </div>
                     </div>
+                </div>
+                @* Summary Generation *@
+                <div class="col-12">
+                    <h6 class="text-accent mb-3">Summary Generation</h6>
+                    <SummarySettingsTab @ref="summaryTabRef"
+                                        Settings="summarySettings"
+                                        ResolvedModelPlaceholder="@LlmOptions.CurrentValue.Model" />
                 </div>
                 @* UI Permissions — Filesystem containers only *@
                 @if (container?.ConnectorType == ConnectorType.Filesystem)
@@ -549,6 +558,9 @@
     private string settingsSearchMode = "";
     private int? settingsTopK;
     private double? settingsMinScore;
+    // Summary overrides
+    private SummarySettings summarySettings = new();
+    private SummarySettingsTab? summaryTabRef;
     // Global defaults (shown as placeholders)
     private string globalChunkingStrategy = "Semantic";
     private int globalMaxChunkSize = 512;
@@ -1486,6 +1498,10 @@
             settingsTopK = overrides?.Search?.TopK;
             settingsMinScore = overrides?.Search?.MinimumScore;
 
+            // Summary: fall back to resolved (global) value when no per-container override
+            var globalSummary = await SettingsResolver.GetSummarySettingsAsync(containerId);
+            summarySettings = overrides?.Summary ?? globalSummary;
+
             // Filesystem permission toggles
             settingsAllowUpload = filesystemConfig?.AllowUpload ?? true;
             settingsAllowDelete = filesystemConfig?.AllowDelete ?? true;
@@ -1511,6 +1527,7 @@
 
         try
         {
+            var summaryToSave = summaryTabRef?.GetCurrentSettings() ?? summarySettings;
             var overrides = new ContainerSettingsOverrides
             {
                 Chunking = (!string.IsNullOrEmpty(settingsChunkingStrategy) || settingsMaxChunkSize.HasValue || settingsOverlap.HasValue)
@@ -1536,7 +1553,8 @@
                         TopK = settingsTopK ?? globalTopK,
                         MinimumScore = settingsMinScore ?? globalMinScore
                     }
-                    : null
+                    : null,
+                Summary = HasSummaryOverride(summaryToSave) ? summaryToSave : null
             };
 
             await ContainerStore.SaveSettingsOverridesAsync(containerId, overrides);
@@ -1589,6 +1607,8 @@
             settingsSearchMode = "";
             settingsTopK = null;
             settingsMinScore = null;
+            // Reset summary to resolved (global) value after clearing per-container override
+            summarySettings = await SettingsResolver.GetSummarySettingsAsync(containerId);
             settingsSaved = true;
         }
         catch (Exception ex)
@@ -1600,6 +1620,16 @@
             settingsSaving = false;
         }
     }
+
+    // Treat an "all-default" SummarySettings (Enabled=false + every override null) as no
+    // per-container override, so we don't pollute settings_overrides_json with empty objects.
+    private static bool HasSummaryOverride(SummarySettings s) =>
+        s.Enabled
+        || s.LlmProvider is not null
+        || s.LlmModel is not null
+        || s.PerDocSystemPrompt is not null
+        || s.ContainerRollupSystemPrompt is not null
+        || s.MaxInputTokens is not null;
 
     public async ValueTask DisposeAsync()
     {

--- a/src/Connapse.Web/Components/Pages/Settings.razor
+++ b/src/Connapse.Web/Components/Pages/Settings.razor
@@ -13,6 +13,7 @@
 @inject IOptionsMonitor<UploadSettings> UploadOptions
 @inject IOptionsMonitor<AwsSsoSettings> AwsSsoOptions
 @inject IOptionsMonitor<AzureAdSettings> AzureAdOptions
+@inject IOptionsMonitor<SummarySettings> SummaryOptions
 @rendermode InteractiveServer
 
 <PageTitle>Settings - Connapse</PageTitle>
@@ -82,6 +83,13 @@
                 Azure AD
             </button>
         </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link @(activeTab == "summary" ? "active" : "")"
+                    @onclick='() => activeTab = "summary"'
+                    type="button">
+                Summary
+            </button>
+        </li>
     </ul>
 
     <!-- Tab Content -->
@@ -114,6 +122,13 @@
         {
             <AzureAdSettingsTab Settings="azureAdSettings" OnSave="SaveAzureAdSettings" />
         }
+        else if (activeTab == "summary")
+        {
+            <SummarySettingsTab @ref="summaryTabRef"
+                                Settings="summarySettings"
+                                ResolvedModelPlaceholder="@LlmOptions.CurrentValue.Model" />
+            <button class="btn btn-primary mt-3" @onclick="SaveSummarySettings">Save Summary Settings</button>
+        }
     </div>
 </div>
 
@@ -129,6 +144,8 @@
     private UploadSettings uploadSettings = new();
     private AwsSsoSettings awsSsoSettings = new();
     private AzureAdSettings azureAdSettings = new();
+    private SummarySettings summarySettings = new();
+    private SummarySettingsTab? summaryTabRef;
 
     protected override async Task OnInitializedAsync()
     {
@@ -140,6 +157,7 @@
         uploadSettings = UploadOptions.CurrentValue;
         awsSsoSettings = AwsSsoOptions.CurrentValue;
         azureAdSettings = AzureAdOptions.CurrentValue;
+        summarySettings = SummaryOptions.CurrentValue;
     }
 
     private async Task SaveEmbeddingSettings(EmbeddingSettings settings)
@@ -182,6 +200,16 @@
     {
         await SaveSettings("azuread", settings);
         azureAdSettings = settings;
+    }
+
+    private async Task SaveSummarySettings()
+    {
+        if (summaryTabRef is null) return;
+        // Use "Summary" (capital S) to match the category key read by
+        // ContainerSettingsResolver.GetSummarySettingsAsync.
+        var toSave = summaryTabRef.GetCurrentSettings();
+        await SaveSettings("Summary", toSave);
+        summarySettings = toSave;
     }
 
     private async Task SaveSettings<T>(string category, T settings) where T : class

--- a/src/Connapse.Web/Components/Settings/SummarySettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/SummarySettingsTab.razor
@@ -1,0 +1,213 @@
+@using Connapse.Core
+@using Connapse.Storage.Llm
+
+<div class="settings-tab">
+    <h4 class="mb-3">Summary Generation</h4>
+    <p class="text-muted mb-4">
+        Configure auto-generated per-document and per-container summaries.
+        Per-doc summaries fire at ingestion; container rollups fire on debounce.
+        Disabled means both skip and no LLM call is made.
+    </p>
+
+    <div class="form-check form-switch mb-4">
+        <input class="form-check-input" type="checkbox" id="summaryEnabled"
+               checked="@enabled"
+               @onchange="OnEnabledChanged" />
+        <label class="form-check-label" for="summaryEnabled">
+            <strong>Enable summary generation</strong>
+        </label>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">LLM Provider (override)</label>
+        <select class="form-select" value="@(llmProvider ?? string.Empty)"
+                @onchange="OnProviderChanged">
+            <option value="">Inherit from global LLM</option>
+            <option value="Ollama">Ollama</option>
+            <option value="OpenAI">OpenAI</option>
+            <option value="AzureOpenAI">AzureOpenAI</option>
+            <option value="Anthropic">Anthropic</option>
+        </select>
+        <div class="form-text">Leave as "Inherit" to use the same provider as chat.</div>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">LLM Model (override)</label>
+        <input type="text" class="form-control"
+               value="@(llmModel ?? string.Empty)"
+               placeholder="@(ResolvedModelPlaceholder ?? "Inherit from global LLM")"
+               @oninput="OnModelChanged" />
+        <div class="form-text">Leave blank to inherit. Example: <code>qwen3:14b</code>, <code>claude-haiku-4-5</code>.</div>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">Max input tokens per document</label>
+        <input type="number" class="form-control"
+               value="@(maxInputTokens?.ToString() ?? string.Empty)"
+               placeholder="5000 (default)"
+               @oninput="OnMaxInputTokensChanged" />
+        <div class="form-text">Cap on how much of each document the LLM sees. Empty = use default (5000).</div>
+    </div>
+
+    <div class="mb-3">
+        <div class="d-flex justify-content-between align-items-center mb-1">
+            <label class="form-label mb-0">Per-document system prompt</label>
+            <button type="button" class="btn btn-link btn-sm p-0"
+                    @onclick="RestorePerDocDefault">Restore default</button>
+        </div>
+        <textarea class="form-control" rows="10"
+                  value="@perDocPromptText"
+                  @oninput="OnPerDocPromptChanged"></textarea>
+        <div class="form-text">
+            @if (IsPerDocAtDefault)
+            {
+                <span>Currently using in-code default. Edit to override.</span>
+            }
+            else
+            {
+                <span class="text-warning">● Modified (override stored)</span>
+            }
+        </div>
+    </div>
+
+    <div class="mb-3">
+        <div class="d-flex justify-content-between align-items-center mb-1">
+            <label class="form-label mb-0">Container rollup system prompt</label>
+            <button type="button" class="btn btn-link btn-sm p-0"
+                    @onclick="RestoreContainerDefault">Restore default</button>
+        </div>
+        <textarea class="form-control" rows="10"
+                  value="@containerPromptText"
+                  @oninput="OnContainerPromptChanged"></textarea>
+        <div class="form-text">
+            @if (IsContainerAtDefault)
+            {
+                <span>Currently using in-code default. Edit to override.</span>
+            }
+            else
+            {
+                <span class="text-warning">● Modified (override stored)</span>
+            }
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public SummarySettings Settings { get; set; } = default!;
+
+    [Parameter]
+    public EventCallback<SummarySettings> SettingsChanged { get; set; }
+
+    [Parameter]
+    public string? ResolvedModelPlaceholder { get; set; }
+
+    // SummarySettings is an init-only record, so we hold edit state in
+    // intermediate fields and reconstruct the record on every change.
+    private bool enabled;
+    private string? llmProvider;
+    private string? llmModel;
+    private int? maxInputTokens;
+    private string perDocPromptText = string.Empty;
+    private string containerPromptText = string.Empty;
+
+    private bool IsPerDocAtDefault =>
+        perDocPromptText.Trim() == SummaryPrompts.PerDocSystemPrompt.Trim();
+
+    private bool IsContainerAtDefault =>
+        containerPromptText.Trim() == SummaryPrompts.ContainerRollupSystemPrompt.Trim();
+
+    protected override void OnParametersSet()
+    {
+        enabled = Settings.Enabled;
+        llmProvider = Settings.LlmProvider;
+        llmModel = Settings.LlmModel;
+        maxInputTokens = Settings.MaxInputTokens;
+        perDocPromptText = !string.IsNullOrWhiteSpace(Settings.PerDocSystemPrompt)
+            ? Settings.PerDocSystemPrompt!
+            : SummaryPrompts.PerDocSystemPrompt;
+        containerPromptText = !string.IsNullOrWhiteSpace(Settings.ContainerRollupSystemPrompt)
+            ? Settings.ContainerRollupSystemPrompt!
+            : SummaryPrompts.ContainerRollupSystemPrompt;
+    }
+
+    private Task OnEnabledChanged(ChangeEventArgs e)
+    {
+        enabled = e.Value is bool b && b;
+        return EmitChanged();
+    }
+
+    private Task OnProviderChanged(ChangeEventArgs e)
+    {
+        string? raw = e.Value as string;
+        llmProvider = string.IsNullOrWhiteSpace(raw) ? null : raw;
+        return EmitChanged();
+    }
+
+    private Task OnModelChanged(ChangeEventArgs e)
+    {
+        string? raw = e.Value as string;
+        llmModel = string.IsNullOrWhiteSpace(raw) ? null : raw;
+        return EmitChanged();
+    }
+
+    private Task OnMaxInputTokensChanged(ChangeEventArgs e)
+    {
+        string? raw = e.Value as string;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            maxInputTokens = null;
+        }
+        else if (int.TryParse(raw, out int parsed))
+        {
+            maxInputTokens = parsed;
+        }
+        return EmitChanged();
+    }
+
+    private Task OnPerDocPromptChanged(ChangeEventArgs e)
+    {
+        perDocPromptText = e.Value as string ?? string.Empty;
+        return EmitChanged();
+    }
+
+    private Task OnContainerPromptChanged(ChangeEventArgs e)
+    {
+        containerPromptText = e.Value as string ?? string.Empty;
+        return EmitChanged();
+    }
+
+    private Task RestorePerDocDefault()
+    {
+        perDocPromptText = SummaryPrompts.PerDocSystemPrompt;
+        return EmitChanged();
+    }
+
+    private Task RestoreContainerDefault()
+    {
+        containerPromptText = SummaryPrompts.ContainerRollupSystemPrompt;
+        return EmitChanged();
+    }
+
+    private Task EmitChanged() => SettingsChanged.InvokeAsync(BuildSettingsFromLocal());
+
+    private SummarySettings BuildSettingsFromLocal()
+    {
+        // Store the textarea content only if it differs from the in-code default —
+        // this keeps users in sync with prompt-default updates we ship later.
+        string? perDoc = IsPerDocAtDefault ? null : perDocPromptText;
+        string? containerRollup = IsContainerAtDefault ? null : containerPromptText;
+
+        return new SummarySettings
+        {
+            Enabled = enabled,
+            LlmProvider = llmProvider,
+            LlmModel = llmModel,
+            MaxInputTokens = maxInputTokens,
+            PerDocSystemPrompt = perDoc,
+            ContainerRollupSystemPrompt = containerRollup
+        };
+    }
+
+    public SummarySettings GetCurrentSettings() => BuildSettingsFromLocal();
+}

--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -163,6 +163,8 @@ builder.Services.Configure<LlmSettings>(
     builder.Configuration.GetSection("Knowledge:LLM"));
 builder.Services.Configure<UploadSettings>(
     builder.Configuration.GetSection("Knowledge:Upload"));
+builder.Services.Configure<SummarySettings>(
+    builder.Configuration.GetSection("Knowledge:Summary"));
 
 // Add rate limiting
 builder.Services.AddConnapseRateLimiting(builder.Configuration);

--- a/tests/Connapse.Core.Tests/Llm/AnthropicLlmProviderTests.cs
+++ b/tests/Connapse.Core.Tests/Llm/AnthropicLlmProviderTests.cs
@@ -76,4 +76,41 @@ public class AnthropicLlmProviderTests
 
         provider.ModelId.Should().Be("claude-opus-4-20250514");
     }
+
+    [Fact]
+    public void BuildParams_NoOverride_UsesConfiguredModel()
+    {
+        var settings = new TestOptionsSnapshot<LlmSettings>(new LlmSettings
+        {
+            Provider = "Anthropic",
+            Model = "claude-haiku-4-5",
+            AnthropicApiKey = "sk-ant-test-key"
+        });
+        var logger = Substitute.For<ILogger<AnthropicLlmProvider>>();
+        var provider = new AnthropicLlmProvider(settings, logger);
+
+        var parameters = provider.BuildParams("sys", "usr", options: null);
+
+        parameters.Model.Raw().Should().Be("claude-haiku-4-5");
+    }
+
+    [Fact]
+    public void BuildParams_WithModelOverride_UsesOverrideInsteadOfConfigured()
+    {
+        var settings = new TestOptionsSnapshot<LlmSettings>(new LlmSettings
+        {
+            Provider = "Anthropic",
+            Model = "claude-haiku-4-5",
+            AnthropicApiKey = "sk-ant-test-key"
+        });
+        var logger = Substitute.For<ILogger<AnthropicLlmProvider>>();
+        var provider = new AnthropicLlmProvider(settings, logger);
+
+        var parameters = provider.BuildParams(
+            "sys",
+            "usr",
+            options: new LlmCompletionOptions(Model: "claude-sonnet-4-6"));
+
+        parameters.Model.Raw().Should().Be("claude-sonnet-4-6");
+    }
 }

--- a/tests/Connapse.Core.Tests/Llm/AzureOpenAiLlmProviderTests.cs
+++ b/tests/Connapse.Core.Tests/Llm/AzureOpenAiLlmProviderTests.cs
@@ -99,4 +99,62 @@ public class AzureOpenAiLlmProviderTests
 
         provider.Provider.Should().Be("AzureOpenAI");
     }
+
+    [Fact]
+    public void ResolveModel_NoOverride_UsesConfiguredDeployment()
+    {
+        var settings = new TestOptionsSnapshot<LlmSettings>(new LlmSettings
+        {
+            Provider = "AzureOpenAI",
+            Model = "gpt-4-deployment",
+            AzureEndpoint = "https://test.openai.azure.com",
+            AzureApiKey = "test-key",
+            AzureDeploymentName = "gpt-4-deployment"
+        });
+        var logger = Substitute.For<ILogger<AzureOpenAiLlmProvider>>();
+        var provider = new AzureOpenAiLlmProvider(settings, logger);
+
+        var resolved = provider.ResolveModel(options: null);
+
+        resolved.Should().Be("gpt-4-deployment");
+    }
+
+    [Fact]
+    public void ResolveModel_WithModelOverride_UsesOverrideAsDeployment()
+    {
+        var settings = new TestOptionsSnapshot<LlmSettings>(new LlmSettings
+        {
+            Provider = "AzureOpenAI",
+            Model = "gpt-4-deployment",
+            AzureEndpoint = "https://test.openai.azure.com",
+            AzureApiKey = "test-key",
+            AzureDeploymentName = "gpt-4-deployment"
+        });
+        var logger = Substitute.For<ILogger<AzureOpenAiLlmProvider>>();
+        var provider = new AzureOpenAiLlmProvider(settings, logger);
+
+        var resolved = provider.ResolveModel(
+            options: new LlmCompletionOptions(Model: "gpt-4o-deployment"));
+
+        resolved.Should().Be("gpt-4o-deployment");
+    }
+
+    [Fact]
+    public void ResolveModel_NoOverrideOrDeployment_FallsBackToModel()
+    {
+        var settings = new TestOptionsSnapshot<LlmSettings>(new LlmSettings
+        {
+            Provider = "AzureOpenAI",
+            Model = "gpt-4o",
+            AzureEndpoint = "https://test.openai.azure.com",
+            AzureApiKey = "test-key",
+            AzureDeploymentName = null
+        });
+        var logger = Substitute.For<ILogger<AzureOpenAiLlmProvider>>();
+        var provider = new AzureOpenAiLlmProvider(settings, logger);
+
+        var resolved = provider.ResolveModel(options: null);
+
+        resolved.Should().Be("gpt-4o");
+    }
 }

--- a/tests/Connapse.Core.Tests/Llm/OllamaLlmProviderTests.cs
+++ b/tests/Connapse.Core.Tests/Llm/OllamaLlmProviderTests.cs
@@ -97,6 +97,27 @@ public class OllamaLlmProviderTests
         tokens.Should().BeEquivalentTo(["Hello", " world", "!"]);
     }
 
+    [Fact]
+    public void ResolveModel_NoOverride_UsesConfiguredModel()
+    {
+        var settings = new LlmSettings { Provider = "Ollama", Model = "llama3.2", BaseUrl = "http://localhost:11434" };
+        var handler = new StubHandler("""{"message":{"role":"assistant","content":"hi"},"done":true}""");
+        var provider = CreateProvider(handler, settings);
+
+        provider.ResolveModel(null).Should().Be("llama3.2");
+    }
+
+    [Fact]
+    public void ResolveModel_WithModelOverride_UsesOverride()
+    {
+        var settings = new LlmSettings { Provider = "Ollama", Model = "llama3.2", BaseUrl = "http://localhost:11434" };
+        var handler = new StubHandler("""{"message":{"role":"assistant","content":"hi"},"done":true}""");
+        var provider = CreateProvider(handler, settings);
+
+        var options = new LlmCompletionOptions(Model: "qwen3:14b");
+        provider.ResolveModel(options).Should().Be("qwen3:14b");
+    }
+
     /// <summary>
     /// Minimal HttpMessageHandler stub that returns a canned response.
     /// </summary>

--- a/tests/Connapse.Core.Tests/Llm/OpenAiLlmProviderTests.cs
+++ b/tests/Connapse.Core.Tests/Llm/OpenAiLlmProviderTests.cs
@@ -107,4 +107,39 @@ public class OpenAiLlmProviderTests
 
         provider.ModelId.Should().Be("gpt-4o-mini");
     }
+
+    [Fact]
+    public void ResolveModel_NoOverride_UsesConfiguredModel()
+    {
+        var settings = new TestOptionsSnapshot<LlmSettings>(new LlmSettings
+        {
+            Provider = "OpenAI",
+            Model = "gpt-4.1-nano",
+            OpenAiApiKey = "sk-test-key"
+        });
+        var logger = Substitute.For<ILogger<OpenAiLlmProvider>>();
+        var provider = new OpenAiLlmProvider(settings, logger);
+
+        var resolved = provider.ResolveModel(options: null);
+
+        resolved.Should().Be("gpt-4.1-nano");
+    }
+
+    [Fact]
+    public void ResolveModel_WithModelOverride_UsesOverrideInsteadOfConfigured()
+    {
+        var settings = new TestOptionsSnapshot<LlmSettings>(new LlmSettings
+        {
+            Provider = "OpenAI",
+            Model = "gpt-4.1-nano",
+            OpenAiApiKey = "sk-test-key"
+        });
+        var logger = Substitute.For<ILogger<OpenAiLlmProvider>>();
+        var provider = new OpenAiLlmProvider(settings, logger);
+
+        var resolved = provider.ResolveModel(
+            options: new LlmCompletionOptions(Model: "gpt-4.1-mini"));
+
+        resolved.Should().Be("gpt-4.1-mini");
+    }
 }

--- a/tests/Connapse.Core.Tests/LlmCompletionOptionsTests.cs
+++ b/tests/Connapse.Core.Tests/LlmCompletionOptionsTests.cs
@@ -1,0 +1,25 @@
+using Connapse.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests;
+
+[Trait("Category", "Unit")]
+public class LlmCompletionOptionsTests
+{
+    [Fact]
+    public void DefaultInstance_HasNullModel()
+    {
+        LlmCompletionOptions opts = new();
+        opts.Model.Should().BeNull();
+        opts.Temperature.Should().BeNull();
+        opts.MaxTokens.Should().BeNull();
+    }
+
+    [Fact]
+    public void Model_CanBeSetViaWithExpression()
+    {
+        LlmCompletionOptions opts = new() { Model = "claude-haiku-4-5" };
+        opts.Model.Should().Be("claude-haiku-4-5");
+    }
+}

--- a/tests/Connapse.Core.Tests/SummarySettingsTests.cs
+++ b/tests/Connapse.Core.Tests/SummarySettingsTests.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using Connapse.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests;
+
+[Trait("Category", "Unit")]
+public class SummarySettingsTests
+{
+    [Fact]
+    public void DefaultInstance_HasOptInDisabledAndNullableOverrides()
+    {
+        SummarySettings settings = new();
+
+        settings.Enabled.Should().BeFalse("opt-in by default");
+        settings.LlmProvider.Should().BeNull();
+        settings.LlmModel.Should().BeNull();
+        settings.PerDocSystemPrompt.Should().BeNull();
+        settings.ContainerRollupSystemPrompt.Should().BeNull();
+        settings.MaxInputTokens.Should().BeNull();
+    }
+
+    [Fact]
+    public void SerializesAndRoundTripsAllFields()
+    {
+        SummarySettings original = new()
+        {
+            Enabled = true,
+            LlmProvider = "Anthropic",
+            LlmModel = "claude-haiku-4-5",
+            PerDocSystemPrompt = "Custom per-doc prompt.",
+            ContainerRollupSystemPrompt = "Custom container prompt.",
+            MaxInputTokens = 8000
+        };
+
+        string json = JsonSerializer.Serialize(original);
+        SummarySettings? round = JsonSerializer.Deserialize<SummarySettings>(json);
+
+        round.Should().BeEquivalentTo(original);
+    }
+
+    [Fact]
+    public void DeserializesPartialJsonWithDefaultsForMissingFields()
+    {
+        string json = """{ "enabled": true, "llmProvider": "Ollama" }""";
+        var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+        SummarySettings? settings = JsonSerializer.Deserialize<SummarySettings>(json, opts);
+
+        settings.Should().NotBeNull();
+        settings!.Enabled.Should().BeTrue();
+        settings.LlmProvider.Should().Be("Ollama");
+        settings.LlmModel.Should().BeNull();
+        settings.PerDocSystemPrompt.Should().BeNull();
+        settings.MaxInputTokens.Should().BeNull();
+    }
+}

--- a/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
@@ -37,6 +37,7 @@ public class IngestionPipelineTests
     private readonly IOptionsMonitor<EmbeddingSettings> _embeddingSettings;
     private readonly IPerDocSummarizer _summarizer;
     private readonly IContainerSummaryQueue _dirtyQueue;
+    private readonly IContainerSettingsResolver _settingsResolver;
     private readonly ILogger<IngestionPipeline> _logger;
 
     public IngestionPipelineTests()
@@ -47,9 +48,12 @@ public class IngestionPipelineTests
         _summarizer = Substitute.For<IPerDocSummarizer>();
         _summarizer.GenerateAsync(
                 Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-                Arg.Any<string>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<SummarySettings>(), Arg.Any<CancellationToken>())
             .Returns(new PerDocSummarizationResult(Skipped: true, SkipReason: "no_provider_configured"));
         _dirtyQueue = Substitute.For<IContainerSummaryQueue>();
+        _settingsResolver = Substitute.For<IContainerSettingsResolver>();
+        _settingsResolver.GetSummarySettingsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new SummarySettings());
         _logger = NullLogger<IngestionPipeline>.Instance;
 
         _parser = Substitute.For<IDocumentParser>();
@@ -99,6 +103,7 @@ public class IngestionPipelineTests
             new EmbeddingCache(dbContext),
             _summarizer,
             _dirtyQueue,
+            _settingsResolver,
             _logger);
 
     private static KnowledgeDbContext CreateInMemoryContext()
@@ -268,7 +273,7 @@ public class IngestionPipelineTests
         // Arrange: summarizer throws — ingestion result should still be returned without throwing.
         _summarizer.GenerateAsync(
                 Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-                Arg.Any<string>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<SummarySettings>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("LLM unavailable"));
 
         using var dbContext = CreateInMemoryContext();

--- a/tests/Connapse.Ingestion.Tests/Summarization/ContainerSummarizerTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Summarization/ContainerSummarizerTests.cs
@@ -32,8 +32,9 @@ public class ContainerSummarizerTests
         tc.CountTokens(Arg.Any<string>()).Returns(3000, 500);
 
         ContainerSummarizer subject = new(llm, tc);
+        SummarySettings settings = new() { Enabled = true };
         ContainerSummarizationResult result =
-            await subject.GenerateAsync("Test Container", MakeDocs(30));
+            await subject.GenerateAsync("Test Container", MakeDocs(30), settings);
 
         result.Regime.Should().Be("stuff");
         result.NumDocs.Should().Be(30);
@@ -54,8 +55,9 @@ public class ContainerSummarizerTests
         tc.CountTokens(Arg.Any<string>()).Returns(3000, 500);
 
         ContainerSummarizer subject = new(llm, tc);
+        SummarySettings settings = new() { Enabled = true };
         ContainerSummarizationResult result =
-            await subject.GenerateAsync("Big Container", MakeDocs(150));
+            await subject.GenerateAsync("Big Container", MakeDocs(150), settings);
 
         result.Regime.Should().Be("cluster");
         result.NumDocs.Should().Be(150);
@@ -68,8 +70,9 @@ public class ContainerSummarizerTests
     {
         ITokenCounter tc = Substitute.For<ITokenCounter>();
         ContainerSummarizer subject = new(llmProvider: null, tc);
+        SummarySettings settings = new() { Enabled = true };
         ContainerSummarizationResult result =
-            await subject.GenerateAsync("Test", MakeDocs(5));
+            await subject.GenerateAsync("Test", MakeDocs(5), settings);
         result.Skipped.Should().BeTrue();
         result.SkipReason.Should().Be("no_provider_configured");
     }
@@ -80,9 +83,81 @@ public class ContainerSummarizerTests
         ILlmProvider llm = Substitute.For<ILlmProvider>();
         ITokenCounter tc = Substitute.For<ITokenCounter>();
         ContainerSummarizer subject = new(llm, tc);
+        SummarySettings settings = new() { Enabled = true };
         ContainerSummarizationResult result =
-            await subject.GenerateAsync("Empty", new List<DocumentWithSummary>());
+            await subject.GenerateAsync("Empty", new List<DocumentWithSummary>(), settings);
         result.Skipped.Should().BeTrue();
         result.SkipReason.Should().Be("no_documents");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WhenEnabledIsFalse_SkipsWithoutCallingProvider()
+    {
+        var llmProvider = Substitute.For<ILlmProvider>();
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        var summarizer = new ContainerSummarizer(llmProvider, tokenCounter);
+        var docs = new List<DocumentWithSummary>
+        {
+            new(Guid.NewGuid(), "sum1", new float[] { 0.1f })
+        };
+        var settings = new SummarySettings { Enabled = false };
+
+        var result = await summarizer.GenerateAsync("container", docs, settings, CancellationToken.None);
+
+        result.Skipped.Should().BeTrue();
+        result.SkipReason.Should().Be("summaries_disabled");
+        await llmProvider.DidNotReceive().CompleteAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LlmCompletionOptions?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithCustomContainerRollupSystemPrompt_SendsThatPromptToProvider()
+    {
+        var llmProvider = Substitute.For<ILlmProvider>();
+        llmProvider.ModelId.Returns("test-model");
+        llmProvider.CompleteAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LlmCompletionOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult("rollup"));
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        tokenCounter.CountTokens(Arg.Any<string>()).Returns(10);
+        var summarizer = new ContainerSummarizer(llmProvider, tokenCounter);
+        var docs = new List<DocumentWithSummary>
+        {
+            new(Guid.NewGuid(), "sum1", new float[] { 0.1f })
+        };
+        string customPrompt = "CONTAINER ROLLUP OVERRIDE — verbatim to LLM.";
+        var settings = new SummarySettings { Enabled = true, ContainerRollupSystemPrompt = customPrompt };
+
+        await summarizer.GenerateAsync("container", docs, settings, CancellationToken.None);
+
+        await llmProvider.Received(1).CompleteAsync(
+            customPrompt,
+            Arg.Any<string>(),
+            Arg.Any<LlmCompletionOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithLlmModelOverride_PassesModelInOptions()
+    {
+        var llmProvider = Substitute.For<ILlmProvider>();
+        llmProvider.ModelId.Returns("default-model");
+        llmProvider.CompleteAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LlmCompletionOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult("rollup"));
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        tokenCounter.CountTokens(Arg.Any<string>()).Returns(10);
+        var summarizer = new ContainerSummarizer(llmProvider, tokenCounter);
+        var docs = new List<DocumentWithSummary>
+        {
+            new(Guid.NewGuid(), "sum1", new float[] { 0.1f })
+        };
+        var settings = new SummarySettings { Enabled = true, LlmModel = "claude-sonnet-4-6" };
+
+        await summarizer.GenerateAsync("container", docs, settings, CancellationToken.None);
+
+        await llmProvider.Received(1).CompleteAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Is<LlmCompletionOptions?>(o => o != null && o.Model == "claude-sonnet-4-6"),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Connapse.Ingestion.Tests/Summarization/ContainerSummaryWorkerTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Summarization/ContainerSummaryWorkerTests.cs
@@ -122,7 +122,7 @@ public class ContainerSummaryWorkerTests
         documentStore.ListAsync(containerId, null, 0, 10_000, Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<Document>)[doc]);
         settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
-            .Returns(new SummarySettings());
+            .Returns(new SummarySettings { Enabled = true });
 
         // Use a real ServiceProvider so CreateAsyncScope() works correctly.
         ServiceCollection services = new();
@@ -185,7 +185,7 @@ public class ContainerSummaryWorkerTests
             .Returns((IReadOnlyList<DocumentWithSummary>)
                 [new DocumentWithSummary(Guid.Parse(docId), "some summary", [0.1f, 0.2f])]);
         settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
-            .Returns(new SummarySettings()); // no override — falls back to global ILlmProvider
+            .Returns(new SummarySettings { Enabled = true }); // no LLM override — falls back to global ILlmProvider
         llmProvider.Provider.Returns("Ollama");
         llmProvider.ModelId.Returns("llama3.2");
         llmProvider.CompleteAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LlmCompletionOptions?>(),
@@ -224,5 +224,57 @@ public class ContainerSummaryWorkerTests
             Arg.Any<DateTime?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessContainerAsync_WhenSummarySettingsDisabled_SkipsBeforeFetchingDocs()
+    {
+        Guid containerId = Guid.NewGuid();
+
+        Container container = new(
+            Id: containerId.ToString(),
+            Name: "Test Container",
+            Description: null,
+            ConnectorType: ConnectorType.ManagedStorage,
+            CreatedAt: DateTime.UtcNow,
+            UpdatedAt: DateTime.UtcNow);
+
+        IContainerStore containerStore = Substitute.For<IContainerStore>();
+        IDocumentStore documentStore = Substitute.For<IDocumentStore>();
+        IDocumentSummaryEmbeddingProvider embeddingProvider =
+            Substitute.For<IDocumentSummaryEmbeddingProvider>();
+        IContainerSettingsResolver settingsResolver = Substitute.For<IContainerSettingsResolver>();
+
+        containerStore.GetAsync(containerId, Arg.Any<CancellationToken>()).Returns(container);
+        settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
+            .Returns(new SummarySettings { Enabled = false });
+
+        // Note: ITokenCounter and SummaryLlmResolver are intentionally NOT registered. If the
+        // Enabled-gate short-circuit fails, scope resolution will throw, which fails the test.
+        ServiceCollection services = new();
+        services.AddSingleton(containerStore);
+        services.AddSingleton(documentStore);
+        services.AddSingleton(embeddingProvider);
+        services.AddSingleton<IContainerSettingsResolver>(settingsResolver);
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        IServiceScopeFactory scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        IContainerSummaryQueue queue = Substitute.For<IContainerSummaryQueue>();
+        ContainerSummaryWorker worker = new(
+            queue,
+            scopeFactory,
+            NullLogger<ContainerSummaryWorker>.Instance);
+
+        worker.SetDirtyForTest(containerId, 30);
+
+        await worker.ProcessContainerAsync(containerId, "test_trigger", CancellationToken.None);
+
+        // documentStore.ListAsync was never called — short-circuit happened before doc fetch
+        await documentStore.DidNotReceive().ListAsync(
+            Arg.Any<Guid>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+        // And UpdateSummaryAsync was never called — no rollup write
+        await containerStore.DidNotReceiveWithAnyArgs()
+            .UpdateSummaryAsync(default, default, default, default, default);
     }
 }

--- a/tests/Connapse.Ingestion.Tests/Summarization/PerDocSummarizerTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Summarization/PerDocSummarizerTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Ingestion.Summarization;
+using Connapse.Storage.Llm;
 using FluentAssertions;
 using NSubstitute;
 
@@ -40,7 +41,8 @@ public class PerDocSummarizerTests
             .Returns(MakeDoc(docId, hash, existingSummaryHash: hash));
 
         PerDocSummarizer subject = new(llm, docStore, tokenCounter);
-        PerDocSummarizationResult result = await subject.GenerateAsync(docId, docText, "text/plain", "file.txt");
+        SummarySettings settings = new() { Enabled = true };
+        PerDocSummarizationResult result = await subject.GenerateAsync(docId, docText, "text/plain", "file.txt", settings, CancellationToken.None);
 
         result.Skipped.Should().BeTrue();
         result.SkipReason.Should().Be("content_hash_match");
@@ -65,7 +67,8 @@ public class PerDocSummarizerTests
         tokenCounter.CountTokens(Arg.Any<string>()).Returns(5100, 100); // input total, output
 
         PerDocSummarizer subject = new(llm, docStore, tokenCounter);
-        PerDocSummarizationResult result = await subject.GenerateAsync(docId, "doc text", "text/plain", "file.txt");
+        SummarySettings settings = new() { Enabled = true };
+        PerDocSummarizationResult result = await subject.GenerateAsync(docId, "doc text", "text/plain", "file.txt", settings, CancellationToken.None);
 
         result.Skipped.Should().BeFalse();
         result.Summary.Should().Be("Apple earnings summary");
@@ -86,7 +89,8 @@ public class PerDocSummarizerTests
         string docId = Guid.NewGuid().ToString();
 
         PerDocSummarizer subject = new(llmProvider: null, docStore, tokenCounter);
-        PerDocSummarizationResult result = await subject.GenerateAsync(docId, "text", "text/plain", "x.txt");
+        SummarySettings settings = new() { Enabled = true };
+        PerDocSummarizationResult result = await subject.GenerateAsync(docId, "text", "text/plain", "x.txt", settings, CancellationToken.None);
 
         result.Skipped.Should().BeTrue();
         result.SkipReason.Should().Be("no_provider_configured");
@@ -101,11 +105,110 @@ public class PerDocSummarizerTests
         ITokenCounter tokenCounter = Substitute.For<ITokenCounter>();
 
         PerDocSummarizer subject = new(llm, docStore, tokenCounter);
+        SummarySettings settings = new() { Enabled = true };
         PerDocSummarizationResult result = await subject.GenerateAsync(
-            Guid.NewGuid().ToString(), "  \n\t  ", "text/plain", "empty.txt");
+            Guid.NewGuid().ToString(), "  \n\t  ", "text/plain", "empty.txt", settings, CancellationToken.None);
 
         result.Skipped.Should().BeTrue();
         result.SkipReason.Should().Be("extraction_empty");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WhenEnabledIsFalse_SkipsWithoutCallingProvider()
+    {
+        var llmProvider = Substitute.For<ILlmProvider>();
+        var docStore = Substitute.For<IDocumentStore>();
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        var summarizer = new PerDocSummarizer(llmProvider, docStore, tokenCounter);
+        var settings = new SummarySettings { Enabled = false };
+
+        var result = await summarizer.GenerateAsync(
+            "doc-1", "some text", "text/plain", "doc.txt", settings, CancellationToken.None);
+
+        result.Skipped.Should().BeTrue();
+        result.SkipReason.Should().Be("summaries_disabled");
+        await llmProvider.DidNotReceive().CompleteAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LlmCompletionOptions?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithCustomPerDocSystemPrompt_SendsThatPromptToProvider()
+    {
+        var llmProvider = Substitute.For<ILlmProvider>();
+        llmProvider.ModelId.Returns("test-model");
+        llmProvider.CompleteAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LlmCompletionOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult("generated summary"));
+
+        var docStore = Substitute.For<IDocumentStore>();
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        tokenCounter.CountTokens(Arg.Any<string>()).Returns(10);
+
+        var summarizer = new PerDocSummarizer(llmProvider, docStore, tokenCounter);
+        string customPrompt = "OVERRIDE SYSTEM PROMPT — must reach the LLM verbatim.";
+        var settings = new SummarySettings
+        {
+            Enabled = true,
+            PerDocSystemPrompt = customPrompt
+        };
+
+        await summarizer.GenerateAsync(
+            "doc-1", "some text", "text/plain", "doc.txt", settings, CancellationToken.None);
+
+        await llmProvider.Received(1).CompleteAsync(
+            customPrompt,
+            Arg.Any<string>(),
+            Arg.Any<LlmCompletionOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithLlmModelOverride_PassesModelInOptions()
+    {
+        var llmProvider = Substitute.For<ILlmProvider>();
+        llmProvider.ModelId.Returns("default-model");
+        llmProvider.CompleteAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LlmCompletionOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult("generated"));
+
+        var docStore = Substitute.For<IDocumentStore>();
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        tokenCounter.CountTokens(Arg.Any<string>()).Returns(10);
+
+        var summarizer = new PerDocSummarizer(llmProvider, docStore, tokenCounter);
+        var settings = new SummarySettings { Enabled = true, LlmModel = "qwen3:14b" };
+
+        await summarizer.GenerateAsync(
+            "doc-1", "text", "text/plain", "doc.txt", settings, CancellationToken.None);
+
+        await llmProvider.Received(1).CompleteAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Is<LlmCompletionOptions?>(o => o != null && o.Model == "qwen3:14b"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithMaxInputTokens_TruncatesInputToFourTimesTheLimit()
+    {
+        var llmProvider = Substitute.For<ILlmProvider>();
+        llmProvider.ModelId.Returns("test-model");
+        string? capturedUserPrompt = null;
+        llmProvider.CompleteAsync(Arg.Any<string>(), Arg.Do<string>(s => capturedUserPrompt = s), Arg.Any<LlmCompletionOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult("done"));
+
+        var docStore = Substitute.For<IDocumentStore>();
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        tokenCounter.CountTokens(Arg.Any<string>()).Returns(10);
+
+        var summarizer = new PerDocSummarizer(llmProvider, docStore, tokenCounter);
+        string longText = new string('a', 5000);  // 5000 chars
+        var settings = new SummarySettings { Enabled = true, MaxInputTokens = 100 };  // 100 tokens × 4 = 400 chars
+
+        await summarizer.GenerateAsync(
+            "doc-1", longText, "text/plain", "doc.txt", settings, CancellationToken.None);
+
+        capturedUserPrompt.Should().NotBeNull();
+        capturedUserPrompt!.Should().Contain(new string('a', 400));
+        capturedUserPrompt.Should().NotContain(new string('a', 401));
     }
 
     private static string ComputeSha256(string s)

--- a/tests/Connapse.Integration.Tests/SummarySettingsIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SummarySettingsIntegrationTests.cs
@@ -1,0 +1,223 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Integration tests for SummarySettings round-trip — both global (DB via ISettingsStore)
+/// and per-container (HTTP via /api/containers/{id}/settings).
+///
+/// Note: as of #330 the global /api/settings/{category} REST endpoint does NOT include
+/// a "summary" case in its switch — only the Blazor UI and ISettingsStore touch global
+/// summary settings today. The global test exercises the service layer directly to prove
+/// persistence. A separate test pins the current 404 behaviour so the gap is visible if
+/// someone later wires the HTTP endpoint without removing the assertion.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class SummarySettingsIntegrationTests(SharedWebAppFixture fixture)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    // ── Global SummarySettings — service-layer round-trip ─────────────────
+
+    [Fact]
+    public async Task SaveAsync_ThenGetAsync_GlobalSummarySettings_RoundTrips()
+    {
+        // Arrange — ISettingsStore is the source of truth for global settings;
+        // the global HTTP endpoint doesn't expose "summary" yet (see class doc).
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var settingsStore = scope.ServiceProvider.GetRequiredService<ISettingsStore>();
+
+        var original = await settingsStore.GetAsync<SummarySettings>("Summary");
+        try
+        {
+            var saved = new SummarySettings
+            {
+                Enabled = true,
+                LlmProvider = "Ollama",
+                LlmModel = "qwen3:14b",
+                PerDocSystemPrompt = "Test per-doc prompt.",
+                ContainerRollupSystemPrompt = "Test container prompt.",
+                MaxInputTokens = 3000
+            };
+
+            // Act
+            await settingsStore.SaveAsync("Summary", saved);
+            var loaded = await settingsStore.GetAsync<SummarySettings>("Summary");
+
+            // Assert
+            loaded.Should().NotBeNull();
+            loaded!.Enabled.Should().BeTrue();
+            loaded.LlmProvider.Should().Be("Ollama");
+            loaded.LlmModel.Should().Be("qwen3:14b");
+            loaded.PerDocSystemPrompt.Should().Be("Test per-doc prompt.");
+            loaded.ContainerRollupSystemPrompt.Should().Be("Test container prompt.");
+            loaded.MaxInputTokens.Should().Be(3000);
+        }
+        finally
+        {
+            // Restore (or reset to defaults if nothing was there originally) so we don't
+            // leak state into sibling tests that share the fixture.
+            if (original is null)
+                await settingsStore.ResetAsync("Summary");
+            else
+                await settingsStore.SaveAsync("Summary", original);
+        }
+    }
+
+    [Fact]
+    public async Task SaveAsync_NullOptionalFields_PreservesNulls()
+    {
+        // Arrange
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var settingsStore = scope.ServiceProvider.GetRequiredService<ISettingsStore>();
+
+        var original = await settingsStore.GetAsync<SummarySettings>("Summary");
+        try
+        {
+            // Only Enabled is set — every other field is null, exercising the
+            // "inherit from LLM settings / fall back to defaults" path.
+            var saved = new SummarySettings { Enabled = false };
+
+            // Act
+            await settingsStore.SaveAsync("Summary", saved);
+            var loaded = await settingsStore.GetAsync<SummarySettings>("Summary");
+
+            // Assert
+            loaded.Should().NotBeNull();
+            loaded!.Enabled.Should().BeFalse();
+            loaded.LlmProvider.Should().BeNull();
+            loaded.LlmModel.Should().BeNull();
+            loaded.PerDocSystemPrompt.Should().BeNull();
+            loaded.ContainerRollupSystemPrompt.Should().BeNull();
+            loaded.MaxInputTokens.Should().BeNull();
+        }
+        finally
+        {
+            if (original is null)
+                await settingsStore.ResetAsync("Summary");
+            else
+                await settingsStore.SaveAsync("Summary", original);
+        }
+    }
+
+    // ── Global SummarySettings — pins the missing HTTP endpoint ───────────
+
+    [Fact]
+    public async Task GetSettings_SummaryCategory_Returns404_BecauseHttpEndpointNotWired()
+    {
+        // Documents the current gap: SettingsEndpoints.cs has no "summary" case in its
+        // GET/PUT switch — global summary settings flow through the Blazor UI and
+        // ISettingsStore only. If this test ever fails with 200, the HTTP endpoint
+        // has been wired up and this test should be replaced with a real round-trip.
+        var response = await fixture.AdminClient.GetAsync("/api/settings/summary");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Per-container SummarySettings — HTTP round-trip ───────────────────
+
+    [Fact]
+    public async Task SaveContainerSettings_SummaryOverride_PersistsAndRetrieves()
+    {
+        // Arrange — create a fresh container so this test is self-contained.
+        var createResponse = await fixture.AdminClient.PostAsJsonAsync("/api/containers",
+            new { Name = "summary-settings-override-test" });
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var container = await createResponse.Content.ReadFromJsonAsync<ContainerDto>(JsonOptions);
+        container.Should().NotBeNull();
+
+        try
+        {
+            var overrides = new ContainerSettingsOverrides
+            {
+                Summary = new SummarySettings
+                {
+                    Enabled = true,
+                    LlmProvider = "Anthropic",
+                    LlmModel = "claude-haiku-4-5",
+                    PerDocSystemPrompt = "Container-scoped per-doc prompt.",
+                    ContainerRollupSystemPrompt = "Container-scoped rollup prompt.",
+                    MaxInputTokens = 2000
+                }
+            };
+
+            // Act — PUT then GET the per-container settings.
+            var putResponse = await fixture.AdminClient.PutAsJsonAsync(
+                $"/api/containers/{container!.Id}/settings", overrides);
+            putResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var getResponse = await fixture.AdminClient.GetAsync(
+                $"/api/containers/{container.Id}/settings");
+            getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            var retrieved = await getResponse.Content.ReadFromJsonAsync<ContainerSettingsOverrides>(JsonOptions);
+
+            // Assert — only the Summary slot should be populated.
+            retrieved.Should().NotBeNull();
+            retrieved!.Summary.Should().NotBeNull();
+            retrieved.Summary!.Enabled.Should().BeTrue();
+            retrieved.Summary.LlmProvider.Should().Be("Anthropic");
+            retrieved.Summary.LlmModel.Should().Be("claude-haiku-4-5");
+            retrieved.Summary.PerDocSystemPrompt.Should().Be("Container-scoped per-doc prompt.");
+            retrieved.Summary.ContainerRollupSystemPrompt.Should().Be("Container-scoped rollup prompt.");
+            retrieved.Summary.MaxInputTokens.Should().Be(2000);
+
+            retrieved.Chunking.Should().BeNull("only summary was overridden");
+            retrieved.Embedding.Should().BeNull("only summary was overridden");
+            retrieved.Search.Should().BeNull("only summary was overridden");
+            retrieved.Upload.Should().BeNull("only summary was overridden");
+        }
+        finally
+        {
+            await fixture.AdminClient.DeleteAsync($"/api/containers/{container!.Id}");
+        }
+    }
+
+    [Fact]
+    public async Task SaveContainerSettings_SummaryOverride_ResetToNull_ClearsOverride()
+    {
+        // Arrange
+        var createResponse = await fixture.AdminClient.PostAsJsonAsync("/api/containers",
+            new { Name = "summary-settings-reset-test" });
+        var container = await createResponse.Content.ReadFromJsonAsync<ContainerDto>(JsonOptions);
+
+        try
+        {
+            // Set a summary override.
+            var withOverride = new ContainerSettingsOverrides
+            {
+                Summary = new SummarySettings { Enabled = true, LlmModel = "to-be-cleared" }
+            };
+            await fixture.AdminClient.PutAsJsonAsync(
+                $"/api/containers/{container!.Id}/settings", withOverride);
+
+            // Act — clear it by writing empty overrides.
+            var cleared = new ContainerSettingsOverrides();
+            var putResponse = await fixture.AdminClient.PutAsJsonAsync(
+                $"/api/containers/{container.Id}/settings", cleared);
+            putResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            // Assert — Summary slot is back to null.
+            var getResponse = await fixture.AdminClient.GetAsync(
+                $"/api/containers/{container.Id}/settings");
+            var retrieved = await getResponse.Content.ReadFromJsonAsync<ContainerSettingsOverrides>(JsonOptions);
+
+            retrieved.Should().NotBeNull();
+            retrieved!.Summary.Should().BeNull("override was cleared");
+        }
+        finally
+        {
+            await fixture.AdminClient.DeleteAsync($"/api/containers/{container!.Id}");
+        }
+    }
+
+    // DTOs
+
+    private record ContainerDto(string Id, string Name);
+}


### PR DESCRIPTION
Closes #330.

Stacks on top of #329 (container summaries v1). Once #329 merges to main, this PR's base will be retargeted automatically (or rebased manually).

## Summary

Makes container/document summary generation configurable via the existing `SummarySettings` record and a new `SummarySettingsTab.razor` mounted on both the global Settings page and the per-container FileBrowser settings tab.

## What changed

- `SummarySettings` record restructured: removed 5 never-wired reserved fields; added `Enabled` (default `false`, opt-in); split the never-wired `PromptOverride` into `PerDocSystemPrompt` + `ContainerRollupSystemPrompt`
- `LlmCompletionOptions` gained a `Model` field; all 4 ILlmProvider implementations honor `options?.Model ?? this.ModelId` per-call (Anthropic via `BuildParams` SDK params; OpenAI/AzureOpenAI via per-request `GetChatClient(resolved)`; Ollama via direct request body)
- `PerDocSummarizer` and `ContainerSummarizer` now take `SummarySettings` and gate on `Enabled`, use prompt overrides, pass `LlmModel` via options, and use `MaxInputTokens × 4` chars for input truncation (replaces hardcoded 20_000)
- `ContainerSummaryWorker.ProcessContainerAsync` short-circuits on `Enabled=false` before fetching docs (logs `ContainerRollupSkipped {ContainerId} reason=summaries_disabled`)
- `IngestionPipeline` resolves `SummarySettings` via `IContainerSettingsResolver` and passes through to `PerDocSummarizer`
- New `SummarySettingsTab.razor` Blazor component with toggle, provider dropdown, model input, max-tokens, two prompt textareas pre-filled with in-code defaults, and "Restore default" links
- Mounted in `Settings.razor` (global) and `FileBrowser.razor` (per-container)
- Integration tests: 5 tests covering global service-layer round-trip + per-container HTTP round-trip + a pinning test for the discovered HTTP gap on the global REST endpoint
- Unit tests: 4 new PerDocSummarizer tests, 3 new ContainerSummarizer tests, 1 new ContainerSummaryWorker test, 8 new provider-level Model-override tests across 4 ILlmProvider impls, 3 new SummarySettings record tests, 2 new LlmCompletionOptions tests

## Behavioral migration (release notes)

`Enabled` defaults `false` (opt-in). Existing installations with summaries generating today will **stop** on subsequent uploads after this lands, until someone enables via the new UI / `Knowledge__Summary__Enabled=true` env var / DB. Existing stored summaries persist.

## Follow-up issues to file separately

1. **Global REST endpoint for Summary category** — `/api/settings/{category}` switch has no "summary" arm. Global settings work via the Blazor UI (uses `ISettingsStore` directly) but not via REST. Integration test pin verifies the gap.
2. **Settings category case-sensitivity** — discovered during Task 16: existing tabs save with lowercase keys (`"embedding"`, `"llm"`), but `ContainerSettingsResolver` reads capitalized (`"Embedding"`, `"LLM"`). EF case-sensitive comparison means per-container resolvers may not pick up globally-saved values for those types. Summary was saved capitalized to avoid baking in the bug.

## Spec

`docs/superpowers/specs/2026-05-25-summary-settings-design.md` in the ConnapseInfrastructure repo.

## Test plan

- [x] Unit tests pass (full suite)
- [x] Integration tests pass (`SummarySettingsIntegrationTests`)
- [ ] Manual QA per `docs/agent/container-summaries-qa.md` v2 section


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Summary generation can be enabled or disabled per container.
  - Custom system prompts for per-document and container summaries.
  - Override the LLM model used for summary generation.
  - Summary settings configuration in Settings and FileBrowser.

* **Documentation**
  - QA scenarios for configurable summary generation.

* **Tests**
  - Extended test coverage for summary settings and LLM model overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Destrayon/Connapse/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->