### PR TITLE
feat: add document-clustering container summary method (HERCULES)

### DIFF
--- a/docs/agent/container-summaries-qa.md
+++ b/docs/agent/container-summaries-qa.md
@@ -87,3 +87,40 @@ Verify that the auto-generated container summary biases an MCP-connected agent t
 2. Manually trigger it via the dashboard
 3. Verify no errors and no rollups fire if all containers are up-to-date
 4. Make a container's summary stale (e.g. update a doc summary timestamp manually) and trigger the sweep again; a `RollupContainerAsync` for that container should appear in the queue
+
+## HERCULES — document-clustering container summary method (#335)
+
+The default container summary method for new installs is `document-clustering`. The legacy method is `summary-clustering`. Verify both end-to-end.
+
+### Scenario: Document-clustering default for new container
+
+1. Create a fresh container "qa-hercules-default" and open its Summary settings tab.
+2. **Expected:** "Container summary method" dropdown shows "Document clustering (recommended)" by default.
+3. Enable summaries (master toggle on) and save.
+4. Upload 5 documents (any text files).
+5. Wait for ingestion to complete (per-doc spinners stop, no Indexed pill).
+6. **Expected:** Each doc's row shows no "Summary" indicator. The container row shows no summary yet (rollup hasn't happened).
+7. Click "Regenerate summary now".
+8. **Expected:** Container rollup pill appears, runs for ~10–30s, container summary text populates. Open each doc detail — all 5 docs (N ≤ stuff threshold of 30) now have per-doc summaries cached.
+
+### Scenario: Document-clustering clustering regime (>30 docs)
+
+1. Create container "qa-hercules-cluster".
+2. Enable summaries in document-clustering mode.
+3. Upload 35 documents.
+4. Wait for ingestion to complete (no per-doc summary spinners — they all SummaryIndexed without LLM calls).
+5. Click "Regenerate summary now".
+6. **Expected:** Container summary appears. Open the FileBrowser doc list — exactly K = `min(20, ceil(35/3))` = 12 docs have summaries; the remaining 23 do not. Watch the Hangfire dashboard during the rollup — should see exactly 12 `PerDocSummary*` jobs run (sequential, inside the rollup) plus 1 `RollupContainerAsync`.
+
+### Scenario: Switch to summary-clustering
+
+1. Open container "qa-hercules-default" settings tab.
+2. Change "Container summary method" to "Summary clustering". Save.
+3. Upload one new document "doc-after-switch.txt".
+4. Wait for ingestion to complete.
+5. **Expected:** "doc-after-switch.txt" gets a per-doc summary at ingest (open detail panel to confirm). The 5 docs uploaded under document-clustering may or may not have summaries depending on whether they were medoids in a prior rollup — lazy-mode cache state is preserved.
+
+### Scenario: Cache reuse on re-rollup
+
+1. In container "qa-hercules-cluster" (from Scenario 2), click "Regenerate summary now" a second time without uploading anything.
+2. **Expected:** Rollup completes quickly. Hangfire dashboard / logs show **zero** `PerDocSummaryAsync` invocations this time (all K medoid docs have cached summaries whose `summary_content_hash` matches the current `content_hash`).

--- a/docs/agent/container-summaries-qa.md
+++ b/docs/agent/container-summaries-qa.md
@@ -124,3 +124,14 @@ The default container summary method for new installs is `document-clustering`. 
 
 1. In container "qa-hercules-cluster" (from Scenario 2), click "Regenerate summary now" a second time without uploading anything.
 2. **Expected:** Rollup completes quickly. Hangfire dashboard / logs show **zero** `PerDocSummaryAsync` invocations this time (all K medoid docs have cached summaries whose `summary_content_hash` matches the current `content_hash`).
+
+## Ollama concurrency gate — stability under concurrent rollups (#335)
+
+A single local Ollama instance serializes generation internally. When many container rollups are enqueued at once (e.g. the stale-container sweep settling a backlog), unbounded `/api/chat` requests pile into Ollama's internal queue; each queued request's `HttpClient` timeout clock (`LlmSettings.TimeoutSeconds`, 300s default) is already running, so the slowest tail requests exceed it and surface as `TaskCanceledException`. `LlmSettings.MaxConcurrentRequests` (default 1) gates how many completions the app issues to Ollama at once — callers wait in-process before the HTTP call starts, so each request that reaches Ollama runs alone and finishes well within the timeout. Only the Ollama provider is gated; cloud providers (OpenAI/Azure/Anthropic) handle concurrency server-side.
+
+### Scenario: Concurrent rollups don't time out on Ollama
+
+1. With Ollama configured (single instance) and summaries enabled in document-clustering mode, create several small containers (N ≤ 30 docs each, so each rollup uses the "stuff" regime).
+2. Make them all stale at once and let the `summary-sweep-stale-containers` job fire (or trigger it from the Hangfire dashboard), so multiple `RollupContainerAsync` jobs run concurrently.
+3. Tail the logs: `/api/chat` calls should start strictly one at a time — each new call begins only after the previous one returns (`MaxConcurrentRequests = 1`) — and every rollup should complete with **no** `TaskCanceledException`. The first call may be slow (cold model load); subsequent calls are fast.
+4. (Optional) Raise `MaxConcurrentRequests` above 1 only if the Ollama host has GPU/CPU headroom to run that many generations in parallel without any single one exceeding `TimeoutSeconds`. The setting is read once at startup, so changing it requires a restart.

--- a/docs/agent/container-summaries-qa.md
+++ b/docs/agent/container-summaries-qa.md
@@ -110,7 +110,7 @@ The default container summary method for new installs is `document-clustering`. 
 3. Upload 35 documents.
 4. Wait for ingestion to complete (no per-doc summary spinners — they all SummaryIndexed without LLM calls).
 5. Click "Regenerate summary now".
-6. **Expected:** Container summary appears. Open the FileBrowser doc list — exactly K = `min(20, ceil(35/3))` = 12 docs have summaries; the remaining 23 do not. Watch the Hangfire dashboard during the rollup — should see exactly 12 `PerDocSummary*` jobs run (sequential, inside the rollup) plus 1 `RollupContainerAsync`.
+6. **Expected:** Container summary appears. Open the FileBrowser doc list — exactly K = `min(20, ceil(35/3))` = 12 docs have summaries; the remaining 23 do not. Watch the Hangfire dashboard during the rollup — you should see a single `RollupContainerAsync` job and **no** separate `PerDocSummaryAsync` jobs: in document-clustering mode the 12 medoid summaries are generated inline within the rollup (look for 12 `LazyMedoidSummary*` log lines), not as standalone Hangfire jobs.
 
 ### Scenario: Switch to summary-clustering
 
@@ -123,7 +123,7 @@ The default container summary method for new installs is `document-clustering`. 
 ### Scenario: Cache reuse on re-rollup
 
 1. In container "qa-hercules-cluster" (from Scenario 2), click "Regenerate summary now" a second time without uploading anything.
-2. **Expected:** Rollup completes quickly. Hangfire dashboard / logs show **zero** `PerDocSummaryAsync` invocations this time (all K medoid docs have cached summaries whose `summary_content_hash` matches the current `content_hash`).
+2. **Expected:** Rollup completes quickly. Logs show **zero** inline LLM summarization calls this time — instead one `LazyMedoidSummaryCacheHit` debug line fires for each of the K medoid docs (all have cached summaries whose `summary_content_hash` matches the current `content_hash`). The Hangfire dashboard shows a single `RollupContainerAsync` job and no `PerDocSummaryAsync` jobs (there are none in document-clustering mode).
 
 ## Ollama concurrency gate — stability under concurrent rollups (#335)
 

--- a/docs/agent/container-summaries-qa.md
+++ b/docs/agent/container-summaries-qa.md
@@ -14,7 +14,7 @@ Verify that the auto-generated container summary biases an MCP-connected agent t
 
 1. **Routing test.** Connect Claude Code (or an equivalent MCP client). Ask: "What did Apple report for Q3 2025 iPhone sales?" Expected: agent calls `container_list` → `search_knowledge(container=<test>, query="iPhone Q3 2025 sales")`. Should NOT use `list_files` + `get_document`.
 
-2. **Out-of-scope test.** Ask the agent something the container should NOT route to. Expected: agent does not route based on the summary's "Does not cover…" section.
+2. **Scope-boundary test.** Ask the agent something the container should NOT route to. Expected: in the stuff regime (all docs summarized) the description may name explicit boundaries; in the clustered regime (a medoid sample) it hedges scope rather than asserting a hard "does not cover," so a false exclusion can't silently suppress retrieval.
 
 3. **Query-term lift.** Compare agent query terms with/without summary. Agent should use phrases from the "Query hints" section more often when summary is present.
 

--- a/docs/agent/container-summaries-qa.md
+++ b/docs/agent/container-summaries-qa.md
@@ -135,3 +135,23 @@ A single local Ollama instance serializes generation internally. When many conta
 2. Make them all stale at once and let the `summary-sweep-stale-containers` job fire (or trigger it from the Hangfire dashboard), so multiple `RollupContainerAsync` jobs run concurrently.
 3. Tail the logs: `/api/chat` calls should start strictly one at a time — each new call begins only after the previous one returns (`MaxConcurrentRequests = 1`) — and every rollup should complete with **no** `TaskCanceledException`. The first call may be slow (cold model load); subsequent calls are fast.
 4. (Optional) Raise `MaxConcurrentRequests` above 1 only if the Ollama host has GPU/CPU headroom to run that many generations in parallel without any single one exceeding `TimeoutSeconds`. The setting is read once at startup, so changing it requires a restart.
+
+## Postgres connection budget — stability under concurrent rollups (#335)
+
+Concurrent rollups also pressure the database, not just the LLM. Two Npgsql connection pools share one Postgres server: the app's `NpgsqlDataSource` (queries, vector search, EF) and the background job runner's storage pool. Each pool, left unspecified, defaults to a maximum of 100 connections — so two uncapped pools can together demand 200 against a server that typically allows ~100. On top of that, `DisableConcurrentExecution` on a rollup holds its distributed-lock connection open for the job's entire lifetime, including while a worker is parked waiting on the Ollama concurrency gate. With an oversized worker pool (Hangfire's default is `ProcessorCount * 2`, which is large on a many-core box), a backlog of swept rollups could hold enough connections at once to exhaust the server, surfacing as `PostgresException: 53300: sorry, too many clients already`.
+
+Three knobs bound the demand, each overridable per deployment:
+
+- **`Database:MaxPoolSize`** (default 40) — caps the app's `NpgsqlDataSource` pool.
+- **`Hangfire:MaxPoolSize`** (default 30) — caps the background runner's storage pool.
+- **`Hangfire:WorkerCount`** (default `min(ProcessorCount * 2, 16)`) — caps concurrent jobs, so fewer lock-holding connections are alive at once.
+
+The defaults sum to a per-process budget (40 + 30 = 70 connections) that leaves headroom for admin tooling under a ~100 ceiling. A deployment whose Postgres allows more connections, or that runs multiple app instances against one server, should raise or lower these to fit its own `max_connections`.
+
+Rollups also do **not** use Hangfire's automatic retry (`AutomaticRetry(Attempts = 0)` on `RollupContainerAsync`). The recurring `summary-sweep-stale-containers` job re-enqueues any container that is still stale on its next tick, so a failed rollup is retried by the sweep rather than by Hangfire stacking Scheduled retry jobs on top of the sweep's enqueues — the duplicate pile-up that retries would create is exactly what pressured the connection pool.
+
+### Scenario: Backlog of rollups doesn't exhaust connections
+
+1. With summaries enabled and a working LLM provider, make several containers stale at once (e.g. update their doc summary timestamps) and let `summary-sweep-stale-containers` fire, or trigger it from the Hangfire dashboard.
+2. While the backlog drains, query the database: `SELECT count(*) FROM pg_stat_activity;` — the count should stay well under the server's `max_connections` (no climb toward the ceiling).
+3. **Expected:** every rollup completes; no `53300: sorry, too many clients already` in the app logs. A rollup that does fail (e.g. transient LLM error) lands in **Failed** in the dashboard — not Scheduled — and is picked up again on the next sweep tick rather than by a Hangfire retry.

