### PR TITLE
feat(storage): connections and sources schema with document owner bridge

### DIFF
--- a/src/Connapse.Core/Interfaces/IConnectionStore.cs
+++ b/src/Connapse.Core/Interfaces/IConnectionStore.cs
@@ -1,0 +1,24 @@
+namespace Connapse.Core.Interfaces;
+
+public interface IConnectionStore
+{
+    Task<Connection> CreateAsync(CreateConnectionRequest request, Guid? createdByUserId, CancellationToken ct = default);
+    Task<Connection?> GetAsync(Guid id, CancellationToken ct = default);
+    Task<IReadOnlyList<Connection>> ListAsync(int skip = 0, int take = 50, CancellationToken ct = default);
+    Task<Connection?> UpdateAsync(Guid id, UpdateConnectionRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes a connection. Throws InvalidOperationException if any source still
+    /// references it — sources must be removed or repointed first.
+    /// </summary>
+    Task<bool> DeleteAsync(Guid id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Decrypts and returns the stored secret. Only the sync engine and connection
+    /// testers should call this; it is never surfaced through the Connection model.
+    /// Returns null when the connection has no secret (for example Filesystem).
+    /// Throws System.Security.Cryptography.CryptographicException if the stored
+    /// ciphertext cannot be unprotected, which happens after DataProtection key loss.
+    /// </summary>
+    Task<string?> GetSecretAsync(Guid id, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/ISourceStore.cs
+++ b/src/Connapse.Core/Interfaces/ISourceStore.cs
@@ -1,0 +1,23 @@
+namespace Connapse.Core.Interfaces;
+
+public interface ISourceStore
+{
+    Task<Source> CreateAsync(CreateSourceRequest request, CancellationToken ct = default);
+    Task<Source?> GetAsync(Guid id, CancellationToken ct = default);
+    Task<Source?> GetByNameAsync(string name, CancellationToken ct = default);
+    Task<IReadOnlyList<Source>> ListAsync(int skip = 0, int take = 50, CancellationToken ct = default);
+    Task<IReadOnlyList<Source>> ListByConnectionAsync(Guid connectionId, CancellationToken ct = default);
+    Task<Source?> UpdateAsync(Guid id, UpdateSourceRequest request, CancellationToken ct = default);
+    Task<bool> DeleteAsync(Guid id, CancellationToken ct = default);
+    Task<bool> ExistsAsync(Guid id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists the sync cursor and outcome after a sync cycle. Passing a null
+    /// cursor clears it, which is what a RequiresFullResync response demands.
+    /// </summary>
+    Task UpdateSyncStateAsync(Guid id, string? cursor, SyncStatus status, string? error, DateTime? syncedAt, CancellationToken ct = default);
+
+    Task<ContainerSettingsOverrides?> GetSettingsOverridesAsync(Guid id, CancellationToken ct = default);
+    Task SaveSettingsOverridesAsync(Guid id, ContainerSettingsOverrides overrides, CancellationToken ct = default);
+    Task UpdateSummaryAsync(Guid id, string? summary, DateTime? generatedAt, string? docSetHash, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Models/ConnectionModels.cs
+++ b/src/Connapse.Core/Models/ConnectionModels.cs
@@ -1,0 +1,31 @@
+namespace Connapse.Core;
+
+/// <summary>
+/// External provider a Connection authenticates to. Values match ConnectorType
+/// so Phase 2 can backfill existing containers with a direct cast.
+/// ManagedStorage is deliberately absent: it is Connapse's own backend, not an
+/// external system requiring credentials.
+/// </summary>
+public enum ConnectionProvider { Filesystem = 1, S3 = 3, AzureBlob = 4 }
+
+public record Connection(
+    Guid Id,
+    string Name,
+    ConnectionProvider Provider,
+    string? ConfigJson,
+    Guid? CreatedByUserId,
+    DateTime CreatedAt,
+    DateTime UpdatedAt,
+    bool HasSecret = false,
+    int SourceCount = 0);
+
+public record CreateConnectionRequest(
+    string Name,
+    ConnectionProvider Provider,
+    string? ConfigJson = null,
+    string? Secret = null);
+
+public record UpdateConnectionRequest(
+    string? Name = null,
+    string? ConfigJson = null,
+    string? Secret = null);

--- a/src/Connapse.Core/Models/SourceModels.cs
+++ b/src/Connapse.Core/Models/SourceModels.cs
@@ -1,0 +1,37 @@
+namespace Connapse.Core;
+
+public enum SyncStatus { Never = 0, Running = 1, Succeeded = 2, Failed = 3 }
+
+public record Source(
+    Guid Id,
+    string Name,
+    string? Description,
+    Guid ConnectionId,
+    string ScopeJson,
+    DateTime CreatedAt,
+    DateTime UpdatedAt,
+    bool Enabled = true,
+    string? SyncCursor = null,
+    DateTime? LastSyncedAt = null,
+    SyncStatus LastSyncStatus = SyncStatus.Never,
+    string? LastSyncError = null,
+    int? SyncIntervalSeconds = null,
+    ContainerSettingsOverrides? SettingsOverrides = null,
+    string? Summary = null,
+    DateTime? SummaryGeneratedAt = null,
+    string? SummaryDocSetHash = null,
+    int DocumentCount = 0);
+
+public record CreateSourceRequest(
+    string Name,
+    Guid ConnectionId,
+    string ScopeJson,
+    string? Description = null,
+    int? SyncIntervalSeconds = null);
+
+public record UpdateSourceRequest(
+    string? Name = null,
+    string? Description = null,
+    string? ScopeJson = null,
+    int? SyncIntervalSeconds = null,
+    bool? Enabled = null);

--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -341,7 +341,7 @@ public class IngestionPipeline : IKnowledgeIngester
                 {
                     Id = chunkId,
                     DocumentId = documentEntity.Id,
-                    ContainerId = containerId,
+                    OwnerId = containerId,
                     Content = chunkInfo.Content,
                     ChunkIndex = chunkInfo.ChunkIndex,
                     TokenCount = chunkInfo.TokenCount,

--- a/src/Connapse.Ingestion/Reindex/ReindexService.cs
+++ b/src/Connapse.Ingestion/Reindex/ReindexService.cs
@@ -51,7 +51,11 @@ public class ReindexService : IReindexService
     /// </summary>
     private async Task<bool> FileExistsAsync(DocumentEntity doc, CancellationToken ct)
     {
-        var container = await _containerStore.GetAsync(doc.ContainerId, ct);
+        // Source-owned documents have no container; they fall through to the legacy
+        // file system path until the sync engine gives sources their own connector.
+        var container = doc.ContainerId.HasValue
+            ? await _containerStore.GetAsync(doc.ContainerId.Value, ct)
+            : null;
         if (container is not null)
         {
             try
@@ -74,7 +78,11 @@ public class ReindexService : IReindexService
     /// </summary>
     private async Task<Stream> OpenFileAsync(DocumentEntity doc, CancellationToken ct)
     {
-        var container = await _containerStore.GetAsync(doc.ContainerId, ct);
+        // Source-owned documents have no container; they fall through to the legacy
+        // file system path until the sync engine gives sources their own connector.
+        var container = doc.ContainerId.HasValue
+            ? await _containerStore.GetAsync(doc.ContainerId.Value, ct)
+            : null;
         if (container is not null)
         {
             try

--- a/src/Connapse.Search/Keyword/KeywordSearchService.cs
+++ b/src/Connapse.Search/Keyword/KeywordSearchService.cs
@@ -37,7 +37,7 @@ public class KeywordSearchService
         if (!string.IsNullOrEmpty(options.ContainerId))
         {
             var idx = parameters.Count;
-            whereClauses.Add($"d.container_id = {{{idx}}}");
+            whereClauses.Add($"d.owner_id = {{{idx}}}");
             parameters.Add(Guid.Parse(options.ContainerId));
         }
 
@@ -81,7 +81,7 @@ public class KeywordSearchService
                     32) as Rank,
                 d.file_name as FileName,
                 d.content_type as ContentType,
-                d.container_id as ContainerId,
+                d.owner_id as ContainerId,
                 d.path as Path
             FROM chunks c
             INNER JOIN documents d ON c.document_id = d.id

--- a/src/Connapse.Storage/Data/Entities/ChunkEntity.cs
+++ b/src/Connapse.Storage/Data/Entities/ChunkEntity.cs
@@ -6,7 +6,8 @@ public class ChunkEntity
 {
     public Guid Id { get; set; }
     public Guid DocumentId { get; set; }
-    public Guid ContainerId { get; set; }
+    /// <summary>Denormalized owner: the container or source that owns this chunk.</summary>
+    public Guid OwnerId { get; set; }
     public string Content { get; set; } = string.Empty;
     public int ChunkIndex { get; set; }
     public int TokenCount { get; set; }

--- a/src/Connapse.Storage/Data/Entities/ChunkVectorEntity.cs
+++ b/src/Connapse.Storage/Data/Entities/ChunkVectorEntity.cs
@@ -9,7 +9,8 @@ public class ChunkVectorEntity
 {
     public Guid ChunkId { get; set; }
     public Guid DocumentId { get; set; }
-    public Guid ContainerId { get; set; }
+    /// <summary>Denormalized owner: the container or source that owns this chunk.</summary>
+    public Guid OwnerId { get; set; }
     public Vector Embedding { get; set; } = null!;
     public string ModelId { get; set; } = string.Empty;
     /// <summary>SHA-256 hex hash of the chunk content, used for embedding cache lookups.</summary>

--- a/src/Connapse.Storage/Data/Entities/ConnectionEntity.cs
+++ b/src/Connapse.Storage/Data/Entities/ConnectionEntity.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+
+namespace Connapse.Storage.Data.Entities;
+
+public class ConnectionEntity
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Provider { get; set; } // maps to ConnectionProvider enum
+    public JsonDocument? ConfigJson { get; set; } // JSONB: non-secret provider settings
+    public string? SecretProtected { get; set; } // DataProtection ciphertext, purpose "Connection.v1"
+    public Guid? CreatedByUserId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    // Navigation properties
+    public List<SourceEntity> Sources { get; set; } = [];
+}

--- a/src/Connapse.Storage/Data/Entities/DocumentEntity.cs
+++ b/src/Connapse.Storage/Data/Entities/DocumentEntity.cs
@@ -5,7 +5,26 @@ namespace Connapse.Storage.Data.Entities;
 public class DocumentEntity
 {
     public Guid Id { get; set; }
-    public Guid ContainerId { get; set; }
+
+    /// <summary>
+    /// Set when this document belongs to a managed container. Exactly one of
+    /// ContainerId and SourceId is non-null, enforced by a database CHECK.
+    /// </summary>
+    public Guid? ContainerId { get; set; }
+
+    /// <summary>
+    /// Set when this document belongs to an external source. Exactly one of
+    /// ContainerId and SourceId is non-null, enforced by a database CHECK.
+    /// </summary>
+    public Guid? SourceId { get; set; }
+
+    /// <summary>
+    /// Stored generated column: COALESCE(container_id, source_id). Never assign to
+    /// this — PostgreSQL computes it. Search filters on it so the query path does
+    /// not need to know whether the owner is a container or a source.
+    /// </summary>
+    public Guid OwnerId { get; private set; }
+
     public string FileName { get; set; } = string.Empty;
     public string? ContentType { get; set; }
     public string Path { get; set; } = string.Empty;
@@ -29,7 +48,8 @@ public class DocumentEntity
     public IngestionState IngestionState { get; set; } = IngestionState.Pending;
 
     // Navigation properties
-    public ContainerEntity Container { get; set; } = null!;
+    public ContainerEntity? Container { get; set; }
+    public SourceEntity? Source { get; set; }
     public List<ChunkEntity> Chunks { get; set; } = [];
     public List<ChunkVectorEntity> ChunkVectors { get; set; } = [];
     public List<BatchDocumentEntity> BatchDocuments { get; set; } = [];

--- a/src/Connapse.Storage/Data/Entities/SourceEntity.cs
+++ b/src/Connapse.Storage/Data/Entities/SourceEntity.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+
+namespace Connapse.Storage.Data.Entities;
+
+public class SourceEntity
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public Guid ConnectionId { get; set; }
+    public JsonDocument ScopeJson { get; set; } = null!; // JSONB: bucket prefix, root subpath, space key
+    public JsonDocument? SettingsOverridesJson { get; set; }
+    public bool Enabled { get; set; } = true;
+
+    // Sync state
+    public string? SyncCursor { get; set; }
+    public DateTime? LastSyncedAt { get; set; }
+    public int LastSyncStatus { get; set; } // maps to SyncStatus enum
+    public string? LastSyncError { get; set; }
+    public int? SyncIntervalSeconds { get; set; } // null inherits the connection default
+
+    // Auto-generated summary (agent-optimized prose for routing)
+    public string? Summary { get; set; }
+    public DateTime? SummaryGeneratedAt { get; set; }
+    public string? SummaryDocSetHash { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    // Navigation properties
+    public ConnectionEntity Connection { get; set; } = null!;
+    public List<DocumentEntity> Documents { get; set; } = [];
+}

--- a/src/Connapse.Storage/Data/KnowledgeDbContext.cs
+++ b/src/Connapse.Storage/Data/KnowledgeDbContext.cs
@@ -135,8 +135,16 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
                 .HasDefaultValueSql("gen_random_uuid()");
 
             entity.Property(e => e.ContainerId)
-                .HasColumnName("container_id")
-                .IsRequired();
+                .HasColumnName("container_id");
+
+            entity.Property(e => e.SourceId)
+                .HasColumnName("source_id");
+
+            // Stored generated column. The search path filters on owner_id so it never
+            // has to know whether the owner is a container or a source.
+            entity.Property(e => e.OwnerId)
+                .HasColumnName("owner_id")
+                .HasComputedColumnSql("COALESCE(container_id, source_id)", stored: true);
 
             entity.Property(e => e.FileName)
                 .HasColumnName("file_name")
@@ -204,16 +212,35 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
             entity.HasIndex(e => e.IngestionState)
                 .HasDatabaseName("ix_documents_ingestion_state");
 
+            // Exactly one owner. Postgres treats "(a IS NULL) <> (b IS NULL)" as XOR.
+            entity.ToTable(t => t.HasCheckConstraint(
+                "ck_documents_single_owner",
+                "(container_id IS NULL) <> (source_id IS NULL)"));
+
             entity.HasIndex(e => e.ContainerId)
                 .HasDatabaseName("idx_documents_container_id");
 
-            entity.HasIndex(e => new { e.ContainerId, e.Path })
-                .HasDatabaseName("idx_documents_container_path")
+            entity.HasIndex(e => e.SourceId)
+                .HasDatabaseName("idx_documents_source_id");
+
+            entity.HasIndex(e => e.OwnerId)
+                .HasDatabaseName("ix_documents_owner_id");
+
+            // Keyed on owner_id, not container_id: a unique index over a nullable
+            // container_id would not constrain source-owned rows at all, since
+            // Postgres treats each NULL as distinct.
+            entity.HasIndex(e => new { e.OwnerId, e.Path })
+                .HasDatabaseName("idx_documents_owner_path")
                 .IsUnique();
 
             entity.HasOne(e => e.Container)
                 .WithMany(c => c.Documents)
                 .HasForeignKey(e => e.ContainerId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(e => e.Source)
+                .WithMany(s => s.Documents)
+                .HasForeignKey(e => e.SourceId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
     }
@@ -245,8 +272,8 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
             entity.Property(e => e.DocumentId)
                 .HasColumnName("document_id");
 
-            entity.Property(e => e.ContainerId)
-                .HasColumnName("container_id")
+            entity.Property(e => e.OwnerId)
+                .HasColumnName("owner_id")
                 .IsRequired();
 
             entity.Property(e => e.TokenCount)
@@ -271,8 +298,8 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
             entity.HasIndex(e => e.DocumentId)
                 .HasDatabaseName("idx_chunks_document_id");
 
-            entity.HasIndex(e => e.ContainerId)
-                .HasDatabaseName("idx_chunks_container_id");
+            entity.HasIndex(e => e.OwnerId)
+                .HasDatabaseName("idx_chunks_owner_id");
 
             entity.HasIndex(e => e.SearchVector)
                 .HasDatabaseName("idx_chunks_fts")
@@ -298,8 +325,8 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
             entity.Property(e => e.DocumentId)
                 .HasColumnName("document_id");
 
-            entity.Property(e => e.ContainerId)
-                .HasColumnName("container_id")
+            entity.Property(e => e.OwnerId)
+                .HasColumnName("owner_id")
                 .IsRequired();
 
             entity.Property(e => e.Embedding)
@@ -325,8 +352,8 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
             entity.HasIndex(e => e.DocumentId)
                 .HasDatabaseName("idx_chunk_vectors_document_id");
 
-            entity.HasIndex(e => e.ContainerId)
-                .HasDatabaseName("idx_chunk_vectors_container_id");
+            entity.HasIndex(e => e.OwnerId)
+                .HasDatabaseName("idx_chunk_vectors_owner_id");
 
             // B-tree index on model_id for search filtering and partial index WHERE clauses
             entity.HasIndex(e => e.ModelId)

--- a/src/Connapse.Storage/Data/KnowledgeDbContext.cs
+++ b/src/Connapse.Storage/Data/KnowledgeDbContext.cs
@@ -13,6 +13,8 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
     public DbSet<SettingEntity> Settings => Set<SettingEntity>();
     public DbSet<BatchEntity> Batches => Set<BatchEntity>();
     public DbSet<BatchDocumentEntity> BatchDocuments => Set<BatchDocumentEntity>();
+    public DbSet<ConnectionEntity> Connections => Set<ConnectionEntity>();
+    public DbSet<SourceEntity> Sources => Set<SourceEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -28,6 +30,8 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
         ConfigureSettings(modelBuilder);
         ConfigureBatches(modelBuilder);
         ConfigureBatchDocuments(modelBuilder);
+        ConfigureConnections(modelBuilder);
+        ConfigureSources(modelBuilder);
     }
 
     private static void ConfigureContainers(ModelBuilder modelBuilder)
@@ -422,6 +426,129 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
                 .WithMany(d => d.BatchDocuments)
                 .HasForeignKey(e => e.DocumentId)
                 .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+
+    private static void ConfigureConnections(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ConnectionEntity>(entity =>
+        {
+            entity.ToTable("connections");
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.Id)
+                .HasColumnName("id");
+
+            entity.Property(e => e.Name)
+                .HasColumnName("name")
+                .HasMaxLength(128)
+                .IsRequired();
+
+            entity.Property(e => e.Provider)
+                .HasColumnName("provider")
+                .IsRequired();
+
+            entity.Property(e => e.ConfigJson)
+                .HasColumnName("config")
+                .HasColumnType("jsonb");
+
+            entity.Property(e => e.SecretProtected)
+                .HasColumnName("secret_protected");
+
+            entity.Property(e => e.CreatedByUserId)
+                .HasColumnName("created_by_user_id");
+
+            entity.Property(e => e.CreatedAt)
+                .HasColumnName("created_at");
+
+            entity.Property(e => e.UpdatedAt)
+                .HasColumnName("updated_at");
+
+            entity.HasIndex(e => e.Name)
+                .IsUnique()
+                .HasDatabaseName("ix_connections_name");
+        });
+    }
+
+    private static void ConfigureSources(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<SourceEntity>(entity =>
+        {
+            entity.ToTable("sources");
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.Id)
+                .HasColumnName("id");
+
+            entity.Property(e => e.Name)
+                .HasColumnName("name")
+                .HasMaxLength(128)
+                .IsRequired();
+
+            entity.Property(e => e.Description)
+                .HasColumnName("description");
+
+            entity.Property(e => e.ConnectionId)
+                .HasColumnName("connection_id")
+                .IsRequired();
+
+            entity.Property(e => e.ScopeJson)
+                .HasColumnName("scope")
+                .HasColumnType("jsonb")
+                .IsRequired();
+
+            entity.Property(e => e.SettingsOverridesJson)
+                .HasColumnName("settings_overrides")
+                .HasColumnType("jsonb");
+
+            entity.Property(e => e.Enabled)
+                .HasColumnName("enabled")
+                .HasDefaultValue(true);
+
+            entity.Property(e => e.SyncCursor)
+                .HasColumnName("sync_cursor");
+
+            entity.Property(e => e.LastSyncedAt)
+                .HasColumnName("last_synced_at");
+
+            entity.Property(e => e.LastSyncStatus)
+                .HasColumnName("last_sync_status")
+                .HasDefaultValue(0);
+
+            entity.Property(e => e.LastSyncError)
+                .HasColumnName("last_sync_error");
+
+            entity.Property(e => e.SyncIntervalSeconds)
+                .HasColumnName("sync_interval_seconds");
+
+            entity.Property(e => e.Summary)
+                .HasColumnName("summary");
+
+            entity.Property(e => e.SummaryGeneratedAt)
+                .HasColumnName("summary_generated_at");
+
+            entity.Property(e => e.SummaryDocSetHash)
+                .HasColumnName("summary_doc_set_hash");
+
+            entity.Property(e => e.CreatedAt)
+                .HasColumnName("created_at");
+
+            entity.Property(e => e.UpdatedAt)
+                .HasColumnName("updated_at");
+
+            entity.HasIndex(e => e.Name)
+                .IsUnique()
+                .HasDatabaseName("ix_sources_name");
+
+            entity.HasIndex(e => e.ConnectionId)
+                .HasDatabaseName("ix_sources_connection_id");
+
+            // Restrict, not Cascade: deleting a connection that still has sources
+            // must fail loudly rather than silently destroying their documents.
+            entity.HasOne(e => e.Connection)
+                .WithMany(c => c.Sources)
+                .HasForeignKey(e => e.ConnectionId)
+                .OnDelete(DeleteBehavior.Restrict);
         });
     }
 }

--- a/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
+++ b/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
@@ -164,7 +164,7 @@ public class PostgresDocumentStore : IDocumentStore
         }
 
         bool docHadSummary = !string.IsNullOrEmpty(entity.Summary);
-        Guid containerId = entity.ContainerId;
+        Guid? containerId = entity.ContainerId;
 
         context.Documents.Remove(entity);
         await context.SaveChangesAsync(ct);
@@ -172,9 +172,11 @@ public class PostgresDocumentStore : IDocumentStore
         // If the deleted doc contributed to the container summary, mark the container as
         // stale so the next sweep tick triggers a re-rollup. Without this, the sweep query
         // wouldn't detect pure-deletion changes (no doc has a "newer" summary timestamp).
-        if (docHadSummary)
+        // Source-owned documents have no container, so there is no container summary
+        // to invalidate — the source summary rollup arrives with the sync engine.
+        if (docHadSummary && containerId.HasValue)
         {
-            await _containerStore.MarkSummaryStaleAsync(containerId, ct);
+            await _containerStore.MarkSummaryStaleAsync(containerId.Value, ct);
         }
 
         _logger.LogInformation(
@@ -269,7 +271,10 @@ public class PostgresDocumentStore : IDocumentStore
         // excluded document-clustering containers (whose docs are mostly null-summary) — the
         // sweep then reported "no stale containers" forever and rollups never fired.
         return await context.Documents
-            .GroupBy(d => d.ContainerId)
+            // Source-owned documents have a null container_id and never roll up into a
+            // container summary, so they are excluded before grouping.
+            .Where(d => d.ContainerId != null)
+            .GroupBy(d => d.ContainerId!.Value)
             .Select(g => new
             {
                 ContainerId = g.Key,

--- a/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
+++ b/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
@@ -42,7 +42,10 @@ public class PostgresDocumentStore : IDocumentStore
         var containerId = Guid.Parse(document.ContainerId);
         var metadata = document.Metadata ?? new Dictionary<string, string>();
 
-        // Atomic upsert: INSERT ... ON CONFLICT (container_id, path) DO UPDATE.
+        // Atomic upsert: INSERT ... ON CONFLICT (owner_id, path) DO UPDATE.
+        // The conflict target is owner_id, not container_id, because that is the column
+        // the unique index covers — a unique index over the nullable container_id would
+        // not constrain source-owned rows, since Postgres treats each NULL as distinct.
         // On conflict, increments generation so stale ingestion jobs can detect they're outdated.
         // Returns the winning row's id and generation.
         var conn = context.Database.GetDbConnection();
@@ -51,7 +54,7 @@ public class PostgresDocumentStore : IDocumentStore
         cmd.CommandText = """
             INSERT INTO documents (id, container_id, file_name, content_type, path, content_hash, size_bytes, chunk_count, generation, status, created_at, metadata)
             VALUES (@id, @cid, @fname, @ctype, @path, @hash, @size, 0, 1, 'Pending', @created, @meta::jsonb)
-            ON CONFLICT (container_id, path) DO UPDATE SET
+            ON CONFLICT (owner_id, path) DO UPDATE SET
                 file_name    = EXCLUDED.file_name,
                 content_type = EXCLUDED.content_type,
                 content_hash = EXCLUDED.content_hash,

--- a/src/Connapse.Storage/Migrations/20260814053525_AddConnectionsAndSources.Designer.cs
+++ b/src/Connapse.Storage/Migrations/20260814053525_AddConnectionsAndSources.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Connapse.Storage.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -15,9 +16,11 @@ using Pgvector;
 namespace Connapse.Storage.Migrations
 {
     [DbContext(typeof(KnowledgeDbContext))]
-    partial class KnowledgeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260814053525_AddConnectionsAndSources")]
+    partial class AddConnectionsAndSources
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Connapse.Storage/Migrations/20260814053525_AddConnectionsAndSources.cs
+++ b/src/Connapse.Storage/Migrations/20260814053525_AddConnectionsAndSources.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Connapse.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConnectionsAndSources : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "idx_documents_container_path",
+                table: "documents");
+
+            migrationBuilder.RenameColumn(
+                name: "container_id",
+                table: "chunks",
+                newName: "owner_id");
+
+            migrationBuilder.RenameIndex(
+                name: "idx_chunks_container_id",
+                table: "chunks",
+                newName: "idx_chunks_owner_id");
+
+            migrationBuilder.RenameColumn(
+                name: "container_id",
+                table: "chunk_vectors",
+                newName: "owner_id");
+
+            migrationBuilder.RenameIndex(
+                name: "idx_chunk_vectors_container_id",
+                table: "chunk_vectors",
+                newName: "idx_chunk_vectors_owner_id");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "container_id",
+                table: "documents",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "source_id",
+                table: "documents",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "owner_id",
+                table: "documents",
+                type: "uuid",
+                nullable: false,
+                computedColumnSql: "COALESCE(container_id, source_id)",
+                stored: true);
+
+            migrationBuilder.CreateTable(
+                name: "connections",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    provider = table.Column<int>(type: "integer", nullable: false),
+                    config = table.Column<JsonDocument>(type: "jsonb", nullable: true),
+                    secret_protected = table.Column<string>(type: "text", nullable: true),
+                    created_by_user_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_connections", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "sources",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    description = table.Column<string>(type: "text", nullable: true),
+                    connection_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    scope = table.Column<JsonDocument>(type: "jsonb", nullable: false),
+                    settings_overrides = table.Column<JsonDocument>(type: "jsonb", nullable: true),
+                    enabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    sync_cursor = table.Column<string>(type: "text", nullable: true),
+                    last_synced_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    last_sync_status = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    last_sync_error = table.Column<string>(type: "text", nullable: true),
+                    sync_interval_seconds = table.Column<int>(type: "integer", nullable: true),
+                    summary = table.Column<string>(type: "text", nullable: true),
+                    summary_generated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    summary_doc_set_hash = table.Column<string>(type: "text", nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_sources", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_sources_connections_connection_id",
+                        column: x => x.connection_id,
+                        principalTable: "connections",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_documents_owner_path",
+                table: "documents",
+                columns: new[] { "owner_id", "path" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "idx_documents_source_id",
+                table: "documents",
+                column: "source_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_documents_owner_id",
+                table: "documents",
+                column: "owner_id");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_documents_single_owner",
+                table: "documents",
+                sql: "(container_id IS NULL) <> (source_id IS NULL)");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_connections_name",
+                table: "connections",
+                column: "name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_sources_connection_id",
+                table: "sources",
+                column: "connection_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_sources_name",
+                table: "sources",
+                column: "name",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_documents_sources_source_id",
+                table: "documents",
+                column: "source_id",
+                principalTable: "sources",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_documents_sources_source_id",
+                table: "documents");
+
+            migrationBuilder.DropTable(
+                name: "sources");
+
+            migrationBuilder.DropTable(
+                name: "connections");
+
+            migrationBuilder.DropIndex(
+                name: "idx_documents_owner_path",
+                table: "documents");
+
+            migrationBuilder.DropIndex(
+                name: "idx_documents_source_id",
+                table: "documents");
+
+            migrationBuilder.DropIndex(
+                name: "ix_documents_owner_id",
+                table: "documents");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_documents_single_owner",
+                table: "documents");
+
+            migrationBuilder.DropColumn(
+                name: "owner_id",
+                table: "documents");
+
+            migrationBuilder.DropColumn(
+                name: "source_id",
+                table: "documents");
+
+            migrationBuilder.RenameColumn(
+                name: "owner_id",
+                table: "chunks",
+                newName: "container_id");
+
+            migrationBuilder.RenameIndex(
+                name: "idx_chunks_owner_id",
+                table: "chunks",
+                newName: "idx_chunks_container_id");
+
+            migrationBuilder.RenameColumn(
+                name: "owner_id",
+                table: "chunk_vectors",
+                newName: "container_id");
+
+            migrationBuilder.RenameIndex(
+                name: "idx_chunk_vectors_owner_id",
+                table: "chunk_vectors",
+                newName: "idx_chunk_vectors_container_id");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "container_id",
+                table: "documents",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "idx_documents_container_path",
+                table: "documents",
+                columns: new[] { "container_id", "path" },
+                unique: true);
+        }
+    }
+}

--- a/src/Connapse.Storage/Migrations/20260814053525_AddConnectionsAndSources.cs
+++ b/src/Connapse.Storage/Migrations/20260814053525_AddConnectionsAndSources.cs
@@ -159,6 +159,24 @@ namespace Connapse.Storage.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            // Refuse the rollback before dropping anything. Source-owned documents have a
+            // null container_id and no container to revert to, so restoring the NOT NULL
+            // constraint would either rewrite their ownership to the zero GUID or fail
+            // obscurely on the containers foreign key. Fail fast with an actionable message
+            // instead, while the schema is still intact.
+            migrationBuilder.Sql("""
+                DO $$
+                DECLARE source_owned_count bigint;
+                BEGIN
+                    SELECT count(*) INTO source_owned_count FROM documents WHERE source_id IS NOT NULL;
+                    IF source_owned_count > 0 THEN
+                        RAISE EXCEPTION
+                            'Cannot roll back AddConnectionsAndSources: % document(s) are owned by a source and have no container to revert to. Delete or repoint them before rolling back.',
+                            source_owned_count;
+                    END IF;
+                END $$;
+                """);
+
             migrationBuilder.DropForeignKey(
                 name: "FK_documents_sources_source_id",
                 table: "documents");
@@ -218,7 +236,6 @@ namespace Connapse.Storage.Migrations
                 table: "documents",
                 type: "uuid",
                 nullable: false,
-                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
                 oldClrType: typeof(Guid),
                 oldType: "uuid",
                 oldNullable: true);

--- a/src/Connapse.Storage/Vectors/PgVectorStore.cs
+++ b/src/Connapse.Storage/Vectors/PgVectorStore.cs
@@ -86,7 +86,7 @@ public class PgVectorStore : IVectorStore
             existing.Embedding = new Vector(vector);
             existing.ModelId = modelId;
             existing.DocumentId = documentId;
-            existing.ContainerId = containerId;
+            existing.OwnerId = containerId;
         }
         else
         {
@@ -95,7 +95,7 @@ public class PgVectorStore : IVectorStore
             {
                 ChunkId = chunkId,
                 DocumentId = documentId,
-                ContainerId = containerId,
+                OwnerId = containerId,
                 Embedding = new Vector(vector),
                 ModelId = modelId
             };
@@ -168,7 +168,7 @@ public class PgVectorStore : IVectorStore
             {
                 ChunkId = chunkId,
                 DocumentId = documentId,
-                ContainerId = containerId,
+                OwnerId = containerId,
                 Embedding = new Vector(vector),
                 ModelId = modelId,
                 ContentHash = metadata.TryGetValue("contentHash", out var hash) ? hash : null,
@@ -352,9 +352,9 @@ public class PgVectorStore : IVectorStore
         CancellationToken ct = default)
     {
         // Step 1: pick the dominant model_id in the container. ChunkVectorEntity carries
-        // ContainerId and ModelId directly — no JOIN needed.
+        // OwnerId and ModelId directly — no JOIN needed.
         var modelCounts = await _context.ChunkVectors
-            .Where(cv => cv.ContainerId == containerId)
+            .Where(cv => cv.OwnerId == containerId)
             .GroupBy(cv => cv.ModelId)
             .Select(g => new { ModelId = g.Key, Count = g.Count() })
             .OrderByDescending(x => x.Count)
@@ -374,12 +374,12 @@ public class PgVectorStore : IVectorStore
             // dominant model — docs with mixed-model chunks still contribute their dominant
             // ones. Compute total vs. dominant-reachable distinct docs (mixed-model path only).
             int totalDocs = await _context.ChunkVectors
-                .Where(cv => cv.ContainerId == containerId)
+                .Where(cv => cv.OwnerId == containerId)
                 .Select(cv => cv.DocumentId)
                 .Distinct()
                 .CountAsync(ct);
             int includedDocs = await _context.ChunkVectors
-                .Where(cv => cv.ContainerId == containerId && cv.ModelId == dominantModelId)
+                .Where(cv => cv.OwnerId == containerId && cv.ModelId == dominantModelId)
                 .Select(cv => cv.DocumentId)
                 .Distinct()
                 .CountAsync(ct);

--- a/src/Connapse.Storage/Vectors/PgVectorStore.cs
+++ b/src/Connapse.Storage/Vectors/PgVectorStore.cs
@@ -212,7 +212,7 @@ public class PgVectorStore : IVectorStore
             if (filters.TryGetValue("containerId", out var containerIdStr) &&
                 Guid.TryParse(containerIdStr, out var containerId))
             {
-                whereClauses.Add("cv.container_id = @containerId");
+                whereClauses.Add("cv.owner_id = @containerId");
                 parameters.Add(new NpgsqlParameter("@containerId", NpgsqlDbType.Uuid) { Value = containerId });
             }
 
@@ -241,7 +241,7 @@ public class PgVectorStore : IVectorStore
             SELECT
                 cv.chunk_id as ""ChunkId"",
                 cv.document_id as ""DocumentId"",
-                cv.container_id as ""ContainerId"",
+                cv.owner_id as ""ContainerId"",
                 (cv.embedding::vector({dims}) <=> @queryVector) as ""Distance"",
                 c.content as ""Content"",
                 c.chunk_index as ""ChunkIndex"",
@@ -407,7 +407,7 @@ public class PgVectorStore : IVectorStore
             cmd.CommandText = """
                 SELECT document_id, AVG(embedding)::vector AS pooled
                 FROM chunk_vectors
-                WHERE container_id = @cid
+                WHERE owner_id = @cid
                   AND model_id = @model_id
                 GROUP BY document_id
                 """;

--- a/src/Connapse.Storage/Vectors/VectorModelDiscovery.cs
+++ b/src/Connapse.Storage/Vectors/VectorModelDiscovery.cs
@@ -33,7 +33,7 @@ public class VectorModelDiscovery(
             cmd.CommandText =
                 "SELECT model_id, vector_dims(embedding) AS dims, COUNT(*) AS cnt " +
                 "FROM chunk_vectors " +
-                "WHERE container_id = @containerId " +
+                "WHERE owner_id = @containerId " +
                 "GROUP BY model_id, vector_dims(embedding) " +
                 "ORDER BY cnt DESC";
 

--- a/tests/Connapse.Core.Tests/Sources/SourceModelTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceModelTests.cs
@@ -1,0 +1,60 @@
+using Connapse.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Sources;
+
+[Trait("Category", "Unit")]
+public class SourceModelTests
+{
+    [Fact]
+    public void ConnectionProvider_Values_MatchConnectorTypeForBackfill()
+    {
+        // Phase 2 backfills existing containers by casting ConnectorType to
+        // ConnectionProvider. The numeric values must line up or the cast silently
+        // mislabels every migrated connection.
+        ((int)ConnectionProvider.Filesystem).Should().Be((int)ConnectorType.Filesystem);
+        ((int)ConnectionProvider.S3).Should().Be((int)ConnectorType.S3);
+        ((int)ConnectionProvider.AzureBlob).Should().Be((int)ConnectorType.AzureBlob);
+    }
+
+    [Fact]
+    public void ConnectionProvider_DoesNotContainManagedStorage()
+    {
+        // Managed storage is Connapse's own backend, never an external system
+        // it authenticates to, so it must not be expressible as a connection.
+        Enum.GetNames<ConnectionProvider>().Should().NotContain("ManagedStorage");
+    }
+
+    [Fact]
+    public void Source_NewInstance_DefaultsToNeverSynced()
+    {
+        var source = new Source(
+            Id: Guid.NewGuid(),
+            Name: "docs-bucket",
+            Description: null,
+            ConnectionId: Guid.NewGuid(),
+            ScopeJson: """{"prefix":"docs/"}""",
+            CreatedAt: DateTime.UtcNow,
+            UpdatedAt: DateTime.UtcNow);
+
+        source.LastSyncStatus.Should().Be(SyncStatus.Never);
+        source.SyncCursor.Should().BeNull();
+        source.LastSyncedAt.Should().BeNull();
+        source.Enabled.Should().BeTrue();
+        source.DocumentCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Connection_NeverExposesSecret()
+    {
+        // The Connection read model is returned to callers, so the secret VALUE must
+        // not be a property on it. HasSecret is fine — it is a bool flag telling the
+        // UI whether a credential is stored, and carries none of the credential.
+        var propertyNames = typeof(Connection).GetProperties().Select(p => p.Name).ToList();
+
+        propertyNames.Should().NotContain(["Secret", "SecretProtected"]);
+        typeof(Connection).GetProperty(nameof(Connection.HasSecret))!
+            .PropertyType.Should().Be<bool>();
+    }
+}

--- a/tests/Connapse.Integration.Tests/OwnerBridgeSchemaTests.cs
+++ b/tests/Connapse.Integration.Tests/OwnerBridgeSchemaTests.cs
@@ -1,0 +1,126 @@
+using Connapse.Storage.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Verifies the database-level guarantees behind the container/source owner bridge:
+/// exactly one owner per document, a generated owner_id that mirrors it, and a
+/// connection that cannot be deleted while sources still reference it.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class OwnerBridgeSchemaTests(SharedWebAppFixture fixture)
+{
+    private static string ShortName(string prefix) => $"{prefix}-{Guid.NewGuid():N}"[..20];
+
+    private static async Task<Guid> SeedContainerAsync(KnowledgeDbContext context)
+    {
+        var containerId = Guid.NewGuid();
+        await context.Database.ExecuteSqlRawAsync(
+            "INSERT INTO containers (id, name, connector_type, created_at, updated_at) VALUES ({0}, {1}, 0, now(), now())",
+            containerId, ShortName("owner-test"));
+        return containerId;
+    }
+
+    [Fact]
+    public async Task Documents_WithBothOwners_ViolatesCheckConstraint()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var context = await factory.CreateDbContextAsync();
+
+        Guid containerId = await SeedContainerAsync(context);
+
+        Func<Task> act = async () => await context.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO documents (id, container_id, source_id, file_name, path, content_hash, size_bytes, created_at)
+            VALUES (gen_random_uuid(), {0}, gen_random_uuid(), 'x.md', '/x.md', '', 1, now())
+            """, containerId);
+
+        // Either constraint rejecting this is correct: the CHECK forbids two owners, and
+        // the source FK forbids a source_id that does not exist. Both mean "not written".
+        (await act.Should().ThrowAsync<PostgresException>())
+            .Which.SqlState.Should().BeOneOf(
+                PostgresErrorCodes.CheckViolation,
+                PostgresErrorCodes.ForeignKeyViolation);
+    }
+
+    [Fact]
+    public async Task Documents_WithNoOwner_ViolatesCheckConstraint()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var context = await factory.CreateDbContextAsync();
+
+        Func<Task> act = async () => await context.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO documents (id, container_id, source_id, file_name, path, content_hash, size_bytes, created_at)
+            VALUES (gen_random_uuid(), NULL, NULL, 'x.md', '/x.md', '', 1, now())
+            """);
+
+        // Two constraints independently forbid an ownerless row, and Postgres does not
+        // guarantee which reports first: the CHECK requires exactly one owner, and
+        // owner_id is NOT NULL while COALESCE(NULL, NULL) evaluates to NULL. Either
+        // rejection is the guarantee we want.
+        (await act.Should().ThrowAsync<PostgresException>())
+            .Which.SqlState.Should().BeOneOf(
+                PostgresErrorCodes.CheckViolation,
+                PostgresErrorCodes.NotNullViolation);
+    }
+
+    [Fact]
+    public async Task Documents_OwnerId_MirrorsWhicheverOwnerIsSet()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var context = await factory.CreateDbContextAsync();
+
+        Guid containerId = await SeedContainerAsync(context);
+        var documentId = Guid.NewGuid();
+
+        await context.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO documents (id, container_id, source_id, file_name, path, content_hash, size_bytes, created_at)
+            VALUES ({0}, {1}, NULL, 'x.md', '/x.md', '', 1, now())
+            """, documentId, containerId);
+
+        var ownerId = await context.Documents
+            .AsNoTracking()
+            .Where(d => d.Id == documentId)
+            .Select(d => d.OwnerId)
+            .SingleAsync();
+
+        ownerId.Should().Be(containerId);
+    }
+
+    [Fact]
+    public async Task Connections_DeleteWithReferencingSource_IsRestricted()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var context = await factory.CreateDbContextAsync();
+
+        var connectionId = Guid.NewGuid();
+
+        await context.Database.ExecuteSqlRawAsync(
+            "INSERT INTO connections (id, name, provider, created_at, updated_at) VALUES ({0}, {1}, 3, now(), now())",
+            connectionId, ShortName("conn"));
+
+        await context.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO sources (id, name, connection_id, scope, enabled, last_sync_status, created_at, updated_at)
+            VALUES (gen_random_uuid(), {0}, {1}, '{{}}'::jsonb, true, 0, now(), now())
+            """, ShortName("src"), connectionId);
+
+        Func<Task> act = async () => await context.Database.ExecuteSqlRawAsync(
+            "DELETE FROM connections WHERE id = {0}", connectionId);
+
+        (await act.Should().ThrowAsync<PostgresException>())
+            .Which.SqlState.Should().Be(PostgresErrorCodes.ForeignKeyViolation);
+    }
+}

--- a/tests/Connapse.Integration.Tests/PgVectorStorePooledEmbeddingsTests.cs
+++ b/tests/Connapse.Integration.Tests/PgVectorStorePooledEmbeddingsTests.cs
@@ -155,7 +155,7 @@ public class PgVectorStorePooledEmbeddingsTests(SharedWebAppFixture fixture)
         {
             Id = chunkId,
             DocumentId = documentId,
-            ContainerId = containerId,
+            OwnerId = containerId,
             ChunkIndex = 0,
             Content = "test",
             TokenCount = 1,
@@ -166,7 +166,7 @@ public class PgVectorStorePooledEmbeddingsTests(SharedWebAppFixture fixture)
         {
             ChunkId = chunkId,
             DocumentId = documentId,
-            ContainerId = containerId,
+            OwnerId = containerId,
             Embedding = new Vector(embedding),
             ModelId = modelId,
             ContentHash = $"hash-{chunkId:N}",


### PR DESCRIPTION
Part of #349. First of two PRs for Phase 1 — this one is schema only, no stores.

## What

Adds the `connections` and `sources` tables, bridges `documents` to both owner kinds, and renames the denormalized owner column on `chunks` / `chunk_vectors`. **Nothing in the running application reads any of it** — `git diff main --stat -- src/Connapse.Web/` is empty.

## Why

Everything in #348 depends on a stable owner model. Landing the schema first, with no consumers, means the irreversible backfill in #350 happens against tables that already exist and are already tested.

## How

`documents` gains a nullable `source_id` beside `container_id`, a CHECK that exactly one is set, and a stored generated column:

```sql
owner_id uuid GENERATED ALWAYS AS (COALESCE(container_id, source_id)) STORED
```

The search path filters on `owner_id` and never has to classify its owner.

**The unique index moved from `(container_id, path)` to `(owner_id, path)`.** This is the subtle part: with `container_id` now nullable, a unique index over it would stop constraining source-owned rows entirely, because Postgres treats each NULL as distinct — two sources could each hold `/readme.md`. The documents upsert's `ON CONFLICT` target had to follow it.

`chunks` and `chunk_vectors` rename `container_id` to `owner_id`. EF generated a catalog-only `RenameColumn`, so there is **no table rewrite and no IVFFlat reindex** — important, since `chunk_vectors` is the largest table in the system. Neither table ever had an FK to `containers`, only a denormalized column and an index, so nothing had to be dropped.

Six raw-SQL sites had to follow the rename and could not be caught by the compiler: the documents upsert conflict target, the keyword search filter and projection, the vector search filter and projection, pooled embeddings, and model discovery.

`PostgresDocumentStore`'s container-summary paths are touched only because `container_id` became nullable — the two changes are compiler-forced, and behaviour is byte-identical for every document that exists today.

## Testing

- **1017 tests pass at this commit, 0 failures** (757 unit + 260 integration), verified standalone so this PR is independently mergeable.
- **Migration verified against populated data**, not just an empty schema: seeded 2 containers / 3 documents / 3 chunks / 3 embeddings at the previous migration, then applied this one. Row counts preserved, `owner_id` correctly mirrors `container_id`, both chunk tables carried their old values, embeddings still parse as 3-dimension vectors, and the new constraints reject an ownerless row and a duplicate `(owner_id, path)`.
- **Rollback verified with data present.** `Down` reverts cleanly: 3/3/3 intact, `chunk_vectors` back to `container_id`, both new tables gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for managing external connections, including Filesystem, S3, and Azure Blob providers.
  - Added source management with configurable scopes, synchronization intervals, enablement, and sync status tracking.
  - Sources can now organize and own indexed documents alongside existing managed storage.
  - Added source summaries and document counts to improve content visibility.
- **Bug Fixes**
  - Improved compatibility when accessing documents created under legacy storage arrangements.
  - Protected connection secrets from exposure in standard connection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->