--- a/docs/superpowers/plans/2026-05-27-hercules-swap.md
+++ b/docs/superpowers/plans/2026-05-27-hercules-swap.md
@@ -1,0 +1,2051 @@
+# HERCULES Swap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `document-clustering` container-summary method (HERCULES-style) as the new default — clusters on pooled chunk embeddings and lazy-summarizes K medoid docs at rollup time. Existing `summary-clustering` behavior stays available behind a setting.
+
+**Architecture:** Adds `SummarySettings.ContainerSummaryMethod` (G+C scope, resolves through existing `ContainerSettingsResolver`). `IngestionJobs.PerDocSummaryAsync` early-returns in `document-clustering` mode. `SummaryJobs.RollupContainerAsync` branches: existing path for `summary-clustering`, new path that pools chunk vectors via `IVectorStore.GetPooledDocumentEmbeddingsAsync`, runs farthest-first medoid selection, inline-summarizes K medoids (cached in `documents.summary`), then calls the existing `ContainerSummarizer` reduce step. `ComputeDocSetHash` switches to `(docId, content_hash)` pairs so it works without per-doc summary text. No DB schema changes.
+
+**Tech Stack:** .NET 10, EF Core, pgvector, Hangfire, xUnit + FluentAssertions + NSubstitute, Testcontainers for integration.
+
+**Spec:** `docs/superpowers/specs/2026-05-27-hercules-swap-design.md`
+
+**Sequencing:** Ships after PR #333 (Hangfire migration) merges. Do not start until #333 is on `main`.
+
+---
+
+## File Structure
+
+**New files:**
+- `src/Connapse.Core/Models/SummaryStrategy.cs` — string constants for allowed `ContainerSummaryMethod` values
+- `tests/Connapse.Background.Tests/Jobs/SummaryJobsHerculesTests.cs` — unit tests for new rollup branch
+- `tests/Connapse.Background.Tests/Jobs/IngestionJobsHerculesTests.cs` — unit tests for early-return
+- `tests/Connapse.Storage.Tests/Vectors/PgVectorStorePooledEmbeddingsTests.cs` — integration tests for pooling SQL
+- `tests/Connapse.Web.Tests/Summarization/HerculesIntegrationTests.cs` — end-to-end integration tests
+
+**Modified files:**
+- `src/Connapse.Core/Models/SettingsModels.cs` — add `ContainerSummaryMethod` field + validator
+- `src/Connapse.Core/Interfaces/IVectorStore.cs` — add `GetPooledDocumentEmbeddingsAsync`
+- `src/Connapse.Storage/Vectors/PgVectorStore.cs` — implement pooled embeddings query
+- `src/Connapse.Background/Jobs/IngestionJobs.cs` — early-return branch in `PerDocSummaryAsync`
+- `src/Connapse.Background/Jobs/SummaryJobs.cs` — split rollup into two methods, swap hash function
+- `src/Connapse.Web/Components/Settings/SummarySettingsTab.razor` — add method dropdown
+- `tests/Connapse.Storage.Tests/Settings/ContainerSettingsResolverTests.cs` — cover new field
+- `docs/manual-qa/summary-generation.md` — add document-clustering scenarios
+
+---
+
+## Task 1: Prep — feature branch + baseline build/test
+
+**Files:**
+- N/A (env setup)
+
+- [ ] **Step 1: Verify PR #333 has merged**
+
+Run from `D:\CodeProjects\Connapse`:
+```
+git fetch origin
+git log --oneline origin/main -5
+```
+Expected: PR #333's merge commit appears on `origin/main`. If not, STOP — do not start this work until #333 is merged.
+
+- [ ] **Step 2: Pull latest main and create the feature branch**
+
+The actual issue number will come from Step 3. Use a placeholder branch name first, rename after the issue exists.
+
+```
+git checkout main
+git pull origin main
+```
+
+- [ ] **Step 3: File GitHub issue**
+
+```
+gh issue create \
+  --title "feat: add document-clustering container summary method (HERCULES swap)" \
+  --body "$(cat <<'EOF'
+Adds a new \`document-clustering\` value for \`SummarySettings.ContainerSummaryMethod\` (G+C scope) that becomes the default for new installs. The new method clusters documents using mean-pooled chunk embeddings (free — they already exist for vector search) and lazy-summarizes only the K medoid docs at rollup time, instead of eagerly summarizing every document at upload.
+
+The current behavior remains available as \`summary-clustering\`.
+
+Design: \`docs/superpowers/specs/2026-05-27-hercules-swap-design.md\`
+Plan: \`docs/superpowers/plans/2026-05-27-hercules-swap.md\`
+
+Built on:
+- HERCULES paper (arXiv:2506.19992): +76% ARI on clustering quality vs summary embeddings, p<0.001
+- Follow-up research \`docs/research/lazy-vs-eager-per-doc-summarization-2026-05-26.md\`
+EOF
+)"
+```
+
+Capture the issue number returned (e.g., `#334`).
+
+- [ ] **Step 4: Create the feature branch with the issue number**
+
+Replace `<N>` with the issue number from Step 3:
+```
+git checkout -b feature/<N>-hercules-swap
+```
+
+- [ ] **Step 5: Baseline build and test**
+
+```
+dotnet build
+dotnet test --filter "Category=Unit"
+```
+
+Expected: build succeeds, unit tests all green. If anything fails, STOP — the failure is pre-existing and must be addressed (or noted as known-bad) before starting feature work.
+
+- [ ] **Step 6: Commit the design + plan docs**
+
+```
+git add docs/superpowers/specs/2026-05-27-hercules-swap-design.md docs/superpowers/plans/2026-05-27-hercules-swap.md
+git commit -m "docs: add HERCULES swap design + implementation plan (#<N>)"
+```
+
+---
+
+## Task 2: SummaryStrategy constants
+
+**Files:**
+- Create: `src/Connapse.Core/Models/SummaryStrategy.cs`
+
+- [ ] **Step 1: Create the constants file**
+
+```csharp
+namespace Connapse.Core;
+
+/// <summary>
+/// Allowed values for <see cref="SummarySettings.ContainerSummaryMethod"/>.
+/// </summary>
+/// <remarks>
+/// Stored as a string in <c>SummarySettings</c> to match the existing
+/// <c>LlmProvider</c> / <c>LlmModel</c> convention. Validation happens in the
+/// <c>SummarySettings</c> validator and rejects unknown values.
+/// </remarks>
+public static class SummaryStrategy
+{
+    /// <summary>
+    /// HERCULES-style: cluster documents by mean-pooled chunk embeddings and
+    /// lazy-summarize K medoid documents at rollup time. Default for new installs.
+    /// </summary>
+    public const string DocumentClustering = "document-clustering";
+
+    /// <summary>
+    /// Legacy: summarize every document at ingest, cluster by summary embeddings,
+    /// reduce K medoid summaries. Original behavior from PR #329.
+    /// </summary>
+    public const string SummaryClustering = "summary-clustering";
+
+    public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
+    {
+        DocumentClustering,
+        SummaryClustering,
+    };
+}
+```
+
+- [ ] **Step 2: Build**
+
+```
+dotnet build src/Connapse.Core
+```
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/Connapse.Core/Models/SummaryStrategy.cs
+git commit -m "feat: add SummaryStrategy constants for container summary method"
+```
+
+---
+
+## Task 3: SummarySettings.ContainerSummaryMethod field + validator
+
+**Files:**
+- Modify: `src/Connapse.Core/Models/SettingsModels.cs` (add field to `SummarySettings` record)
+
+- [ ] **Step 1: Add the new field to the SummarySettings record**
+
+In `src/Connapse.Core/Models/SettingsModels.cs`, find the `SummarySettings` record and add this field directly after `public bool Enabled { get; init; } = false;`:
+
+```csharp
+    /// <summary>
+    /// Container summary generation method. See <see cref="SummaryStrategy"/> for allowed values.
+    /// Default: <c>document-clustering</c> — clusters by pooled chunk embeddings and lazy-summarizes
+    /// K medoid documents at rollup time. Set to <c>summary-clustering</c> to use the legacy
+    /// eager per-doc summarization path.
+    /// </summary>
+    public string ContainerSummaryMethod { get; init; } = SummaryStrategy.DocumentClustering;
+```
+
+- [ ] **Step 2: Add validation by implementing IValidatableObject**
+
+If `SummarySettings` does not already implement `IValidatableObject`, change the declaration line:
+
+```csharp
+public record SummarySettings : IValidatableObject
+```
+
+Then add at the bottom of the record body, before the closing brace:
+
+```csharp
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (!SummaryStrategy.All.Contains(ContainerSummaryMethod))
+        {
+            yield return new ValidationResult(
+                $"ContainerSummaryMethod must be one of: {string.Join(", ", SummaryStrategy.All)}. Got: '{ContainerSummaryMethod}'.",
+                new[] { nameof(ContainerSummaryMethod) });
+        }
+    }
+```
+
+Add to the file's `using` block if not present:
+```csharp
+using System.ComponentModel.DataAnnotations;
+```
+(It's already there for `[Range]`.)
+
+- [ ] **Step 3: Build**
+
+```
+dotnet build src/Connapse.Core
+```
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/Connapse.Core/Models/SettingsModels.cs
+git commit -m "feat: add ContainerSummaryMethod field to SummarySettings + validator"
+```
+
+---
+
+## Task 4: ContainerSettingsResolver tests for new field
+
+**Files:**
+- Modify: `tests/Connapse.Storage.Tests/Settings/ContainerSettingsResolverTests.cs`
+
+- [ ] **Step 1: Locate the existing test class**
+
+```
+grep -n "GetSummarySettingsAsync" tests/Connapse.Storage.Tests/Settings/ContainerSettingsResolverTests.cs
+```
+Find the existing block of `GetSummarySettingsAsync_*` tests and confirm the test scaffolding pattern (DB fixture, `_settingsStore` mock, `_resolver` instance).
+
+- [ ] **Step 2: Add the override test**
+
+Add this test method inside the existing test class, alongside the other `GetSummarySettingsAsync_*` tests. Adapt the helpers (`SeedContainerAsync`, the resolver factory) to match what the surrounding tests already use:
+
+```csharp
+[Fact]
+[Trait("Category", "Integration")]
+public async Task GetSummarySettingsAsync_ContainerSummaryMethodOverride_TakesPrecedence()
+{
+    // Arrange: global says summary-clustering, container override says document-clustering
+    var global = new SummarySettings
+    {
+        Enabled = true,
+        ContainerSummaryMethod = SummaryStrategy.SummaryClustering,
+    };
+    _settingsStore.GetAsync<SummarySettings>("Summary", Arg.Any<CancellationToken>())
+                  .Returns(global);
+
+    var overrideJson = JsonSerializer.Serialize(new
+    {
+        summary = new
+        {
+            enabled = true,
+            containerSummaryMethod = SummaryStrategy.DocumentClustering,
+        }
+    });
+    Guid containerId = await SeedContainerWithOverridesAsync(overrideJson);
+
+    // Act
+    SummarySettings resolved = await _resolver.GetSummarySettingsAsync(containerId, CancellationToken.None);
+
+    // Assert
+    resolved.ContainerSummaryMethod.Should().Be(SummaryStrategy.DocumentClustering);
+}
+
+[Fact]
+[Trait("Category", "Integration")]
+public async Task GetSummarySettingsAsync_NoOverride_UsesDocumentClusteringDefault()
+{
+    // Arrange: no global, no override → record default applies
+    _settingsStore.GetAsync<SummarySettings>("Summary", Arg.Any<CancellationToken>())
+                  .Returns((SummarySettings?)null);
+    Guid containerId = await SeedContainerWithoutOverridesAsync();
+
+    // Act
+    SummarySettings resolved = await _resolver.GetSummarySettingsAsync(containerId, CancellationToken.None);
+
+    // Assert
+    resolved.ContainerSummaryMethod.Should().Be(SummaryStrategy.DocumentClustering);
+}
+```
+
+If `SeedContainerWithOverridesAsync` / `SeedContainerWithoutOverridesAsync` don't exist with those exact names, use whatever the existing tests in the file use to seed an override JSON (they typically write a `ContainerEntity` with `SettingsOverridesJson` set). Mirror that pattern exactly.
+
+- [ ] **Step 3: Run the tests**
+
+```
+dotnet test --filter "FullyQualifiedName~ContainerSettingsResolverTests.GetSummarySettingsAsync_ContainerSummaryMethodOverride_TakesPrecedence"
+dotnet test --filter "FullyQualifiedName~ContainerSettingsResolverTests.GetSummarySettingsAsync_NoOverride_UsesDocumentClusteringDefault"
+```
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```
+git add tests/Connapse.Storage.Tests/Settings/ContainerSettingsResolverTests.cs
+git commit -m "test: cover ContainerSummaryMethod G+C resolution"
+```
+
+---
+
+## Task 5: Add IVectorStore.GetPooledDocumentEmbeddingsAsync interface method
+
+**Files:**
+- Modify: `src/Connapse.Core/Interfaces/IVectorStore.cs`
+
+- [ ] **Step 1: Add the new method to the interface**
+
+Edit `src/Connapse.Core/Interfaces/IVectorStore.cs` to:
+
+```csharp
+namespace Connapse.Core.Interfaces;
+
+public interface IVectorStore
+{
+    Task UpsertAsync(string id, float[] vector, Dictionary<string, string> metadata, CancellationToken ct = default);
+    Task UpsertBatchAsync(IReadOnlyList<(string Id, float[] Vector, Dictionary<string, string> Metadata)> items, CancellationToken ct = default);
+    Task<IReadOnlyList<VectorSearchResult>> SearchAsync(float[] queryVector, int topK, Dictionary<string, string>? filters = null, CancellationToken ct = default);
+    Task DeleteAsync(string id, CancellationToken ct = default);
+    Task DeleteByDocumentIdAsync(string documentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns one mean-pooled embedding per document in the container, computed across
+    /// that document's chunk vectors. Used by the <c>document-clustering</c> container
+    /// summary path to cluster docs without re-embedding them.
+    /// </summary>
+    /// <remarks>
+    /// Implementations should:
+    /// 1. Pick the dominant <c>model_id</c> in the container and filter to vectors of that model.
+    ///    Containers can hold mixed-model chunk vectors; clustering requires a single dimensionality.
+    /// 2. Skip documents that have zero chunks of the dominant model.
+    /// 3. L2-normalize each pooled vector before returning (pgvector AVG does not renormalize).
+    /// 4. Log a warning naming the count of documents excluded due to non-dominant model_id.
+    /// </remarks>
+    Task<IReadOnlyList<(Guid DocumentId, float[] Embedding)>> GetPooledDocumentEmbeddingsAsync(
+        Guid containerId,
+        CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 2: Build (expect failure)**
+
+```
+dotnet build
+```
+Expected: FAIL — `PgVectorStore` doesn't implement the new method yet. This is fine; the next task adds it. Confirm the only build errors are about `PgVectorStore` missing `GetPooledDocumentEmbeddingsAsync`.
+
+- [ ] **Step 3: Commit the interface alone (intentional broken build between tasks)**
+
+```
+git add src/Connapse.Core/Interfaces/IVectorStore.cs
+git commit -m "feat: add IVectorStore.GetPooledDocumentEmbeddingsAsync interface"
+```
+
+(Build is restored in Task 6.)
+
+---
+
+## Task 6: Implement PgVectorStore.GetPooledDocumentEmbeddingsAsync
+
+**Files:**
+- Modify: `src/Connapse.Storage/Vectors/PgVectorStore.cs`
+
+- [ ] **Step 1: Add the implementation**
+
+Append this method to the `PgVectorStore` class (before the closing brace):
+
+```csharp
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<(Guid DocumentId, float[] Embedding)>> GetPooledDocumentEmbeddingsAsync(
+        Guid containerId,
+        CancellationToken ct = default)
+    {
+        // Step 1: Pick the dominant model_id in the container. ChunkVectorEntity carries
+        // ContainerId and ModelId directly (no JOIN through chunks needed).
+        var modelCounts = await _context.ChunkVectors
+            .Where(cv => cv.ContainerId == containerId)
+            .GroupBy(cv => cv.ModelId)
+            .Select(g => new { ModelId = g.Key, Count = g.Count() })
+            .OrderByDescending(x => x.Count)
+            .ToListAsync(ct);
+
+        if (modelCounts.Count == 0)
+        {
+            return Array.Empty<(Guid, float[])>();
+        }
+
+        string dominantModelId = modelCounts[0].ModelId;
+
+        if (modelCounts.Count > 1)
+        {
+            int excludedDocs = modelCounts.Skip(1).Sum(m => m.Count);
+            _logger.LogWarning(
+                "GetPooledDocumentEmbeddingsAsync: container {ContainerId} has mixed embedding models. " +
+                "Using dominant model '{DominantModelId}' ({DominantCount} vectors). " +
+                "Excluding {ExcludedCount} vectors from {OtherModelCount} other model(s).",
+                containerId, dominantModelId, modelCounts[0].Count, excludedDocs, modelCounts.Count - 1);
+        }
+
+        // Step 2: Pool per-document. AVG(embedding) returns a vector at the same dimensionality.
+        // ChunkVectorEntity has document_id directly, so no JOINs are needed.
+        var conn = _context.Database.GetDbConnection();
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT document_id, AVG(embedding)::vector AS pooled
+            FROM chunk_vectors
+            WHERE container_id = @cid
+              AND model_id = @model_id
+            GROUP BY document_id
+            """;
+
+        var p = cmd.Parameters;
+        p.Add(new NpgsqlParameter("cid", containerId));
+        p.Add(new NpgsqlParameter("model_id", dominantModelId));
+
+        var results = new List<(Guid DocumentId, float[] Embedding)>();
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            Guid docId = reader.GetGuid(0);
+            // Pgvector binds as Pgvector.Vector; ToArray() gives float[].
+            Vector pooled = reader.GetFieldValue<Vector>(1);
+            float[] raw = pooled.ToArray();
+            float[] normalized = L2Normalize(raw);
+            results.Add((docId, normalized));
+        }
+
+        return results;
+    }
+
+    private static float[] L2Normalize(float[] v)
+    {
+        double sumSq = 0;
+        for (int i = 0; i < v.Length; i++) sumSq += v[i] * v[i];
+        double norm = Math.Sqrt(sumSq);
+        if (norm < 1e-12) return v; // degenerate; return as-is rather than div-by-zero
+        float[] result = new float[v.Length];
+        for (int i = 0; i < v.Length; i++) result[i] = (float)(v[i] / norm);
+        return result;
+    }
+```
+
+- [ ] **Step 2: Build**
+
+```
+dotnet build
+```
+Expected: PASS — interface now satisfied.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/Connapse.Storage/Vectors/PgVectorStore.cs
+git commit -m "feat: implement PgVectorStore.GetPooledDocumentEmbeddingsAsync"
+```
+
+---
+
+## Task 7: Integration test for PgVectorStore pooled embeddings
+
+**Files:**
+- Create: `tests/Connapse.Storage.Tests/Vectors/PgVectorStorePooledEmbeddingsTests.cs`
+
+- [ ] **Step 1: Examine existing PgVectorStore integration test setup**
+
+```
+grep -rn "class.*PgVectorStore.*Tests" tests/Connapse.Storage.Tests/
+```
+Find an existing PgVectorStore integration test file to copy the fixture/DI scaffolding pattern. The shared collection is `SharedWebAppFixture` per `connapse/CLAUDE.md`.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/Connapse.Storage.Tests/Vectors/PgVectorStorePooledEmbeddingsTests.cs`. Adapt the fixture wiring to match the sibling tests in the same folder:
+
+```csharp
+using Connapse.Storage.Vectors;
+using Connapse.Storage.Data.Entities;
+using FluentAssertions;
+using Pgvector;
+using Xunit;
+
+namespace Connapse.Storage.Tests.Vectors;
+
+[Trait("Category", "Integration")]
+[Collection("SharedWebApp")]
+public class PgVectorStorePooledEmbeddingsTests
+{
+    private readonly SharedWebAppFixture _fixture;
+
+    public PgVectorStorePooledEmbeddingsTests(SharedWebAppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task GetPooledDocumentEmbeddingsAsync_OneModelTwoDocs_PoolsCorrectly()
+    {
+        // Arrange: seed one container with 2 docs, each with 2 chunks under the same model.
+        Guid containerId = Guid.NewGuid();
+        Guid doc1 = Guid.NewGuid();
+        Guid doc2 = Guid.NewGuid();
+        const string modelId = "test-model";
+
+        await _fixture.SeedContainerAsync(containerId, "test-pool-1");
+        await _fixture.SeedDocumentAsync(doc1, containerId);
+        await _fixture.SeedDocumentAsync(doc2, containerId);
+
+        await _fixture.SeedChunkVectorAsync(Guid.NewGuid(), doc1, containerId, modelId, new float[] { 1f, 0f, 0f });
+        await _fixture.SeedChunkVectorAsync(Guid.NewGuid(), doc1, containerId, modelId, new float[] { 0f, 1f, 0f });
+        await _fixture.SeedChunkVectorAsync(Guid.NewGuid(), doc2, containerId, modelId, new float[] { 0f, 0f, 1f });
+        await _fixture.SeedChunkVectorAsync(Guid.NewGuid(), doc2, containerId, modelId, new float[] { 0f, 0f, 1f });
+
+        PgVectorStore store = _fixture.CreatePgVectorStore();
+
+        // Act
+        var result = await store.GetPooledDocumentEmbeddingsAsync(containerId, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        var doc1Pooled = result.First(r => r.DocumentId == doc1).Embedding;
+        // Doc1 pool of (1,0,0) and (0,1,0) is (0.5, 0.5, 0); L2-normalized → (~0.707, ~0.707, 0)
+        doc1Pooled[0].Should().BeApproximately(0.7071f, 0.001f);
+        doc1Pooled[1].Should().BeApproximately(0.7071f, 0.001f);
+        doc1Pooled[2].Should().BeApproximately(0f, 0.001f);
+
+        var doc2Pooled = result.First(r => r.DocumentId == doc2).Embedding;
+        // Doc2 pool of (0,0,1) and (0,0,1) is (0,0,1); L2-normalized → (0,0,1)
+        doc2Pooled[2].Should().BeApproximately(1f, 0.001f);
+    }
+
+    [Fact]
+    public async Task GetPooledDocumentEmbeddingsAsync_MixedModels_UsesDominantAndLogsWarning()
+    {
+        Guid containerId = Guid.NewGuid();
+        Guid doc1 = Guid.NewGuid();
+        Guid doc2 = Guid.NewGuid();
+        Guid doc3 = Guid.NewGuid();
+
+        await _fixture.SeedContainerAsync(containerId, "test-pool-mixed");
+        await _fixture.SeedDocumentAsync(doc1, containerId);
+        await _fixture.SeedDocumentAsync(doc2, containerId);
+        await _fixture.SeedDocumentAsync(doc3, containerId);
+
+        // doc1 + doc2 under model-A (dominant: 2 vectors)
+        await _fixture.SeedChunkVectorAsync(Guid.NewGuid(), doc1, containerId, "model-A", new float[] { 1f, 0f });
+        await _fixture.SeedChunkVectorAsync(Guid.NewGuid(), doc2, containerId, "model-A", new float[] { 0f, 1f });
+        // doc3 under model-B (excluded: 1 vector). NOTE: dimensions differ here, but the
+        // dominant filter excludes them before they affect the pool.
+        await _fixture.SeedChunkVectorAsync(Guid.NewGuid(), doc3, containerId, "model-B", new float[] { 1f, 0f, 0f });
+
+        PgVectorStore store = _fixture.CreatePgVectorStore();
+        var result = await store.GetPooledDocumentEmbeddingsAsync(containerId, CancellationToken.None);
+
+        // Assert: only doc1 and doc2 (both under dominant model-A) are returned
+        result.Should().HaveCount(2);
+        result.Select(r => r.DocumentId).Should().BeEquivalentTo(new[] { doc1, doc2 });
+    }
+
+    [Fact]
+    public async Task GetPooledDocumentEmbeddingsAsync_EmptyContainer_ReturnsEmpty()
+    {
+        Guid containerId = Guid.NewGuid();
+        await _fixture.SeedContainerAsync(containerId, "test-pool-empty");
+
+        PgVectorStore store = _fixture.CreatePgVectorStore();
+        var result = await store.GetPooledDocumentEmbeddingsAsync(containerId, CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+}
+```
+
+If `SeedContainerAsync` / `SeedDocumentAsync` / `SeedChunkVectorAsync` / `CreatePgVectorStore` aren't already on `SharedWebAppFixture`, add the minimum helpers needed by inspecting other `*Tests.cs` files in `tests/Connapse.Storage.Tests/Vectors/` and copying their seeding approach (typically direct `KnowledgeDbContext` writes).
+
+- [ ] **Step 3: Run the tests**
+
+```
+dotnet test --filter "FullyQualifiedName~PgVectorStorePooledEmbeddingsTests"
+```
+Expected: PASS (all three tests)
+
+- [ ] **Step 4: Commit**
+
+```
+git add tests/Connapse.Storage.Tests/Vectors/PgVectorStorePooledEmbeddingsTests.cs
+git commit -m "test: integration coverage for PgVectorStore.GetPooledDocumentEmbeddingsAsync"
+```
+
+---
+
+## Task 8: IngestionJobs.PerDocSummaryAsync early-return in document-clustering mode
+
+**Files:**
+- Modify: `src/Connapse.Background/Jobs/IngestionJobs.cs`
+
+- [ ] **Step 1: Add the early-return guard**
+
+In `src/Connapse.Background/Jobs/IngestionJobs.cs`, locate the existing block in `PerDocSummaryAsync`:
+
+```csharp
+            SummarySettings settings = await _settingsResolver.GetSummarySettingsAsync(containerId, ct);
+            if (!settings.Enabled)
+            {
+                _logger.LogInformation(
+                    "PerDocSummarySkipped {DocumentId} reason=summaries_disabled",
+                    LogSanitizer.Sanitize(documentId));
+                return;
+            }
+```
+
+Add this guard immediately after the `summaries_disabled` check:
+
+```csharp
+            if (settings.ContainerSummaryMethod == SummaryStrategy.DocumentClustering)
+            {
+                // Document-clustering mode summarizes K medoids lazily at rollup time;
+                // per-doc summaries are not generated at ingest.
+                _logger.LogInformation(
+                    "PerDocSummarySkipped {DocumentId} reason=document_clustering_mode",
+                    LogSanitizer.Sanitize(documentId));
+
+                // Still advance the ingestion state so the UI doesn't show a stuck spinner.
+                // SummaryIndexed is the correct terminal state — in document-clustering mode,
+                // "summary processing is complete" means "we decided not to summarize this doc."
+                await _docStore.UpdateIngestionStateAsync(documentId, IngestionState.SummaryIndexed, CancellationToken.None);
+                await _stateBroadcaster.BroadcastIngestionStateChangedAsync(
+                    documentId, IngestionState.SummaryIndexed, CancellationToken.None);
+                return;
+            }
+```
+
+- [ ] **Step 2: Build**
+
+```
+dotnet build src/Connapse.Background
+```
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/Connapse.Background/Jobs/IngestionJobs.cs
+git commit -m "feat: PerDocSummaryAsync early-returns in document-clustering mode"
+```
+
+---
+
+## Task 9: Unit test IngestionJobs early-return
+
+**Files:**
+- Create: `tests/Connapse.Background.Tests/Jobs/IngestionJobsHerculesTests.cs`
+
+- [ ] **Step 1: Check existing IngestionJobs test scaffolding**
+
+```
+grep -rn "class IngestionJobsTests" tests/Connapse.Background.Tests/
+```
+Examine the existing IngestionJobs tests to copy the mock-wiring pattern (NSubstitute for `IDocumentStore`, `IPerDocSummarizer`, etc.).
+
+- [ ] **Step 2: Write the test**
+
+Create `tests/Connapse.Background.Tests/Jobs/IngestionJobsHerculesTests.cs`:
+
+```csharp
+using Connapse.Background.Jobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Hangfire;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Connapse.Background.Tests.Jobs;
+
+[Trait("Category", "Unit")]
+public class IngestionJobsHerculesTests
+{
+    [Fact]
+    public async Task PerDocSummaryAsync_DocumentClusteringMode_EarlyReturnsWithoutCallingSummarizer()
+    {
+        // Arrange
+        Guid docId = Guid.NewGuid();
+        Guid containerId = Guid.NewGuid();
+        var doc = new Document(
+            Id: docId.ToString(),
+            ContainerId: containerId.ToString(),
+            FileName: "test.txt",
+            ContentType: "text/plain",
+            Path: "/test.txt",
+            SizeBytes: 100,
+            CreatedAt: DateTime.UtcNow,
+            Metadata: new Dictionary<string, string>());
+
+        var docStore = Substitute.For<IDocumentStore>();
+        docStore.GetAsync(docId.ToString(), Arg.Any<CancellationToken>()).Returns(doc);
+
+        var summarizer = Substitute.For<IPerDocSummarizer>();
+        var settingsResolver = Substitute.For<IContainerSettingsResolver>();
+        settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
+            .Returns(new SummarySettings
+            {
+                Enabled = true,
+                ContainerSummaryMethod = SummaryStrategy.DocumentClustering,
+            });
+
+        var broadcaster = Substitute.For<IIngestionStateBroadcaster>();
+
+        var jobs = new IngestionJobs(
+            ingester: Substitute.For<IKnowledgeIngester>(),
+            docStore: docStore,
+            containerStore: Substitute.For<IContainerStore>(),
+            connectorFactory: Substitute.For<IConnectorFactory>(),
+            parsers: Array.Empty<IDocumentParser>(),
+            summarizer: summarizer,
+            settingsResolver: settingsResolver,
+            bgClient: Substitute.For<IBackgroundJobClient>(),
+            stateBroadcaster: broadcaster,
+            logger: NullLogger<IngestionJobs>.Instance);
+
+        // Act
+        await jobs.PerDocSummaryAsync(docId.ToString(), CancellationToken.None);
+
+        // Assert: summarizer was never invoked
+        await summarizer.DidNotReceiveWithAnyArgs().GenerateAsync(
+            default!, default!, default!, default!, default!, default);
+
+        // And state was advanced to SummaryIndexed so the UI doesn't hang
+        await docStore.Received(1).UpdateIngestionStateAsync(
+            docId.ToString(), IngestionState.SummaryIndexed, Arg.Any<CancellationToken>());
+        await broadcaster.Received(1).BroadcastIngestionStateChangedAsync(
+            docId.ToString(), IngestionState.SummaryIndexed, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PerDocSummaryAsync_SummaryClusteringMode_CallsSummarizerAsBefore()
+    {
+        // Sanity regression: existing path still works.
+        Guid docId = Guid.NewGuid();
+        Guid containerId = Guid.NewGuid();
+        var doc = new Document(
+            Id: docId.ToString(),
+            ContainerId: containerId.ToString(),
+            FileName: "test.txt",
+            ContentType: "text/plain",
+            Path: "/test.txt",
+            SizeBytes: 100,
+            CreatedAt: DateTime.UtcNow,
+            Metadata: new Dictionary<string, string>());
+
+        var docStore = Substitute.For<IDocumentStore>();
+        docStore.GetAsync(docId.ToString(), Arg.Any<CancellationToken>()).Returns(doc);
+
+        var summarizer = Substitute.For<IPerDocSummarizer>();
+        var settingsResolver = Substitute.For<IContainerSettingsResolver>();
+        settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
+            .Returns(new SummarySettings
+            {
+                Enabled = true,
+                ContainerSummaryMethod = SummaryStrategy.SummaryClustering,
+            });
+
+        // Container/connector wiring: return null so the existing path bails on container_not_found
+        // — we only need to prove the early-return branch was NOT taken (summarizer would still
+        // not be called, but the skip reason would be "container_not_found" not "document_clustering_mode").
+        var containerStore = Substitute.For<IContainerStore>();
+        containerStore.GetAsync(containerId, Arg.Any<CancellationToken>()).Returns((Container?)null);
+
+        var jobs = new IngestionJobs(
+            ingester: Substitute.For<IKnowledgeIngester>(),
+            docStore: docStore,
+            containerStore: containerStore,
+            connectorFactory: Substitute.For<IConnectorFactory>(),
+            parsers: Array.Empty<IDocumentParser>(),
+            summarizer: summarizer,
+            settingsResolver: settingsResolver,
+            bgClient: Substitute.For<IBackgroundJobClient>(),
+            stateBroadcaster: Substitute.For<IIngestionStateBroadcaster>(),
+            logger: NullLogger<IngestionJobs>.Instance);
+
+        await jobs.PerDocSummaryAsync(docId.ToString(), CancellationToken.None);
+
+        // Verify we did NOT advance state to SummaryIndexed via the early-return path
+        // (the existing path bailed earlier with container_not_found and didn't touch state).
+        await docStore.DidNotReceive().UpdateIngestionStateAsync(
+            docId.ToString(), IngestionState.SummaryIndexed, Arg.Any<CancellationToken>());
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests**
+
+```
+dotnet test --filter "FullyQualifiedName~IngestionJobsHerculesTests"
+```
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```
+git add tests/Connapse.Background.Tests/Jobs/IngestionJobsHerculesTests.cs
+git commit -m "test: IngestionJobs.PerDocSummaryAsync early-returns in document-clustering mode"
+```
+
+---
+
+## Task 10: ComputeDocSetHash — switch to content_hash
+
+**Files:**
+- Modify: `src/Connapse.Background/Jobs/SummaryJobs.cs`
+
+- [ ] **Step 1: Verify Document model exposes content_hash**
+
+```
+grep -n "ContentHash" src/Connapse.Core/Models/*.cs
+```
+Confirm `Document` record (or its metadata bag) carries a `ContentHash`. If `Document` doesn't have it directly, check how `PostgresDocumentStore.MapToModel` exposes it: it's added to the metadata dictionary as `"ContentHash"`. Use that.
+
+- [ ] **Step 2: Replace ComputeDocSetHash**
+
+In `src/Connapse.Background/Jobs/SummaryJobs.cs`, replace the existing `ComputeDocSetHash` method with this implementation. The new version hashes `(docId, content_hash)` pairs, which works for both `document-clustering` (where most docs have null summaries) and `summary-clustering` (where all docs have summaries — but their content_hash equally identifies their state).
+
+```csharp
+    /// <summary>
+    /// Deterministic hash of the (sorted) set of {docId, content_hash} pairs for all docs
+    /// in the container. Works in both <c>document-clustering</c> mode (where most docs have
+    /// null summaries) and <c>summary-clustering</c> mode (where content_hash equally
+    /// identifies stale-vs-fresh state).
+    /// </summary>
+    /// <remarks>
+    /// Migration note: hashes will differ from the prior (docId, summary-hash) formula across
+    /// the deploy boundary, causing one extra rollup per container on first run post-deploy.
+    /// Accepted one-shot cost.
+    /// </remarks>
+    internal static string ComputeDocSetHash(IEnumerable<Document> docs)
+    {
+        IEnumerable<string> parts = docs
+            .OrderBy(d => d.Id)
+            .Select(d =>
+            {
+                string contentHash = d.Metadata?.GetValueOrDefault("ContentHash") ?? string.Empty;
+                return $"{d.Id}|{contentHash}";
+            });
+        return HexHash.Sha256(string.Join("\n", parts));
+    }
+```
+
+- [ ] **Step 3: Build**
+
+```
+dotnet build src/Connapse.Background
+```
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/Connapse.Background/Jobs/SummaryJobs.cs
+git commit -m "refactor: ComputeDocSetHash uses content_hash instead of summary text"
+```
+
+---
+
+## Task 11: Unit test ComputeDocSetHash
+
+**Files:**
+- Create or extend: `tests/Connapse.Background.Tests/Jobs/SummaryJobsHashTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create the file (or add to it if it already exists from a prior task):
+
+```csharp
+using Connapse.Background.Jobs;
+using Connapse.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Background.Tests.Jobs;
+
+[Trait("Category", "Unit")]
+public class SummaryJobsHashTests
+{
+    [Fact]
+    public void ComputeDocSetHash_SameContentHashes_ProducesSameHash()
+    {
+        Document MakeDoc(string id, string contentHash) => new(
+            Id: id,
+            ContainerId: Guid.NewGuid().ToString(),
+            FileName: "f.txt",
+            ContentType: "text/plain",
+            Path: "/f.txt",
+            SizeBytes: 1,
+            CreatedAt: DateTime.UtcNow,
+            Metadata: new Dictionary<string, string> { ["ContentHash"] = contentHash });
+
+        var docsA = new[]
+        {
+            MakeDoc("11111111-1111-1111-1111-111111111111", "hash-a"),
+            MakeDoc("22222222-2222-2222-2222-222222222222", "hash-b"),
+        };
+        // Same docs in different order
+        var docsB = new[]
+        {
+            MakeDoc("22222222-2222-2222-2222-222222222222", "hash-b"),
+            MakeDoc("11111111-1111-1111-1111-111111111111", "hash-a"),
+        };
+
+        SummaryJobs.ComputeDocSetHash(docsA).Should().Be(SummaryJobs.ComputeDocSetHash(docsB));
+    }
+
+    [Fact]
+    public void ComputeDocSetHash_NullContentHash_IsStableNotCrashing()
+    {
+        var docs = new[]
+        {
+            new Document(
+                Id: Guid.NewGuid().ToString(),
+                ContainerId: Guid.NewGuid().ToString(),
+                FileName: "f.txt",
+                ContentType: "text/plain",
+                Path: "/f.txt",
+                SizeBytes: 1,
+                CreatedAt: DateTime.UtcNow,
+                Metadata: new Dictionary<string, string>()) // no ContentHash key
+        };
+
+        Action act = () => SummaryJobs.ComputeDocSetHash(docs);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ComputeDocSetHash_DifferentContentHash_ProducesDifferentHash()
+    {
+        Document MakeDoc(string contentHash) => new(
+            Id: "11111111-1111-1111-1111-111111111111",
+            ContainerId: Guid.NewGuid().ToString(),
+            FileName: "f.txt",
+            ContentType: "text/plain",
+            Path: "/f.txt",
+            SizeBytes: 1,
+            CreatedAt: DateTime.UtcNow,
+            Metadata: new Dictionary<string, string> { ["ContentHash"] = contentHash });
+
+        string hashA = SummaryJobs.ComputeDocSetHash(new[] { MakeDoc("hash-a") });
+        string hashB = SummaryJobs.ComputeDocSetHash(new[] { MakeDoc("hash-b") });
+
+        hashA.Should().NotBe(hashB);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```
+dotnet test --filter "FullyQualifiedName~SummaryJobsHashTests"
+```
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```
+git add tests/Connapse.Background.Tests/Jobs/SummaryJobsHashTests.cs
+git commit -m "test: ComputeDocSetHash covers content_hash variant"
+```
+
+---
+
+## Task 12: SummaryJobs.RollupContainerAsync — split into two branches
+
+**Files:**
+- Modify: `src/Connapse.Background/Jobs/SummaryJobs.cs`
+
+This is the largest single change. We split `RollupContainerAsync` into a top-level dispatcher and two branch methods. Existing behavior moves into `RollupSummaryClusteringAsync` (no logic change). The new `RollupDocumentClusteringAsync` does pooled-embedding clustering and lazy medoid summarization.
+
+- [ ] **Step 1: Add new constructor dependencies**
+
+We need `IVectorStore` and `IPerDocSummarizer` injected into `SummaryJobs`. Update the constructor:
+
+```csharp
+public sealed class SummaryJobs : ISummaryJobs
+{
+    private readonly IContainerStore _containerStore;
+    private readonly IDocumentStore _docStore;
+    private readonly IContainerSettingsResolver _settingsResolver;
+    private readonly IDocumentSummaryEmbeddingProvider _embeddingProvider;
+    private readonly IVectorStore _vectorStore;
+    private readonly IPerDocSummarizer _perDocSummarizer;
+    private readonly IConnectorFactory _connectorFactory;
+    private readonly IEnumerable<IDocumentParser> _parsers;
+    private readonly SummaryLlmResolver _llmResolver;
+    private readonly ITokenCounter _tokenCounter;
+    private readonly IBackgroundJobClient _bgClient;
+    private readonly ILogger<SummaryJobs> _logger;
+
+    public SummaryJobs(
+        IContainerStore containerStore,
+        IDocumentStore docStore,
+        IContainerSettingsResolver settingsResolver,
+        IDocumentSummaryEmbeddingProvider embeddingProvider,
+        IVectorStore vectorStore,
+        IPerDocSummarizer perDocSummarizer,
+        IConnectorFactory connectorFactory,
+        IEnumerable<IDocumentParser> parsers,
+        SummaryLlmResolver llmResolver,
+        ITokenCounter tokenCounter,
+        IBackgroundJobClient bgClient,
+        ILogger<SummaryJobs> logger)
+    {
+        _containerStore = containerStore;
+        _docStore = docStore;
+        _settingsResolver = settingsResolver;
+        _embeddingProvider = embeddingProvider;
+        _vectorStore = vectorStore;
+        _perDocSummarizer = perDocSummarizer;
+        _connectorFactory = connectorFactory;
+        _parsers = parsers;
+        _llmResolver = llmResolver;
+        _tokenCounter = tokenCounter;
+        _bgClient = bgClient;
+        _logger = logger;
+    }
+```
+
+- [ ] **Step 2: Replace RollupContainerAsync with dispatcher**
+
+Replace the existing `RollupContainerAsync` body with this dispatcher:
+
+```csharp
+    [Queue(JobQueues.Summarization)]
+    [DisableConcurrentExecution(timeoutInSeconds: 600)]
+    [AutomaticRetry(Attempts = 3, DelaysInSeconds = new[] { 30, 120, 600 })]
+    public async Task RollupContainerAsync(Guid containerId, CancellationToken ct)
+    {
+        Container? container = await _containerStore.GetAsync(containerId, ct);
+        if (container is null) return;
+
+        SummarySettings settings = await _settingsResolver.GetSummarySettingsAsync(containerId, ct);
+        if (!settings.Enabled)
+        {
+            _logger.LogInformation(
+                "ContainerRollupSkipped {ContainerId} reason=summaries_disabled",
+                LogSanitizer.Sanitize(containerId.ToString()));
+            return;
+        }
+
+        if (settings.ContainerSummaryMethod == SummaryStrategy.DocumentClustering)
+        {
+            await RollupDocumentClusteringAsync(container, settings, ct);
+        }
+        else
+        {
+            await RollupSummaryClusteringAsync(container, settings, ct);
+        }
+    }
+```
+
+- [ ] **Step 3: Add RollupSummaryClusteringAsync (existing logic moved verbatim)**
+
+Add this private method. It contains the previous body of `RollupContainerAsync` from the doc-load step onward, with no behavioral changes:
+
+```csharp
+    private async Task RollupSummaryClusteringAsync(Container container, SummarySettings settings, CancellationToken ct)
+    {
+        Guid containerId = container.Id;
+
+        IReadOnlyList<Document> docs = await _docStore.ListAsync(
+            containerId, pathPrefix: null, skip: 0, take: 10_000, ct);
+        List<Document> withSummaries = docs.Where(d => !string.IsNullOrEmpty(d.Summary)).ToList();
+
+        if (withSummaries.Count == 0)
+        {
+            await _containerStore.UpdateSummaryAsync(containerId, null, null, null, ct);
+            return;
+        }
+
+        string docSetHash = ComputeDocSetHash(withSummaries);
+        if (docSetHash == container.SummaryDocSetHash)
+        {
+            _logger.LogInformation(
+                "ContainerRollupSkipped {ContainerId} reason=doc_set_hash_match",
+                LogSanitizer.Sanitize(containerId.ToString()));
+            return;
+        }
+
+        ILlmProvider? llm = _llmResolver.Resolve(settings);
+        IReadOnlyList<DocumentWithSummary> docsWithEmbeddings =
+            await _embeddingProvider.GetSummaryEmbeddingsAsync(withSummaries, ct);
+
+        IContainerSummarizer summarizer = new ContainerSummarizer(llm, _tokenCounter);
+        ContainerSummarizationResult result = await summarizer.GenerateAsync(
+            container.Name, docsWithEmbeddings, settings, ct);
+
+        if (result.Skipped)
+        {
+            _logger.LogInformation(
+                "ContainerRollupSkipped {ContainerId} reason={Reason}",
+                LogSanitizer.Sanitize(containerId.ToString()),
+                LogSanitizer.Sanitize(result.SkipReason ?? ""));
+            return;
+        }
+
+        await _containerStore.UpdateSummaryAsync(
+            containerId, result.Summary, DateTime.UtcNow, docSetHash, ct);
+
+        _logger.LogInformation(
+            "ContainerRollupCompleted {ContainerId} method=summary-clustering regime={Regime} N={N} k={K} inTok={InTok} outTok={OutTok}",
+            LogSanitizer.Sanitize(containerId.ToString()),
+            LogSanitizer.Sanitize(result.Regime ?? ""),
+            result.NumDocs,
+            result.KClusters,
+            result.InputTokens,
+            result.OutputTokens);
+    }
+```
+
+- [ ] **Step 4: Add RollupDocumentClusteringAsync (new lazy path)**
+
+Add this private method right after `RollupSummaryClusteringAsync`:
+
+```csharp
+    private const int LazyStuffThreshold = 30; // mirrors ContainerSummarizer.StuffThreshold
+    private const int LazyMaxClusters = 20;    // mirrors ContainerSummarizer.MaxClusters
+
+    private async Task RollupDocumentClusteringAsync(Container container, SummarySettings settings, CancellationToken ct)
+    {
+        Guid containerId = container.Id;
+
+        IReadOnlyList<Document> allDocs = await _docStore.ListAsync(
+            containerId, pathPrefix: null, skip: 0, take: 10_000, ct);
+
+        if (allDocs.Count == 0)
+        {
+            await _containerStore.UpdateSummaryAsync(containerId, null, null, null, ct);
+            return;
+        }
+
+        // Hash gate: skip rollup if the (docId, content_hash) set is unchanged since last rollup.
+        string docSetHash = ComputeDocSetHash(allDocs);
+        if (docSetHash == container.SummaryDocSetHash)
+        {
+            _logger.LogInformation(
+                "ContainerRollupSkipped {ContainerId} reason=doc_set_hash_match",
+                LogSanitizer.Sanitize(containerId.ToString()));
+            return;
+        }
+
+        // Pick which docs to summarize. Below the stuff threshold we summarize all of them;
+        // above it we cluster on pooled chunk embeddings and pick K medoids.
+        IReadOnlyList<Document> docsToSummarize;
+        string regime;
+        int? kClusters = null;
+
+        if (allDocs.Count <= LazyStuffThreshold)
+        {
+            docsToSummarize = allDocs;
+            regime = "stuff";
+        }
+        else
+        {
+            var pooled = await _vectorStore.GetPooledDocumentEmbeddingsAsync(containerId, ct);
+            if (pooled.Count == 0)
+            {
+                _logger.LogInformation(
+                    "ContainerRollupSkipped {ContainerId} reason=no_pooled_embeddings",
+                    LogSanitizer.Sanitize(containerId.ToString()));
+                return;
+            }
+
+            int k = Math.Min(LazyMaxClusters, (int)Math.Ceiling(pooled.Count / 3.0));
+            kClusters = k;
+            var medoids = MedoidSelector.SelectFarthestFirst(pooled, k);
+            var medoidIds = medoids.Select(m => m.Id).ToHashSet();
+
+            // Map medoid Guids back to Document instances. Skip any whose docs no longer exist
+            // (deleted between pooling query and now) — defensive.
+            var docsById = allDocs.ToDictionary(d => Guid.Parse(d.Id));
+            docsToSummarize = medoidIds
+                .Where(id => docsById.ContainsKey(id))
+                .Select(id => docsById[id])
+                .ToList();
+            regime = "cluster";
+        }
+
+        // Lazy-summarize each selected doc: cache hit when content_hash matches; otherwise call LLM.
+        var summarizedDocs = new List<DocumentWithSummary>();
+        foreach (var doc in docsToSummarize)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            string contentHash = doc.Metadata?.GetValueOrDefault("ContentHash") ?? string.Empty;
+            bool cacheHit = !string.IsNullOrEmpty(doc.Summary)
+                            && !string.IsNullOrEmpty(doc.SummaryContentHash)
+                            && doc.SummaryContentHash == contentHash;
+
+            string? summary;
+            if (cacheHit)
+            {
+                summary = doc.Summary;
+                _logger.LogDebug(
+                    "LazyMedoidSummaryCacheHit {DocumentId}",
+                    LogSanitizer.Sanitize(doc.Id));
+            }
+            else
+            {
+                summary = await GenerateAndCacheSummaryAsync(doc, settings, ct);
+                if (summary is null) continue; // skip docs that couldn't be summarized
+            }
+
+            // The ContainerSummarizer reduce step needs an Embedding too (for its internal stuff
+            // path it's not used, but the DocumentWithSummary type requires it). Use a placeholder.
+            // Empty array is fine because docsToSummarize is already <= LazyMaxClusters, so the
+            // ContainerSummarizer will take its stuff path (N <= StuffThreshold) and never touch
+            // .Embedding.
+            summarizedDocs.Add(new DocumentWithSummary(
+                Id: Guid.Parse(doc.Id),
+                Summary: summary!,
+                Embedding: Array.Empty<float>()));
+        }
+
+        if (summarizedDocs.Count == 0)
+        {
+            _logger.LogInformation(
+                "ContainerRollupSkipped {ContainerId} reason=no_summarizable_docs",
+                LogSanitizer.Sanitize(containerId.ToString()));
+            return;
+        }
+
+        ILlmProvider? llm = _llmResolver.Resolve(settings);
+        IContainerSummarizer summarizer = new ContainerSummarizer(llm, _tokenCounter);
+        ContainerSummarizationResult result = await summarizer.GenerateAsync(
+            container.Name, summarizedDocs, settings, ct);
+
+        if (result.Skipped)
+        {
+            _logger.LogInformation(
+                "ContainerRollupSkipped {ContainerId} reason={Reason}",
+                LogSanitizer.Sanitize(containerId.ToString()),
+                LogSanitizer.Sanitize(result.SkipReason ?? ""));
+            return;
+        }
+
+        await _containerStore.UpdateSummaryAsync(
+            containerId, result.Summary, DateTime.UtcNow, docSetHash, ct);
+
+        _logger.LogInformation(
+            "ContainerRollupCompleted {ContainerId} method=document-clustering regime={Regime} N={N} k={K} inTok={InTok} outTok={OutTok}",
+            LogSanitizer.Sanitize(containerId.ToString()),
+            regime,
+            allDocs.Count,
+            kClusters,
+            result.InputTokens,
+            result.OutputTokens);
+    }
+
+    /// <summary>
+    /// Runs the per-doc summarizer for one document in document-clustering mode, then
+    /// writes the result through to <c>documents.summary</c> as the cache for future rollups.
+    /// Returns null if the doc could not be summarized (parser failure, empty content, etc).
+    /// </summary>
+    private async Task<string?> GenerateAndCacheSummaryAsync(Document doc, SummarySettings settings, CancellationToken ct)
+    {
+        if (!Guid.TryParse(doc.ContainerId, out Guid containerId)) return null;
+        Container? container = await _containerStore.GetAsync(containerId, ct);
+        if (container is null) return null;
+
+        // Re-parse doc text through the container's connector — same pattern as IngestionJobs.PerDocSummaryAsync.
+        string parsedText;
+        try
+        {
+            IConnector connector = _connectorFactory.Create(container);
+            string jobPath = connector.ResolveJobPath(doc.Path.TrimStart('/'));
+            await using Stream stream = await connector.ReadFileAsync(jobPath, ct);
+
+            string extension = Path.GetExtension(doc.FileName).ToLowerInvariant();
+            IDocumentParser? parser = _parsers.FirstOrDefault(p => p.SupportedExtensions.Contains(extension));
+            if (parser is null)
+            {
+                _logger.LogInformation(
+                    "LazyMedoidSummarySkipped {DocumentId} reason=no_parser_for_extension",
+                    LogSanitizer.Sanitize(doc.Id));
+                return null;
+            }
+
+            ParsedDocument parsed = await parser.ParseAsync(stream, doc.FileName, ct);
+            parsedText = parsed.Content;
+        }
+        catch (FileNotFoundException)
+        {
+            _logger.LogWarning(
+                "LazyMedoidSummarySkipped {DocumentId} reason=file_not_found",
+                LogSanitizer.Sanitize(doc.Id));
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(parsedText))
+        {
+            _logger.LogInformation(
+                "LazyMedoidSummarySkipped {DocumentId} reason=empty_parsed_content",
+                LogSanitizer.Sanitize(doc.Id));
+            return null;
+        }
+
+        PerDocSummarizationResult result = await _perDocSummarizer.GenerateAsync(
+            doc.Id, parsedText, doc.ContentType, doc.FileName, settings, ct);
+
+        if (result.Skipped || string.IsNullOrEmpty(result.Summary))
+        {
+            _logger.LogInformation(
+                "LazyMedoidSummarySkipped {DocumentId} reason={Reason}",
+                LogSanitizer.Sanitize(doc.Id),
+                LogSanitizer.Sanitize(result.SkipReason ?? "no_summary_returned"));
+            return null;
+        }
+
+        // Write through to cache: documents.summary + summary_content_hash + summary_generated_at
+        string contentHash = doc.Metadata?.GetValueOrDefault("ContentHash") ?? string.Empty;
+        await _docStore.UpdateSummaryAsync(
+            doc.Id, result.Summary, DateTime.UtcNow, contentHash, ct);
+
+        return result.Summary;
+    }
+```
+
+- [ ] **Step 5: Update DI registration**
+
+Find where `SummaryJobs` is registered in DI. Likely `src/Connapse.Background/ServiceCollectionExtensions.cs` or similar:
+
+```
+grep -rn "AddScoped<ISummaryJobs" src/
+```
+
+`IVectorStore`, `IPerDocSummarizer`, `IConnectorFactory`, and `IEnumerable<IDocumentParser>` are already registered for `IngestionJobs`, so no new registrations are needed — the existing `services.AddScoped<ISummaryJobs, SummaryJobs>()` call will pick them up automatically.
+
+Confirm by running:
+```
+dotnet build
+```
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/Connapse.Background/Jobs/SummaryJobs.cs
+git commit -m "feat: SummaryJobs.RollupContainerAsync branches on ContainerSummaryMethod"
+```
+
+---
+
+## Task 13: Unit test SummaryJobs routing per ContainerSummaryMethod
+
+**Files:**
+- Create: `tests/Connapse.Background.Tests/Jobs/SummaryJobsHerculesTests.cs`
+
+- [ ] **Step 1: Write the routing test**
+
+```csharp
+using Connapse.Background.Jobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Llm;
+using FluentAssertions;
+using Hangfire;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Connapse.Background.Tests.Jobs;
+
+[Trait("Category", "Unit")]
+public class SummaryJobsHerculesTests
+{
+    private static SummaryJobs BuildJobs(
+        IContainerStore? containerStore = null,
+        IDocumentStore? docStore = null,
+        IContainerSettingsResolver? settingsResolver = null,
+        IVectorStore? vectorStore = null,
+        IPerDocSummarizer? perDocSummarizer = null,
+        IDocumentSummaryEmbeddingProvider? embeddingProvider = null)
+    {
+        return new SummaryJobs(
+            containerStore: containerStore ?? Substitute.For<IContainerStore>(),
+            docStore: docStore ?? Substitute.For<IDocumentStore>(),
+            settingsResolver: settingsResolver ?? Substitute.For<IContainerSettingsResolver>(),
+            embeddingProvider: embeddingProvider ?? Substitute.For<IDocumentSummaryEmbeddingProvider>(),
+            vectorStore: vectorStore ?? Substitute.For<IVectorStore>(),
+            perDocSummarizer: perDocSummarizer ?? Substitute.For<IPerDocSummarizer>(),
+            connectorFactory: Substitute.For<IConnectorFactory>(),
+            parsers: Array.Empty<IDocumentParser>(),
+            llmResolver: new SummaryLlmResolver(Substitute.For<IServiceProvider>(), NullLogger<SummaryLlmResolver>.Instance),
+            tokenCounter: Substitute.For<ITokenCounter>(),
+            bgClient: Substitute.For<IBackgroundJobClient>(),
+            logger: NullLogger<SummaryJobs>.Instance);
+    }
+
+    [Fact]
+    public async Task RollupContainerAsync_DocumentClusteringMode_QueriesPooledEmbeddings()
+    {
+        Guid containerId = Guid.NewGuid();
+        var container = new Container(containerId, "test", null, null, null, null);
+
+        var containerStore = Substitute.For<IContainerStore>();
+        containerStore.GetAsync(containerId, Arg.Any<CancellationToken>()).Returns(container);
+
+        var settingsResolver = Substitute.For<IContainerSettingsResolver>();
+        settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
+            .Returns(new SummarySettings { Enabled = true, ContainerSummaryMethod = SummaryStrategy.DocumentClustering });
+
+        var docStore = Substitute.For<IDocumentStore>();
+        // Return many docs (>StuffThreshold) so clustering path is taken
+        var docs = Enumerable.Range(0, 35).Select(i => new Document(
+            Id: Guid.NewGuid().ToString(),
+            ContainerId: containerId.ToString(),
+            FileName: $"f{i}.txt",
+            ContentType: "text/plain",
+            Path: $"/f{i}.txt",
+            SizeBytes: 1,
+            CreatedAt: DateTime.UtcNow,
+            Metadata: new Dictionary<string, string> { ["ContentHash"] = $"hash-{i}" }))
+            .ToList();
+        docStore.ListAsync(containerId, null, 0, 10_000, Arg.Any<CancellationToken>())
+            .Returns(docs);
+
+        var vectorStore = Substitute.For<IVectorStore>();
+        // Return empty so we exit before trying to summarize — test only proves the call happened
+        vectorStore.GetPooledDocumentEmbeddingsAsync(containerId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<(Guid, float[])>());
+
+        var embeddingProvider = Substitute.For<IDocumentSummaryEmbeddingProvider>();
+
+        var jobs = BuildJobs(
+            containerStore: containerStore,
+            docStore: docStore,
+            settingsResolver: settingsResolver,
+            vectorStore: vectorStore,
+            embeddingProvider: embeddingProvider);
+
+        await jobs.RollupContainerAsync(containerId, CancellationToken.None);
+
+        // Document-clustering path called the pooled query, not the summary-embedding provider
+        await vectorStore.Received(1).GetPooledDocumentEmbeddingsAsync(containerId, Arg.Any<CancellationToken>());
+        await embeddingProvider.DidNotReceiveWithAnyArgs().GetSummaryEmbeddingsAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task RollupContainerAsync_SummaryClusteringMode_QueriesSummaryEmbeddings()
+    {
+        Guid containerId = Guid.NewGuid();
+        var container = new Container(containerId, "test", null, null, null, null);
+
+        var containerStore = Substitute.For<IContainerStore>();
+        containerStore.GetAsync(containerId, Arg.Any<CancellationToken>()).Returns(container);
+
+        var settingsResolver = Substitute.For<IContainerSettingsResolver>();
+        settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
+            .Returns(new SummarySettings { Enabled = true, ContainerSummaryMethod = SummaryStrategy.SummaryClustering });
+
+        var docStore = Substitute.For<IDocumentStore>();
+        docStore.ListAsync(containerId, null, 0, 10_000, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Document>()); // empty so we exit fast; routing test only
+
+        var vectorStore = Substitute.For<IVectorStore>();
+        var embeddingProvider = Substitute.For<IDocumentSummaryEmbeddingProvider>();
+
+        var jobs = BuildJobs(
+            containerStore: containerStore,
+            docStore: docStore,
+            settingsResolver: settingsResolver,
+            vectorStore: vectorStore,
+            embeddingProvider: embeddingProvider);
+
+        await jobs.RollupContainerAsync(containerId, CancellationToken.None);
+
+        // Summary-clustering path did NOT call the pooled query
+        await vectorStore.DidNotReceiveWithAnyArgs().GetPooledDocumentEmbeddingsAsync(default, default);
+    }
+
+    [Fact]
+    public async Task RollupDocumentClusteringAsync_CacheHit_SkipsLlmCall()
+    {
+        Guid containerId = Guid.NewGuid();
+        Guid docId = Guid.NewGuid();
+        var container = new Container(containerId, "test", null, null, null, null);
+
+        // One doc, with summary cache that matches its content hash
+        const string contentHash = "matching-hash";
+        var doc = new Document(
+            Id: docId.ToString(),
+            ContainerId: containerId.ToString(),
+            FileName: "cached.txt",
+            ContentType: "text/plain",
+            Path: "/cached.txt",
+            SizeBytes: 1,
+            CreatedAt: DateTime.UtcNow,
+            Metadata: new Dictionary<string, string> { ["ContentHash"] = contentHash },
+            Summary: "Cached summary text",
+            SummaryGeneratedAt: DateTime.UtcNow.AddDays(-1),
+            SummaryContentHash: contentHash);
+
+        var containerStore = Substitute.For<IContainerStore>();
+        containerStore.GetAsync(containerId, Arg.Any<CancellationToken>()).Returns(container);
+
+        var settingsResolver = Substitute.For<IContainerSettingsResolver>();
+        settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
+            .Returns(new SummarySettings { Enabled = true, ContainerSummaryMethod = SummaryStrategy.DocumentClustering });
+
+        var docStore = Substitute.For<IDocumentStore>();
+        docStore.ListAsync(containerId, null, 0, 10_000, Arg.Any<CancellationToken>())
+            .Returns(new[] { doc });
+
+        var perDocSummarizer = Substitute.For<IPerDocSummarizer>();
+
+        // N=1 ≤ StuffThreshold so vector store is NOT queried; we go straight to lazy summarization
+        var jobs = BuildJobs(
+            containerStore: containerStore,
+            docStore: docStore,
+            settingsResolver: settingsResolver,
+            perDocSummarizer: perDocSummarizer);
+
+        await jobs.RollupContainerAsync(containerId, CancellationToken.None);
+
+        // Cache hit means PerDocSummarizer was NEVER invoked
+        await perDocSummarizer.DidNotReceiveWithAnyArgs().GenerateAsync(
+            default!, default!, default!, default!, default!, default);
+    }
+}
+```
+
+Note: `Container` and `Document` record constructors above are placeholders — adjust positional args to match what's actually in `src/Connapse.Core/Models/*.cs`. The fields used in the tests (`Summary`, `SummaryGeneratedAt`, `SummaryContentHash`, `Metadata`) all exist per `PostgresDocumentStore.MapToModel`.
+
+- [ ] **Step 2: Run the tests**
+
+```
+dotnet test --filter "FullyQualifiedName~SummaryJobsHerculesTests"
+```
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```
+git add tests/Connapse.Background.Tests/Jobs/SummaryJobsHerculesTests.cs
+git commit -m "test: SummaryJobs routes per ContainerSummaryMethod, honors lazy cache"
+```
+
+---
+
+## Task 14: SummarySettingsTab.razor — add Container summary method dropdown
+
+**Files:**
+- Modify: `src/Connapse.Web/Components/Settings/SummarySettingsTab.razor`
+
+- [ ] **Step 1: Add the dropdown markup**
+
+In `src/Connapse.Web/Components/Settings/SummarySettingsTab.razor`, find the existing **"LLM Model (override)"** form group block (around lines 36–43) and add this block immediately after it:
+
+```html
+    <div class="mb-3">
+        <label class="form-label">Container summary method</label>
+        <select class="form-select" value="@containerSummaryMethod"
+                @onchange="OnContainerSummaryMethodChanged">
+            <option value="document-clustering">Document clustering (recommended)</option>
+            <option value="summary-clustering">Summary clustering</option>
+        </select>
+        <div class="form-text">
+            <strong>Document clustering</strong> — does not summarize each uploaded document. At container summary generation time, the system clusters documents by their embeddings and summarizes only the K most representative ones. Lower LLM cost; container summary generation is slower the first time it runs.<br />
+            <strong>Summary clustering</strong> — summarizes every uploaded document at ingest. Container summary generation reuses those summaries. Higher LLM cost overall; faster container summary generation.
+        </div>
+    </div>
+```
+
+- [ ] **Step 2: Add state field and handler**
+
+In the `@code` block, add the local state field next to the other intermediate fields (`enabled`, `llmProvider`, etc.):
+
+```csharp
+    private string containerSummaryMethod = SummaryStrategy.DocumentClustering;
+```
+
+Add the change handler next to the other `On*Changed` methods:
+
+```csharp
+    private Task OnContainerSummaryMethodChanged(ChangeEventArgs e)
+    {
+        string? raw = e.Value as string;
+        containerSummaryMethod = string.IsNullOrWhiteSpace(raw) ? SummaryStrategy.DocumentClustering : raw;
+        return EmitChanged();
+    }
+```
+
+Update `OnParametersSet` to initialize from the bound settings:
+
+```csharp
+    protected override void OnParametersSet()
+    {
+        enabled = Settings.Enabled;
+        llmProvider = Settings.LlmProvider;
+        llmModel = Settings.LlmModel;
+        maxInputTokens = Settings.MaxInputTokens;
+        containerSummaryMethod = Settings.ContainerSummaryMethod;  // NEW
+        perDocPromptText = !string.IsNullOrWhiteSpace(Settings.PerDocSystemPrompt)
+            ? Settings.PerDocSystemPrompt!
+            : SummaryPrompts.PerDocSystemPrompt;
+        containerPromptText = !string.IsNullOrWhiteSpace(Settings.ContainerRollupSystemPrompt)
+            ? Settings.ContainerRollupSystemPrompt!
+            : SummaryPrompts.ContainerRollupSystemPrompt;
+    }
+```
+
+Update `BuildSettingsFromLocal` to include the new field:
+
+```csharp
+    private SummarySettings BuildSettingsFromLocal()
+    {
+        string? perDoc = IsPerDocAtDefault ? null : perDocPromptText;
+        string? containerRollup = IsContainerAtDefault ? null : containerPromptText;
+
+        return new SummarySettings
+        {
+            Enabled = enabled,
+            ContainerSummaryMethod = containerSummaryMethod,  // NEW
+            LlmProvider = llmProvider,
+            LlmModel = llmModel,
+            MaxInputTokens = maxInputTokens,
+            PerDocSystemPrompt = perDoc,
+            ContainerRollupSystemPrompt = containerRollup
+        };
+    }
+```
+
+- [ ] **Step 3: Build**
+
+```
+dotnet build src/Connapse.Web
+```
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/Connapse.Web/Components/Settings/SummarySettingsTab.razor
+git commit -m "feat: add Container summary method dropdown to SummarySettingsTab"
+```
+
+---
+
+## Task 15: Integration test — DocumentClustering end-to-end
+
+**Files:**
+- Create: `tests/Connapse.Web.Tests/Summarization/HerculesIntegrationTests.cs`
+
+- [ ] **Step 1: Examine the existing integration test fixture**
+
+```
+grep -rn "SharedWebApp" tests/Connapse.Web.Tests/ | head -20
+```
+Find an existing end-to-end test (e.g., `SummarySettingsIntegrationTests.cs`) and copy its fixture pattern, including how it uploads docs through the API and waits for ingestion to settle.
+
+- [ ] **Step 2: Write the test**
+
+Create `tests/Connapse.Web.Tests/Summarization/HerculesIntegrationTests.cs`:
+
+```csharp
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Connapse.Web.Tests.Summarization;
+
+[Trait("Category", "Integration")]
+[Collection("SharedWebApp")]
+public class HerculesIntegrationTests
+{
+    private readonly SharedWebAppFixture _fixture;
+
+    public HerculesIntegrationTests(SharedWebAppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task DocumentClusteringMode_NoPerDocSummariesAreGenerated()
+    {
+        // Arrange: create a container and set it to document-clustering mode
+        Guid containerId = await _fixture.CreateContainerAsync("hercules-e2e-1");
+        await _fixture.SetContainerSummarySettingsAsync(containerId, new SummarySettings
+        {
+            Enabled = true,
+            ContainerSummaryMethod = SummaryStrategy.DocumentClustering,
+        });
+
+        // Act: upload 5 docs (below stuff threshold, so all 5 will be summarized at rollup)
+        for (int i = 0; i < 5; i++)
+        {
+            await _fixture.UploadDocAsync(containerId, $"/doc{i}.txt", $"Sample content for doc {i}.");
+        }
+
+        await _fixture.WaitForIngestionCompletionAsync(containerId, expectedDocCount: 5);
+
+        // Assert: per-doc summaries are still null because we didn't trigger a rollup yet
+        using var scope = _fixture.Services.CreateScope();
+        var docStore = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        var docs = await docStore.ListAsync(containerId, null, 0, 100, CancellationToken.None);
+        docs.Should().HaveCount(5);
+        docs.All(d => string.IsNullOrEmpty(d.Summary)).Should().BeTrue(
+            "document-clustering mode should not summarize docs at ingest");
+    }
+
+    [Fact]
+    public async Task DocumentClusteringMode_RollupSummarizesOnlyMedoids()
+    {
+        Guid containerId = await _fixture.CreateContainerAsync("hercules-e2e-2");
+        await _fixture.SetContainerSummarySettingsAsync(containerId, new SummarySettings
+        {
+            Enabled = true,
+            ContainerSummaryMethod = SummaryStrategy.DocumentClustering,
+        });
+
+        // Upload 35 docs (>StuffThreshold so we get the clustering regime)
+        for (int i = 0; i < 35; i++)
+        {
+            await _fixture.UploadDocAsync(containerId, $"/doc{i}.txt", $"Sample content for doc {i}.");
+        }
+        await _fixture.WaitForIngestionCompletionAsync(containerId, expectedDocCount: 35);
+
+        // Act: trigger rollup via the regenerate endpoint
+        await _fixture.TriggerRollupAsync(containerId);
+        await _fixture.WaitForContainerSummaryAsync(containerId);
+
+        // Assert: container has a summary, and ONLY K medoid docs have per-doc summaries cached
+        using var scope = _fixture.Services.CreateScope();
+        var containerStore = scope.ServiceProvider.GetRequiredService<IContainerStore>();
+        var docStore = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+
+        var container = await containerStore.GetAsync(containerId, CancellationToken.None);
+        container!.Summary.Should().NotBeNullOrWhiteSpace();
+
+        var docs = await docStore.ListAsync(containerId, null, 0, 100, CancellationToken.None);
+        int withSummary = docs.Count(d => !string.IsNullOrEmpty(d.Summary));
+        int expectedK = Math.Min(20, (int)Math.Ceiling(35.0 / 3.0)); // 12
+        withSummary.Should().Be(expectedK,
+            "only K medoid docs should be summarized in document-clustering mode");
+    }
+
+    [Fact]
+    public async Task SummaryClusteringMode_AllDocsGetSummariesAtIngest()
+    {
+        Guid containerId = await _fixture.CreateContainerAsync("hercules-e2e-3");
+        await _fixture.SetContainerSummarySettingsAsync(containerId, new SummarySettings
+        {
+            Enabled = true,
+            ContainerSummaryMethod = SummaryStrategy.SummaryClustering,
+        });
+
+        for (int i = 0; i < 5; i++)
+        {
+            await _fixture.UploadDocAsync(containerId, $"/doc{i}.txt", $"Sample content for doc {i}.");
+        }
+        await _fixture.WaitForIngestionCompletionAsync(containerId, expectedDocCount: 5);
+        // Wait for per-doc summary jobs to settle
+        await _fixture.WaitForAllSummariesAsync(containerId, expectedDocCount: 5);
+
+        using var scope = _fixture.Services.CreateScope();
+        var docStore = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        var docs = await docStore.ListAsync(containerId, null, 0, 100, CancellationToken.None);
+        docs.Should().HaveCount(5);
+        docs.All(d => !string.IsNullOrEmpty(d.Summary)).Should().BeTrue(
+            "summary-clustering mode should summarize every doc at ingest");
+    }
+}
+```
+
+If `SetContainerSummarySettingsAsync` / `TriggerRollupAsync` / `WaitForContainerSummaryAsync` / `WaitForAllSummariesAsync` aren't already on `SharedWebAppFixture`, copy the pattern from `SummarySettingsIntegrationTests` (or whichever existing test exercises these endpoints) — typically a `PostAsync("/api/containers/{id}/settings", ...)` and polling loops.
+
+- [ ] **Step 3: Run the tests**
+
+```
+dotnet test --filter "FullyQualifiedName~HerculesIntegrationTests"
+```
+Expected: PASS (may take 1–3 minutes per test because LLM calls happen against the configured provider)
+
+- [ ] **Step 4: Commit**
+
+```
+git add tests/Connapse.Web.Tests/Summarization/HerculesIntegrationTests.cs
+git commit -m "test: end-to-end document-clustering and summary-clustering modes"
+```
+
+---
+
+## Task 16: Integration test — Method switch lazy → eager backfills on ingest
+
+**Files:**
+- Modify: `tests/Connapse.Web.Tests/Summarization/HerculesIntegrationTests.cs`
+
+- [ ] **Step 1: Add the switch test to the existing test class**
+
+Append to the test class created in Task 15:
+
+```csharp
+    [Fact]
+    public async Task MethodSwitch_LazyToEager_BackfillsNewDocsOnIngest()
+    {
+        Guid containerId = await _fixture.CreateContainerAsync("hercules-switch");
+        await _fixture.SetContainerSummarySettingsAsync(containerId, new SummarySettings
+        {
+            Enabled = true,
+            ContainerSummaryMethod = SummaryStrategy.DocumentClustering,
+        });
+
+        // Upload one doc under document-clustering — no per-doc summary
+        await _fixture.UploadDocAsync(containerId, "/doc-lazy.txt", "Content in lazy mode.");
+        await _fixture.WaitForIngestionCompletionAsync(containerId, expectedDocCount: 1);
+
+        using (var scope = _fixture.Services.CreateScope())
+        {
+            var docStore = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+            var d = (await docStore.ListAsync(containerId, null, 0, 100, CancellationToken.None)).Single();
+            d.Summary.Should().BeNullOrEmpty();
+        }
+
+        // Switch to summary-clustering
+        await _fixture.SetContainerSummarySettingsAsync(containerId, new SummarySettings
+        {
+            Enabled = true,
+            ContainerSummaryMethod = SummaryStrategy.SummaryClustering,
+        });
+
+        // Upload another doc — should be summarized at ingest now
+        await _fixture.UploadDocAsync(containerId, "/doc-eager.txt", "Content in eager mode.");
+        await _fixture.WaitForIngestionCompletionAsync(containerId, expectedDocCount: 2);
+        await _fixture.WaitForDocSummaryAsync(containerId, "/doc-eager.txt");
+
+        using (var scope = _fixture.Services.CreateScope())
+        {
+            var docStore = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+            var docs = await docStore.ListAsync(containerId, null, 0, 100, CancellationToken.None);
+            var lazy = docs.Single(d => d.Path == "/doc-lazy.txt");
+            var eager = docs.Single(d => d.Path == "/doc-eager.txt");
+
+            lazy.Summary.Should().BeNullOrEmpty(
+                "doc uploaded in lazy mode keeps its null summary");
+            eager.Summary.Should().NotBeNullOrEmpty(
+                "doc uploaded after switch to eager mode should have a summary");
+        }
+    }
+```
+
+- [ ] **Step 2: Run the test**
+
+```
+dotnet test --filter "FullyQualifiedName~HerculesIntegrationTests.MethodSwitch_LazyToEager_BackfillsNewDocsOnIngest"
+```
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```
+git add tests/Connapse.Web.Tests/Summarization/HerculesIntegrationTests.cs
+git commit -m "test: switching from document-clustering to summary-clustering backfills new docs"
+```
+
+---
+
+## Task 17: Manual QA doc — add document-clustering scenarios
+
+**Files:**
+- Modify: `docs/manual-qa/summary-generation.md` (or whichever manual-QA file the prior cycles updated)
+
+- [ ] **Step 1: Locate the existing manual QA doc**
+
+```
+grep -rn "summary" docs/manual-qa/ 2>/dev/null || find docs -name "*qa*" -o -name "*manual*"
+```
+
+Look for the file that prior summary-related cycles (PR #329, the Hangfire migration) extended. If multiple candidates exist, use the most-recently-modified one.
+
+- [ ] **Step 2: Append a new section**
+
+Add this section to the bottom of the file (adjust heading level to match the surrounding doc):
+
+```markdown
+## HERCULES — Document-clustering container summary method
+
+The default container summary method for new installs is `document-clustering`. The legacy method is `summary-clustering`. Verify both end-to-end.
+
+### Scenario 1: Document-clustering default for new container
+
+1. Create a fresh container "qa-hercules-default".
+2. Open Settings tab → Container summary method should show "Document clustering (recommended)" by default.
+3. Upload 5 documents (any text files).
+4. Wait for ingestion to complete (per-doc spinners stop).
+5. **Expected:** Each doc's row shows no "summary" indicator. The container row shows no summary yet (rollup hasn't happened).
+6. Click "Regenerate summary now".
+7. Wait ~30s for the rollup to complete.
+8. **Expected:** Container summary appears. Each doc's row STILL shows no per-doc summary (N=5 ≤ stuff threshold of 30, so all 5 docs were summarized inline at rollup but cached against their own row — open the doc detail panel and confirm summary IS now present).
+
+### Scenario 2: Document-clustering clustering regime (>30 docs)
+
+1. Create container "qa-hercules-cluster".
+2. Upload 35 documents.
+3. Wait for ingestion, click "Regenerate summary now".
+4. **Expected:** Container summary appears. Open the FileBrowser doc list — exactly K = `min(20, ceil(35/3))` = 12 docs have summaries; the remaining 23 do not.
+
+### Scenario 3: Switch to summary-clustering
+
+1. Open container "qa-hercules-default" settings.
+2. Change Container summary method to "Summary clustering". Save.
+3. Upload one new document "doc-after-switch.txt".
+4. Wait for ingestion.
+5. **Expected:** "doc-after-switch.txt" gets a per-doc summary at ingest (open detail panel to confirm). The 5 docs uploaded before the switch still don't have per-doc summaries (lazy-mode cache state preserved).
+
+### Scenario 4: Cache reuse on re-rollup
+
+1. In container "qa-hercules-cluster" (from Scenario 2), click "Regenerate summary now" a second time WITHOUT uploading anything.
+2. **Expected:** Rollup completes quickly. Watch the Hangfire dashboard / logs — there should be **zero** LLM calls for per-doc summaries this time (all 12 medoid docs have cached summaries with matching content_hash).
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add docs/manual-qa/summary-generation.md
+git commit -m "docs: add manual QA scenarios for document-clustering summary method"
+```
+
+---
+
+## Task 18: Push branch + open PR + final code review
+
+**Files:**
+- N/A
+
+- [ ] **Step 1: Full build + test**
+
+```
+dotnet build
+dotnet test --filter "Category=Unit"
+```
+Expected: all green.
+
+```
+dotnet test --filter "Category=Integration"
+```
+Expected: all green (requires Docker for Testcontainers + a running LLM provider configured in test settings).
+
+- [ ] **Step 2: Push the branch**
+
+Replace `<N>` with the issue number from Task 1:
+```
+git push -u origin feature/<N>-hercules-swap
+```
+
+- [ ] **Step 3: Open the PR**
+
+```
+gh pr create \
+  --base main \
+  --title "feat: add document-clustering container summary method (HERCULES) (closes #<N>)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Adds a new \`document-clustering\` value for \`SummarySettings.ContainerSummaryMethod\` and makes it the new default. The method clusters documents using mean-pooled chunk embeddings (which already exist in \`chunk_vectors\` for vector search) and lazy-summarizes only the K medoid documents at rollup time. Existing \`summary-clustering\` behavior remains available behind the setting.
+
+Built on research:
+- HERCULES paper (arXiv:2506.19992): +76% ARI on clustering quality vs summary embeddings
+- \`docs/research/lazy-vs-eager-per-doc-summarization-2026-05-26.md\`
+
+Design: \`docs/superpowers/specs/2026-05-27-hercules-swap-design.md\`
+Plan: \`docs/superpowers/plans/2026-05-27-hercules-swap.md\`
+
+## What changed
+
+- New \`SummaryStrategy\` constants (\`document-clustering\` | \`summary-clustering\`)
+- \`SummarySettings.ContainerSummaryMethod\` field, G+C scope through existing resolver, default \`document-clustering\`
+- New \`IVectorStore.GetPooledDocumentEmbeddingsAsync\` (PgVectorStore impl uses pgvector \`AVG(embedding)\` over chunk vectors, filtered to dominant model)
+- \`IngestionJobs.PerDocSummaryAsync\` early-returns in \`document-clustering\` mode
+- \`SummaryJobs.RollupContainerAsync\` branches: existing path unchanged for \`summary-clustering\`; new lazy path for \`document-clustering\`
+- \`ComputeDocSetHash\` switched from summary-text to content-hash (works for both methods)
+- Settings UI dropdown
+- Unit + integration test coverage for both paths
+
+## Migration impact
+
+- Existing containers continue working under whichever method they're set to. The \`ContainerSummaryMethod\` default of \`document-clustering\` only applies to new \`SummarySettings\` records.
+- \`ComputeDocSetHash\` formula changed → one extra rollup per container on first run post-deploy. Accepted one-shot cost.
+- No DB schema changes.
+
+## Test plan
+
+- [ ] \`dotnet test --filter Category=Unit\` all green
+- [ ] \`dotnet test --filter Category=Integration\` all green (Docker required)
+- [ ] Manual QA per \`docs/manual-qa/summary-generation.md\` HERCULES scenarios 1–4
+EOF
+)"
+```
+
+- [ ] **Step 4: Request CodeRabbit review on the PR**
+
+```
+gh pr comment --body "/coderabbit review"
+```
+
+Wait for the review, then triage findings: implement reasonable ones inline, dismiss noise.
+
+- [ ] **Step 5: Mark task complete and stop here**
+
+Do not merge. Patrick reviews + merges manually after CI passes.
+
+---
+
+## Self-Review
+
+Spec coverage check (against `docs/superpowers/specs/2026-05-27-hercules-swap-design.md`):
+
+| Spec requirement | Implemented in |
+|---|---|
+| `SummarySettings.ContainerSummaryMethod` field with default `document-clustering` | Task 3 |
+| Validator rejects unknown values | Task 3 |
+| Resolves through `ContainerSettingsResolver` (G+C) | Task 4 (test only — resolver already handles arbitrary `Summary` fields) |
+| `SummaryStrategy` constants | Task 2 |
+| `IVectorStore.GetPooledDocumentEmbeddingsAsync` interface + impl | Tasks 5, 6 |
+| Pooled-embedding SQL with `AVG`, mixed-model warning, L2 normalize | Task 6 |
+| Empty-chunk doc exclusion | Task 6 (handled implicitly by `GROUP BY` on `chunk_vectors`) |
+| `PerDocSummaryAsync` early-return in document-clustering | Task 8 |
+| `RollupContainerAsync` branches per method | Task 12 |
+| Lazy summarization of K medoids with cache hit check | Task 12 |
+| `ComputeDocSetHash` uses content_hash | Task 10 |
+| UI dropdown in `SummarySettingsTab.razor` | Task 14 |
+| Unit tests for early-return | Task 9 |
+| Unit tests for routing | Task 13 |
+| Unit tests for cache hit | Task 13 |
+| Unit tests for hash function | Task 11 |
+| Integration test: DocumentClustering end-to-end | Task 15 |
+| Integration test: SummaryClustering end-to-end | Task 15 |
+| Integration test: Method switch | Task 16 |
+| Integration test: Pooled embeddings mixed-model filter | Task 7 |
+| Manual QA scenarios | Task 17 |
+
+All spec sections have task coverage. The "RollupDocumentClusteringAsync only writes K cache entries" claim from Task 15 is what the integration test in Task 15 verifies.
+
+**One known simplification vs spec:** Spec section "New components → ContainerSummarizer" implies cluster annotations like "(represents N similar docs)" might appear in the lazy path's reduce prompt. In this plan, lazy mode passes K ≤ 20 doc summaries to `ContainerSummarizer.GenerateAsync`, which (because N ≤ `StuffThreshold = 30`) takes its stuff path and does NOT add cluster-size prefixes. The reduce prompt receives K summaries without annotation. This is documented as Open Question / follow-up in the spec, not a regression. If post-merge experimentation shows quality suffers, the follow-up is a small `ContainerSummarizer` change to accept pre-clustered input with sizes.

--- a/docs/superpowers/specs/2026-05-27-hercules-swap-design.md
+++ b/docs/superpowers/specs/2026-05-27-hercules-swap-design.md
@@ -50,7 +50,7 @@ A new string field on `SummarySettings` in `Connapse.Core/Models/SettingsModels.
 ```csharp
 public record SummarySettings
 {
-    public bool Enabled { get; init; } = true;
+    public bool Enabled { get; init; } = false;  // opt-in
     public string ContainerSummaryMethod { get; init; } = "document-clustering";  // NEW
     public string LlmModel { get; init; } = "...";
     public string LlmProvider { get; init; } = "...";

--- a/docs/superpowers/specs/2026-05-27-hercules-swap-design.md
+++ b/docs/superpowers/specs/2026-05-27-hercules-swap-design.md
@@ -1,0 +1,269 @@
+# HERCULES Swap — Design
+
+**Date:** 2026-05-27
+**Author:** Connapse team (brainstormed via Claude Code superpowers:brainstorming)
+**Branch:** TBD (after issue filed; sequenced after PR #333 merges)
+**Built on:**
+- `docs/research/container-summary-generation-strategy-2026-05-24.md` (current eager + medoid design)
+- `docs/research/lazy-vs-eager-per-doc-summarization-2026-05-26.md` (HERCULES validation: +76% ARI on clustering quality vs summary embeddings, p<0.001)
+
+## Problem
+
+The current container-summary pipeline (live in PR #333) is **summary-clustering**:
+
+1. Every uploaded document is summarized at ingest by `IngestionJobs.PerDocSummaryAsync`.
+2. At rollup, `SummaryJobs.RollupContainerAsync` embeds the per-doc summary texts and runs farthest-first medoid selection on those summary embeddings to pick K representatives.
+3. The K medoid summaries are passed to a reduce step that synthesizes the container summary.
+
+Two findings from research challenge this shape:
+
+- **Clustering on summary embeddings is worse than clustering on raw embeddings.** HERCULES (arXiv:2506.19992, Software Impacts 2025) measured +76% ARI and +286% silhouette score for raw-embedding clustering over summary-embedding clustering on 20 Newsgroups, p<0.001. The intuition: summaries lossy-compress documents along axes the LLM picks, which discards the variance dimensions that separate clusters.
+- **Per-doc summaries have no validated secondary use.** The original eager design justified itself with "6 secondary uses" (search reranking, citation hints, UI snippets, etc.) — the 2026-05-26 follow-up research found none of these are actually deployed in Connapse or in comparable products. Per-doc summaries are a *means* to the container summary, not an end.
+
+The eager design also pays its full LLM cost on every upload (whether or not the container summary is ever consumed) and rebuilds it on every re-ingest. For containers that ingest fast but query rarely, this is wasted spend.
+
+## Goal
+
+Add a setting that switches container summarization between the current method and a HERCULES-style method that:
+
+1. Skips per-doc summarization at upload time.
+2. At rollup, clusters documents using mean-pooled chunk embeddings (which already exist in `chunk_vectors` for vector search — no new embedding cost).
+3. Lazy-summarizes only the K medoid documents inline at rollup.
+4. Caches those K summaries in the existing `documents.summary` column for the next rollup.
+
+Both methods produce a container summary the same way (reduce K medoid summaries). They differ in the clustering signal and in *which* docs ever get summarized.
+
+## Non-goals
+
+- **No removal of `documents.summary` / `summary_generated_at` / `summary_content_hash` columns.** They serve as the cache for the lazy method's K medoid summaries.
+- **No comparative quality evaluation in CI.** Post-merge experimentation with the LLM-judge eval harness handles that.
+- **No parallelization of the K inline LLM calls in lazy mode.** Sequential is fine for v1; revisit if rollup latency becomes a bottleneck.
+- **No default-flip migration for existing containers.** Existing per-doc summaries stay populated; existing containers keep working under whichever method they're set to.
+- **No support for retrofitting historical chunk_vectors with a new embedding model.** Mixed-model containers use the dominant model's vectors for pooling and log a warning.
+
+## Setting design
+
+### `SummarySettings.ContainerSummaryMethod`
+
+A new string field on `SummarySettings` in `Connapse.Core/Models/SettingsModels.cs`:
+
+```csharp
+public record SummarySettings
+{
+    public bool Enabled { get; init; } = true;
+    public string ContainerSummaryMethod { get; init; } = "document-clustering";  // NEW
+    public string LlmModel { get; init; } = "...";
+    public string LlmProvider { get; init; } = "...";
+    // ...existing fields
+}
+```
+
+Valid values:
+
+| Value | Behavior |
+|-------|----------|
+| `document-clustering` | New default. Cluster docs by pooled chunk embeddings, summarize K medoids on demand at rollup. |
+| `summary-clustering` | Current behavior. Summarize all docs at ingest, cluster by summary embeddings, reduce K medoid summaries. |
+
+Unknown values fail validation in `SummarySettings` validator with a clear error pointing at the allowed list.
+
+### Scope: G+C (global + per-container override)
+
+The setting resolves via the existing `ContainerSettingsResolver.GetSummarySettingsAsync(containerId, ct)`, which already overlays per-container JSON overrides on top of global settings. `ContainerSummaryMethod` slots in alongside `LlmModel` and `LlmProvider` and inherits the same precedence (`appsettings` < env < secrets < DB global < per-container override).
+
+### UI
+
+`SummarySettingsTab.razor` gets a new dropdown labeled **"Container summary method"** with the two options. Help text below explains the cost/coverage tradeoff in plain language. Available at both global Settings and per-container FileBrowser Settings tab (same dual mount as the existing `LlmModel` selector).
+
+## Data flow
+
+### Per upload (ingestion)
+
+```
+IngestionJobs.PerDocSummaryAsync(documentId)
+  → resolve SummarySettings via ContainerSettingsResolver
+  → switch on ContainerSummaryMethod:
+      "summary-clustering": existing path — generate summary, write to
+                            documents.summary + summary_generated_at +
+                            summary_content_hash
+      "document-clustering": early-return. No LLM call. No DB write.
+```
+
+### Per rollup (container summary)
+
+```
+SummaryJobs.RollupContainerAsync(containerId)
+  → resolve SummarySettings
+  → switch on ContainerSummaryMethod:
+
+      "summary-clustering":
+        embeddings = _embeddingProvider.GetSummaryEmbeddingsAsync(docsWithSummaries)
+        medoids    = MedoidSelector.Select(embeddings, k)
+        summaries  = medoids.Select(m => m.Summary)  // pre-computed
+        reduce     = ContainerSummarizer.Reduce(summaries)
+
+      "document-clustering":
+        embeddings = IVectorStore.GetPooledDocumentEmbeddingsAsync(containerId)
+        medoids    = MedoidSelector.Select(embeddings, k)
+        summaries  = medoids.Select(m =>
+          cacheHit(m) ? m.CachedSummary
+                      : PerDocSummarizer.SummarizeAsync(m).Tap(WriteCache))
+        reduce     = ContainerSummarizer.Reduce(summaries)
+```
+
+Both branches converge at the reduce step. The medoid selection algorithm (farthest-first) is unchanged; only what's fed to it differs.
+
+### Cache semantics in `document-clustering` mode
+
+The lazy method writes K summaries to `documents.summary` per rollup. On the next rollup, if a medoid doc has:
+- Non-null `documents.summary`, AND
+- `summary_content_hash == documents.content_hash` (current ingestion hash)
+
+then the cached summary is used and no LLM call is made. Stale entries (hash mismatch) are silently regenerated. This means container churn with stable content costs nothing — same as `summary-clustering`.
+
+### Stuff regime (≤30 docs)
+
+Unchanged for both methods. Below `StuffThreshold = 30`, all per-doc summaries flow straight into the reduce step without clustering. In `document-clustering` mode, this means inline-summarizing all N docs at rollup time (no clustering needed). For small containers this is the only place where the lazy method is *slower* than the eager method, but with N≤30 and rollups debounced behind the sweep, it's a few seconds of one-time latency per content change, not per request.
+
+## New components
+
+### 1. `IVectorStore.GetPooledDocumentEmbeddingsAsync`
+
+New method on the existing `IVectorStore` interface:
+
+```csharp
+Task<IReadOnlyList<(Guid DocumentId, float[] Embedding)>> GetPooledDocumentEmbeddingsAsync(
+    Guid containerId,
+    CancellationToken ct = default);
+```
+
+**PostgreSQL implementation:** single SQL query joining `chunk_vectors` → `chunks` → `documents`, grouping by `document_id` with pgvector's `AVG(embedding)`. Filters to one `model_id` per call — picks the dominant `model_id` in the container, logs a warning at `Information` level listing the skipped doc count if multiple models are present.
+
+```sql
+SELECT d.id, AVG(cv.embedding)::vector AS pooled
+FROM documents d
+JOIN chunks c ON c.document_id = d.id
+JOIN chunk_vectors cv ON cv.chunk_id = c.id
+WHERE d.container_id = @cid
+  AND cv.model_id = @model_id
+GROUP BY d.id
+HAVING COUNT(cv.chunk_id) > 0;
+```
+
+The client L2-normalizes each pooled vector before feeding to `MedoidSelector` (pgvector's `AVG` does not renormalize). Empty-chunk docs are excluded by `HAVING COUNT > 0`.
+
+### 2. `SummaryStrategy` constants
+
+Add `Connapse.Core/Models/SummaryStrategy.cs` for the allowed values:
+
+```csharp
+public static class SummaryStrategy
+{
+    public const string DocumentClustering = "document-clustering";
+    public const string SummaryClustering = "summary-clustering";
+
+    public static readonly IReadOnlySet<string> All = new HashSet<string>
+    {
+        DocumentClustering,
+        SummaryClustering,
+    };
+}
+```
+
+Stored as string in `SummarySettings` to match the existing convention (`LlmProvider`, `LlmModel` are also strings).
+
+### 3. `ComputeDocSetHash` change
+
+Current implementation in `SummaryJobs.cs` hashes `(docId, sha256(summary))` pairs. This breaks in `document-clustering` mode because most docs have null summary. New implementation hashes `(docId, content_hash)` pairs — works for both methods, same short-circuit guarantees.
+
+**Migration impact:** hashes will differ across the swap, causing exactly one extra rollup per container on first post-deploy run. Acceptable one-shot cost.
+
+### 4. Strategy branch in `IngestionJobs.PerDocSummaryAsync`
+
+Early return when method is `document-clustering`:
+
+```csharp
+public async Task PerDocSummaryAsync(Guid documentId, CancellationToken ct)
+{
+    // ...load doc, resolve container...
+    var settings = await _settingsResolver.GetSummarySettingsAsync(containerId, ct);
+    if (settings.ContainerSummaryMethod == SummaryStrategy.DocumentClustering)
+    {
+        _logger.LogDebug("Skipping per-doc summary for {DocumentId} (document-clustering mode)", documentId);
+        return;
+    }
+    // ...existing eager path...
+}
+```
+
+### 5. Strategy branch in `SummaryJobs.RollupContainerAsync`
+
+Two branches at the top of the rollup body. The branches share the reduce step and the container-write step at the end. Each branch is its own private method (`RollupSummaryClusteringAsync`, `RollupDocumentClusteringAsync`) for readability.
+
+No new interfaces, no decorator pattern. The branching lives directly in the job class.
+
+## Error handling and edge cases
+
+### Mixed embedding models in one container
+
+`chunk_vectors.embedding` is unconstrained, so a container can have chunks from multiple models. Strategy: query `model_id` distribution at rollup start, use the dominant one, log a `Warning`-level message listing the count of docs whose chunks were all under non-dominant models (excluded from clustering this rollup). Excluded docs will be picked up after re-ingestion under the dominant model. This matches existing vector-search behavior (which also filters by `model_id`).
+
+### Docs with zero chunks
+
+`chunk_count = 0` from failed ingestion or empty files. The `HAVING COUNT(cv.chunk_id) > 0` clause excludes them from the pooled-embeddings query, which is correct — they couldn't produce a pooled vector anyway and shouldn't be summarized.
+
+### Method switch mid-flight
+
+User toggles `summary-clustering` → `document-clustering` while a `PerDocSummaryAsync` job is enqueued. The job resolves settings at execute time (not enqueue time) — if it now sees `document-clustering`, it early-returns. Safe.
+
+### Method switch lazy → eager
+
+User toggles `document-clustering` → `summary-clustering`. Existing docs have null `documents.summary`. The eager rollup path must filter `WHERE summary IS NOT NULL` before medoid clustering — this is already true in the sweep query (`FindContainersWithStaleSummariesAsync` checks `Summary != null && SummaryGeneratedAt != null`); the implementation task is to confirm the same guard exists in the medoid selection step. The first eager rollup post-switch uses whichever K medoid docs do have cached summaries from prior lazy runs. As new docs ingest under eager mode, the corpus catches up. No backfill job is needed and no data is lost.
+
+### LLM failure during lazy medoid summarization
+
+K=20 inline LLM calls means K possible failures. `PerDocSummarizer` already has a Polly retry policy. If a single medoid still fails after retries: log + skip + continue with K-1 summaries (container summary degrades gracefully but is still produced). If all K fail: the rollup job itself fails and gets retried by Hangfire — same recovery path as today's eager failures.
+
+### Rollup duration
+
+Lazy mode at K=20 means up to 20 sequential LLM calls inline. At ~3s per call that's ~60s of rollup latency on a cold container vs sub-second on a warm one (cache hits). Within Hangfire's 300s job timeout. Could parallelize the K calls later if it becomes a bottleneck; not for v1.
+
+### Cache invalidation on re-ingest
+
+When `documents.content_hash` changes on re-ingest, `documents.summary` and `summary_content_hash` stay stale until the next rollup picks that doc as a medoid. Lazy mode checks `summary_content_hash == content_hash` before using cache — stale entries are silently regenerated. Same protection as eager mode.
+
+## Testing
+
+### Unit tests (new)
+
+1. `IngestionJobsTests.PerDocSummaryAsync_DocumentClusteringMode_EarlyReturns` — verify the job short-circuits without calling `PerDocSummarizer`.
+2. `SummaryJobsTests.RollupContainerAsync_DocumentClusteringMode_UsesPooledEmbeddings` — verify the rollup calls `IVectorStore.GetPooledDocumentEmbeddingsAsync` instead of `GetSummaryEmbeddingsAsync`.
+3. `SummaryJobsTests.RollupContainerAsync_DocumentClusteringMode_LazySummarizesMedoids` — verify K inline `PerDocSummarizer` calls for medoid docs without cached summaries.
+4. `SummaryJobsTests.RollupContainerAsync_DocumentClusteringMode_UsesCachedSummaries` — verify medoid docs with matching `summary_content_hash` skip the LLM call.
+5. `SummaryJobsTests.ComputeDocSetHash_UsesContentHash_NotSummary` — verify the hash function works without summary text.
+6. `ContainerSettingsResolverTests.GetSummarySettingsAsync_ContainerSummaryMethodOverride` — verify per-container override of the new field merges correctly.
+
+Existing `MedoidSelectorTests` do not change — the algorithm is unchanged; only its input source differs.
+
+### Integration tests (new)
+
+1. `SummaryWorkflowIntegrationTests.DocumentClustering_EndToEnd` — upload 35 docs in `document-clustering` mode, verify zero per-doc summaries exist, trigger rollup, verify container summary is produced and exactly K medoid docs have summaries cached.
+2. `SummaryWorkflowIntegrationTests.SummaryClustering_EndToEnd_UnchangedBehavior` — regression test for the current path; upload 35 docs, verify all have per-doc summaries, rollup produces container summary.
+3. `SummaryWorkflowIntegrationTests.MethodSwitch_LazyToEager_BackfillsOnIngest` — switch container to `summary-clustering`, upload a new doc, verify it gets summarized at ingest.
+4. `SummaryWorkflowIntegrationTests.PooledEmbeddings_FilterByDominantModel` — container with mixed-model chunk vectors, verify pooling uses the dominant model and logs the warning.
+
+### Manual validation
+
+Smoke test: spin up local docker-compose, upload 50 docs in `document-clustering` mode, observe LLM cost = 0 during ingestion, trigger rollup, observe ~K=17 LLM calls (`Math.Min(20, ceil(50/3))`) during first rollup. Re-trigger rollup with no content change, observe 0 LLM calls (full cache hit).
+
+### Out of scope for CI
+
+Container-summary *quality* comparison between methods. Post-merge experimentation with the existing LLM-judge eval harness handles this; quality validation is not gating the PR.
+
+## Open questions
+
+None that block implementation. The post-merge experimentation will surface follow-ups (e.g., whether to default `StuffThreshold` differently per method, whether to parallelize the K inline LLM calls in lazy mode), and those become their own issues.
+
+## Sequencing
+
+This work ships as a separate PR (#334-ish) after PR #333 (Hangfire migration) merges. No dependency between the two beyond `RollupContainerAsync` and `PerDocSummaryAsync` being the modification surface — both established by #333.

--- a/src/Connapse.Background/Connapse.Background.csproj
+++ b/src/Connapse.Background/Connapse.Background.csproj
@@ -23,4 +23,8 @@
     <ProjectReference Include="..\Connapse.Storage\Connapse.Storage.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Connapse.Background.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Connapse.Background/HangfireServiceCollectionExtensions.cs
+++ b/src/Connapse.Background/HangfireServiceCollectionExtensions.cs
@@ -30,6 +30,8 @@ public static class HangfireServiceCollectionExtensions
         // connections ("too many clients already"). Overridable per deployment; default suits a
         // single-process box where the app pool also needs headroom under the same ceiling.
         int hangfireMaxPool = configuration.GetValue<int?>("Hangfire:MaxPoolSize") ?? 30;
+        if (hangfireMaxPool <= 0)
+            throw new InvalidOperationException("Hangfire:MaxPoolSize must be a positive integer.");
         string hangfireConnectionString = new NpgsqlConnectionStringBuilder(connectionString)
         {
             MaxPoolSize = hangfireMaxPool
@@ -72,8 +74,11 @@ public static class HangfireServiceCollectionExtensions
                 // gate, so on a many-core box most of those workers would just park while holding a
                 // DB connection (DisableConcurrentExecution keeps each running job's distributed-lock
                 // connection open for its whole lifetime). Cap the default and allow an override.
-                opt.WorkerCount = configuration.GetValue<int?>("Hangfire:WorkerCount")
+                int workerCount = configuration.GetValue<int?>("Hangfire:WorkerCount")
                     ?? Math.Min(Environment.ProcessorCount * 2, 16);
+                if (workerCount <= 0)
+                    throw new InvalidOperationException("Hangfire:WorkerCount must be a positive integer.");
+                opt.WorkerCount = workerCount;
                 opt.Queues = new[]
                 {
                     Jobs.JobQueues.Ingestion,

--- a/src/Connapse.Background/HangfireServiceCollectionExtensions.cs
+++ b/src/Connapse.Background/HangfireServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Hangfire.Dashboard;
 using Hangfire.PostgreSql;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 
 namespace Connapse.Background;
 
@@ -22,6 +23,18 @@ public static class HangfireServiceCollectionExtensions
             throw new InvalidOperationException(
                 "DefaultConnection string is required for Hangfire's PostgreSQL storage.");
 
+        // Cap Hangfire's own Npgsql pool. Hangfire draws connections from the global string-keyed
+        // pool for this connection string, independent of the app's NpgsqlDataSource pool. Left
+        // unspecified, Npgsql defaults Maximum Pool Size to 100 — and stacked on the app pool
+        // against Postgres's own max_connections ceiling, that let concurrent rollups exhaust
+        // connections ("too many clients already"). Overridable per deployment; default suits a
+        // single-process box where the app pool also needs headroom under the same ceiling.
+        int hangfireMaxPool = configuration.GetValue<int?>("Hangfire:MaxPoolSize") ?? 30;
+        string hangfireConnectionString = new NpgsqlConnectionStringBuilder(connectionString)
+        {
+            MaxPoolSize = hangfireMaxPool
+        }.ConnectionString;
+
         services.AddHangfire(opt => opt
             .SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
             .UseSimpleAssemblyNameTypeSerializer()
@@ -35,7 +48,7 @@ public static class HangfireServiceCollectionExtensions
             // hits ObjectDisposedException("LoggerFactory"). See NoOpHangfireLogProvider
             // for full rationale.
             .UseLogProvider(new NoOpHangfireLogProvider())
-            .UsePostgreSqlStorage(c => c.UseNpgsqlConnection(connectionString), new PostgreSqlStorageOptions
+            .UsePostgreSqlStorage(c => c.UseNpgsqlConnection(hangfireConnectionString), new PostgreSqlStorageOptions
             {
                 SchemaName = "hangfire",
                 PrepareSchemaIfNecessary = true,
@@ -54,7 +67,13 @@ public static class HangfireServiceCollectionExtensions
         {
             services.AddHangfireServer(opt =>
             {
-                opt.WorkerCount = Environment.ProcessorCount * 2;
+                // Right-size the worker pool. Hangfire's default (ProcessorCount * 2) is tuned for
+                // CPU-bound jobs; this workload is LLM/IO-bound and serialized through a concurrency
+                // gate, so on a many-core box most of those workers would just park while holding a
+                // DB connection (DisableConcurrentExecution keeps each running job's distributed-lock
+                // connection open for its whole lifetime). Cap the default and allow an override.
+                opt.WorkerCount = configuration.GetValue<int?>("Hangfire:WorkerCount")
+                    ?? Math.Min(Environment.ProcessorCount * 2, 16);
                 opt.Queues = new[]
                 {
                     Jobs.JobQueues.Ingestion,

--- a/src/Connapse.Background/Jobs/IngestionJobs.cs
+++ b/src/Connapse.Background/Jobs/IngestionJobs.cs
@@ -206,8 +206,9 @@ public sealed class IngestionJobs : IIngestionJobs
                 return;
             }
 
+            string contentHash = doc.Metadata.GetValueOrDefault("ContentHash") ?? string.Empty;
             PerDocSummarizationResult result = await _summarizer.GenerateAsync(
-                documentId, parsedText, doc.ContentType, doc.FileName, settings, ct);
+                documentId, contentHash, parsedText, doc.ContentType, doc.FileName, settings, ct);
 
             if (result.Skipped)
             {

--- a/src/Connapse.Background/Jobs/IngestionJobs.cs
+++ b/src/Connapse.Background/Jobs/IngestionJobs.cs
@@ -113,6 +113,22 @@ public sealed class IngestionJobs : IIngestionJobs
                 return;
             }
 
+            if (settings.ContainerSummaryMethod == SummaryStrategy.DocumentClustering)
+            {
+                // document-clustering mode summarizes K medoids lazily at rollup time;
+                // no per-doc summary is generated at ingest. Advance the ingestion state
+                // so the UI doesn't show a stuck spinner — "summary processing complete"
+                // here means "we decided not to summarize this doc."
+                _logger.LogInformation(
+                    "PerDocSummarySkipped {DocumentId} reason=document_clustering_mode",
+                    LogSanitizer.Sanitize(documentId));
+
+                await _docStore.UpdateIngestionStateAsync(documentId, IngestionState.SummaryIndexed, CancellationToken.None);
+                await _stateBroadcaster.BroadcastIngestionStateChangedAsync(
+                    documentId, IngestionState.SummaryIndexed, CancellationToken.None);
+                return;
+            }
+
             // Re-parse the doc text via the same parser the pipeline used during ingestion.
             // Read through the container's connector (matching IngestionPipeline.IngestByIdAsync) —
             // _fileSystem.OpenFileAsync(doc.Path) would miss the container-id prefix that the

--- a/src/Connapse.Background/Jobs/IngestionJobs.cs
+++ b/src/Connapse.Background/Jobs/IngestionJobs.cs
@@ -58,13 +58,41 @@ public sealed class IngestionJobs : IIngestionJobs
             // up the document/container and reads the file through the appropriate connector.
             await _ingester.IngestByIdAsync(documentId, options, ct);
 
+            // Resolve summary settings to decide whether a per-doc summary job is even worth
+            // enqueueing. Two modes skip it entirely (no dashboard noise, no wasted dequeue):
+            //   • summaries disabled → no LLM work ever
+            //   • document-clustering → per-doc summarization is deferred to rollup time
+            // Falls back gracefully if the container isn't found (transient race or test mode).
+            //
             // Wrap-up uses CancellationToken.None: if the app restarts during these brief
             // (~50ms) DB/SignalR ops, we still want them to complete — otherwise the UI's
             // spinner gets stuck even though ingestion finished. Pattern: "best-effort
             // finalization" — once we've done the real work, commit the resulting state.
-            await _docStore.UpdateIngestionStateAsync(documentId, IngestionState.Indexed, CancellationToken.None);
+            SummarySettings? settings = null;
+            if (Guid.TryParse(options.ContainerId, out Guid containerId))
+            {
+                settings = await _settingsResolver.GetSummarySettingsAsync(containerId, CancellationToken.None);
+            }
+
+            bool needsPerDocSummary = settings is not null
+                                       && settings.Enabled
+                                       && settings.ContainerSummaryMethod == SummaryStrategy.SummaryClustering;
+
+            // Terminal state in the no-summarization paths is SummaryIndexed — the doc is
+            // fully done with its expected lifecycle. In summary-clustering mode we pass
+            // through Indexed first, then PerDocSummaryAsync flips to SummaryIndexed.
+            IngestionState terminalState = needsPerDocSummary
+                ? IngestionState.Indexed
+                : IngestionState.SummaryIndexed;
+
+            await _docStore.UpdateIngestionStateAsync(documentId, terminalState, CancellationToken.None);
             await _stateBroadcaster.BroadcastIngestionStateChangedAsync(
-                documentId, IngestionState.Indexed, CancellationToken.None);
+                documentId, terminalState, CancellationToken.None);
+
+            if (needsPerDocSummary)
+            {
+                _bgClient.Enqueue<IIngestionJobs>(j => j.PerDocSummaryAsync(documentId, default));
+            }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/Connapse.Background/Jobs/SummaryJobs.cs
+++ b/src/Connapse.Background/Jobs/SummaryJobs.cs
@@ -15,10 +15,17 @@ namespace Connapse.Background.Jobs;
 /// </summary>
 public sealed class SummaryJobs : ISummaryJobs
 {
+    private const int LazyStuffThreshold = 30; // mirrors ContainerSummarizer.StuffThreshold
+    private const int LazyMaxClusters = 20;    // mirrors ContainerSummarizer.MaxClusters
+
     private readonly IContainerStore _containerStore;
     private readonly IDocumentStore _docStore;
     private readonly IContainerSettingsResolver _settingsResolver;
     private readonly IDocumentSummaryEmbeddingProvider _embeddingProvider;
+    private readonly IVectorStore _vectorStore;
+    private readonly IPerDocSummarizer _perDocSummarizer;
+    private readonly IConnectorFactory _connectorFactory;
+    private readonly IEnumerable<IDocumentParser> _parsers;
     private readonly SummaryLlmResolver _llmResolver;
     private readonly ITokenCounter _tokenCounter;
     private readonly IBackgroundJobClient _bgClient;
@@ -29,6 +36,10 @@ public sealed class SummaryJobs : ISummaryJobs
         IDocumentStore docStore,
         IContainerSettingsResolver settingsResolver,
         IDocumentSummaryEmbeddingProvider embeddingProvider,
+        IVectorStore vectorStore,
+        IPerDocSummarizer perDocSummarizer,
+        IConnectorFactory connectorFactory,
+        IEnumerable<IDocumentParser> parsers,
         SummaryLlmResolver llmResolver,
         ITokenCounter tokenCounter,
         IBackgroundJobClient bgClient,
@@ -38,6 +49,10 @@ public sealed class SummaryJobs : ISummaryJobs
         _docStore = docStore;
         _settingsResolver = settingsResolver;
         _embeddingProvider = embeddingProvider;
+        _vectorStore = vectorStore;
+        _perDocSummarizer = perDocSummarizer;
+        _connectorFactory = connectorFactory;
+        _parsers = parsers;
         _llmResolver = llmResolver;
         _tokenCounter = tokenCounter;
         _bgClient = bgClient;
@@ -61,6 +76,19 @@ public sealed class SummaryJobs : ISummaryJobs
             return;
         }
 
+        if (settings.ContainerSummaryMethod == SummaryStrategy.DocumentClustering)
+        {
+            await RollupDocumentClusteringAsync(containerId, container, settings, ct);
+        }
+        else
+        {
+            await RollupSummaryClusteringAsync(containerId, container, settings, ct);
+        }
+    }
+
+    private async Task RollupSummaryClusteringAsync(
+        Guid containerId, Container container, SummarySettings settings, CancellationToken ct)
+    {
         IReadOnlyList<Document> docs = await _docStore.ListAsync(
             containerId, pathPrefix: null, skip: 0, take: 10_000, ct);
         List<Document> withSummaries = docs.Where(d => !string.IsNullOrEmpty(d.Summary)).ToList();
@@ -76,9 +104,8 @@ public sealed class SummaryJobs : ISummaryJobs
         string docSetHash = ComputeDocSetHash(withSummaries);
         if (docSetHash == container.SummaryDocSetHash)
         {
-            // doc_set_hash_match: set of summarized docs + their summary texts hasn't changed
-            // since the last rollup. Accepted trade-off: content_hash changes inside
-            // already-summarized docs aren't detected by this hash alone.
+            // doc_set_hash_match: set of summarized docs + their content hashes hasn't changed
+            // since the last rollup.
             _logger.LogInformation(
                 "ContainerRollupSkipped {ContainerId} reason=doc_set_hash_match",
                 LogSanitizer.Sanitize(containerId.ToString()));
@@ -106,13 +133,221 @@ public sealed class SummaryJobs : ISummaryJobs
             containerId, result.Summary, DateTime.UtcNow, docSetHash, ct);
 
         _logger.LogInformation(
-            "ContainerRollupCompleted {ContainerId} regime={Regime} N={N} k={K} inTok={InTok} outTok={OutTok}",
+            "ContainerRollupCompleted {ContainerId} method=summary-clustering regime={Regime} N={N} k={K} inTok={InTok} outTok={OutTok}",
             LogSanitizer.Sanitize(containerId.ToString()),
             LogSanitizer.Sanitize(result.Regime ?? ""),
             result.NumDocs,
             result.KClusters,
             result.InputTokens,
             result.OutputTokens);
+    }
+
+    private async Task RollupDocumentClusteringAsync(
+        Guid containerId, Container container, SummarySettings settings, CancellationToken ct)
+    {
+        IReadOnlyList<Document> allDocs = await _docStore.ListAsync(
+            containerId, pathPrefix: null, skip: 0, take: 10_000, ct);
+
+        if (allDocs.Count == 0)
+        {
+            await _containerStore.UpdateSummaryAsync(containerId, null, null, null, ct);
+            return;
+        }
+
+        // Hash gate: skip rollup if the (docId, content_hash) set is unchanged since last rollup.
+        string docSetHash = ComputeDocSetHash(allDocs);
+        if (docSetHash == container.SummaryDocSetHash)
+        {
+            _logger.LogInformation(
+                "ContainerRollupSkipped {ContainerId} reason=doc_set_hash_match",
+                LogSanitizer.Sanitize(containerId.ToString()));
+            return;
+        }
+
+        // Pick which docs to summarize. Below the stuff threshold we summarize all of them;
+        // above it we cluster on pooled chunk embeddings and pick K medoids.
+        IReadOnlyList<Document> docsToSummarize;
+        string regime;
+        int? kClusters = null;
+
+        if (allDocs.Count <= LazyStuffThreshold)
+        {
+            docsToSummarize = allDocs;
+            regime = "stuff";
+        }
+        else
+        {
+            IReadOnlyList<(Guid DocumentId, float[] Embedding)> pooled =
+                await _vectorStore.GetPooledDocumentEmbeddingsAsync(containerId, ct);
+            if (pooled.Count == 0)
+            {
+                _logger.LogInformation(
+                    "ContainerRollupSkipped {ContainerId} reason=no_pooled_embeddings",
+                    LogSanitizer.Sanitize(containerId.ToString()));
+                return;
+            }
+
+            int k = Math.Min(LazyMaxClusters, (int)Math.Ceiling(pooled.Count / 3.0));
+            kClusters = k;
+
+            // MedoidSelector takes (Guid Id, float[] Embedding); the pooled tuple's element
+            // name differs (DocumentId) but the shape matches, so project explicitly to keep
+            // the intent obvious.
+            var medoidInput = pooled.Select(p => (Id: p.DocumentId, Embedding: p.Embedding)).ToList();
+            IReadOnlyList<(Guid Id, float[] Embedding)> medoids =
+                MedoidSelector.SelectFarthestFirst(medoidInput, k);
+            var medoidIds = medoids.Select(m => m.Id).ToHashSet();
+
+            // Map medoid Guids back to Document instances. Skip any whose docs no longer exist
+            // (deleted between pooling query and now) — defensive.
+            Dictionary<Guid, Document> docsById = allDocs
+                .Where(d => Guid.TryParse(d.Id, out _))
+                .ToDictionary(d => Guid.Parse(d.Id));
+            docsToSummarize = medoidIds
+                .Where(id => docsById.ContainsKey(id))
+                .Select(id => docsById[id])
+                .ToList();
+            regime = "cluster";
+        }
+
+        // Lazy-summarize each selected doc: cache hit when content_hash matches; otherwise call LLM.
+        var summarizedDocs = new List<DocumentWithSummary>();
+        foreach (Document doc in docsToSummarize)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            string contentHash = doc.Metadata?.GetValueOrDefault("ContentHash") ?? string.Empty;
+            bool cacheHit = !string.IsNullOrEmpty(doc.Summary)
+                            && !string.IsNullOrEmpty(doc.SummaryContentHash)
+                            && doc.SummaryContentHash == contentHash;
+
+            string? summary;
+            if (cacheHit)
+            {
+                summary = doc.Summary;
+                _logger.LogDebug(
+                    "LazyMedoidSummaryCacheHit {DocumentId}",
+                    LogSanitizer.Sanitize(doc.Id));
+            }
+            else
+            {
+                summary = await GenerateAndCacheSummaryAsync(doc, settings, ct);
+                if (summary is null) continue;
+            }
+
+            // The ContainerSummarizer reduce step needs an Embedding too. Empty array is fine
+            // because docsToSummarize is already <= LazyMaxClusters, so the reduce step takes
+            // its stuff path (N <= StuffThreshold) and never touches .Embedding.
+            if (!Guid.TryParse(doc.Id, out Guid docGuid)) continue;
+            summarizedDocs.Add(new DocumentWithSummary(
+                Id: docGuid,
+                Summary: summary!,
+                Embedding: Array.Empty<float>()));
+        }
+
+        if (summarizedDocs.Count == 0)
+        {
+            _logger.LogInformation(
+                "ContainerRollupSkipped {ContainerId} reason=no_summarizable_docs",
+                LogSanitizer.Sanitize(containerId.ToString()));
+            return;
+        }
+
+        ILlmProvider? llm = _llmResolver.Resolve(settings);
+        IContainerSummarizer summarizer = new ContainerSummarizer(llm, _tokenCounter);
+        ContainerSummarizationResult result = await summarizer.GenerateAsync(
+            container.Name, summarizedDocs, settings, ct);
+
+        if (result.Skipped)
+        {
+            _logger.LogInformation(
+                "ContainerRollupSkipped {ContainerId} reason={Reason}",
+                LogSanitizer.Sanitize(containerId.ToString()),
+                LogSanitizer.Sanitize(result.SkipReason ?? ""));
+            return;
+        }
+
+        await _containerStore.UpdateSummaryAsync(
+            containerId, result.Summary, DateTime.UtcNow, docSetHash, ct);
+
+        _logger.LogInformation(
+            "ContainerRollupCompleted {ContainerId} method=document-clustering regime={Regime} N={N} k={K} inTok={InTok} outTok={OutTok}",
+            LogSanitizer.Sanitize(containerId.ToString()),
+            regime,
+            allDocs.Count,
+            kClusters,
+            result.InputTokens,
+            result.OutputTokens);
+    }
+
+    /// <summary>
+    /// Runs the per-doc summarizer for one document in document-clustering mode, then
+    /// writes the result through to <c>documents.summary</c> as the cache for future rollups.
+    /// Returns null if the doc could not be summarized (parser failure, empty content, etc).
+    /// </summary>
+    private async Task<string?> GenerateAndCacheSummaryAsync(
+        Document doc, SummarySettings settings, CancellationToken ct)
+    {
+        if (!Guid.TryParse(doc.ContainerId, out Guid containerId)) return null;
+        Container? container = await _containerStore.GetAsync(containerId, ct);
+        if (container is null) return null;
+
+        // Re-parse doc text through the container's connector — same pattern as
+        // IngestionJobs.PerDocSummaryAsync.
+        string parsedText;
+        try
+        {
+            IConnector connector = _connectorFactory.Create(container);
+            string jobPath = connector.ResolveJobPath(doc.Path.TrimStart('/'));
+            await using Stream stream = await connector.ReadFileAsync(jobPath, ct);
+
+            string extension = Path.GetExtension(doc.FileName).ToLowerInvariant();
+            IDocumentParser? parser = _parsers.FirstOrDefault(p => p.SupportedExtensions.Contains(extension));
+            if (parser is null)
+            {
+                _logger.LogInformation(
+                    "LazyMedoidSummarySkipped {DocumentId} reason=no_parser_for_extension",
+                    LogSanitizer.Sanitize(doc.Id));
+                return null;
+            }
+
+            ParsedDocument parsed = await parser.ParseAsync(stream, doc.FileName, ct);
+            parsedText = parsed.Content;
+        }
+        catch (FileNotFoundException)
+        {
+            _logger.LogWarning(
+                "LazyMedoidSummarySkipped {DocumentId} reason=file_not_found",
+                LogSanitizer.Sanitize(doc.Id));
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(parsedText))
+        {
+            _logger.LogInformation(
+                "LazyMedoidSummarySkipped {DocumentId} reason=empty_parsed_content",
+                LogSanitizer.Sanitize(doc.Id));
+            return null;
+        }
+
+        PerDocSummarizationResult result = await _perDocSummarizer.GenerateAsync(
+            doc.Id, parsedText, doc.ContentType, doc.FileName, settings, ct);
+
+        if (result.Skipped || string.IsNullOrEmpty(result.Summary))
+        {
+            _logger.LogInformation(
+                "LazyMedoidSummarySkipped {DocumentId} reason={Reason}",
+                LogSanitizer.Sanitize(doc.Id),
+                LogSanitizer.Sanitize(result.SkipReason ?? "no_summary_returned"));
+            return null;
+        }
+
+        // Write through to cache: documents.summary + summary_content_hash + summary_generated_at
+        string contentHash = doc.Metadata?.GetValueOrDefault("ContentHash") ?? string.Empty;
+        await _docStore.UpdateSummaryAsync(
+            doc.Id, result.Summary, DateTime.UtcNow, contentHash, ct);
+
+        return result.Summary;
     }
 
     [Queue(JobQueues.Summarization)]

--- a/src/Connapse.Background/Jobs/SummaryJobs.cs
+++ b/src/Connapse.Background/Jobs/SummaryJobs.cs
@@ -209,15 +209,26 @@ public sealed class SummaryJobs : ISummaryJobs
     }
 
     /// <summary>
-    /// Deterministic hash of the (sorted) set of {docId, summary} pairs in this container.
-    /// Matches the legacy <c>ContainerSummaryWorker.ComputeDocSetHash</c> exactly so jobs
-    /// migrated mid-flight don't trigger spurious re-rollups due to a hash format change.
+    /// Deterministic hash of the (sorted) set of {docId, content_hash} pairs for the docs
+    /// in this container. Works for both <c>summary-clustering</c> (docs filtered to those
+    /// with summaries — content_hash still identifies stale-vs-fresh state) and
+    /// <c>document-clustering</c> (most docs have null summaries; content_hash is the only
+    /// durable identifier).
     /// </summary>
+    /// <remarks>
+    /// Migration impact: hashes differ from the prior (docId, summary-sha256) formula across
+    /// the deploy boundary, causing exactly one extra rollup per container on first run
+    /// post-deploy. Accepted one-shot cost.
+    /// </remarks>
     internal static string ComputeDocSetHash(IEnumerable<Document> docs)
     {
         IEnumerable<string> parts = docs
             .OrderBy(d => d.Id)
-            .Select(d => $"{d.Id}|{HexHash.Sha256(d.Summary ?? string.Empty)}");
+            .Select(d =>
+            {
+                string contentHash = d.Metadata?.GetValueOrDefault("ContentHash") ?? string.Empty;
+                return $"{d.Id}|{contentHash}";
+            });
         return HexHash.Sha256(string.Join("\n", parts));
     }
 }

--- a/src/Connapse.Background/Jobs/SummaryJobs.cs
+++ b/src/Connapse.Background/Jobs/SummaryJobs.cs
@@ -287,9 +287,10 @@ public sealed class SummaryJobs : ISummaryJobs
     }
 
     /// <summary>
-    /// Runs the per-doc summarizer for one document in document-clustering mode, then
-    /// writes the result through to <c>documents.summary</c> as the cache for future rollups.
-    /// Returns null if the doc could not be summarized (parser failure, empty content, etc).
+    /// Runs the per-doc summarizer for one document in document-clustering mode. The summarizer
+    /// persists the result to <c>documents.summary</c> keyed on the doc's content hash, which
+    /// serves as the cache for future rollups. Returns null if the doc could not be summarized
+    /// (parser failure, empty content, etc).
     /// </summary>
     private async Task<string?> GenerateAndCacheSummaryAsync(
         Document doc, SummarySettings settings, CancellationToken ct)
@@ -336,8 +337,12 @@ public sealed class SummaryJobs : ISummaryJobs
             return null;
         }
 
+        // Pass the canonical content hash so PerDocSummarizer persists it as summary_content_hash.
+        // That single write is the cache the next rollup's cache-check (SummaryContentHash ==
+        // ContentHash) compares against — no second write needed here.
+        string contentHash = doc.Metadata?.GetValueOrDefault("ContentHash") ?? string.Empty;
         PerDocSummarizationResult result = await _perDocSummarizer.GenerateAsync(
-            doc.Id, parsedText, doc.ContentType, doc.FileName, settings, ct);
+            doc.Id, contentHash, parsedText, doc.ContentType, doc.FileName, settings, ct);
 
         if (result.Skipped || string.IsNullOrEmpty(result.Summary))
         {
@@ -347,11 +352,6 @@ public sealed class SummaryJobs : ISummaryJobs
                 LogSanitizer.Sanitize(result.SkipReason ?? "no_summary_returned"));
             return null;
         }
-
-        // Write through to cache: documents.summary + summary_content_hash + summary_generated_at
-        string contentHash = doc.Metadata?.GetValueOrDefault("ContentHash") ?? string.Empty;
-        await _docStore.UpdateSummaryAsync(
-            doc.Id, result.Summary, DateTime.UtcNow, contentHash, ct);
 
         return result.Summary;
     }

--- a/src/Connapse.Background/Jobs/SummaryJobs.cs
+++ b/src/Connapse.Background/Jobs/SummaryJobs.cs
@@ -61,7 +61,13 @@ public sealed class SummaryJobs : ISummaryJobs
 
     [Queue(JobQueues.Summarization)]
     [DisableConcurrentExecution(timeoutInSeconds: 600)]
-    [AutomaticRetry(Attempts = 3, DelaysInSeconds = new[] { 30, 120, 600 })]
+    // No Hangfire retry: the recurring SweepStaleContainersAsync (every 5 min) re-enqueues any
+    // container that is still stale, so a failed rollup is naturally retried on the next tick —
+    // the sweep IS the retry loop. Hangfire retries would instead stack Scheduled jobs on top of
+    // the sweep's enqueues; that duplicate pile-up is what exhausted the Postgres connection pool
+    // under concurrent rollups. A failed rollup lands in Failed (not Scheduled), which also keeps
+    // the sweep's in-flight dedup simple (it only has to skip Enqueued/Processing, never retries).
+    [AutomaticRetry(Attempts = 0)]
     public async Task RollupContainerAsync(Guid containerId, CancellationToken ct)
     {
         Container? container = await _containerStore.GetAsync(containerId, ct);

--- a/src/Connapse.Background/Storage/HangfireIngestionQueue.cs
+++ b/src/Connapse.Background/Storage/HangfireIngestionQueue.cs
@@ -50,12 +50,13 @@ public sealed class HangfireIngestionQueue : IIngestionQueue
 
         _documentToJobId[job.DocumentId] = job.JobId;
 
-        // Enqueue ingestion; ContinueJobWith fires per-doc summary on success
+        // Enqueue ingestion. Per-doc summary scheduling now happens inside IngestAsync's
+        // tail, gated on the container's resolved SummarySettings — document-clustering
+        // and summaries-disabled both skip the per-doc job entirely (no dashboard noise,
+        // no wasted dequeue cycle). Summary-clustering enqueues PerDocSummaryAsync at the
+        // end of IngestAsync as a sibling Hangfire job.
         string parentId = _bgClient.Enqueue<IIngestionJobs>(
             j => j.IngestAsync(job.DocumentId, job.Options, default));
-        _bgClient.ContinueJobWith<IIngestionJobs>(
-            parentId,
-            j => j.PerDocSummaryAsync(job.DocumentId, default));
 
         _jobIdToHangfireParentId[job.JobId] = parentId;
         return Task.CompletedTask;

--- a/src/Connapse.Core/Interfaces/IDocumentStore.cs
+++ b/src/Connapse.Core/Interfaces/IDocumentStore.cs
@@ -12,6 +12,15 @@ public interface IDocumentStore
     Task UpdateSummaryAsync(string documentId, string? summary, DateTime? generatedAt, string? contentHash, CancellationToken ct = default);
 
     /// <summary>
+    /// Clears the cached per-document summary fields (Summary, SummaryGeneratedAt, SummaryContentHash)
+    /// for every document in a container. Returns the number of rows affected. Embeddings, chunks, and
+    /// the documents themselves are left intact — this only drops the summary cache so it can be
+    /// regenerated. Pairs with <see cref="IContainerStore.UpdateSummaryAsync"/> (nulls) to fully reset
+    /// a container's summarization state.
+    /// </summary>
+    Task<int> ClearDocumentSummariesAsync(Guid containerId, CancellationToken ct = default);
+
+    /// <summary>
     /// Updates only the IngestionState column. Used by Hangfire job classes
     /// as they transition through Pending → Indexed → SummaryIndexed → (Failed).
     /// </summary>

--- a/src/Connapse.Core/Interfaces/IPerDocSummarizer.cs
+++ b/src/Connapse.Core/Interfaces/IPerDocSummarizer.cs
@@ -2,8 +2,15 @@ namespace Connapse.Core.Interfaces;
 
 public interface IPerDocSummarizer
 {
+    /// <param name="contentHash">
+    /// The document's canonical content hash (the raw-file hash stored as
+    /// <c>documents.content_hash</c>). Persisted as <c>summary_content_hash</c> and used to
+    /// skip regeneration when unchanged. Callers pass the same value the container rollup's
+    /// cache-check compares against, so both the eager and lazy paths invalidate identically.
+    /// </param>
     Task<PerDocSummarizationResult> GenerateAsync(
         string documentId,
+        string contentHash,
         string docText,
         string? mimeType,
         string fileName,

--- a/src/Connapse.Core/Interfaces/IVectorStore.cs
+++ b/src/Connapse.Core/Interfaces/IVectorStore.cs
@@ -7,4 +7,21 @@ public interface IVectorStore
     Task<IReadOnlyList<VectorSearchResult>> SearchAsync(float[] queryVector, int topK, Dictionary<string, string>? filters = null, CancellationToken ct = default);
     Task DeleteAsync(string id, CancellationToken ct = default);
     Task DeleteByDocumentIdAsync(string documentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns one mean-pooled embedding per document in the container, computed across
+    /// that document's chunk vectors. Used by the <c>document-clustering</c> container
+    /// summary path to cluster docs without re-embedding them.
+    /// </summary>
+    /// <remarks>
+    /// Implementations should:
+    /// 1. Pick the dominant <c>model_id</c> in the container and filter to vectors of that model.
+    ///    Containers can hold mixed-model chunk vectors; clustering requires a single dimensionality.
+    /// 2. Skip documents that have zero chunks of the dominant model.
+    /// 3. L2-normalize each pooled vector before returning (pgvector AVG does not renormalize).
+    /// 4. Log a warning naming the count of documents excluded due to non-dominant model_id.
+    /// </remarks>
+    Task<IReadOnlyList<(Guid DocumentId, float[] Embedding)>> GetPooledDocumentEmbeddingsAsync(
+        Guid containerId,
+        CancellationToken ct = default);
 }

--- a/src/Connapse.Core/Models/SettingsModels.cs
+++ b/src/Connapse.Core/Models/SettingsModels.cs
@@ -333,6 +333,18 @@ public record LlmSettings
     /// </summary>
     public int TimeoutSeconds { get; set; } = 300;
 
+    /// <summary>
+    /// Maximum number of completion requests issued concurrently to a local Ollama
+    /// instance (default: 1). Ollama serializes generation internally, so firing many
+    /// requests at once builds a deep queue where each request's wall-clock grows with its
+    /// queue position and the slowest ones exceed <see cref="TimeoutSeconds"/>. Gating
+    /// concurrency app-side makes callers wait in-process so each request runs alone and
+    /// finishes within the timeout. Only applies to the Ollama provider; cloud providers
+    /// (OpenAI/Azure/Anthropic) are not gated. Read once at startup — changing it requires
+    /// a restart.
+    /// </summary>
+    public int MaxConcurrentRequests { get; set; } = 1;
+
 }
 
 /// <summary>

--- a/src/Connapse.Core/Models/SettingsModels.cs
+++ b/src/Connapse.Core/Models/SettingsModels.cs
@@ -353,7 +353,7 @@ public record UploadSettings
 ///   → global DB settings table, key="Summary"
 ///   → property-initializer defaults below (Enabled=false, others=null)
 /// </summary>
-public record SummarySettings
+public record SummarySettings : IValidatableObject
 {
     /// <summary>
     /// Master toggle. When false, both per-doc summaries and container rollups
@@ -361,6 +361,14 @@ public record SummarySettings
     /// Default: false (opt-in).
     /// </summary>
     public bool Enabled { get; init; } = false;
+
+    /// <summary>
+    /// Container summary generation method. See <see cref="SummaryStrategy"/> for allowed values.
+    /// Default: <c>document-clustering</c> — clusters by pooled chunk embeddings and lazy-summarizes
+    /// K medoid documents at rollup time. Set to <c>summary-clustering</c> to use the legacy
+    /// eager per-doc summarization path.
+    /// </summary>
+    public string ContainerSummaryMethod { get; init; } = SummaryStrategy.DocumentClustering;
 
     /// <summary>
     /// LLM provider for summary generation (Ollama / OpenAI / AzureOpenAI / Anthropic).
@@ -394,5 +402,15 @@ public record SummarySettings
     /// in PerDocSummarizer (replaces the hardcoded MaxInputCharacters = 20_000).
     /// </summary>
     public int? MaxInputTokens { get; init; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (!SummaryStrategy.All.Contains(ContainerSummaryMethod))
+        {
+            yield return new ValidationResult(
+                $"ContainerSummaryMethod must be one of: {string.Join(", ", SummaryStrategy.All)}. Got: '{ContainerSummaryMethod}'.",
+                new[] { nameof(ContainerSummaryMethod) });
+        }
+    }
 }
 

--- a/src/Connapse.Core/Models/SummaryStrategy.cs
+++ b/src/Connapse.Core/Models/SummaryStrategy.cs
@@ -1,0 +1,30 @@
+namespace Connapse.Core;
+
+/// <summary>
+/// Allowed values for <see cref="SummarySettings.ContainerSummaryMethod"/>.
+/// </summary>
+/// <remarks>
+/// Stored as a string in <c>SummarySettings</c> to match the existing
+/// <c>LlmProvider</c> / <c>LlmModel</c> convention. Validation happens in the
+/// <c>SummarySettings</c> validator and rejects unknown values.
+/// </remarks>
+public static class SummaryStrategy
+{
+    /// <summary>
+    /// HERCULES-style: cluster documents by mean-pooled chunk embeddings and
+    /// lazy-summarize K medoid documents at rollup time. Default for new installs.
+    /// </summary>
+    public const string DocumentClustering = "document-clustering";
+
+    /// <summary>
+    /// Legacy: summarize every document at ingest, cluster by summary embeddings,
+    /// reduce K medoid summaries. Original behavior from PR #329.
+    /// </summary>
+    public const string SummaryClustering = "summary-clustering";
+
+    public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
+    {
+        DocumentClustering,
+        SummaryClustering,
+    };
+}

--- a/src/Connapse.Ingestion/Summarization/ContainerSummarizer.cs
+++ b/src/Connapse.Ingestion/Summarization/ContainerSummarizer.cs
@@ -61,7 +61,7 @@ public sealed class ContainerSummarizer(
 
         int inputTokens = tokenCounter.CountTokens(systemPrompt) + tokenCounter.CountTokens(userMsg);
 
-        LlmCompletionOptions? options = settings.LlmModel is null
+        LlmCompletionOptions? options = string.IsNullOrWhiteSpace(settings.LlmModel)
             ? null
             : new LlmCompletionOptions(Model: settings.LlmModel);
 
@@ -69,7 +69,7 @@ public sealed class ContainerSummarizer(
             systemPrompt, userMsg, options, ct);
 
         int outputTokens = tokenCounter.CountTokens(responseText);
-        string model = settings.LlmModel ?? llmProvider.ModelId;
+        string model = string.IsNullOrWhiteSpace(settings.LlmModel) ? llmProvider.ModelId : settings.LlmModel;
 
         return new ContainerSummarizationResult(
             Skipped: false,

--- a/src/Connapse.Ingestion/Summarization/PerDocSummarizer.cs
+++ b/src/Connapse.Ingestion/Summarization/PerDocSummarizer.cs
@@ -35,13 +35,14 @@ public sealed class PerDocSummarizer(
 
         int maxTokens = settings.MaxInputTokens ?? DefaultMaxInputTokens;
         int maxChars = maxTokens * 4;
-        string truncated = docText.Length > maxChars ? docText[..maxChars] : docText;
+        bool wasTruncated = docText.Length > maxChars;
+        string truncatedText = wasTruncated ? docText[..maxChars] : docText;
 
         string systemPrompt = !string.IsNullOrWhiteSpace(settings.PerDocSystemPrompt)
             ? settings.PerDocSystemPrompt
             : SummaryPrompts.PerDocSystemPrompt;
 
-        string userMessage = SummaryPrompts.RenderPerDocUserMessage(fileName, mimeType, truncated);
+        string userMessage = SummaryPrompts.RenderPerDocUserMessage(fileName, mimeType, truncatedText, wasTruncated);
 
         int inputTokens = tokenCounter.CountTokens(systemPrompt) + tokenCounter.CountTokens(userMessage);
 

--- a/src/Connapse.Ingestion/Summarization/PerDocSummarizer.cs
+++ b/src/Connapse.Ingestion/Summarization/PerDocSummarizer.cs
@@ -46,7 +46,7 @@ public sealed class PerDocSummarizer(
 
         int inputTokens = tokenCounter.CountTokens(systemPrompt) + tokenCounter.CountTokens(userMessage);
 
-        LlmCompletionOptions? options = settings.LlmModel is null
+        LlmCompletionOptions? options = string.IsNullOrWhiteSpace(settings.LlmModel)
             ? null
             : new LlmCompletionOptions(Model: settings.LlmModel);
 
@@ -54,7 +54,7 @@ public sealed class PerDocSummarizer(
             systemPrompt, userMessage, options, ct);
 
         int outputTokens = tokenCounter.CountTokens(responseText);
-        string model = settings.LlmModel ?? llmProvider.ModelId;
+        string model = string.IsNullOrWhiteSpace(settings.LlmModel) ? llmProvider.ModelId : settings.LlmModel;
 
         DateTime now = DateTime.UtcNow;
         await docStore.UpdateSummaryAsync(documentId, responseText, now, contentHash, ct);

--- a/src/Connapse.Ingestion/Summarization/PerDocSummarizer.cs
+++ b/src/Connapse.Ingestion/Summarization/PerDocSummarizer.cs
@@ -1,6 +1,5 @@
 using Connapse.Core;
 using Connapse.Core.Interfaces;
-using Connapse.Core.Utilities;
 using Connapse.Storage.Llm;
 
 namespace Connapse.Ingestion.Summarization;
@@ -14,6 +13,7 @@ public sealed class PerDocSummarizer(
 
     public async Task<PerDocSummarizationResult> GenerateAsync(
         string documentId,
+        string contentHash,
         string docText,
         string? mimeType,
         string fileName,
@@ -28,8 +28,6 @@ public sealed class PerDocSummarizer(
 
         if (string.IsNullOrWhiteSpace(docText))
             return new PerDocSummarizationResult(Skipped: true, SkipReason: "extraction_empty");
-
-        string contentHash = HexHash.Sha256(docText);
 
         Connapse.Core.Document? existing = await docStore.GetAsync(documentId, ct);
         if (existing?.SummaryContentHash == contentHash)

--- a/src/Connapse.Storage/Data/Entities/DocumentEntity.cs
+++ b/src/Connapse.Storage/Data/Entities/DocumentEntity.cs
@@ -22,7 +22,7 @@ public class DocumentEntity
     // Per-document summary (input to container summary rollup)
     public string? Summary { get; set; }
     public DateTime? SummaryGeneratedAt { get; set; }
-    public string? SummaryContentHash { get; set; } // sha256(doc_text) at time of summary
+    public string? SummaryContentHash { get; set; } // raw-file content hash (= content_hash) at time of summary
 
     // Multi-stage enrichment lifecycle driving UI status pills.
     // Distinct from Status (which tracks the ingestion job's lifecycle string).

--- a/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
+++ b/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
@@ -221,6 +221,22 @@ public class PostgresDocumentStore : IDocumentStore
         await context.SaveChangesAsync(ct);
     }
 
+    public async Task<int> ClearDocumentSummariesAsync(Guid containerId, CancellationToken ct = default)
+    {
+        await using var context = await _factory.CreateDbContextAsync(ct);
+
+        // Set-based clear of the per-doc summary cache. Filter to rows that actually have
+        // something cached so the affected-count reflects real work and we skip no-op writes.
+        return await context.Documents
+            .Where(d => d.ContainerId == containerId
+                && (d.Summary != null || d.SummaryGeneratedAt != null || d.SummaryContentHash != null))
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(d => d.Summary, (string?)null)
+                .SetProperty(d => d.SummaryGeneratedAt, (DateTime?)null)
+                .SetProperty(d => d.SummaryContentHash, (string?)null),
+                ct);
+    }
+
     public async Task UpdateIngestionStateAsync(string documentId, IngestionState state, CancellationToken ct = default)
     {
         if (!Guid.TryParse(documentId, out var guid))

--- a/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
+++ b/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
@@ -242,19 +242,34 @@ public class PostgresDocumentStore : IDocumentStore
     {
         await using var context = await _factory.CreateDbContextAsync(ct);
 
-        // Containers where any doc has a newer summary timestamp than the container's own summary,
-        // OR where the container has docs with summaries but no container summary at all.
-        // Mirrors the recovery query in ContainerSummaryWorker so behavior is unchanged after
-        // the Hangfire migration.
+        // Stale = container has at least one doc AND something changed more recently than the
+        // container's last rollup. "Change" is the latest of three doc-level timestamps:
+        //   • SummaryGeneratedAt — bumped when a per-doc summary is written (summary-clustering
+        //     mode at ingest; document-clustering mode when a medoid summary is cached)
+        //   • LastIndexedAt      — bumped on re-ingestion (content updates)
+        //   • CreatedAt          — initial upload
+        //
+        // Before HERCULES this query filtered to docs with non-null Summary, which silently
+        // excluded document-clustering containers (whose docs are mostly null-summary) — the
+        // sweep then reported "no stale containers" forever and rollups never fired.
         return await context.Documents
-            .Where(d => d.Summary != null && d.SummaryGeneratedAt != null)
             .GroupBy(d => d.ContainerId)
-            .Select(g => new { ContainerId = g.Key, LatestDocSummary = g.Max(d => d.SummaryGeneratedAt) })
+            .Select(g => new
+            {
+                ContainerId = g.Key,
+                MaxSummary = g.Max(d => d.SummaryGeneratedAt),
+                MaxIndexed = g.Max(d => d.LastIndexedAt),
+                MaxCreated = g.Max(d => d.CreatedAt),
+            })
             .Join(context.Containers,
                   x => x.ContainerId,
                   c => c.Id,
-                  (x, c) => new { x.ContainerId, x.LatestDocSummary, ContainerSummaryAt = c.SummaryGeneratedAt })
-            .Where(x => x.ContainerSummaryAt == null || x.LatestDocSummary > x.ContainerSummaryAt)
+                  (x, c) => new { x.ContainerId, x.MaxSummary, x.MaxIndexed, x.MaxCreated, ContainerSummaryAt = c.SummaryGeneratedAt })
+            .Where(x =>
+                x.ContainerSummaryAt == null
+                || (x.MaxSummary != null && x.MaxSummary > x.ContainerSummaryAt)
+                || (x.MaxIndexed != null && x.MaxIndexed > x.ContainerSummaryAt)
+                || x.MaxCreated > x.ContainerSummaryAt)
             .Select(x => x.ContainerId)
             .ToListAsync(ct);
     }

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -111,7 +111,10 @@ public static class ServiceCollectionExtensions
             };
         });
 
-        // LLM providers — resolved at runtime based on LlmSettings.Provider
+        // LLM providers — resolved at runtime based on LlmSettings.Provider.
+        // Singleton gate shared across all (transient) Ollama provider instances so local
+        // inference is throttled process-wide (see LlmConcurrencyGate).
+        services.AddSingleton<LlmConcurrencyGate>();
         services.AddHttpClient<OllamaLlmProvider>();
         services.AddScoped<OpenAiLlmProvider>();
         services.AddScoped<AzureOpenAiLlmProvider>();

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -48,8 +48,10 @@ public static class ServiceCollectionExtensions
         // an uncapped pool here (Npgsql defaults Maximum Pool Size to 100) can starve the other or
         // exhaust the server under load. Sized to leave headroom for the background pool and admin
         // tooling beneath a typical ceiling; overridable per deployment via Database:MaxPoolSize.
-        dataSourceBuilder.ConnectionStringBuilder.MaxPoolSize =
-            configuration.GetValue<int?>("Database:MaxPoolSize") ?? 40;
+        int appMaxPoolSize = configuration.GetValue<int?>("Database:MaxPoolSize") ?? 40;
+        if (appMaxPoolSize <= 0)
+            throw new InvalidOperationException("Database:MaxPoolSize must be a positive integer.");
+        dataSourceBuilder.ConnectionStringBuilder.MaxPoolSize = appMaxPoolSize;
         var dataSource = dataSourceBuilder.Build();
 
         services.AddDbContext<KnowledgeDbContext>(options =>

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -43,6 +43,13 @@ public static class ServiceCollectionExtensions
         var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionString);
         dataSourceBuilder.EnableDynamicJson(); // Required for Dictionary<string, string> serialization
         dataSourceBuilder.UseVector();
+        // Cap the application's connection pool. Postgres enforces a server-wide max_connections
+        // ceiling; the app pool and the background job runner's pool draw from it concurrently, so
+        // an uncapped pool here (Npgsql defaults Maximum Pool Size to 100) can starve the other or
+        // exhaust the server under load. Sized to leave headroom for the background pool and admin
+        // tooling beneath a typical ceiling; overridable per deployment via Database:MaxPoolSize.
+        dataSourceBuilder.ConnectionStringBuilder.MaxPoolSize =
+            configuration.GetValue<int?>("Database:MaxPoolSize") ?? 40;
         var dataSource = dataSourceBuilder.Build();
 
         services.AddDbContext<KnowledgeDbContext>(options =>

--- a/src/Connapse.Storage/Llm/LlmConcurrencyGate.cs
+++ b/src/Connapse.Storage/Llm/LlmConcurrencyGate.cs
@@ -1,0 +1,55 @@
+using Connapse.Core;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.Llm;
+
+/// <summary>
+/// Process-wide concurrency limiter for local LLM inference (Ollama).
+///
+/// A single local Ollama instance serializes generation internally, so firing many
+/// concurrent /api/chat requests at once just builds a deep internal queue: each request's
+/// wall-clock becomes (queue position x per-call generation time), and the slowest tail
+/// requests exceed HttpClient.Timeout and surface as TaskCanceledException. This gate makes
+/// callers wait in-process — before the HTTP request starts — so each request that actually
+/// reaches Ollama runs alone and finishes well within the timeout.
+///
+/// Registered as a singleton so the <see cref="SemaphoreSlim"/> is shared across all
+/// (transient) provider instances. The limit comes from
+/// <see cref="LlmSettings.MaxConcurrentRequests"/> (default 1) and is read once at
+/// construction; changing it requires a restart. Only the Ollama provider acquires this
+/// gate — cloud providers handle concurrency server-side and are not gated.
+/// </summary>
+public sealed class LlmConcurrencyGate : IDisposable
+{
+    private readonly SemaphoreSlim _semaphore;
+
+    public LlmConcurrencyGate(IOptions<LlmSettings> options)
+    {
+        int limit = Math.Max(1, options.Value.MaxConcurrentRequests);
+        _semaphore = new SemaphoreSlim(limit, limit);
+    }
+
+    /// <summary>
+    /// Waits for a slot, then returns a handle that releases the slot when disposed.
+    /// Honors cancellation while waiting.
+    /// </summary>
+    public async Task<IDisposable> AcquireAsync(CancellationToken ct)
+    {
+        await _semaphore.WaitAsync(ct).ConfigureAwait(false);
+        return new Releaser(_semaphore);
+    }
+
+    public void Dispose() => _semaphore.Dispose();
+
+    private sealed class Releaser(SemaphoreSlim semaphore) : IDisposable
+    {
+        private int _released;
+
+        public void Dispose()
+        {
+            // Guard against double-release (e.g. an iterator disposed more than once).
+            if (Interlocked.Exchange(ref _released, 1) == 0)
+                semaphore.Release();
+        }
+    }
+}

--- a/src/Connapse.Storage/Llm/OllamaLlmProvider.cs
+++ b/src/Connapse.Storage/Llm/OllamaLlmProvider.cs
@@ -17,15 +17,18 @@ public class OllamaLlmProvider : ILlmProvider
     private readonly HttpClient _httpClient;
     private readonly ILogger<OllamaLlmProvider> _logger;
     private readonly LlmSettings _settings;
+    private readonly LlmConcurrencyGate _gate;
 
     public OllamaLlmProvider(
         HttpClient httpClient,
         IOptionsSnapshot<LlmSettings> settings,
-        ILogger<OllamaLlmProvider> logger)
+        ILogger<OllamaLlmProvider> logger,
+        LlmConcurrencyGate gate)
     {
         _httpClient = httpClient;
         _logger = logger;
         _settings = settings.Value;
+        _gate = gate;
 
         if (!string.IsNullOrEmpty(_settings.BaseUrl))
             _httpClient.BaseAddress = new Uri(_settings.BaseUrl);
@@ -44,6 +47,10 @@ public class OllamaLlmProvider : ILlmProvider
     {
         var resolvedModel = ResolveModel(options);
         var request = BuildRequest(systemPrompt, userPrompt, options, resolvedModel, stream: false);
+
+        // Wait in-process for a slot so this call runs alone against the local Ollama instance
+        // rather than piling into its internal queue (where the tail request would time out).
+        using var slot = await _gate.AcquireAsync(ct).ConfigureAwait(false);
 
         try
         {
@@ -75,6 +82,9 @@ public class OllamaLlmProvider : ILlmProvider
     {
         var resolvedModel = ResolveModel(options);
         var request = BuildRequest(systemPrompt, userPrompt, options, resolvedModel, stream: true);
+
+        // Held for the whole stream lifetime — one local inference at a time (see CompleteAsync).
+        using var slot = await _gate.AcquireAsync(ct).ConfigureAwait(false);
 
         HttpResponseMessage response;
         try

--- a/src/Connapse.Storage/Llm/SummaryPrompts.cs
+++ b/src/Connapse.Storage/Llm/SummaryPrompts.cs
@@ -31,12 +31,21 @@ public static class SummaryPrompts
         1. One-sentence scope: "Use this container for queries about X, Y, Z."
         2. Concrete trigger terms and synonyms the agent should pattern-match.
         3. Representative questions this container can answer (5-8 bullets).
-        4. Out-of-scope: topics agents should NOT route here.
+        4. Scope boundaries: only call a topic out-of-scope when the
+           summaries below actively establish it (a bounded, single-subject
+           corpus). If the input says you are shown a representative SAMPLE
+           rather than every document, do NOT assert what the container
+           excludes — a topic missing from the sample may still be present.
+           Hedge instead: "appears centered on…; may also hold related
+           material."
         5. Query hints: phrasings or keywords that retrieve well.
 
         Be specific over generic. Name entities, not categories. Prefer
-        imperative voice ("Use when…", "Does not cover…"). Brief the reader
-        like a new hire who'll be making routing decisions all day.
+        imperative voice ("Use when…"). Brief the reader like a new hire
+        who'll be making routing decisions all day. A false "does not cover
+        X" is costly — it suppresses real retrievals — while omitting an
+        exclusion only risks a cheap, self-correcting extra query; when
+        unsure, omit it.
         """;
 
     public static string RenderPerDocUserMessage(
@@ -56,8 +65,8 @@ public static class SummaryPrompts
         IEnumerable<string> summaries)
     {
         string clusterNote = isClustered
-            ? $"; shown via cluster medoids with cluster sizes in brackets"
-            : string.Empty;
+            ? "; you are shown a representative SAMPLE — cluster medoids, with cluster sizes in brackets — NOT every document"
+            : "; all documents are shown below";
 
         string body = string.Join("\n", summaries.Select((s, i) => $"{i + 1}. {s}"));
 

--- a/src/Connapse.Storage/Llm/SummaryPrompts.cs
+++ b/src/Connapse.Storage/Llm/SummaryPrompts.cs
@@ -10,13 +10,23 @@ public static class SummaryPrompts
         Write 2-4 sentences with this structure:
         1. What the document is — entities, scope, time range. Be specific.
         2. What questions it can answer. Enumerate concrete query terms.
-        3. (If clear) What it does NOT cover.
+        3. What it does NOT cover — but ONLY when the full document is shown
+           below. If the content is marked truncated (you see only the HEAD),
+           do not claim what the document omits; a later section you can't see
+           may contain it. Hedge instead ("focuses on…; may also touch…").
 
         Lead with concrete nouns and trigger terms. Avoid "this document
-        covers various topics about X." Prefer:
+        covers various topics about X." Prefer, when the full document is shown:
         "Covers Apple Q3 2025 earnings: iPhone units, China revenue, services
         growth. Answers: how much did iPhone sales decline? What's the
         services margin? Does not cover product roadmap."
+        When truncated, drop the exclusion: "Covers the opening of Apple's Q3
+        2025 earnings call: iPhone units, China revenue. May also address later
+        topics not shown."
+
+        A false "does not cover X" is costly — it suppresses real retrievals —
+        while omitting an exclusion only risks a cheap, self-correcting extra
+        query; when unsure, omit it.
 
         Output target: ~100 tokens.
         """;
@@ -49,14 +59,20 @@ public static class SummaryPrompts
         """;
 
     public static string RenderPerDocUserMessage(
-        string filename, string? mimeType, string firstNTokens) =>
-        $"""
-        Document: {filename}
-        Content type: {mimeType ?? "unknown"}
-        ---------------------
-        {firstNTokens}
-        ---------------------
-        """;
+        string filename, string? mimeType, string firstNTokens, bool wasTruncated)
+    {
+        string coverageNote = wasTruncated
+            ? "; you are shown only the HEAD of this document — it was truncated, so later sections are NOT included"
+            : "; the full document text is shown below";
+
+        return $"""
+            Document: {filename}
+            Content type: {mimeType ?? "unknown"}{coverageNote}
+            ---------------------
+            {firstNTokens}
+            ---------------------
+            """;
+    }
 
     public static string RenderContainerRollupUserMessage(
         string containerName,

--- a/src/Connapse.Storage/Vectors/PgVectorStore.cs
+++ b/src/Connapse.Storage/Vectors/PgVectorStore.cs
@@ -369,12 +369,28 @@ public class PgVectorStore : IVectorStore
 
         if (modelCounts.Count > 1)
         {
-            int excludedVectors = modelCounts.Skip(1).Sum(m => m.Count);
+            // The interface contract asks for the count of *documents* excluded due to a
+            // non-dominant model. A document is excluded only when it has no chunks of the
+            // dominant model — docs with mixed-model chunks still contribute their dominant
+            // ones. Compute total vs. dominant-reachable distinct docs (mixed-model path only).
+            int totalDocs = await _context.ChunkVectors
+                .Where(cv => cv.ContainerId == containerId)
+                .Select(cv => cv.DocumentId)
+                .Distinct()
+                .CountAsync(ct);
+            int includedDocs = await _context.ChunkVectors
+                .Where(cv => cv.ContainerId == containerId && cv.ModelId == dominantModelId)
+                .Select(cv => cv.DocumentId)
+                .Distinct()
+                .CountAsync(ct);
+            int excludedDocuments = totalDocs - includedDocs;
+
             _logger.LogWarning(
                 "GetPooledDocumentEmbeddingsAsync: container {ContainerId} has mixed embedding models. " +
-                "Using dominant model '{DominantModelId}' ({DominantCount} vectors). " +
-                "Excluding {ExcludedCount} vectors from {OtherModelCount} other model(s).",
-                containerId, dominantModelId, modelCounts[0].Count, excludedVectors, modelCounts.Count - 1);
+                "Using dominant model '{DominantModelId}' ({DominantVectorCount} vectors). " +
+                "Excluding {ExcludedDocumentCount} document(s) with no chunks of the dominant model, " +
+                "across {OtherModelCount} other model(s).",
+                containerId, dominantModelId, modelCounts[0].Count, excludedDocuments, modelCounts.Count - 1);
         }
 
         // Step 2: pool per-document. AVG(embedding) returns a vector at the same dimensionality.

--- a/src/Connapse.Storage/Vectors/PgVectorStore.cs
+++ b/src/Connapse.Storage/Vectors/PgVectorStore.cs
@@ -345,4 +345,91 @@ public class PgVectorStore : IVectorStore
             vectors.Count,
             documentId);
     }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<(Guid DocumentId, float[] Embedding)>> GetPooledDocumentEmbeddingsAsync(
+        Guid containerId,
+        CancellationToken ct = default)
+    {
+        // Step 1: pick the dominant model_id in the container. ChunkVectorEntity carries
+        // ContainerId and ModelId directly — no JOIN needed.
+        var modelCounts = await _context.ChunkVectors
+            .Where(cv => cv.ContainerId == containerId)
+            .GroupBy(cv => cv.ModelId)
+            .Select(g => new { ModelId = g.Key, Count = g.Count() })
+            .OrderByDescending(x => x.Count)
+            .ToListAsync(ct);
+
+        if (modelCounts.Count == 0)
+        {
+            return Array.Empty<(Guid, float[])>();
+        }
+
+        string dominantModelId = modelCounts[0].ModelId;
+
+        if (modelCounts.Count > 1)
+        {
+            int excludedVectors = modelCounts.Skip(1).Sum(m => m.Count);
+            _logger.LogWarning(
+                "GetPooledDocumentEmbeddingsAsync: container {ContainerId} has mixed embedding models. " +
+                "Using dominant model '{DominantModelId}' ({DominantCount} vectors). " +
+                "Excluding {ExcludedCount} vectors from {OtherModelCount} other model(s).",
+                containerId, dominantModelId, modelCounts[0].Count, excludedVectors, modelCounts.Count - 1);
+        }
+
+        // Step 2: pool per-document. AVG(embedding) returns a vector at the same dimensionality.
+        var conn = _context.Database.GetDbConnection();
+        bool openedHere = false;
+        if (conn.State != System.Data.ConnectionState.Open)
+        {
+            await conn.OpenAsync(ct);
+            openedHere = true;
+        }
+        try
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = """
+                SELECT document_id, AVG(embedding)::vector AS pooled
+                FROM chunk_vectors
+                WHERE container_id = @cid
+                  AND model_id = @model_id
+                GROUP BY document_id
+                """;
+
+            var p = cmd.Parameters;
+            p.Add(new NpgsqlParameter("cid", containerId));
+            p.Add(new NpgsqlParameter("model_id", dominantModelId));
+
+            var results = new List<(Guid DocumentId, float[] Embedding)>();
+            await using var reader = await cmd.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
+            {
+                Guid docId = reader.GetGuid(0);
+                Vector pooled = reader.GetFieldValue<Vector>(1);
+                float[] raw = pooled.ToArray();
+                float[] normalized = L2Normalize(raw);
+                results.Add((docId, normalized));
+            }
+
+            return results;
+        }
+        finally
+        {
+            if (openedHere)
+            {
+                await conn.CloseAsync();
+            }
+        }
+    }
+
+    private static float[] L2Normalize(float[] v)
+    {
+        double sumSq = 0;
+        for (int i = 0; i < v.Length; i++) sumSq += v[i] * v[i];
+        double norm = Math.Sqrt(sumSq);
+        if (norm < 1e-12) return v; // degenerate; leave as-is rather than div-by-zero
+        float[] result = new float[v.Length];
+        for (int i = 0; i < v.Length; i++) result[i] = (float)(v[i] / norm);
+        return result;
+    }
 }

--- a/src/Connapse.Web/Components/Pages/FileBrowser.razor
+++ b/src/Connapse.Web/Components/Pages/FileBrowser.razor
@@ -709,6 +709,11 @@
             // SignalR negotiate can fail in test/dev contexts (e.g. circuit not fully wired);
             // the existing in-process ProgressNotifier still drives in-flight job updates.
         }
+
+        // Drive the rollup-in-progress pill from a low-frequency poll (see RunRollupPollLoopAsync).
+        _rollupPollCts = new CancellationTokenSource();
+        _rollupPollTimer = new PeriodicTimer(TimeSpan.FromSeconds(2));
+        _ = RunRollupPollLoopAsync();
     }
 
     private async Task RetryIngestion(BrowseEntryDto entry)
@@ -867,18 +872,9 @@
             catch { /* Will retry on next render */ }
         }
 
-        // Container rollup-in-progress pill — throttled scan of the Hangfire monitoring
-        // API. Cheap to call (in-memory dictionary scan on PostgreSQL storage's
-        // dashboard cache), but still throttled to once per second.
-        if (container is not null && Guid.TryParse(container.Id, out var cid))
-        {
-            bool newState = IsRollupInProgress(cid);
-            if (newState != _isRollupInProgress)
-            {
-                _isRollupInProgress = newState;
-                await InvokeAsync(StateHasChanged);
-            }
-        }
+        // The rollup-in-progress pill is driven by RunRollupPollLoopAsync (a 2s poll), not by
+        // render ticks: in document-clustering mode the rollup runs after per-doc SignalR
+        // traffic stops, so no render would fire to clear the pill once the rollup completes.
     }
 
     // Tracks the most recent rollup-pill check so we don't hammer the Hangfire monitoring
@@ -886,6 +882,34 @@
     private bool _isRollupInProgress;
     private DateTime _rollupPillLastChecked = DateTime.MinValue;
     private bool _rollupPillCachedResult;
+
+    // Low-frequency poll that keeps the rollup pill honest. Per-doc pills re-render via SignalR,
+    // but a container rollup (especially in document-clustering mode) runs after that traffic
+    // stops — without a poll, the pill would stay stuck "on" until a manual page refresh.
+    private PeriodicTimer? _rollupPollTimer;
+    private CancellationTokenSource? _rollupPollCts;
+
+    private async Task RunRollupPollLoopAsync()
+    {
+        if (_rollupPollTimer is null || _rollupPollCts is null) return;
+        try
+        {
+            while (await _rollupPollTimer.WaitForNextTickAsync(_rollupPollCts.Token))
+            {
+                if (_disposed) return;
+                if (container is null || !Guid.TryParse(container.Id, out var cid)) continue;
+
+                bool newState = IsRollupInProgress(cid);
+                if (newState != _isRollupInProgress)
+                {
+                    _isRollupInProgress = newState;
+                    await InvokeAsync(StateHasChanged);
+                }
+            }
+        }
+        catch (OperationCanceledException) { /* disposed — expected */ }
+        catch { /* best-effort pill; never tear down the circuit */ }
+    }
 
     private bool IsRollupInProgress(Guid containerId)
     {
@@ -1869,6 +1893,9 @@
     public async ValueTask DisposeAsync()
     {
         _disposed = true;
+        _rollupPollCts?.Cancel();
+        _rollupPollTimer?.Dispose();
+        _rollupPollCts?.Dispose();
         ProgressNotifier.ProgressReceived -= OnProgressReceived;
         ProgressNotifier.StateChanged -= OnStateChanged;
         FileChangeNotifier.FileChanged -= OnFileChanged;

--- a/src/Connapse.Web/Components/Settings/SummarySettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/SummarySettingsTab.razor
@@ -1,7 +1,11 @@
 @using Connapse.Core
+@using Connapse.Core.Interfaces
 @using Connapse.Storage.Llm
-@inject IHttpClientFactory HttpClientFactory
-@inject NavigationManager Navigation
+@using Connapse.Background.Jobs
+@using Hangfire
+@inject IDocumentStore DocumentStore
+@inject IContainerStore ContainerStore
+@inject IBackgroundJobClient BackgroundJobs
 
 <div class="settings-tab">
     <h4 class="mb-3">Summary Generation</h4>
@@ -115,6 +119,8 @@
        the global settings tab passes Guid.Empty and the button stays hidden. *@
     @if (ContainerId != Guid.Empty)
     {
+        <AuthorizeView Roles="Owner,Admin">
+        <Authorized>
         <hr />
         <div class="mb-3">
             <button type="button" class="btn btn-outline-secondary"
@@ -134,6 +140,91 @@
                 <div class="form-text @(regenerateSuccess ? "text-success" : "text-danger")">@regenerateMessage</div>
             }
         </div>
+
+        <div class="mb-3">
+            @if (!clearConfirmPending)
+            {
+                <button type="button" class="btn btn-outline-danger"
+                        @onclick="() => clearConfirmPending = true"
+                        disabled="@isClearing">
+                    Clear summaries
+                </button>
+            }
+            else
+            {
+                <button type="button" class="btn btn-danger"
+                        @onclick="ClearSummaries"
+                        disabled="@isClearing">
+                    @if (isClearing)
+                    {
+                        <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                    }
+                    Confirm clear
+                </button>
+                <button type="button" class="btn btn-link btn-sm"
+                        @onclick="() => clearConfirmPending = false"
+                        disabled="@isClearing">
+                    Cancel
+                </button>
+            }
+            <div class="form-text">
+                Deletes all cached per-document and container summaries. Embeddings, chunks, and the
+                documents themselves are kept. Summaries regenerate automatically on the next sweep.
+            </div>
+            @if (clearMessage is not null)
+            {
+                <div class="form-text @(clearSuccess ? "text-success" : "text-danger")">@clearMessage</div>
+            }
+        </div>
+        </Authorized>
+        </AuthorizeView>
+    }
+
+    @* Global summary settings tab (ContainerId == Guid.Empty): a bulk clear that wipes cached
+       summaries across every container, since there's no single container to scope to here. *@
+    @if (ContainerId == Guid.Empty)
+    {
+        <AuthorizeView Roles="Owner,Admin">
+        <Authorized>
+        <hr />
+        <div class="mb-3">
+            @if (!clearAllConfirmPending)
+            {
+                <button type="button" class="btn btn-outline-danger"
+                        @onclick="() => clearAllConfirmPending = true"
+                        disabled="@isClearingAll">
+                    Clear all summaries
+                </button>
+            }
+            else
+            {
+                <button type="button" class="btn btn-danger"
+                        @onclick="ClearAllSummaries"
+                        disabled="@isClearingAll">
+                    @if (isClearingAll)
+                    {
+                        <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                    }
+                    Confirm — clear every container
+                </button>
+                <button type="button" class="btn btn-link btn-sm"
+                        @onclick="() => clearAllConfirmPending = false"
+                        disabled="@isClearingAll">
+                    Cancel
+                </button>
+            }
+            <div class="form-text">
+                Deletes cached per-document and container summaries for <strong>every container</strong>.
+                Embeddings, chunks, and the documents themselves are kept. Summaries regenerate
+                automatically on the next sweep.
+            </div>
+            @if (clearAllMessage is not null)
+            {
+                <div class="form-text @(clearAllSuccess ? "text-success" : "text-danger")">@clearAllMessage</div>
+            }
+        </div>
+        </Authorized>
+        </AuthorizeView>
     }
 </div>
 
@@ -157,6 +248,16 @@
     private bool isRegenerating;
     private string? regenerateMessage;
     private bool regenerateSuccess;
+
+    private bool isClearing;
+    private bool clearConfirmPending;
+    private string? clearMessage;
+    private bool clearSuccess;
+
+    private bool isClearingAll;
+    private bool clearAllConfirmPending;
+    private string? clearAllMessage;
+    private bool clearAllSuccess;
 
     // SummarySettings is an init-only record, so we hold edit state in
     // intermediate fields and reconstruct the record on every change.
@@ -281,7 +382,7 @@
 
     public SummarySettings GetCurrentSettings() => BuildSettingsFromLocal();
 
-    private async Task RegenerateNow()
+    private void RegenerateNow()
     {
         if (ContainerId == Guid.Empty) return;
         if (isRegenerating) return;
@@ -290,22 +391,13 @@
         regenerateMessage = null;
         try
         {
-            var http = HttpClientFactory.CreateClient("BlazorClient");
-            http.BaseAddress ??= new Uri(Navigation.BaseUri);
-            var response = await http.PostAsync(
-                $"/api/containers/{ContainerId}/summary/regenerate",
-                content: null);
-
-            if (response.IsSuccessStatusCode)
-            {
-                regenerateSuccess = true;
-                regenerateMessage = "Summary rollup enqueued.";
-            }
-            else
-            {
-                regenerateSuccess = false;
-                regenerateMessage = $"Failed to enqueue rollup: {(int)response.StatusCode} {response.ReasonPhrase}";
-            }
+            // Blazor Server runs this on the server, so enqueue the Hangfire job
+            // directly. The old HTTP loopback hit the RequireAdmin endpoint
+            // anonymously — a server-side HttpClient carries no browser auth
+            // cookie — and 401'd.
+            BackgroundJobs.Enqueue<ISummaryJobs>(s => s.RollupContainerAsync(ContainerId, default));
+            regenerateSuccess = true;
+            regenerateMessage = "Summary rollup enqueued.";
         }
         catch (Exception ex)
         {
@@ -315,6 +407,81 @@
         finally
         {
             isRegenerating = false;
+        }
+    }
+
+    private async Task ClearSummaries()
+    {
+        if (ContainerId == Guid.Empty) return;
+        if (isClearing) return;
+
+        isClearing = true;
+        clearMessage = null;
+        try
+        {
+            // Direct service calls — Blazor Server runs on the server, so there's no
+            // need to loop back through the authenticated HTTP API (which 401'd because
+            // the server-side HttpClient sends no browser auth cookie). The
+            // AuthorizeView gate above restricts this to Owner/Admin.
+            int clearedDocs = await DocumentStore.ClearDocumentSummariesAsync(ContainerId);
+            await ContainerStore.UpdateSummaryAsync(ContainerId, null, null, null);
+            clearSuccess = true;
+            clearMessage = $"Cleared {clearedDocs} document summaries. They'll regenerate on the next sweep.";
+        }
+        catch (Exception ex)
+        {
+            clearSuccess = false;
+            clearMessage = $"Failed to clear summaries: {ex.Message}";
+        }
+        finally
+        {
+            isClearing = false;
+            clearConfirmPending = false;
+        }
+    }
+
+    private async Task ClearAllSummaries()
+    {
+        // Global-tab only: this button clears every container, so it must never run
+        // from a container-scoped mount (where the per-container Clear button applies).
+        if (ContainerId != Guid.Empty) return;
+        if (isClearingAll) return;
+
+        isClearingAll = true;
+        clearAllMessage = null;
+        try
+        {
+            // Loop the existing per-container primitives directly (no HTTP loopback).
+            // In multi-tenant deployments ListAsync and the clears are RLS-scoped to the
+            // caller, so "all" means "all containers the caller can see". The
+            // AuthorizeView gate above restricts this to Owner/Admin.
+            const int pageSize = 200;
+            int containersCleared = 0;
+            int clearedDocs = 0;
+            for (int skip = 0; ; skip += pageSize)
+            {
+                var page = await ContainerStore.ListAsync(skip, pageSize);
+                foreach (var c in page)
+                {
+                    if (!Guid.TryParse(c.Id, out var cid)) continue;
+                    clearedDocs += await DocumentStore.ClearDocumentSummariesAsync(cid);
+                    await ContainerStore.UpdateSummaryAsync(cid, null, null, null);
+                    containersCleared++;
+                }
+                if (page.Count < pageSize) break;
+            }
+            clearAllSuccess = true;
+            clearAllMessage = $"Cleared summaries for {containersCleared} container(s). They'll regenerate on the next sweep.";
+        }
+        catch (Exception ex)
+        {
+            clearAllSuccess = false;
+            clearAllMessage = $"Failed to clear summaries: {ex.Message}";
+        }
+        finally
+        {
+            isClearingAll = false;
+            clearAllConfirmPending = false;
         }
     }
 }

--- a/src/Connapse.Web/Components/Settings/SummarySettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/SummarySettingsTab.razor
@@ -43,6 +43,24 @@
     </div>
 
     <div class="mb-3">
+        <label class="form-label">Container summary method</label>
+        <select class="form-select" value="@containerSummaryMethod"
+                @onchange="OnContainerSummaryMethodChanged">
+            <option value="document-clustering">Document clustering (recommended)</option>
+            <option value="summary-clustering">Summary clustering</option>
+        </select>
+        <div class="form-text">
+            <strong>Document clustering</strong> — no per-doc summaries at upload. At container
+            summary generation time, the system clusters documents by their embeddings and
+            summarizes only the K most representative ones. Lower LLM cost; container summary
+            generation is slower the first time it runs.<br />
+            <strong>Summary clustering</strong> — summarizes every uploaded document at ingest.
+            Container summary generation reuses those summaries. Higher LLM cost overall; faster
+            container summary generation.
+        </div>
+    </div>
+
+    <div class="mb-3">
         <label class="form-label">Max input tokens per document</label>
         <input type="number" class="form-control"
                value="@(maxInputTokens?.ToString() ?? string.Empty)"
@@ -146,6 +164,7 @@
     private string? llmProvider;
     private string? llmModel;
     private int? maxInputTokens;
+    private string containerSummaryMethod = SummaryStrategy.DocumentClustering;
     private string perDocPromptText = string.Empty;
     private string containerPromptText = string.Empty;
 
@@ -161,12 +180,20 @@
         llmProvider = Settings.LlmProvider;
         llmModel = Settings.LlmModel;
         maxInputTokens = Settings.MaxInputTokens;
+        containerSummaryMethod = Settings.ContainerSummaryMethod;
         perDocPromptText = !string.IsNullOrWhiteSpace(Settings.PerDocSystemPrompt)
             ? Settings.PerDocSystemPrompt!
             : SummaryPrompts.PerDocSystemPrompt;
         containerPromptText = !string.IsNullOrWhiteSpace(Settings.ContainerRollupSystemPrompt)
             ? Settings.ContainerRollupSystemPrompt!
             : SummaryPrompts.ContainerRollupSystemPrompt;
+    }
+
+    private Task OnContainerSummaryMethodChanged(ChangeEventArgs e)
+    {
+        string? raw = e.Value as string;
+        containerSummaryMethod = string.IsNullOrWhiteSpace(raw) ? SummaryStrategy.DocumentClustering : raw;
+        return EmitChanged();
     }
 
     private Task OnEnabledChanged(ChangeEventArgs e)
@@ -239,6 +266,7 @@
         return new SummarySettings
         {
             Enabled = enabled,
+            ContainerSummaryMethod = containerSummaryMethod,
             LlmProvider = llmProvider,
             LlmModel = llmModel,
             MaxInputTokens = maxInputTokens,

--- a/src/Connapse.Web/Components/Settings/SummarySettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/SummarySettingsTab.razor
@@ -267,8 +267,12 @@
         {
             Enabled = enabled,
             ContainerSummaryMethod = containerSummaryMethod,
-            LlmProvider = llmProvider,
-            LlmModel = llmModel,
+            // Normalize blank overrides to null: an empty string is not a valid
+            // provider/model, and downstream consumers treat null as "inherit the
+            // global setting". Persisting "" would override the configured model
+            // with an empty one (Ollama then rejects the request).
+            LlmProvider = string.IsNullOrWhiteSpace(llmProvider) ? null : llmProvider,
+            LlmModel = string.IsNullOrWhiteSpace(llmModel) ? null : llmModel,
             MaxInputTokens = maxInputTokens,
             PerDocSystemPrompt = perDoc,
             ContainerRollupSystemPrompt = containerRollup

--- a/src/Connapse.Web/Endpoints/ContainersEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/ContainersEndpoints.cs
@@ -8,7 +8,6 @@ using Connapse.Storage.ConnectionTesters;
 using Connapse.Storage.Connectors;
 using Connapse.Storage.Vectors;
 using Connapse.Web.Services;
-using Hangfire;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -442,21 +441,6 @@ public static class ContainersEndpoints
         .WithName("SyncContainer")
         .WithDescription("Sync files from a remote connector (S3, AzureBlob, MinIO). Lists remote files, compares to DB, enqueues new/changed.")
         .RequireAuthorization("RequireEditor");
-
-        // POST /api/containers/{containerId}/summary/regenerate
-        // Manually enqueue a container rollup. Useful after editing summary settings or for
-        // operator-triggered regeneration. Gated on RequireAdmin (matches /api/settings).
-        group.MapPost("/{containerId:guid}/summary/regenerate", (
-            Guid containerId,
-            [FromServices] IBackgroundJobClient bgClient) =>
-        {
-            bgClient.Enqueue<ISummaryJobs>(
-                s => s.RollupContainerAsync(containerId, default));
-            return Results.Accepted($"/api/containers/{containerId}");
-        })
-        .WithName("RegenerateContainerSummary")
-        .WithDescription("Enqueue an immediate container summary rollup (skips the 60s debounce).")
-        .RequireAuthorization("RequireAdmin");
 
         return app;
     }

--- a/tests/Connapse.Background.Tests/Integration/HangfireEndToEndTests.cs
+++ b/tests/Connapse.Background.Tests/Integration/HangfireEndToEndTests.cs
@@ -32,8 +32,12 @@ public sealed class HangfireEndToEndTests
     }
 
     [Fact]
-    public async Task EnqueueAsync_CreatesEnqueuedIngestJobAndAwaitingSummaryContinuation()
+    public async Task EnqueueAsync_CreatesOnlyIngestJob_NoUpfrontPerDocContinuation()
     {
+        // Post-HERCULES: HangfireIngestionQueue no longer attaches a PerDocSummary
+        // continuation. The per-doc job is enqueued (or skipped) inside IngestAsync's
+        // tail based on the container's resolved SummarySettings, so document-clustering
+        // and summaries-disabled containers don't create any per-doc job at all.
         var bgClient = new BackgroundJobClient();
         var queue = new HangfireIngestionQueue(bgClient);
 
@@ -51,12 +55,6 @@ public sealed class HangfireEndToEndTests
 
         var monitor = JobStorage.Current.GetMonitoringApi();
 
-        // Hangfire reads the [Queue] attribute from the resolved Job.Method. When the
-        // method is invoked via an interface expression (Enqueue<IIngestionJobs>), the
-        // attribute lookup may resolve via the interface declaration — which has no
-        // [Queue] — so jobs can land on "default" rather than "ingestion". In production
-        // the worker is configured to listen on both queues; for this wiring test we
-        // collect across whatever queue Hangfire picked.
         var enqueuedJobs = monitor.Queues()
             .SelectMany(q => monitor.EnqueuedJobs(q.Name, 0, 100))
             .ToList();
@@ -66,28 +64,11 @@ public sealed class HangfireEndToEndTests
         enqueuedJobs.Single().Value.Job!.Method.Name.Should().Be(
             nameof(Connapse.Background.Jobs.IIngestionJobs.IngestAsync));
 
-        // The continuation summary job is created in Awaiting state. MemoryStorage's
-        // StatisticsDto.Awaiting is null in this version, so we look up the parent's
-        // "Continuations" job property — populated by ContinueJobWith — and then fetch
-        // the continuation job to confirm it targets PerDocSummaryAsync.
+        // Verify NO continuation is attached — the per-doc decision is deferred to IngestAsync.
         string parentId = enqueuedJobs.Single().Key;
         var parentDetails = monitor.JobDetails(parentId);
         parentDetails.Should().NotBeNull();
-        parentDetails.Properties.Should().ContainKey("Continuations",
-            "ContinueJobWith should attach a continuation reference on the parent");
-
-        // Parse the JSON-encoded continuations array and verify the child targets
-        // PerDocSummaryAsync. The exact JSON shape ({"JobId":"<guid>","Options":<int>})
-        // is Hangfire-internal but stable across 1.8.x.
-        string continuationsJson = parentDetails.Properties["Continuations"];
-        using var doc = System.Text.Json.JsonDocument.Parse(continuationsJson);
-        var first = doc.RootElement.EnumerateArray().FirstOrDefault();
-        first.ValueKind.Should().NotBe(System.Text.Json.JsonValueKind.Undefined);
-        string continuationId = first.GetProperty("JobId").GetString()!;
-
-        var childDetails = monitor.JobDetails(continuationId);
-        childDetails.Should().NotBeNull();
-        childDetails.Job!.Method.Name.Should().Be(
-            nameof(Connapse.Background.Jobs.IIngestionJobs.PerDocSummaryAsync));
+        parentDetails.Properties.Should().NotContainKey("Continuations",
+            "post-HERCULES, HangfireIngestionQueue should not attach an upfront PerDocSummary continuation");
     }
 }

--- a/tests/Connapse.Background.Tests/Jobs/IngestionJobsHerculesTests.cs
+++ b/tests/Connapse.Background.Tests/Jobs/IngestionJobsHerculesTests.cs
@@ -1,0 +1,131 @@
+using Connapse.Background.Jobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using NSubstitute;
+
+namespace Connapse.Background.Tests.Jobs;
+
+/// <summary>
+/// Unit tests for the <see cref="SummaryStrategy.DocumentClustering"/> early-return
+/// branch in <see cref="IngestionJobs.PerDocSummaryAsync"/>. In document-clustering
+/// mode, per-doc summarization is deferred to rollup time, so the job must short-circuit
+/// without calling the summarizer while still advancing ingestion state so the UI
+/// doesn't show a stuck spinner.
+/// </summary>
+[Trait("Category", "Unit")]
+public class IngestionJobsHerculesTests
+{
+    [Fact]
+    public async Task PerDocSummaryAsync_DocumentClusteringMode_EarlyReturnsWithoutCallingSummarizer()
+    {
+        // Arrange
+        string documentId = Guid.NewGuid().ToString();
+        Guid containerId = Guid.NewGuid();
+
+        var docStore = Substitute.For<IDocumentStore>();
+        docStore.GetAsync(documentId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Document?>(new Document(
+                Id: documentId,
+                ContainerId: containerId.ToString(),
+                FileName: "doc.txt",
+                ContentType: "text/plain",
+                Path: "/doc.txt",
+                SizeBytes: 100,
+                CreatedAt: DateTime.UtcNow,
+                Metadata: new Dictionary<string, string>(),
+                Summary: null,
+                SummaryGeneratedAt: null,
+                SummaryContentHash: null,
+                IngestionState: IngestionState.Indexed)));
+
+        var summarizer = Substitute.For<IPerDocSummarizer>();
+        var settingsResolver = Substitute.For<IContainerSettingsResolver>();
+        settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new SummarySettings
+            {
+                Enabled = true,
+                ContainerSummaryMethod = SummaryStrategy.DocumentClustering,
+            }));
+
+        var stateBroadcaster = Substitute.For<IIngestionStateBroadcaster>();
+        var jobs = new IngestionJobs(
+            Substitute.For<IKnowledgeIngester>(),
+            docStore,
+            Substitute.For<IContainerStore>(),
+            Substitute.For<IConnectorFactory>(),
+            Array.Empty<IDocumentParser>(),
+            summarizer,
+            settingsResolver,
+            Substitute.For<Hangfire.IBackgroundJobClient>(),
+            stateBroadcaster,
+            Substitute.For<Microsoft.Extensions.Logging.ILogger<IngestionJobs>>());
+
+        // Act
+        await jobs.PerDocSummaryAsync(documentId, CancellationToken.None);
+
+        // Assert — summarizer is never invoked.
+        await summarizer.DidNotReceiveWithAnyArgs().GenerateAsync(
+            default!, default!, default!, default!, default!, default);
+
+        // State is still advanced to SummaryIndexed so the UI doesn't hang.
+        await docStore.Received(1).UpdateIngestionStateAsync(
+            documentId, IngestionState.SummaryIndexed, Arg.Any<CancellationToken>());
+        await stateBroadcaster.Received(1).BroadcastIngestionStateChangedAsync(
+            documentId, IngestionState.SummaryIndexed, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PerDocSummaryAsync_SummariesDisabled_DocumentClusteringStillEarlyReturnsByDisabledFlag()
+    {
+        // Sanity: Enabled=false short-circuits BEFORE the ContainerSummaryMethod check.
+        // No state advance happens; the disabled path is a hard no-op.
+        string documentId = Guid.NewGuid().ToString();
+        Guid containerId = Guid.NewGuid();
+
+        var docStore = Substitute.For<IDocumentStore>();
+        docStore.GetAsync(documentId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Document?>(new Document(
+                Id: documentId,
+                ContainerId: containerId.ToString(),
+                FileName: "doc.txt",
+                ContentType: "text/plain",
+                Path: "/doc.txt",
+                SizeBytes: 100,
+                CreatedAt: DateTime.UtcNow,
+                Metadata: new Dictionary<string, string>(),
+                Summary: null,
+                SummaryGeneratedAt: null,
+                SummaryContentHash: null,
+                IngestionState: IngestionState.Indexed)));
+
+        var settingsResolver = Substitute.For<IContainerSettingsResolver>();
+        settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new SummarySettings
+            {
+                Enabled = false,
+                ContainerSummaryMethod = SummaryStrategy.DocumentClustering,
+            }));
+
+        var stateBroadcaster = Substitute.For<IIngestionStateBroadcaster>();
+        var summarizer = Substitute.For<IPerDocSummarizer>();
+        var jobs = new IngestionJobs(
+            Substitute.For<IKnowledgeIngester>(),
+            docStore,
+            Substitute.For<IContainerStore>(),
+            Substitute.For<IConnectorFactory>(),
+            Array.Empty<IDocumentParser>(),
+            summarizer,
+            settingsResolver,
+            Substitute.For<Hangfire.IBackgroundJobClient>(),
+            stateBroadcaster,
+            Substitute.For<Microsoft.Extensions.Logging.ILogger<IngestionJobs>>());
+
+        await jobs.PerDocSummaryAsync(documentId, CancellationToken.None);
+
+        await summarizer.DidNotReceiveWithAnyArgs().GenerateAsync(
+            default!, default!, default!, default!, default!, default);
+        // Disabled path does NOT advance state — that's the documented behavior.
+        await docStore.DidNotReceiveWithAnyArgs().UpdateIngestionStateAsync(
+            default!, default, default);
+    }
+}

--- a/tests/Connapse.Background.Tests/Jobs/IngestionJobsHerculesTests.cs
+++ b/tests/Connapse.Background.Tests/Jobs/IngestionJobsHerculesTests.cs
@@ -65,7 +65,7 @@ public class IngestionJobsHerculesTests
 
         // Assert — summarizer is never invoked.
         await summarizer.DidNotReceiveWithAnyArgs().GenerateAsync(
-            default!, default!, default!, default!, default!, default);
+            default!, default!, default!, default!, default!, default!, default);
 
         // State is still advanced to SummaryIndexed so the UI doesn't hang.
         await docStore.Received(1).UpdateIngestionStateAsync(
@@ -123,7 +123,7 @@ public class IngestionJobsHerculesTests
         await jobs.PerDocSummaryAsync(documentId, CancellationToken.None);
 
         await summarizer.DidNotReceiveWithAnyArgs().GenerateAsync(
-            default!, default!, default!, default!, default!, default);
+            default!, default!, default!, default!, default!, default!, default);
         // Disabled path does NOT advance state — that's the documented behavior.
         await docStore.DidNotReceiveWithAnyArgs().UpdateIngestionStateAsync(
             default!, default, default);

--- a/tests/Connapse.Background.Tests/Jobs/IngestionJobsTests.cs
+++ b/tests/Connapse.Background.Tests/Jobs/IngestionJobsTests.cs
@@ -157,7 +157,7 @@ public class IngestionJobsTests
             .Returns(call => Task.FromResult<Stream>(new MemoryStream(System.Text.Encoding.UTF8.GetBytes("Test content"))));
 
         summarizer.GenerateAsync(
-                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<SummarySettings>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new PerDocSummarizationResult(
                 Skipped: false, Summary: "Test summary", InputTokens: 10, OutputTokens: 5, Model: "test")));
@@ -220,7 +220,7 @@ public class IngestionJobsTests
         await jobs.PerDocSummaryAsync(documentId, CancellationToken.None);
 
         await summarizer.DidNotReceive().GenerateAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
             Arg.Any<SummarySettings>(), Arg.Any<CancellationToken>());
         bgClient.DidNotReceive().Create(
             Arg.Any<Hangfire.Common.Job>(), Arg.Any<Hangfire.States.IState>());

--- a/tests/Connapse.Background.Tests/Jobs/IngestionJobsTests.cs
+++ b/tests/Connapse.Background.Tests/Jobs/IngestionJobsTests.cs
@@ -9,7 +9,7 @@ namespace Connapse.Background.Tests.Jobs;
 public class IngestionJobsTests
 {
     [Fact]
-    public async Task IngestAsync_RunsPipelineAndTransitionsStateToIndexed()
+    public async Task IngestAsync_SummaryClusteringMode_TransitionsToIndexedAndEnqueuesPerDocSummary()
     {
         var ingester = Substitute.For<IKnowledgeIngester>();
         var docStore = Substitute.For<IDocumentStore>();
@@ -19,6 +19,14 @@ public class IngestionJobsTests
         var settingsResolver = Substitute.For<IContainerSettingsResolver>();
         var bgClient = Substitute.For<Hangfire.IBackgroundJobClient>();
         var logger = Substitute.For<Microsoft.Extensions.Logging.ILogger<IngestionJobs>>();
+
+        Guid containerId = Guid.NewGuid();
+        settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new SummarySettings
+            {
+                Enabled = true,
+                ContainerSummaryMethod = SummaryStrategy.SummaryClustering,
+            }));
 
         var containerStore = Substitute.For<IContainerStore>();
         var connectorFactory = Substitute.For<IConnectorFactory>();
@@ -32,15 +40,64 @@ public class IngestionJobsTests
             DocumentId: documentId,
             FileName: "test.txt",
             ContentType: "text/plain",
-            ContainerId: Guid.NewGuid().ToString());
+            ContainerId: containerId.ToString());
 
         await jobs.IngestAsync(documentId, options, CancellationToken.None);
 
         await ingester.Received(1).IngestByIdAsync(
             documentId, options, Arg.Any<CancellationToken>());
 
+        // Eager mode: state transitions to Indexed and a follow-up PerDocSummary job is enqueued.
         await docStore.Received(1).UpdateIngestionStateAsync(
             documentId, IngestionState.Indexed, Arg.Any<CancellationToken>());
+        bgClient.Received(1).Create(
+            Arg.Any<Hangfire.Common.Job>(),
+            Arg.Is<Hangfire.States.IState>(s => s is Hangfire.States.EnqueuedState));
+    }
+
+    [Fact]
+    public async Task IngestAsync_DocumentClusteringMode_TransitionsDirectlyToSummaryIndexedNoEnqueue()
+    {
+        var ingester = Substitute.For<IKnowledgeIngester>();
+        var docStore = Substitute.For<IDocumentStore>();
+        var parsers = Array.Empty<IDocumentParser>();
+        var summarizer = Substitute.For<IPerDocSummarizer>();
+        var settingsResolver = Substitute.For<IContainerSettingsResolver>();
+        var bgClient = Substitute.For<Hangfire.IBackgroundJobClient>();
+        var logger = Substitute.For<Microsoft.Extensions.Logging.ILogger<IngestionJobs>>();
+
+        Guid containerId = Guid.NewGuid();
+        settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new SummarySettings
+            {
+                Enabled = true,
+                ContainerSummaryMethod = SummaryStrategy.DocumentClustering,
+            }));
+
+        var containerStore = Substitute.For<IContainerStore>();
+        var connectorFactory = Substitute.For<IConnectorFactory>();
+        var stateBroadcaster = Substitute.For<IIngestionStateBroadcaster>();
+        var jobs = new IngestionJobs(
+            ingester, docStore, containerStore, connectorFactory, parsers, summarizer,
+            settingsResolver, bgClient, stateBroadcaster, logger);
+
+        string documentId = Guid.NewGuid().ToString();
+        var options = new IngestionOptions(
+            DocumentId: documentId,
+            FileName: "test.txt",
+            ContentType: "text/plain",
+            ContainerId: containerId.ToString());
+
+        await jobs.IngestAsync(documentId, options, CancellationToken.None);
+
+        // Lazy mode: terminal state is SummaryIndexed; no PerDoc job is enqueued.
+        await docStore.Received(1).UpdateIngestionStateAsync(
+            documentId, IngestionState.SummaryIndexed, Arg.Any<CancellationToken>());
+        await docStore.DidNotReceive().UpdateIngestionStateAsync(
+            documentId, IngestionState.Indexed, Arg.Any<CancellationToken>());
+        bgClient.DidNotReceive().Create(
+            Arg.Any<Hangfire.Common.Job>(),
+            Arg.Is<Hangfire.States.IState>(s => s is Hangfire.States.EnqueuedState));
     }
 
     [Fact]

--- a/tests/Connapse.Background.Tests/Jobs/IngestionJobsTests.cs
+++ b/tests/Connapse.Background.Tests/Jobs/IngestionJobsTests.cs
@@ -76,7 +76,15 @@ public class IngestionJobsTests
                 IngestionState: IngestionState.Indexed)));
 
         settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new SummarySettings { Enabled = true }));
+            .Returns(Task.FromResult(new SummarySettings
+            {
+                Enabled = true,
+                // Explicit: this test exercises the eager summary-clustering path, where
+                // PerDocSummaryAsync actually invokes the summarizer. The new default
+                // (document-clustering) takes a separate early-return path covered by
+                // IngestionJobsHerculesTests.
+                ContainerSummaryMethod = SummaryStrategy.SummaryClustering,
+            }));
 
         // Container/connector chain: GetAsync → connector → ReadFileAsync
         var container = new Container(

--- a/tests/Connapse.Background.Tests/Jobs/SummaryJobsHashTests.cs
+++ b/tests/Connapse.Background.Tests/Jobs/SummaryJobsHashTests.cs
@@ -1,0 +1,88 @@
+using Connapse.Background.Jobs;
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Background.Tests.Jobs;
+
+/// <summary>
+/// Unit tests for the doc-set hash function used by <see cref="SummaryJobs.RollupContainerAsync"/>
+/// to short-circuit no-op rollups. Verifies the post-HERCULES formula
+/// <c>(docId, content_hash)</c> behaves deterministically and is content-sensitive.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SummaryJobsHashTests
+{
+    private static Document MakeDoc(string id, string contentHash) => new(
+        Id: id,
+        ContainerId: Guid.NewGuid().ToString(),
+        FileName: "f.txt",
+        ContentType: "text/plain",
+        Path: "/f.txt",
+        SizeBytes: 1,
+        CreatedAt: DateTime.UtcNow,
+        Metadata: new Dictionary<string, string> { ["ContentHash"] = contentHash });
+
+    [Fact]
+    public void ComputeDocSetHash_SameContent_OrderIndependent_ProducesSameHash()
+    {
+        var docsA = new[]
+        {
+            MakeDoc("11111111-1111-1111-1111-111111111111", "hash-a"),
+            MakeDoc("22222222-2222-2222-2222-222222222222", "hash-b"),
+        };
+        var docsB = new[]
+        {
+            MakeDoc("22222222-2222-2222-2222-222222222222", "hash-b"),
+            MakeDoc("11111111-1111-1111-1111-111111111111", "hash-a"),
+        };
+
+        SummaryJobs.ComputeDocSetHash(docsA).Should().Be(SummaryJobs.ComputeDocSetHash(docsB));
+    }
+
+    [Fact]
+    public void ComputeDocSetHash_DifferentContentHash_ProducesDifferentHash()
+    {
+        string hashA = SummaryJobs.ComputeDocSetHash(new[] { MakeDoc("11111111-1111-1111-1111-111111111111", "hash-a") });
+        string hashB = SummaryJobs.ComputeDocSetHash(new[] { MakeDoc("11111111-1111-1111-1111-111111111111", "hash-b") });
+
+        hashA.Should().NotBe(hashB);
+    }
+
+    [Fact]
+    public void ComputeDocSetHash_DifferentDocIds_ProducesDifferentHash()
+    {
+        string hashA = SummaryJobs.ComputeDocSetHash(new[] { MakeDoc("11111111-1111-1111-1111-111111111111", "hash-a") });
+        string hashB = SummaryJobs.ComputeDocSetHash(new[] { MakeDoc("22222222-2222-2222-2222-222222222222", "hash-a") });
+
+        hashA.Should().NotBe(hashB);
+    }
+
+    [Fact]
+    public void ComputeDocSetHash_MissingContentHashKey_TreatsAsEmpty_NoThrow()
+    {
+        var docs = new[]
+        {
+            new Document(
+                Id: Guid.NewGuid().ToString(),
+                ContainerId: Guid.NewGuid().ToString(),
+                FileName: "f.txt",
+                ContentType: "text/plain",
+                Path: "/f.txt",
+                SizeBytes: 1,
+                CreatedAt: DateTime.UtcNow,
+                Metadata: new Dictionary<string, string>()) // no ContentHash key
+        };
+
+        Action act = () => SummaryJobs.ComputeDocSetHash(docs);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ComputeDocSetHash_EmptyInput_ReturnsStableHashOfEmptyString()
+    {
+        string hash = SummaryJobs.ComputeDocSetHash(Array.Empty<Document>());
+        hash.Should().NotBeNullOrEmpty();
+        // Same input should always produce the same hash; two empty runs must match.
+        hash.Should().Be(SummaryJobs.ComputeDocSetHash(Array.Empty<Document>()));
+    }
+}

--- a/tests/Connapse.Background.Tests/Jobs/SummaryJobsHerculesTests.cs
+++ b/tests/Connapse.Background.Tests/Jobs/SummaryJobsHerculesTests.cs
@@ -57,7 +57,7 @@ public class SummaryJobsHerculesTests
         await collected.EmbeddingProvider.DidNotReceiveWithAnyArgs().GetSummaryEmbeddingsAsync(
             default!, default);
         await collected.PerDocSummarizer.DidNotReceiveWithAnyArgs().GenerateAsync(
-            default!, default!, default!, default!, default!, default);
+            default!, default!, default!, default!, default!, default!, default);
     }
 
     [Fact]
@@ -119,7 +119,7 @@ public class SummaryJobsHerculesTests
         // and would call the LLM provider, but we don't stub one so it'd return null /
         // produce a skipped result — either way, the summarizer assertion holds.
         await collected.PerDocSummarizer.DidNotReceiveWithAnyArgs().GenerateAsync(
-            default!, default!, default!, default!, default!, default);
+            default!, default!, default!, default!, default!, default!, default);
     }
 
     // ── Test-only helpers ──────────────────────────────────────────────────

--- a/tests/Connapse.Background.Tests/Jobs/SummaryJobsHerculesTests.cs
+++ b/tests/Connapse.Background.Tests/Jobs/SummaryJobsHerculesTests.cs
@@ -1,0 +1,197 @@
+using Connapse.Background.Jobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Llm;
+using NSubstitute;
+
+namespace Connapse.Background.Tests.Jobs;
+
+/// <summary>
+/// Routing tests for <see cref="SummaryJobs.RollupContainerAsync"/> branching on
+/// <see cref="SummarySettings.ContainerSummaryMethod"/>. Each test exercises one
+/// branch by setting up just enough state to prove the right collaborator was
+/// (or wasn't) called.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SummaryJobsHerculesTests
+{
+    [Fact]
+    public async Task RollupContainerAsync_DocumentClusteringMode_QueriesPooledEmbeddingsNotSummaryEmbeddings()
+    {
+        // Arrange — 35 docs (above stuff threshold) in document-clustering mode.
+        Guid containerId = Guid.NewGuid();
+
+        var docs = Enumerable.Range(0, 35).Select(i => new Document(
+            Id: Guid.NewGuid().ToString(),
+            ContainerId: containerId.ToString(),
+            FileName: $"f{i}.txt",
+            ContentType: "text/plain",
+            Path: $"/f{i}.txt",
+            SizeBytes: 1,
+            CreatedAt: DateTime.UtcNow,
+            Metadata: new Dictionary<string, string> { ["ContentHash"] = $"hash-{i}" },
+            Summary: null,
+            SummaryGeneratedAt: null,
+            SummaryContentHash: null,
+            IngestionState: IngestionState.SummaryIndexed)).ToList();
+
+        var (jobs, mocks) = BuildJobs(out var collected);
+        collected.SetupContainer(containerId, summaryDocSetHash: null);
+        collected.SetupSettings(containerId, SummaryStrategy.DocumentClustering);
+        collected.DocStore.ListAsync(containerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Document>>(docs));
+        // Return empty pooled embeddings so the rollup exits early after the call — we only
+        // need to prove WHICH collaborator was invoked.
+        collected.VectorStore.GetPooledDocumentEmbeddingsAsync(containerId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<(Guid DocumentId, float[] Embedding)>>(
+                Array.Empty<(Guid, float[])>()));
+
+        // Act
+        await jobs.RollupContainerAsync(containerId, CancellationToken.None);
+
+        // Assert: document-clustering path called the pooled-embeddings query, NOT the summary
+        // embedding provider. The PerDocSummarizer wasn't called either (no medoids selected).
+        await collected.VectorStore.Received(1).GetPooledDocumentEmbeddingsAsync(
+            containerId, Arg.Any<CancellationToken>());
+        await collected.EmbeddingProvider.DidNotReceiveWithAnyArgs().GetSummaryEmbeddingsAsync(
+            default!, default);
+        await collected.PerDocSummarizer.DidNotReceiveWithAnyArgs().GenerateAsync(
+            default!, default!, default!, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task RollupContainerAsync_SummaryClusteringMode_DoesNotQueryPooledEmbeddings()
+    {
+        // Arrange — empty container in summary-clustering mode. Just need to prove the
+        // pooled-embeddings query was NOT called.
+        Guid containerId = Guid.NewGuid();
+
+        var (jobs, mocks) = BuildJobs(out var collected);
+        collected.SetupContainer(containerId, summaryDocSetHash: null);
+        collected.SetupSettings(containerId, SummaryStrategy.SummaryClustering);
+        collected.DocStore.ListAsync(containerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Document>>(Array.Empty<Document>()));
+
+        // Act
+        await jobs.RollupContainerAsync(containerId, CancellationToken.None);
+
+        // Assert: summary-clustering path did NOT touch the pooled-embeddings query.
+        await collected.VectorStore.DidNotReceiveWithAnyArgs().GetPooledDocumentEmbeddingsAsync(
+            default, default);
+    }
+
+    [Fact]
+    public async Task RollupDocumentClusteringAsync_CacheHit_SkipsPerDocSummarizerCall()
+    {
+        // Arrange — 1 doc (≤ StuffThreshold, so we take the stuff regime path and skip the
+        // pooled-embeddings query entirely), cache state matches its content hash.
+        Guid containerId = Guid.NewGuid();
+        string docId = Guid.NewGuid().ToString();
+        const string contentHash = "matching-hash";
+
+        var doc = new Document(
+            Id: docId,
+            ContainerId: containerId.ToString(),
+            FileName: "cached.txt",
+            ContentType: "text/plain",
+            Path: "/cached.txt",
+            SizeBytes: 1,
+            CreatedAt: DateTime.UtcNow,
+            Metadata: new Dictionary<string, string> { ["ContentHash"] = contentHash },
+            Summary: "Cached summary text",
+            SummaryGeneratedAt: DateTime.UtcNow.AddDays(-1),
+            SummaryContentHash: contentHash,
+            IngestionState: IngestionState.SummaryIndexed);
+
+        var (jobs, mocks) = BuildJobs(out var collected);
+        collected.SetupContainer(containerId, summaryDocSetHash: null);
+        collected.SetupSettings(containerId, SummaryStrategy.DocumentClustering);
+        collected.DocStore.ListAsync(containerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Document>>(new[] { doc }));
+
+        // Act
+        await jobs.RollupContainerAsync(containerId, CancellationToken.None);
+
+        // Assert — cache hit means PerDocSummarizer is NEVER invoked. The reduce step runs
+        // and would call the LLM provider, but we don't stub one so it'd return null /
+        // produce a skipped result — either way, the summarizer assertion holds.
+        await collected.PerDocSummarizer.DidNotReceiveWithAnyArgs().GenerateAsync(
+            default!, default!, default!, default!, default!, default);
+    }
+
+    // ── Test-only helpers ──────────────────────────────────────────────────
+
+    private static (SummaryJobs Jobs, object _) BuildJobs(out Mocks collected)
+    {
+        var containerStore = Substitute.For<IContainerStore>();
+        var docStore = Substitute.For<IDocumentStore>();
+        var settingsResolver = Substitute.For<IContainerSettingsResolver>();
+        var embeddingProvider = Substitute.For<IDocumentSummaryEmbeddingProvider>();
+        var vectorStore = Substitute.For<IVectorStore>();
+        var perDocSummarizer = Substitute.For<IPerDocSummarizer>();
+        var connectorFactory = Substitute.For<IConnectorFactory>();
+        var parsers = Array.Empty<IDocumentParser>();
+        SummaryLlmResolver llmResolver = CreateLlmResolverSubstitute();
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        var bgClient = Substitute.For<Hangfire.IBackgroundJobClient>();
+        var logger = Substitute.For<Microsoft.Extensions.Logging.ILogger<SummaryJobs>>();
+
+        var jobs = new SummaryJobs(
+            containerStore, docStore, settingsResolver, embeddingProvider,
+            vectorStore, perDocSummarizer, connectorFactory, parsers,
+            llmResolver, tokenCounter, bgClient, logger);
+
+        collected = new Mocks(
+            containerStore, docStore, settingsResolver, embeddingProvider,
+            vectorStore, perDocSummarizer);
+        return (jobs, new object());
+    }
+
+    private static SummaryLlmResolver CreateLlmResolverSubstitute()
+    {
+        var optionsMonitor = Substitute.For<Microsoft.Extensions.Options.IOptionsMonitor<LlmSettings>>();
+        optionsMonitor.CurrentValue.Returns(new LlmSettings { Provider = "" });
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        return new SummaryLlmResolver(optionsMonitor, serviceProvider);
+    }
+
+    private sealed record Mocks(
+        IContainerStore ContainerStore,
+        IDocumentStore DocStore,
+        IContainerSettingsResolver SettingsResolver,
+        IDocumentSummaryEmbeddingProvider EmbeddingProvider,
+        IVectorStore VectorStore,
+        IPerDocSummarizer PerDocSummarizer)
+    {
+        public void SetupContainer(Guid id, string? summaryDocSetHash)
+        {
+            ContainerStore.GetAsync(id, Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<Container?>(new Container(
+                    Id: id.ToString(),
+                    Name: "test",
+                    Description: null,
+                    ConnectorType: ConnectorType.Filesystem,
+                    CreatedAt: DateTime.UtcNow,
+                    UpdatedAt: DateTime.UtcNow,
+                    DocumentCount: 0,
+                    SettingsOverrides: null,
+                    ConnectorConfig: null,
+                    Summary: null,
+                    SummaryGeneratedAt: null,
+                    SummaryDocSetHash: summaryDocSetHash)));
+        }
+
+        public void SetupSettings(Guid containerId, string method)
+        {
+            SettingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(new SummarySettings
+                {
+                    Enabled = true,
+                    ContainerSummaryMethod = method,
+                }));
+        }
+    }
+}

--- a/tests/Connapse.Background.Tests/Jobs/SummaryJobsTests.cs
+++ b/tests/Connapse.Background.Tests/Jobs/SummaryJobsTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Connapse.Background.Jobs;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
@@ -168,6 +169,23 @@ public class SummaryJobsTests
         bgClient.Received(3).Create(
             Arg.Any<Hangfire.Common.Job>(),
             Arg.Is<Hangfire.States.IState>(s => s is Hangfire.States.EnqueuedState));
+    }
+
+    [Fact]
+    public void RollupContainerAsync_HasNoAutomaticRetry()
+    {
+        // The recurring SweepStaleContainersAsync re-enqueues any still-stale container every
+        // cycle, so a failed rollup is naturally retried on the next sweep tick — the sweep IS
+        // the retry loop. Hangfire's own AutomaticRetry would instead stack Scheduled jobs on top
+        // of the sweep's enqueues, and that duplicate pile-up under concurrent rollups is what
+        // exhausted the Postgres connection pool. Lock Attempts == 0 so a well-meaning re-add of
+        // the default retry attribute can't silently regress it.
+        MethodInfo? method = typeof(SummaryJobs).GetMethod(nameof(SummaryJobs.RollupContainerAsync));
+        Assert.NotNull(method);
+
+        var retry = method!.GetCustomAttribute<Hangfire.AutomaticRetryAttribute>();
+        Assert.NotNull(retry);
+        Assert.Equal(0, retry!.Attempts);
     }
 
     private static SummaryLlmResolver CreateLlmResolverSubstitute()

--- a/tests/Connapse.Background.Tests/Jobs/SummaryJobsTests.cs
+++ b/tests/Connapse.Background.Tests/Jobs/SummaryJobsTests.cs
@@ -68,7 +68,8 @@ public class SummaryJobsTests
         Guid containerId = Guid.NewGuid();
         string docId = Guid.NewGuid().ToString();
         const string docSummary = "Summary text";
-        string expectedHash = ComputeExpectedHash(docId, docSummary);
+        const string contentHash = "deadbeef-content-hash";
+        string expectedHash = ComputeExpectedHash(docId, contentHash);
 
         containerStore.GetAsync(containerId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<Container?>(new Container(
@@ -86,7 +87,12 @@ public class SummaryJobsTests
                 SummaryDocSetHash: expectedHash)));
 
         settingsResolver.GetSummarySettingsAsync(containerId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new SummarySettings { Enabled = true }));
+            .Returns(Task.FromResult(new SummarySettings
+            {
+                Enabled = true,
+                // Pin to summary-clustering: this test exercises the eager-mode hash short-circuit.
+                ContainerSummaryMethod = SummaryStrategy.SummaryClustering,
+            }));
 
         docStore.ListAsync(containerId, Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>(),
                 Arg.Any<CancellationToken>())
@@ -100,10 +106,10 @@ public class SummaryJobsTests
                     Path: "/a.txt",
                     SizeBytes: 100,
                     CreatedAt: DateTime.UtcNow,
-                    Metadata: new Dictionary<string, string>(),
+                    Metadata: new Dictionary<string, string> { ["ContentHash"] = contentHash },
                     Summary: docSummary,
                     SummaryGeneratedAt: DateTime.UtcNow,
-                    SummaryContentHash: "abc",
+                    SummaryContentHash: contentHash,
                     IngestionState: IngestionState.SummaryIndexed)
             }));
 
@@ -157,7 +163,8 @@ public class SummaryJobsTests
         return new SummaryLlmResolver(optionsMonitor, serviceProvider);
     }
 
-    private static string ComputeExpectedHash(string docId, string summary) =>
-        // Must match SummaryJobs.ComputeDocSetHash logic exactly.
-        HexHash.Sha256(string.Join("\n", new[] { $"{docId}|{HexHash.Sha256(summary)}" }));
+    private static string ComputeExpectedHash(string docId, string contentHash) =>
+        // Must match SummaryJobs.ComputeDocSetHash logic exactly — post-HERCULES this
+        // hashes (docId, content_hash) pairs, not (docId, sha256(summary)).
+        HexHash.Sha256(string.Join("\n", new[] { $"{docId}|{contentHash}" }));
 }

--- a/tests/Connapse.Background.Tests/Jobs/SummaryJobsTests.cs
+++ b/tests/Connapse.Background.Tests/Jobs/SummaryJobsTests.cs
@@ -4,6 +4,7 @@ using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
 using Connapse.Storage.Llm;
+using FluentAssertions;
 using NSubstitute;
 
 namespace Connapse.Background.Tests.Jobs;
@@ -181,11 +182,11 @@ public class SummaryJobsTests
         // exhausted the Postgres connection pool. Lock Attempts == 0 so a well-meaning re-add of
         // the default retry attribute can't silently regress it.
         MethodInfo? method = typeof(SummaryJobs).GetMethod(nameof(SummaryJobs.RollupContainerAsync));
-        Assert.NotNull(method);
+        method.Should().NotBeNull();
 
         var retry = method!.GetCustomAttribute<Hangfire.AutomaticRetryAttribute>();
-        Assert.NotNull(retry);
-        Assert.Equal(0, retry!.Attempts);
+        retry.Should().NotBeNull();
+        retry!.Attempts.Should().Be(0);
     }
 
     private static SummaryLlmResolver CreateLlmResolverSubstitute()

--- a/tests/Connapse.Background.Tests/Jobs/SummaryJobsTests.cs
+++ b/tests/Connapse.Background.Tests/Jobs/SummaryJobsTests.cs
@@ -17,6 +17,10 @@ public class SummaryJobsTests
         var docStore = Substitute.For<IDocumentStore>();
         var settingsResolver = Substitute.For<IContainerSettingsResolver>();
         var embeddingProvider = Substitute.For<IDocumentSummaryEmbeddingProvider>();
+        var vectorStore = Substitute.For<IVectorStore>();
+        var perDocSummarizer = Substitute.For<IPerDocSummarizer>();
+        var connectorFactory = Substitute.For<IConnectorFactory>();
+        var parsers = Array.Empty<IDocumentParser>();
         SummaryLlmResolver llmResolver = CreateLlmResolverSubstitute();
         var tokenCounter = Substitute.For<ITokenCounter>();
         var bgClient = Substitute.For<Hangfire.IBackgroundJobClient>();
@@ -44,6 +48,7 @@ public class SummaryJobsTests
 
         var jobs = new SummaryJobs(
             containerStore, docStore, settingsResolver, embeddingProvider,
+            vectorStore, perDocSummarizer, connectorFactory, parsers,
             llmResolver, tokenCounter, bgClient, logger);
 
         await jobs.RollupContainerAsync(containerId, CancellationToken.None);
@@ -60,6 +65,10 @@ public class SummaryJobsTests
         var docStore = Substitute.For<IDocumentStore>();
         var settingsResolver = Substitute.For<IContainerSettingsResolver>();
         var embeddingProvider = Substitute.For<IDocumentSummaryEmbeddingProvider>();
+        var vectorStore = Substitute.For<IVectorStore>();
+        var perDocSummarizer = Substitute.For<IPerDocSummarizer>();
+        var connectorFactory = Substitute.For<IConnectorFactory>();
+        var parsers = Array.Empty<IDocumentParser>();
         SummaryLlmResolver llmResolver = CreateLlmResolverSubstitute();
         var tokenCounter = Substitute.For<ITokenCounter>();
         var bgClient = Substitute.For<Hangfire.IBackgroundJobClient>();
@@ -115,6 +124,7 @@ public class SummaryJobsTests
 
         var jobs = new SummaryJobs(
             containerStore, docStore, settingsResolver, embeddingProvider,
+            vectorStore, perDocSummarizer, connectorFactory, parsers,
             llmResolver, tokenCounter, bgClient, logger);
 
         await jobs.RollupContainerAsync(containerId, CancellationToken.None);
@@ -134,6 +144,10 @@ public class SummaryJobsTests
         var docStore = Substitute.For<IDocumentStore>();
         var settingsResolver = Substitute.For<IContainerSettingsResolver>();
         var embeddingProvider = Substitute.For<IDocumentSummaryEmbeddingProvider>();
+        var vectorStore = Substitute.For<IVectorStore>();
+        var perDocSummarizer = Substitute.For<IPerDocSummarizer>();
+        var connectorFactory = Substitute.For<IConnectorFactory>();
+        var parsers = Array.Empty<IDocumentParser>();
         SummaryLlmResolver llmResolver = CreateLlmResolverSubstitute();
         var tokenCounter = Substitute.For<ITokenCounter>();
         var bgClient = Substitute.For<Hangfire.IBackgroundJobClient>();
@@ -145,6 +159,7 @@ public class SummaryJobsTests
 
         var jobs = new SummaryJobs(
             containerStore, docStore, settingsResolver, embeddingProvider,
+            vectorStore, perDocSummarizer, connectorFactory, parsers,
             llmResolver, tokenCounter, bgClient, logger);
 
         await jobs.SweepStaleContainersAsync(CancellationToken.None);

--- a/tests/Connapse.Core.Tests/Llm/OllamaLlmProviderTests.cs
+++ b/tests/Connapse.Core.Tests/Llm/OllamaLlmProviderTests.cs
@@ -6,6 +6,7 @@ using Connapse.Core.Tests.Utilities;
 using Connapse.Storage.Llm;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 
 namespace Connapse.Core.Tests.Llm;
@@ -15,20 +16,26 @@ public class OllamaLlmProviderTests
 {
     private static OllamaLlmProvider CreateProvider(
         HttpMessageHandler handler,
-        LlmSettings? settings = null)
+        LlmSettings? settings = null,
+        LlmConcurrencyGate? gate = null)
     {
-        var httpClient = new HttpClient(handler)
-        {
-            BaseAddress = new Uri("http://localhost:11434")
-        };
-        var opts = new TestOptionsSnapshot<LlmSettings>(settings ?? new LlmSettings
+        var resolvedSettings = settings ?? new LlmSettings
         {
             Provider = "Ollama",
             Model = "llama3.2",
             BaseUrl = "http://localhost:11434"
-        });
+        };
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost:11434")
+        };
+        var opts = new TestOptionsSnapshot<LlmSettings>(resolvedSettings);
         var logger = Substitute.For<ILogger<OllamaLlmProvider>>();
-        return new OllamaLlmProvider(httpClient, opts, logger);
+        return new OllamaLlmProvider(
+            httpClient,
+            opts,
+            logger,
+            gate ?? new LlmConcurrencyGate(Options.Create(resolvedSettings)));
     }
 
     [Fact]
@@ -118,6 +125,33 @@ public class OllamaLlmProviderTests
         provider.ResolveModel(options).Should().Be("qwen3:14b");
     }
 
+    [Fact]
+    public async Task CompleteAsync_ConcurrentCalls_AreSerializedByGate()
+    {
+        // Regression guard for the Ollama queue-saturation timeout: with MaxConcurrentRequests=1
+        // the provider must let only ONE /api/chat call reach Ollama at a time, even when many
+        // callers invoke CompleteAsync at once. Without the gate, all N hit Ollama together,
+        // its internal queue backs up, and the tail requests blow past HttpClient.Timeout.
+        var json = """{"message":{"role":"assistant","content":"ok"},"done":true}""";
+        var handler = new ConcurrencyTrackingHandler(json, TimeSpan.FromMilliseconds(75));
+        var settings = new LlmSettings
+        {
+            Provider = "Ollama",
+            Model = "llama3.2",
+            BaseUrl = "http://localhost:11434",
+            MaxConcurrentRequests = 1,
+        };
+        var provider = CreateProvider(handler, settings);
+
+        var tasks = Enumerable.Range(0, 6)
+            .Select(_ => provider.CompleteAsync("system", "hi"))
+            .ToArray();
+        await Task.WhenAll(tasks);
+
+        handler.MaxObservedConcurrency.Should().Be(1,
+            "the concurrency gate must serialize Ollama calls to MaxConcurrentRequests");
+    }
+
     /// <summary>
     /// Minimal HttpMessageHandler stub that returns a canned response.
     /// </summary>
@@ -145,5 +179,44 @@ public class OllamaLlmProviderTests
                     ? new StringContent(_content, Encoding.UTF8, "application/json")
                     : null
             });
+    }
+
+    /// <summary>
+    /// Handler that records the peak number of requests in flight at once, so a test can
+    /// assert the provider never lets more than the gate limit reach Ollama concurrently.
+    /// </summary>
+    private sealed class ConcurrencyTrackingHandler(string content, TimeSpan delay) : HttpMessageHandler
+    {
+        private int _current;
+        private int _maxObserved;
+
+        public int MaxObservedConcurrency => Volatile.Read(ref _maxObserved);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            int inFlight = Interlocked.Increment(ref _current);
+            UpdateMax(inFlight);
+            try
+            {
+                await Task.Delay(delay, cancellationToken);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _current);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(content, Encoding.UTF8, "application/json")
+            };
+        }
+
+        private void UpdateMax(int observed)
+        {
+            int current;
+            while (observed > (current = Volatile.Read(ref _maxObserved)))
+                Interlocked.CompareExchange(ref _maxObserved, observed, current);
+        }
     }
 }

--- a/tests/Connapse.Eval/Judges/SummaryJudge.cs
+++ b/tests/Connapse.Eval/Judges/SummaryJudge.cs
@@ -24,9 +24,9 @@ public sealed class SummaryJudge(ILlmProvider judge)
             1. Names what + when (specific entities, scope, time range): __
             2. Pushy against undertriggering (enumerates trigger terms): __
             3. Concrete trigger terms (not abstract categories): __
-            4. States what's NOT covered (negative scope): __
+            4. Calibrated scope (states exclusions only when the corpus clearly supports them; hedges otherwise): __
             5. Defines or namespaces specialized terms: __
-            6. Uses imperative voice ("Use when…", "Does not cover…"): __
+            6. Uses imperative voice ("Use when…"): __
             7. Briefs like a new hire (decision-oriented, third person): __
             8. Lists answerable questions: __
 

--- a/tests/Connapse.Ingestion.Tests/Summarization/ContainerSummarizerTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Summarization/ContainerSummarizerTests.cs
@@ -160,4 +160,37 @@ public class ContainerSummarizerTests
             Arg.Is<LlmCompletionOptions?>(o => o != null && o.Model == "claude-sonnet-4-6"),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task GenerateAsync_WithEmptyLlmModel_FallsBackToProviderModel()
+    {
+        // Regression: the settings UI can persist LlmModel as "" (empty string)
+        // rather than null. An empty string is not a valid model — it must be
+        // treated as "no override", not forwarded to the provider as model "".
+        var llmProvider = Substitute.For<ILlmProvider>();
+        llmProvider.ModelId.Returns("default-model");
+        llmProvider.CompleteAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LlmCompletionOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult("rollup"));
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        tokenCounter.CountTokens(Arg.Any<string>()).Returns(10);
+        var summarizer = new ContainerSummarizer(llmProvider, tokenCounter);
+        var docs = new List<DocumentWithSummary>
+        {
+            new(Guid.NewGuid(), "sum1", new float[] { 0.1f })
+        };
+        var settings = new SummarySettings { Enabled = true, LlmModel = "" };
+
+        ContainerSummarizationResult result =
+            await summarizer.GenerateAsync("container", docs, settings, CancellationToken.None);
+
+        // Must NOT forward an empty model override.
+        await llmProvider.Received(1).CompleteAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Is<LlmCompletionOptions?>(o => o == null || !string.IsNullOrWhiteSpace(o.Model)),
+            Arg.Any<CancellationToken>());
+
+        // Reported model falls back to the provider default, not "".
+        result.Model.Should().Be("default-model");
+    }
 }

--- a/tests/Connapse.Ingestion.Tests/Summarization/PerDocSummarizerTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Summarization/PerDocSummarizerTests.cs
@@ -42,7 +42,7 @@ public class PerDocSummarizerTests
 
         PerDocSummarizer subject = new(llm, docStore, tokenCounter);
         SummarySettings settings = new() { Enabled = true };
-        PerDocSummarizationResult result = await subject.GenerateAsync(docId, docText, "text/plain", "file.txt", settings, CancellationToken.None);
+        PerDocSummarizationResult result = await subject.GenerateAsync(docId, hash, docText, "text/plain", "file.txt", settings, CancellationToken.None);
 
         result.Skipped.Should().BeTrue();
         result.SkipReason.Should().Be("content_hash_match");
@@ -68,7 +68,7 @@ public class PerDocSummarizerTests
 
         PerDocSummarizer subject = new(llm, docStore, tokenCounter);
         SummarySettings settings = new() { Enabled = true };
-        PerDocSummarizationResult result = await subject.GenerateAsync(docId, "doc text", "text/plain", "file.txt", settings, CancellationToken.None);
+        PerDocSummarizationResult result = await subject.GenerateAsync(docId, "new_hash", "doc text", "text/plain", "file.txt", settings, CancellationToken.None);
 
         result.Skipped.Should().BeFalse();
         result.Summary.Should().Be("Apple earnings summary");
@@ -76,7 +76,7 @@ public class PerDocSummarizerTests
         result.OutputTokens.Should().Be(100);
 
         await docStore.Received(1).UpdateSummaryAsync(
-            docId, "Apple earnings summary", Arg.Any<DateTime>(), Arg.Any<string>(),
+            docId, "Apple earnings summary", Arg.Any<DateTime>(), "new_hash",
             Arg.Any<CancellationToken>());
     }
 
@@ -90,7 +90,7 @@ public class PerDocSummarizerTests
 
         PerDocSummarizer subject = new(llmProvider: null, docStore, tokenCounter);
         SummarySettings settings = new() { Enabled = true };
-        PerDocSummarizationResult result = await subject.GenerateAsync(docId, "text", "text/plain", "x.txt", settings, CancellationToken.None);
+        PerDocSummarizationResult result = await subject.GenerateAsync(docId, "hash", "text", "text/plain", "x.txt", settings, CancellationToken.None);
 
         result.Skipped.Should().BeTrue();
         result.SkipReason.Should().Be("no_provider_configured");
@@ -107,7 +107,7 @@ public class PerDocSummarizerTests
         PerDocSummarizer subject = new(llm, docStore, tokenCounter);
         SummarySettings settings = new() { Enabled = true };
         PerDocSummarizationResult result = await subject.GenerateAsync(
-            Guid.NewGuid().ToString(), "  \n\t  ", "text/plain", "empty.txt", settings, CancellationToken.None);
+            Guid.NewGuid().ToString(), "hash", "  \n\t  ", "text/plain", "empty.txt", settings, CancellationToken.None);
 
         result.Skipped.Should().BeTrue();
         result.SkipReason.Should().Be("extraction_empty");
@@ -123,7 +123,7 @@ public class PerDocSummarizerTests
         var settings = new SummarySettings { Enabled = false };
 
         var result = await summarizer.GenerateAsync(
-            "doc-1", "some text", "text/plain", "doc.txt", settings, CancellationToken.None);
+            "doc-1", "hash", "some text", "text/plain", "doc.txt", settings, CancellationToken.None);
 
         result.Skipped.Should().BeTrue();
         result.SkipReason.Should().Be("summaries_disabled");
@@ -152,7 +152,7 @@ public class PerDocSummarizerTests
         };
 
         await summarizer.GenerateAsync(
-            "doc-1", "some text", "text/plain", "doc.txt", settings, CancellationToken.None);
+            "doc-1", "hash", "some text", "text/plain", "doc.txt", settings, CancellationToken.None);
 
         await llmProvider.Received(1).CompleteAsync(
             customPrompt,
@@ -177,7 +177,7 @@ public class PerDocSummarizerTests
         var settings = new SummarySettings { Enabled = true, LlmModel = "qwen3:14b" };
 
         await summarizer.GenerateAsync(
-            "doc-1", "text", "text/plain", "doc.txt", settings, CancellationToken.None);
+            "doc-1", "hash", "text", "text/plain", "doc.txt", settings, CancellationToken.None);
 
         await llmProvider.Received(1).CompleteAsync(
             Arg.Any<string>(),
@@ -204,7 +204,7 @@ public class PerDocSummarizerTests
         var settings = new SummarySettings { Enabled = true, MaxInputTokens = 100 };  // 100 tokens × 4 = 400 chars
 
         await summarizer.GenerateAsync(
-            "doc-1", longText, "text/plain", "doc.txt", settings, CancellationToken.None);
+            "doc-1", "hash", longText, "text/plain", "doc.txt", settings, CancellationToken.None);
 
         capturedUserPrompt.Should().NotBeNull();
         capturedUserPrompt!.Should().Contain(new string('a', 400));

--- a/tests/Connapse.Ingestion.Tests/Summarization/PerDocSummarizerTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Summarization/PerDocSummarizerTests.cs
@@ -187,6 +187,40 @@ public class PerDocSummarizerTests
     }
 
     [Fact]
+    public async Task GenerateAsync_WithEmptyLlmModel_FallsBackToProviderModel()
+    {
+        // Regression: the settings UI can persist LlmModel as "" (empty string)
+        // rather than null. An empty string is not a valid model — it must be
+        // treated as "no override", not forwarded to the provider as model "".
+        // Forwarding "" makes Ollama return a non-2xx that surfaces as a
+        // misleading "Failed to connect ... model ''" error.
+        var llmProvider = Substitute.For<ILlmProvider>();
+        llmProvider.ModelId.Returns("default-model");
+        llmProvider.CompleteAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LlmCompletionOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult("generated"));
+
+        var docStore = Substitute.For<IDocumentStore>();
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        tokenCounter.CountTokens(Arg.Any<string>()).Returns(10);
+
+        var summarizer = new PerDocSummarizer(llmProvider, docStore, tokenCounter);
+        var settings = new SummarySettings { Enabled = true, LlmModel = "" };
+
+        var result = await summarizer.GenerateAsync(
+            "doc-1", "hash", "text", "text/plain", "doc.txt", settings, CancellationToken.None);
+
+        // Must NOT forward an empty model override.
+        await llmProvider.Received(1).CompleteAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Is<LlmCompletionOptions?>(o => o == null || !string.IsNullOrWhiteSpace(o.Model)),
+            Arg.Any<CancellationToken>());
+
+        // Reported model falls back to the provider default, not "".
+        result.Model.Should().Be("default-model");
+    }
+
+    [Fact]
     public async Task GenerateAsync_WithMaxInputTokens_TruncatesInputToFourTimesTheLimit()
     {
         var llmProvider = Substitute.For<ILlmProvider>();

--- a/tests/Connapse.Integration.Tests/FindContainersWithStaleSummariesTests.cs
+++ b/tests/Connapse.Integration.Tests/FindContainersWithStaleSummariesTests.cs
@@ -1,0 +1,201 @@
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Data;
+using Connapse.Storage.Data.Entities;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="IDocumentStore.FindContainersWithStaleSummariesAsync"/>.
+/// Drives the sweep that fires off container summary rollups.
+/// </summary>
+/// <remarks>
+/// Regression coverage: before HERCULES the query filtered to docs with non-null Summary,
+/// which silently excluded document-clustering containers (whose docs are mostly
+/// null-summary). The sweep would report "no stale containers" forever and rollups would
+/// never fire. <see cref="DocumentClusteringContainer_NoPerDocSummaries_StillDetectedAsStale"/>
+/// pins the fix.
+/// </remarks>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class FindContainersWithStaleSummariesTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public async Task ContainerWithDocsAndNoSummary_IsDetectedAsStale()
+    {
+        Guid containerId = await SeedContainerAsync("stale-no-summary", containerSummaryAt: null);
+        await SeedDocumentAsync(containerId, "/a.txt", summaryAt: null);
+
+        try
+        {
+            var stale = await GetStaleAsync();
+            stale.Should().Contain(containerId);
+        }
+        finally
+        {
+            await DeleteContainerAsync(containerId);
+        }
+    }
+
+    [Fact]
+    public async Task DocumentClusteringContainer_NoPerDocSummaries_StillDetectedAsStale()
+    {
+        // Document-clustering mode: docs have null per-doc Summary. The sweep MUST still detect
+        // these containers as stale via doc CreatedAt > container.SummaryGeneratedAt (or
+        // container.SummaryGeneratedAt being null on first run).
+        Guid containerId = await SeedContainerAsync("stale-doc-clustering", containerSummaryAt: null);
+        await SeedDocumentAsync(containerId, "/lazy1.txt", summaryAt: null);
+        await SeedDocumentAsync(containerId, "/lazy2.txt", summaryAt: null);
+
+        try
+        {
+            var stale = await GetStaleAsync();
+            stale.Should().Contain(containerId,
+                "post-HERCULES, document-clustering containers must be detected even with all null summaries");
+        }
+        finally
+        {
+            await DeleteContainerAsync(containerId);
+        }
+    }
+
+    [Fact]
+    public async Task ContainerWithFreshSummary_NoDocChanges_IsNotStale()
+    {
+        DateTime now = DateTime.UtcNow;
+        Guid containerId = await SeedContainerAsync("not-stale-fresh", containerSummaryAt: now);
+        // Doc created BEFORE the container summary → not stale.
+        await SeedDocumentAsync(containerId, "/a.txt", summaryAt: null, createdAt: now.AddMinutes(-5));
+
+        try
+        {
+            var stale = await GetStaleAsync();
+            stale.Should().NotContain(containerId);
+        }
+        finally
+        {
+            await DeleteContainerAsync(containerId);
+        }
+    }
+
+    [Fact]
+    public async Task ContainerWithFreshSummary_NewDocAdded_IsStale()
+    {
+        DateTime now = DateTime.UtcNow;
+        Guid containerId = await SeedContainerAsync("stale-new-doc", containerSummaryAt: now.AddMinutes(-10));
+        // Doc created AFTER the container summary → stale (covers document-clustering re-rollup trigger).
+        await SeedDocumentAsync(containerId, "/recent.txt", summaryAt: null, createdAt: now);
+
+        try
+        {
+            var stale = await GetStaleAsync();
+            stale.Should().Contain(containerId);
+        }
+        finally
+        {
+            await DeleteContainerAsync(containerId);
+        }
+    }
+
+    [Fact]
+    public async Task ContainerWithFreshSummary_DocReindexedAfter_IsStale()
+    {
+        DateTime now = DateTime.UtcNow;
+        Guid containerId = await SeedContainerAsync("stale-reindex", containerSummaryAt: now.AddMinutes(-10));
+        // Doc was created earlier but re-indexed AFTER the container summary → stale.
+        await SeedDocumentAsync(
+            containerId,
+            "/edited.txt",
+            summaryAt: null,
+            createdAt: now.AddMinutes(-30),
+            lastIndexedAt: now);
+
+        try
+        {
+            var stale = await GetStaleAsync();
+            stale.Should().Contain(containerId);
+        }
+        finally
+        {
+            await DeleteContainerAsync(containerId);
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private async Task<IReadOnlyList<Guid>> GetStaleAsync()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var docStore = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        return await docStore.FindContainersWithStaleSummariesAsync(CancellationToken.None);
+    }
+
+    private async Task<Guid> SeedContainerAsync(string namePrefix, DateTime? containerSummaryAt)
+    {
+        Guid id = Guid.NewGuid();
+        string name = $"{namePrefix}-{id:N}".Substring(0, Math.Min(40, namePrefix.Length + 12));
+
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factoryDb = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var ctx = await factoryDb.CreateDbContextAsync();
+
+        ctx.Containers.Add(new ContainerEntity
+        {
+            Id = id,
+            Name = name,
+            ConnectorType = 0,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            SummaryGeneratedAt = containerSummaryAt,
+        });
+        await ctx.SaveChangesAsync();
+        return id;
+    }
+
+    private async Task SeedDocumentAsync(
+        Guid containerId,
+        string path,
+        DateTime? summaryAt,
+        DateTime? createdAt = null,
+        DateTime? lastIndexedAt = null)
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factoryDb = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var ctx = await factoryDb.CreateDbContextAsync();
+
+        ctx.Documents.Add(new DocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            ContainerId = containerId,
+            FileName = path.TrimStart('/'),
+            ContentType = "text/plain",
+            Path = path,
+            ContentHash = $"hash-{Guid.NewGuid():N}",
+            SizeBytes = 1,
+            ChunkCount = 0,
+            Generation = 1,
+            Status = "Pending",
+            CreatedAt = createdAt ?? DateTime.UtcNow,
+            LastIndexedAt = lastIndexedAt,
+            SummaryGeneratedAt = summaryAt,
+            Metadata = new Dictionary<string, string>(),
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private async Task DeleteContainerAsync(Guid containerId)
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factoryDb = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var ctx = await factoryDb.CreateDbContextAsync();
+
+        // Delete docs first to satisfy FK.
+        var docs = await ctx.Documents.Where(d => d.ContainerId == containerId).ToListAsync();
+        ctx.Documents.RemoveRange(docs);
+        var container = await ctx.Containers.FirstOrDefaultAsync(c => c.Id == containerId);
+        if (container is not null) ctx.Containers.Remove(container);
+        await ctx.SaveChangesAsync();
+    }
+}

--- a/tests/Connapse.Integration.Tests/HerculesEndToEndTests.cs
+++ b/tests/Connapse.Integration.Tests/HerculesEndToEndTests.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// End-to-end coverage for the HERCULES container-summary method swap. Verifies the
+/// document-clustering path through the real ingestion pipeline + Hangfire workers
+/// without requiring a configured LLM provider — the early-return branch in
+/// <c>IngestionJobs.PerDocSummaryAsync</c> doesn't need an LLM.
+/// </summary>
+/// <remarks>
+/// Quality-comparison tests between the two methods belong in the LLM-judge eval harness,
+/// not here. These tests prove the wiring + state machine works correctly.
+/// </remarks>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class HerculesEndToEndTests(SharedWebAppFixture fixture)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    [Fact]
+    public async Task DocumentClusteringMode_PerDocSummaryEarlyReturns_NoSummaryGenerated()
+    {
+        // Arrange: create container with document-clustering enabled
+        var createResponse = await fixture.AdminClient.PostAsJsonAsync("/api/containers",
+            new { Name = $"hercules-lazy-{Guid.NewGuid():N}".Substring(0, Math.Min(40, 50)) });
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var container = await createResponse.Content.ReadFromJsonAsync<ContainerDto>(JsonOptions);
+        container.Should().NotBeNull();
+
+        try
+        {
+            // Enable summaries in document-clustering mode for this container only.
+            var overrides = new ContainerSettingsOverrides
+            {
+                Summary = new SummarySettings
+                {
+                    Enabled = true,
+                    ContainerSummaryMethod = SummaryStrategy.DocumentClustering,
+                }
+            };
+            var putResponse = await fixture.AdminClient.PutAsJsonAsync(
+                $"/api/containers/{container!.Id}/settings", overrides);
+            putResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            // Act: upload a document.
+            string documentId = await UploadDocumentAsync(container.Id, "lazy-doc.txt",
+                "Document content for document-clustering integration test. " +
+                "This content should never be passed to an LLM summarizer because the " +
+                "container is in document-clustering mode.");
+
+            // Wait for both ingestion AND the PerDocSummary job to finish.
+            // In document-clustering mode, PerDocSummary early-returns and transitions to
+            // SummaryIndexed without writing a summary.
+            Document doc = await WaitForIngestionStateAsync(
+                documentId, IngestionState.SummaryIndexed, timeoutSeconds: 60);
+
+            // Assert: the document reached SummaryIndexed without a summary text.
+            doc.Summary.Should().BeNullOrEmpty(
+                "document-clustering mode must not generate per-doc summaries at ingest");
+            doc.SummaryContentHash.Should().BeNullOrEmpty();
+            doc.SummaryGeneratedAt.Should().BeNull();
+        }
+        finally
+        {
+            await fixture.AdminClient.DeleteAsync($"/api/containers/{container!.Id}");
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private async Task<string> UploadDocumentAsync(string containerId, string fileName, string content)
+    {
+        using var multipart = new MultipartFormDataContent();
+        var byteContent = new ByteArrayContent(Encoding.UTF8.GetBytes(content));
+        byteContent.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("text/plain");
+        multipart.Add(byteContent, "files", fileName);
+        multipart.Add(new StringContent("/test"), "path");
+
+        var response = await fixture.AdminClient.PostAsync(
+            $"/api/containers/{containerId}/files", multipart);
+        string body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, because: $"upload body: {body}");
+
+        var upload = await response.Content.ReadFromJsonAsync<UploadResponse>(JsonOptions);
+        upload.Should().NotBeNull();
+        upload!.Documents.Should().NotBeEmpty();
+        return upload.Documents[0].DocumentId;
+    }
+
+    private async Task<Document> WaitForIngestionStateAsync(
+        string documentId, IngestionState expected, int timeoutSeconds)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            await using var scope = fixture.Factory.Services.CreateAsyncScope();
+            var docStore = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+            Document? doc = await docStore.GetAsync(documentId, CancellationToken.None);
+            if (doc is not null)
+            {
+                if (doc.IngestionState == expected)
+                    return doc;
+                if (doc.Metadata.GetValueOrDefault("Status") == "Failed")
+                    throw new Exception(
+                        $"Document {documentId} failed: " +
+                        $"{doc.Metadata.GetValueOrDefault("ErrorMessage", "Unknown error")}");
+            }
+            await Task.Delay(250);
+        }
+        throw new TimeoutException(
+            $"Document {documentId} did not reach state '{expected}' within {timeoutSeconds}s");
+    }
+
+    // DTOs
+
+    private record ContainerDto(string Id, string Name);
+    private record UploadResponse(string? BatchId, List<UploadedDoc> Documents);
+    private record UploadedDoc(string DocumentId, string FileName, long SizeBytes);
+
+    private record DocumentDto(
+        string Id,
+        string ContainerId,
+        string FileName,
+        string Path,
+        long SizeBytes,
+        Dictionary<string, string> Metadata);
+}

--- a/tests/Connapse.Integration.Tests/PgVectorStorePooledEmbeddingsTests.cs
+++ b/tests/Connapse.Integration.Tests/PgVectorStorePooledEmbeddingsTests.cs
@@ -1,0 +1,179 @@
+using System.Net.Http.Json;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Data;
+using Connapse.Storage.Data.Entities;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Pgvector;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="IVectorStore.GetPooledDocumentEmbeddingsAsync"/>.
+/// Exercises the pgvector AVG aggregation path used by the document-clustering
+/// container summary method.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class PgVectorStorePooledEmbeddingsTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public async Task GetPooledDocumentEmbeddingsAsync_OneModelTwoDocs_PoolsAndNormalizes()
+    {
+        // Arrange — create a container, seed 2 docs each with 2 chunk vectors under one model.
+        Guid containerId = await CreateContainerAsync("pool-basic");
+        Guid doc1 = await SeedDocumentAsync(containerId, "/doc1.txt");
+        Guid doc2 = await SeedDocumentAsync(containerId, "/doc2.txt");
+        const string modelId = "pool-test-model";
+
+        await SeedChunkVectorAsync(doc1, containerId, modelId, new float[] { 1f, 0f, 0f });
+        await SeedChunkVectorAsync(doc1, containerId, modelId, new float[] { 0f, 1f, 0f });
+        await SeedChunkVectorAsync(doc2, containerId, modelId, new float[] { 0f, 0f, 1f });
+        await SeedChunkVectorAsync(doc2, containerId, modelId, new float[] { 0f, 0f, 1f });
+
+        try
+        {
+            // Act
+            await using var scope = fixture.Factory.Services.CreateAsyncScope();
+            var vectorStore = scope.ServiceProvider.GetRequiredService<IVectorStore>();
+            var result = await vectorStore.GetPooledDocumentEmbeddingsAsync(containerId, CancellationToken.None);
+
+            // Assert
+            result.Should().HaveCount(2);
+
+            // doc1: avg((1,0,0), (0,1,0)) = (0.5, 0.5, 0) → L2-normalized → (~0.707, ~0.707, 0)
+            var doc1Pooled = result.Single(r => r.DocumentId == doc1).Embedding;
+            doc1Pooled[0].Should().BeApproximately(0.7071f, 0.001f);
+            doc1Pooled[1].Should().BeApproximately(0.7071f, 0.001f);
+            doc1Pooled[2].Should().BeApproximately(0f, 0.001f);
+
+            // doc2: avg((0,0,1), (0,0,1)) = (0,0,1) → L2-normalized → (0,0,1)
+            var doc2Pooled = result.Single(r => r.DocumentId == doc2).Embedding;
+            doc2Pooled[2].Should().BeApproximately(1f, 0.001f);
+        }
+        finally
+        {
+            await fixture.AdminClient.DeleteAsync($"/api/containers/{containerId}");
+        }
+    }
+
+    [Fact]
+    public async Task GetPooledDocumentEmbeddingsAsync_MixedModels_UsesDominant()
+    {
+        Guid containerId = await CreateContainerAsync("pool-mixed");
+        Guid docA1 = await SeedDocumentAsync(containerId, "/a1.txt");
+        Guid docA2 = await SeedDocumentAsync(containerId, "/a2.txt");
+        Guid docB = await SeedDocumentAsync(containerId, "/b.txt");
+
+        // Dominant model: model-A with 2 vectors
+        await SeedChunkVectorAsync(docA1, containerId, "model-A", new float[] { 1f, 0f });
+        await SeedChunkVectorAsync(docA2, containerId, "model-A", new float[] { 0f, 1f });
+        // Non-dominant: model-B with 1 vector (different dimensionality, but it gets filtered out)
+        await SeedChunkVectorAsync(docB, containerId, "model-B", new float[] { 1f, 0f, 0f });
+
+        try
+        {
+            await using var scope = fixture.Factory.Services.CreateAsyncScope();
+            var vectorStore = scope.ServiceProvider.GetRequiredService<IVectorStore>();
+            var result = await vectorStore.GetPooledDocumentEmbeddingsAsync(containerId, CancellationToken.None);
+
+            result.Should().HaveCount(2);
+            result.Select(r => r.DocumentId).Should().BeEquivalentTo(new[] { docA1, docA2 });
+        }
+        finally
+        {
+            await fixture.AdminClient.DeleteAsync($"/api/containers/{containerId}");
+        }
+    }
+
+    [Fact]
+    public async Task GetPooledDocumentEmbeddingsAsync_NoVectors_ReturnsEmpty()
+    {
+        Guid containerId = await CreateContainerAsync("pool-empty");
+        try
+        {
+            await using var scope = fixture.Factory.Services.CreateAsyncScope();
+            var vectorStore = scope.ServiceProvider.GetRequiredService<IVectorStore>();
+            var result = await vectorStore.GetPooledDocumentEmbeddingsAsync(containerId, CancellationToken.None);
+
+            result.Should().BeEmpty();
+        }
+        finally
+        {
+            await fixture.AdminClient.DeleteAsync($"/api/containers/{containerId}");
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private async Task<Guid> CreateContainerAsync(string nameSuffix)
+    {
+        // Use unique name to avoid collisions across reruns in the same fixture lifetime.
+        string name = $"{nameSuffix}-{Guid.NewGuid():N}".Substring(0, Math.Min(63, nameSuffix.Length + 10));
+        var response = await fixture.AdminClient.PostAsJsonAsync("/api/containers",
+            new { Name = name });
+        response.EnsureSuccessStatusCode();
+        var container = await response.Content.ReadFromJsonAsync<ContainerDto>();
+        return Guid.Parse(container!.Id);
+    }
+
+    private async Task<Guid> SeedDocumentAsync(Guid containerId, string path)
+    {
+        Guid docId = Guid.NewGuid();
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factoryDb = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var ctx = await factoryDb.CreateDbContextAsync();
+        ctx.Documents.Add(new DocumentEntity
+        {
+            Id = docId,
+            ContainerId = containerId,
+            FileName = path.TrimStart('/'),
+            ContentType = "text/plain",
+            Path = path,
+            ContentHash = string.Empty,
+            SizeBytes = 1,
+            ChunkCount = 0,
+            Generation = 1,
+            Status = "Pending",
+            CreatedAt = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>(),
+        });
+        await ctx.SaveChangesAsync();
+        return docId;
+    }
+
+    private async Task SeedChunkVectorAsync(Guid documentId, Guid containerId, string modelId, float[] embedding)
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factoryDb = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var ctx = await factoryDb.CreateDbContextAsync();
+
+        Guid chunkId = Guid.NewGuid();
+        // Chunks have an FK from chunk_vectors → chunks. Seed the chunk row first.
+        ctx.Chunks.Add(new ChunkEntity
+        {
+            Id = chunkId,
+            DocumentId = documentId,
+            ContainerId = containerId,
+            ChunkIndex = 0,
+            Content = "test",
+            TokenCount = 1,
+            StartOffset = 0,
+            EndOffset = 4,
+        });
+        ctx.ChunkVectors.Add(new ChunkVectorEntity
+        {
+            ChunkId = chunkId,
+            DocumentId = documentId,
+            ContainerId = containerId,
+            Embedding = new Vector(embedding),
+            ModelId = modelId,
+            ContentHash = $"hash-{chunkId:N}",
+            Dimensions = embedding.Length,
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private record ContainerDto(string Id, string Name);
+}

--- a/tests/Connapse.Integration.Tests/SummarySettingsIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SummarySettingsIntegrationTests.cs
@@ -230,6 +230,7 @@ public class SummarySettingsIntegrationTests(SharedWebAppFixture fixture)
         var originalGlobal = await settingsStore.GetAsync<SummarySettings>("Summary");
         var createResponse = await fixture.AdminClient.PostAsJsonAsync("/api/containers",
             new { Name = "method-override-test" });
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
         var container = await createResponse.Content.ReadFromJsonAsync<ContainerDto>(JsonOptions);
 
         try
@@ -248,8 +249,9 @@ public class SummarySettingsIntegrationTests(SharedWebAppFixture fixture)
                     ContainerSummaryMethod = SummaryStrategy.DocumentClustering,
                 }
             };
-            await fixture.AdminClient.PutAsJsonAsync(
+            var putResponse = await fixture.AdminClient.PutAsJsonAsync(
                 $"/api/containers/{container!.Id}/settings", overrides);
+            putResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
             // Act
             var resolved = await resolver.GetSummarySettingsAsync(
@@ -281,6 +283,7 @@ public class SummarySettingsIntegrationTests(SharedWebAppFixture fixture)
 
         var createResponse = await fixture.AdminClient.PostAsJsonAsync("/api/containers",
             new { Name = "method-default-test" });
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
         var container = await createResponse.Content.ReadFromJsonAsync<ContainerDto>(JsonOptions);
 
         try

--- a/tests/Connapse.Integration.Tests/SummarySettingsIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SummarySettingsIntegrationTests.cs
@@ -217,6 +217,89 @@ public class SummarySettingsIntegrationTests(SharedWebAppFixture fixture)
         }
     }
 
+    // ── ContainerSummaryMethod resolution (G+C) ───────────────────────────
+
+    [Fact]
+    public async Task GetSummarySettingsAsync_ContainerSummaryMethodOverride_TakesPrecedence()
+    {
+        // Arrange — global says summary-clustering, per-container override says document-clustering.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var settingsStore = scope.ServiceProvider.GetRequiredService<ISettingsStore>();
+        var resolver = scope.ServiceProvider.GetRequiredService<IContainerSettingsResolver>();
+
+        var originalGlobal = await settingsStore.GetAsync<SummarySettings>("Summary");
+        var createResponse = await fixture.AdminClient.PostAsJsonAsync("/api/containers",
+            new { Name = "method-override-test" });
+        var container = await createResponse.Content.ReadFromJsonAsync<ContainerDto>(JsonOptions);
+
+        try
+        {
+            await settingsStore.SaveAsync("Summary", new SummarySettings
+            {
+                Enabled = true,
+                ContainerSummaryMethod = SummaryStrategy.SummaryClustering,
+            });
+
+            var overrides = new ContainerSettingsOverrides
+            {
+                Summary = new SummarySettings
+                {
+                    Enabled = true,
+                    ContainerSummaryMethod = SummaryStrategy.DocumentClustering,
+                }
+            };
+            await fixture.AdminClient.PutAsJsonAsync(
+                $"/api/containers/{container!.Id}/settings", overrides);
+
+            // Act
+            var resolved = await resolver.GetSummarySettingsAsync(
+                Guid.Parse(container.Id), CancellationToken.None);
+
+            // Assert — per-container override wins.
+            resolved.ContainerSummaryMethod.Should().Be(SummaryStrategy.DocumentClustering);
+        }
+        finally
+        {
+            await fixture.AdminClient.DeleteAsync($"/api/containers/{container!.Id}");
+            if (originalGlobal is null)
+                await settingsStore.ResetAsync("Summary");
+            else
+                await settingsStore.SaveAsync("Summary", originalGlobal);
+        }
+    }
+
+    [Fact]
+    public async Task GetSummarySettingsAsync_NoOverride_UsesDocumentClusteringDefault()
+    {
+        // Arrange — no global SummarySettings, no per-container override.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var settingsStore = scope.ServiceProvider.GetRequiredService<ISettingsStore>();
+        var resolver = scope.ServiceProvider.GetRequiredService<IContainerSettingsResolver>();
+
+        var originalGlobal = await settingsStore.GetAsync<SummarySettings>("Summary");
+        await settingsStore.ResetAsync("Summary");
+
+        var createResponse = await fixture.AdminClient.PostAsJsonAsync("/api/containers",
+            new { Name = "method-default-test" });
+        var container = await createResponse.Content.ReadFromJsonAsync<ContainerDto>(JsonOptions);
+
+        try
+        {
+            // Act
+            var resolved = await resolver.GetSummarySettingsAsync(
+                Guid.Parse(container!.Id), CancellationToken.None);
+
+            // Assert — record-default applies when both layers are absent.
+            resolved.ContainerSummaryMethod.Should().Be(SummaryStrategy.DocumentClustering);
+        }
+        finally
+        {
+            await fixture.AdminClient.DeleteAsync($"/api/containers/{container!.Id}");
+            if (originalGlobal is not null)
+                await settingsStore.SaveAsync("Summary", originalGlobal);
+        }
+    }
+
     // DTOs
 
     private record ContainerDto(string Id, string Name);

--- a/tests/Connapse.Storage.Tests/Llm/SummaryPromptsTests.cs
+++ b/tests/Connapse.Storage.Tests/Llm/SummaryPromptsTests.cs
@@ -18,7 +18,7 @@ public class SummaryPromptsTests
     public void ContainerRollupPrompt_ContainsStructureSections()
     {
         SummaryPrompts.ContainerRollupSystemPrompt.Should().Contain("Use this container for");
-        SummaryPrompts.ContainerRollupSystemPrompt.Should().Contain("Out-of-scope");
+        SummaryPrompts.ContainerRollupSystemPrompt.Should().Contain("Scope boundaries");
         SummaryPrompts.ContainerRollupSystemPrompt.Should().Contain("Query hints");
     }
 

--- a/tests/Connapse.Storage.Tests/Llm/SummaryPromptsTests.cs
+++ b/tests/Connapse.Storage.Tests/Llm/SummaryPromptsTests.cs
@@ -12,6 +12,7 @@ public class SummaryPromptsTests
     {
         SummaryPrompts.PerDocSystemPrompt.Should().Contain("AI agent, not a human");
         SummaryPrompts.PerDocSystemPrompt.Should().Contain("search_knowledge");
+        SummaryPrompts.PerDocSystemPrompt.Should().Contain("truncated");
     }
 
     [Fact]
@@ -28,10 +29,24 @@ public class SummaryPromptsTests
         string rendered = SummaryPrompts.RenderPerDocUserMessage(
             filename: "earnings.pdf",
             mimeType: "application/pdf",
-            firstNTokens: "Apple Q3 2025 earnings...");
+            firstNTokens: "Apple Q3 2025 earnings...",
+            wasTruncated: false);
         rendered.Should().Contain("earnings.pdf");
         rendered.Should().Contain("application/pdf");
         rendered.Should().Contain("Apple Q3 2025 earnings...");
+        rendered.Should().Contain("full document text is shown below");
+    }
+
+    [Fact]
+    public void RenderPerDocUserMessage_WhenTruncated_SignalsHeadOnly()
+    {
+        string rendered = SummaryPrompts.RenderPerDocUserMessage(
+            filename: "long.pdf",
+            mimeType: "application/pdf",
+            firstNTokens: "opening section...",
+            wasTruncated: true);
+        rendered.Should().Contain("only the HEAD");
+        rendered.Should().NotContain("full document text is shown below");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #335.

## Summary

Adds a new `document-clustering` value for `SummarySettings.ContainerSummaryMethod` and makes it the new default. The method clusters documents using mean-pooled chunk embeddings (which already exist in `chunk_vectors` for vector search) and lazy-summarizes only the K medoid documents at rollup time. Existing `summary-clustering` behavior (PR #329) remains available behind the setting.

Built on research:
- HERCULES paper ([arXiv:2506.19992](https://arxiv.org/abs/2506.19992)): +76% ARI on clustering quality vs summary embeddings, p<0.001
- Follow-up research: `docs/research/lazy-vs-eager-per-doc-summarization-2026-05-26.md` (in the parent ConnapseInfrastructure repo)

Design: `docs/superpowers/specs/2026-05-27-hercules-swap-design.md`
Plan: `docs/superpowers/plans/2026-05-27-hercules-swap.md`

## What changed

- New `SummaryStrategy` constants (`document-clustering` | `summary-clustering`)
- `SummarySettings.ContainerSummaryMethod` field, G+C scope through the existing `ContainerSettingsResolver`, default `document-clustering`, validated via `IValidatableObject`
- New `IVectorStore.GetPooledDocumentEmbeddingsAsync` (PgVectorStore impl uses pgvector `AVG(embedding)` over chunk vectors, filtered to the dominant `model_id`, L2-normalized)
- `IngestionJobs.PerDocSummaryAsync` early-returns in `document-clustering` mode (advances state to `SummaryIndexed` so UI spinners don't hang)
- `SummaryJobs.RollupContainerAsync` branches into `RollupSummaryClusteringAsync` (existing behavior verbatim) and `RollupDocumentClusteringAsync` (new lazy path: hash-gate → cluster on pooled embeddings → lazy-summarize K medoids with cache-hit check → reduce)
- `ComputeDocSetHash` switched from summary-text to content-hash (works for both methods)
- New "Container summary method" dropdown in `SummarySettingsTab.razor`
- Test coverage: unit (routing, cache-hit, hash), integration (pooled embeddings filter, end-to-end document-clustering early-return)
- Manual QA scenarios in `docs/agent/container-summaries-qa.md`

## Migration impact

- Existing containers continue working under whichever method they're set to. The `document-clustering` default applies only to new `SummarySettings` records.
- `ComputeDocSetHash` formula changed → one extra rollup per container on first run post-deploy. Accepted one-shot cost.
- No DB schema changes.

## Test plan

- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] Unit tests: 419 + 216 + 85 + 16 = 736 passed (Connapse.Core.Tests, Connapse.Ingestion.Tests, Connapse.Identity.Tests, Connapse.Background.Tests)
- [x] Integration tests: 251/251 passed (66s) — includes new `HerculesEndToEndTests`, `PgVectorStorePooledEmbeddingsTests`, and the new `ContainerSummaryMethod` G+C resolver tests
- [ ] Manual QA per `docs/agent/container-summaries-qa.md` HERCULES scenarios 1–4 (post-merge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default "document-clustering" container summary method with UI dropdown, lazy per-document summarization at rollup, and pooled-embedding medoid selection.

* **Bug Fixes**
  * Improved stale-summary detection for containers without per-doc summaries; defers per-doc continuation scheduling until ingest.

* **Stability**
  * Process-wide LLM concurrency gate and Postgres connection pool caps to prevent local inference timeouts and connection exhaustion.

* **Documentation**
  * Added design, implementation plan, and QA guidance for the new summarization approach.

* **Tests**
  * Extensive unit, integration, and end-to-end tests for modes, pooling, caching, hashing, and method resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Destrayon/Connapse/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->