### PR TITLE
feat(storage): connection and source stores with encrypted secrets

### DIFF
--- a/src/Connapse.Core/Interfaces/ISourceStore.cs
+++ b/src/Connapse.Core/Interfaces/ISourceStore.cs
@@ -12,10 +12,29 @@ public interface ISourceStore
     Task<bool> ExistsAsync(Guid id, CancellationToken ct = default);
 
     /// <summary>
-    /// Persists the sync cursor and outcome after a sync cycle. Passing a null
-    /// cursor clears it, which is what a RequiresFullResync response demands.
+    /// Unconditionally persists the sync cursor and outcome. Passing a null cursor clears
+    /// it, which is what a RequiresFullResync response demands.
+    /// <para>
+    /// This overwrites whatever is stored, so it is only safe when the caller is
+    /// deliberately resetting progress (a full resync, or recording a failure). For normal
+    /// forward advancement use <see cref="TryAdvanceSyncStateAsync"/>, which cannot clobber
+    /// a concurrent sync's newer cursor.
+    /// </para>
     /// </summary>
     Task UpdateSyncStateAsync(Guid id, string? cursor, SyncStatus status, string? error, DateTime? syncedAt, CancellationToken ct = default);
+
+    /// <summary>
+    /// Advances the sync cursor only if the stored cursor still equals <paramref name="expectedCursor"/>,
+    /// as a single atomic statement. Returns false when another sync already moved it, in which case
+    /// nothing is written and the caller should discard its result rather than retry blindly.
+    /// <para>
+    /// Without this, two overlapping syncs racing to completion can regress progress: if B starts
+    /// after A but finishes first, A's unconditional write replaces B's newer cursor and the next
+    /// cycle resumes from stale progress — duplicate ingestion at best, and an invalid continuation
+    /// token for providers whose cursors are opaque.
+    /// </para>
+    /// </summary>
+    Task<bool> TryAdvanceSyncStateAsync(Guid id, string? expectedCursor, string? newCursor, SyncStatus status, string? error, DateTime? syncedAt, CancellationToken ct = default);
 
     Task<ContainerSettingsOverrides?> GetSettingsOverridesAsync(Guid id, CancellationToken ct = default);
     Task SaveSettingsOverridesAsync(Guid id, ContainerSettingsOverrides overrides, CancellationToken ct = default);

--- a/src/Connapse.Core/Models/ConnectionModels.cs
+++ b/src/Connapse.Core/Models/ConnectionModels.cs
@@ -29,3 +29,18 @@ public record UpdateConnectionRequest(
     string? Name = null,
     string? ConfigJson = null,
     string? Secret = null);
+
+/// <summary>
+/// Thrown when a stored connection secret exists but cannot be decrypted — in practice,
+/// because the DataProtection key ring that encrypted it is gone or unreachable (a replaced
+/// volume, or a replica that does not share the key directory). Distinct from "no secret
+/// stored", which returns null. Callers should surface a reconnect prompt rather than
+/// treating this as a transient fault; retrying will not help.
+/// </summary>
+public class ConnectionSecretUnavailableException(Guid connectionId, Exception inner)
+    : Exception($"The stored secret for connection '{connectionId}' could not be decrypted. " +
+                "The DataProtection key ring that encrypted it is unavailable, so the credential " +
+                "must be re-entered.", inner)
+{
+    public Guid ConnectionId { get; } = connectionId;
+}

--- a/src/Connapse.Storage/Connapse.Storage.csproj
+++ b/src/Connapse.Storage/Connapse.Storage.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />

--- a/src/Connapse.Storage/Connections/PostgresConnectionStore.cs
+++ b/src/Connapse.Storage/Connections/PostgresConnectionStore.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Text.Json;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
@@ -139,7 +140,22 @@ public class PostgresConnectionStore(
             .Select(c => c.SecretProtected)
             .FirstOrDefaultAsync(ct);
 
-        return string.IsNullOrEmpty(ciphertext) ? null : Protector.Unprotect(ciphertext);
+        if (string.IsNullOrEmpty(ciphertext)) return null;
+
+        try
+        {
+            return Protector.Unprotect(ciphertext);
+        }
+        catch (CryptographicException ex)
+        {
+            // A raw CryptographicException here is opaque — it reads as a corrupt payload when
+            // the real cause is almost always a lost or unshared DataProtection key ring. Wrap
+            // it so callers can tell "re-enter this credential" apart from a transient fault.
+            logger.LogError(ex,
+                "Failed to decrypt secret for connection {ConnectionId}; the DataProtection key ring is unavailable",
+                id);
+            throw new ConnectionSecretUnavailableException(id, ex);
+        }
     }
 
     private static Connection MapToModel(ConnectionEntity entity, int sourceCount) => new(

--- a/src/Connapse.Storage/Connections/PostgresConnectionStore.cs
+++ b/src/Connapse.Storage/Connections/PostgresConnectionStore.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Data;
+using Connapse.Storage.Data.Entities;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using static Connapse.Core.Utilities.LogSanitizer;
+
+namespace Connapse.Storage.Connections;
+
+/// <summary>
+/// PostgreSQL-backed connection store. Secrets are encrypted at rest via
+/// ASP.NET Core DataProtection and never surface on the Connection read model.
+/// </summary>
+public class PostgresConnectionStore(
+    IDbContextFactory<KnowledgeDbContext> factory,
+    IDataProtectionProvider dataProtection,
+    ILogger<PostgresConnectionStore> logger) : IConnectionStore
+{
+    private IDataProtector Protector => dataProtection.CreateProtector("Connection.v1");
+
+    public async Task<Connection> CreateAsync(CreateConnectionRequest request, Guid? createdByUserId, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var name = request.Name.Trim();
+        if (string.IsNullOrEmpty(name) || name.Length > 128)
+            throw new ArgumentException("Connection name must be 1-128 characters.", nameof(request));
+
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        bool exists = await context.Connections.AnyAsync(c => c.Name == name, ct);
+        if (exists)
+            throw new InvalidOperationException($"A connection with the name '{name}' already exists.");
+
+        var entity = new ConnectionEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Provider = (int)request.Provider,
+            ConfigJson = string.IsNullOrEmpty(request.ConfigJson) ? null : JsonDocument.Parse(request.ConfigJson),
+            SecretProtected = string.IsNullOrEmpty(request.Secret) ? null : Protector.Protect(request.Secret),
+            CreatedByUserId = createdByUserId,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        context.Connections.Add(entity);
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation("Created connection {ConnectionId} ({Name})", entity.Id, Sanitize(entity.Name));
+
+        return MapToModel(entity, 0);
+    }
+
+    public async Task<Connection?> GetAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var result = await context.Connections
+            .AsNoTracking()
+            .Where(c => c.Id == id)
+            .Select(c => new { Connection = c, SourceCount = c.Sources.Count })
+            .FirstOrDefaultAsync(ct);
+
+        return result is null ? null : MapToModel(result.Connection, result.SourceCount);
+    }
+
+    public async Task<IReadOnlyList<Connection>> ListAsync(int skip = 0, int take = 50, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var results = await context.Connections
+            .AsNoTracking()
+            .OrderBy(c => c.Name)
+            .Skip(skip)
+            .Take(take)
+            .Select(c => new { Connection = c, SourceCount = c.Sources.Count })
+            .ToListAsync(ct);
+
+        return results.Select(r => MapToModel(r.Connection, r.SourceCount)).ToList();
+    }
+
+    public async Task<Connection?> UpdateAsync(Guid id, UpdateConnectionRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var entity = await context.Connections.FirstOrDefaultAsync(c => c.Id == id, ct);
+        if (entity is null) return null;
+
+        if (!string.IsNullOrWhiteSpace(request.Name))
+            entity.Name = request.Name.Trim();
+
+        if (request.ConfigJson is not null)
+            entity.ConfigJson = string.IsNullOrEmpty(request.ConfigJson) ? null : JsonDocument.Parse(request.ConfigJson);
+
+        // A null or empty Secret means "leave it alone" — only a real value replaces it.
+        // Without this, a settings-form save that omits the password field would wipe it.
+        if (!string.IsNullOrEmpty(request.Secret))
+            entity.SecretProtected = Protector.Protect(request.Secret);
+
+        entity.UpdatedAt = DateTime.UtcNow;
+        await context.SaveChangesAsync(ct);
+
+        int sourceCount = await context.Sources.CountAsync(s => s.ConnectionId == id, ct);
+        return MapToModel(entity, sourceCount);
+    }
+
+    public async Task<bool> DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var entity = await context.Connections.FirstOrDefaultAsync(c => c.Id == id, ct);
+        if (entity is null) return false;
+
+        int sourceCount = await context.Sources.CountAsync(s => s.ConnectionId == id, ct);
+        if (sourceCount > 0)
+            throw new InvalidOperationException(
+                $"Cannot delete this connection: {sourceCount} source(s) still use it. Remove or repoint them first.");
+
+        context.Connections.Remove(entity);
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation("Deleted connection {ConnectionId}", id);
+        return true;
+    }
+
+    public async Task<string?> GetSecretAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        string? ciphertext = await context.Connections
+            .AsNoTracking()
+            .Where(c => c.Id == id)
+            .Select(c => c.SecretProtected)
+            .FirstOrDefaultAsync(ct);
+
+        return string.IsNullOrEmpty(ciphertext) ? null : Protector.Unprotect(ciphertext);
+    }
+
+    private static Connection MapToModel(ConnectionEntity entity, int sourceCount) => new(
+        Id: entity.Id,
+        Name: entity.Name,
+        Provider: (ConnectionProvider)entity.Provider,
+        ConfigJson: entity.ConfigJson?.RootElement.GetRawText(),
+        CreatedByUserId: entity.CreatedByUserId,
+        CreatedAt: entity.CreatedAt,
+        UpdatedAt: entity.UpdatedAt,
+        HasSecret: !string.IsNullOrEmpty(entity.SecretProtected),
+        SourceCount: sourceCount);
+}

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -4,8 +4,10 @@ using Connapse.Storage.CloudScope;
 using Connapse.Storage.ConnectionTesters;
 using Connapse.Storage.Connectors;
 using Connapse.Storage.Data;
+using Connapse.Storage.Connections;
 using Connapse.Storage.Containers;
 using Connapse.Storage.Documents;
+using Connapse.Storage.Sources;
 using Connapse.Storage.FileSystem;
 using Connapse.Storage.Folders;
 using Connapse.Storage.Settings;
@@ -142,6 +144,8 @@ public static class ServiceCollectionExtensions
 
         // Container store
         services.AddScoped<IContainerStore, PostgresContainerStore>();
+        services.AddScoped<IConnectionStore, PostgresConnectionStore>();
+        services.AddScoped<ISourceStore, PostgresSourceStore>();
 
         // Folder store
         services.AddScoped<IFolderStore, PostgresFolderStore>();

--- a/src/Connapse.Storage/Sources/PostgresSourceStore.cs
+++ b/src/Connapse.Storage/Sources/PostgresSourceStore.cs
@@ -1,0 +1,255 @@
+using System.Text.Json;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Data;
+using Connapse.Storage.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using static Connapse.Core.Utilities.LogSanitizer;
+
+namespace Connapse.Storage.Sources;
+
+/// <summary>
+/// PostgreSQL-backed source store. A source is a read-only scope inside a
+/// connection; its sync cursor is persisted here so incremental sync survives
+/// a process restart.
+/// </summary>
+public class PostgresSourceStore(
+    IDbContextFactory<KnowledgeDbContext> factory,
+    ILogger<PostgresSourceStore> logger) : ISourceStore
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new() { PropertyNameCaseInsensitive = true };
+
+    public async Task<Source> CreateAsync(CreateSourceRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var name = request.Name.Trim();
+        if (string.IsNullOrEmpty(name) || name.Length > 128)
+            throw new ArgumentException("Source name must be 1-128 characters.", nameof(request));
+
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        bool connectionExists = await context.Connections.AnyAsync(c => c.Id == request.ConnectionId, ct);
+        if (!connectionExists)
+            throw new InvalidOperationException($"Connection '{request.ConnectionId}' does not exist.");
+
+        bool nameTaken = await context.Sources.AnyAsync(s => s.Name == name, ct);
+        if (nameTaken)
+            throw new InvalidOperationException($"A source with the name '{name}' already exists.");
+
+        var entity = new SourceEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Description = request.Description?.Trim(),
+            ConnectionId = request.ConnectionId,
+            ScopeJson = JsonDocument.Parse(string.IsNullOrEmpty(request.ScopeJson) ? "{}" : request.ScopeJson),
+            SyncIntervalSeconds = request.SyncIntervalSeconds,
+            Enabled = true,
+            LastSyncStatus = (int)SyncStatus.Never,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        context.Sources.Add(entity);
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation("Created source {SourceId} ({Name})", entity.Id, Sanitize(entity.Name));
+
+        return MapToModel(entity, 0);
+    }
+
+    public async Task<Source?> GetAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var result = await context.Sources
+            .AsNoTracking()
+            .Where(s => s.Id == id)
+            .Select(s => new { Source = s, DocumentCount = s.Documents.Count })
+            .FirstOrDefaultAsync(ct);
+
+        return result is null ? null : MapToModel(result.Source, result.DocumentCount);
+    }
+
+    public async Task<Source?> GetByNameAsync(string name, CancellationToken ct = default)
+    {
+        var normalized = name.Trim();
+
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var result = await context.Sources
+            .AsNoTracking()
+            .Where(s => s.Name == normalized)
+            .Select(s => new { Source = s, DocumentCount = s.Documents.Count })
+            .FirstOrDefaultAsync(ct);
+
+        return result is null ? null : MapToModel(result.Source, result.DocumentCount);
+    }
+
+    public async Task<IReadOnlyList<Source>> ListAsync(int skip = 0, int take = 50, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var results = await context.Sources
+            .AsNoTracking()
+            .OrderBy(s => s.Name)
+            .Skip(skip)
+            .Take(take)
+            .Select(s => new { Source = s, DocumentCount = s.Documents.Count })
+            .ToListAsync(ct);
+
+        return results.Select(r => MapToModel(r.Source, r.DocumentCount)).ToList();
+    }
+
+    public async Task<IReadOnlyList<Source>> ListByConnectionAsync(Guid connectionId, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var results = await context.Sources
+            .AsNoTracking()
+            .Where(s => s.ConnectionId == connectionId)
+            .OrderBy(s => s.Name)
+            .Select(s => new { Source = s, DocumentCount = s.Documents.Count })
+            .ToListAsync(ct);
+
+        return results.Select(r => MapToModel(r.Source, r.DocumentCount)).ToList();
+    }
+
+    public async Task<Source?> UpdateAsync(Guid id, UpdateSourceRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var entity = await context.Sources.FirstOrDefaultAsync(s => s.Id == id, ct);
+        if (entity is null) return null;
+
+        if (!string.IsNullOrWhiteSpace(request.Name))
+            entity.Name = request.Name.Trim();
+
+        if (request.Description is not null)
+            entity.Description = request.Description.Trim();
+
+        if (request.ScopeJson is not null)
+            entity.ScopeJson = JsonDocument.Parse(string.IsNullOrEmpty(request.ScopeJson) ? "{}" : request.ScopeJson);
+
+        if (request.SyncIntervalSeconds.HasValue)
+            entity.SyncIntervalSeconds = request.SyncIntervalSeconds;
+
+        if (request.Enabled.HasValue)
+            entity.Enabled = request.Enabled.Value;
+
+        entity.UpdatedAt = DateTime.UtcNow;
+        await context.SaveChangesAsync(ct);
+
+        int documentCount = await context.Documents.CountAsync(d => d.SourceId == id, ct);
+        return MapToModel(entity, documentCount);
+    }
+
+    public async Task<bool> DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var entity = await context.Sources.FirstOrDefaultAsync(s => s.Id == id, ct);
+        if (entity is null) return false;
+
+        context.Sources.Remove(entity);
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation("Deleted source {SourceId}", id);
+        return true;
+    }
+
+    public async Task<bool> ExistsAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+        return await context.Sources.AnyAsync(s => s.Id == id, ct);
+    }
+
+    public async Task UpdateSyncStateAsync(Guid id, string? cursor, SyncStatus status, string? error, DateTime? syncedAt, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var entity = await context.Sources.FirstOrDefaultAsync(s => s.Id == id, ct);
+        if (entity is null) return;
+
+        // A null cursor is meaningful, not "no change": it is how a RequiresFullResync
+        // response clears a stale delta token so the next cycle re-lists from scratch.
+        entity.SyncCursor = cursor;
+        entity.LastSyncStatus = (int)status;
+        entity.LastSyncError = error;
+        entity.LastSyncedAt = syncedAt;
+        entity.UpdatedAt = DateTime.UtcNow;
+
+        await context.SaveChangesAsync(ct);
+    }
+
+    public async Task<ContainerSettingsOverrides?> GetSettingsOverridesAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var json = await context.Sources
+            .AsNoTracking()
+            .Where(s => s.Id == id)
+            .Select(s => s.SettingsOverridesJson)
+            .FirstOrDefaultAsync(ct);
+
+        return json is null
+            ? null
+            : JsonSerializer.Deserialize<ContainerSettingsOverrides>(json.RootElement.GetRawText(), SerializerOptions);
+    }
+
+    public async Task SaveSettingsOverridesAsync(Guid id, ContainerSettingsOverrides overrides, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(overrides);
+
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var entity = await context.Sources.FirstOrDefaultAsync(s => s.Id == id, ct);
+        if (entity is null) return;
+
+        entity.SettingsOverridesJson = JsonDocument.Parse(JsonSerializer.Serialize(overrides, SerializerOptions));
+        entity.UpdatedAt = DateTime.UtcNow;
+
+        await context.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateSummaryAsync(Guid id, string? summary, DateTime? generatedAt, string? docSetHash, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var entity = await context.Sources.FirstOrDefaultAsync(s => s.Id == id, ct);
+        if (entity is null) return;
+
+        entity.Summary = summary;
+        entity.SummaryGeneratedAt = generatedAt;
+        entity.SummaryDocSetHash = docSetHash;
+        entity.UpdatedAt = DateTime.UtcNow;
+
+        await context.SaveChangesAsync(ct);
+    }
+
+    private static Source MapToModel(SourceEntity entity, int documentCount) => new(
+        Id: entity.Id,
+        Name: entity.Name,
+        Description: entity.Description,
+        ConnectionId: entity.ConnectionId,
+        ScopeJson: entity.ScopeJson.RootElement.GetRawText(),
+        CreatedAt: entity.CreatedAt,
+        UpdatedAt: entity.UpdatedAt,
+        Enabled: entity.Enabled,
+        SyncCursor: entity.SyncCursor,
+        LastSyncedAt: entity.LastSyncedAt,
+        LastSyncStatus: (SyncStatus)entity.LastSyncStatus,
+        LastSyncError: entity.LastSyncError,
+        SyncIntervalSeconds: entity.SyncIntervalSeconds,
+        SettingsOverrides: entity.SettingsOverridesJson is null
+            ? null
+            : JsonSerializer.Deserialize<ContainerSettingsOverrides>(entity.SettingsOverridesJson.RootElement.GetRawText(), SerializerOptions),
+        Summary: entity.Summary,
+        SummaryGeneratedAt: entity.SummaryGeneratedAt,
+        SummaryDocSetHash: entity.SummaryDocSetHash,
+        DocumentCount: documentCount);
+}

--- a/src/Connapse.Storage/Sources/PostgresSourceStore.cs
+++ b/src/Connapse.Storage/Sources/PostgresSourceStore.cs
@@ -186,6 +186,39 @@ public class PostgresSourceStore(
         await context.SaveChangesAsync(ct);
     }
 
+    public async Task<bool> TryAdvanceSyncStateAsync(
+        Guid id, string? expectedCursor, string? newCursor, SyncStatus status, string? error, DateTime? syncedAt, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        // Build the predicate explicitly rather than comparing against a nullable parameter:
+        // `s.SyncCursor == expectedCursor` with a null parameter translates to `sync_cursor = NULL`,
+        // which is never true in SQL, so a first-ever advance (expected null) would always report
+        // a conflict.
+        var matching = expectedCursor is null
+            ? context.Sources.Where(s => s.Id == id && s.SyncCursor == null)
+            : context.Sources.Where(s => s.Id == id && s.SyncCursor == expectedCursor);
+
+        // Single atomic UPDATE ... WHERE — no read-modify-write window for a concurrent sync
+        // to slip through.
+        int affected = await matching.ExecuteUpdateAsync(setters => setters
+            .SetProperty(s => s.SyncCursor, newCursor)
+            .SetProperty(s => s.LastSyncStatus, (int)status)
+            .SetProperty(s => s.LastSyncError, error)
+            .SetProperty(s => s.LastSyncedAt, syncedAt)
+            .SetProperty(s => s.UpdatedAt, DateTime.UtcNow), ct);
+
+        if (affected == 0)
+        {
+            logger.LogWarning(
+                "Sync cursor for source {SourceId} was advanced by another run; discarding this result",
+                id);
+            return false;
+        }
+
+        return true;
+    }
+
     public async Task<ContainerSettingsOverrides?> GetSettingsOverridesAsync(Guid id, CancellationToken ct = default)
     {
         await using var context = await factory.CreateDbContextAsync(ct);

--- a/tests/Connapse.Integration.Tests/ConnectionStoreIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/ConnectionStoreIntegrationTests.cs
@@ -1,0 +1,97 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class ConnectionStoreIntegrationTests(SharedWebAppFixture fixture)
+{
+    private static CreateConnectionRequest NewRequest(string? secret = "super-secret-key") =>
+        new($"conn-{Guid.NewGuid():N}"[..24], ConnectionProvider.S3, """{"region":"us-east-1"}""", secret);
+
+    [Fact]
+    public async Task CreateAsync_WithSecret_DoesNotExposeSecretOnReadModel()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var created = await store.CreateAsync(NewRequest(), createdByUserId: null);
+
+        created.HasSecret.Should().BeTrue();
+        created.ConfigJson.Should().Contain("us-east-1");
+    }
+
+    [Fact]
+    public async Task GetSecretAsync_AfterCreate_RoundTripsThePlaintext()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var created = await store.CreateAsync(NewRequest("round-trip-me"), createdByUserId: null);
+
+        string? secret = await store.GetSecretAsync(created.Id);
+
+        secret.Should().Be("round-trip-me");
+    }
+
+    [Fact]
+    public async Task GetSecretAsync_WhenNoSecretStored_ReturnsNull()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var request = new CreateConnectionRequest(
+            $"fs-{Guid.NewGuid():N}"[..24], ConnectionProvider.Filesystem, """{"root":"/data"}""", Secret: null);
+        var created = await store.CreateAsync(request, createdByUserId: null);
+
+        string? secret = await store.GetSecretAsync(created.Id);
+
+        secret.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_DuplicateName_Throws()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var request = NewRequest();
+        await store.CreateAsync(request, createdByUserId: null);
+
+        Func<Task> act = async () => await store.CreateAsync(request, createdByUserId: null);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithNullSecret_LeavesExistingSecretIntact()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var created = await store.CreateAsync(NewRequest("keep-me"), createdByUserId: null);
+
+        await store.UpdateAsync(created.Id, new UpdateConnectionRequest(Name: $"renamed-{Guid.NewGuid():N}"[..24]));
+
+        string? secret = await store.GetSecretAsync(created.Id);
+        secret.Should().Be("keep-me");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WithNoSources_RemovesTheConnection()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var created = await store.CreateAsync(NewRequest(), createdByUserId: null);
+
+        bool deleted = await store.DeleteAsync(created.Id);
+
+        deleted.Should().BeTrue();
+        (await store.GetAsync(created.Id)).Should().BeNull();
+    }
+}

--- a/tests/Connapse.Integration.Tests/SourceStoreIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceStoreIntegrationTests.cs
@@ -1,0 +1,128 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class SourceStoreIntegrationTests(SharedWebAppFixture fixture)
+{
+    private async Task<Guid> NewConnectionAsync(IConnectionStore connections)
+    {
+        var created = await connections.CreateAsync(
+            new CreateConnectionRequest($"c-{Guid.NewGuid():N}"[..24], ConnectionProvider.S3, """{"region":"us-east-1"}"""),
+            createdByUserId: null);
+        return created.Id;
+    }
+
+    private async Task<Source> NewSourceAsync(ISourceStore sources, IConnectionStore connections)
+    {
+        Guid connectionId = await NewConnectionAsync(connections);
+        return await sources.CreateAsync(new CreateSourceRequest(
+            Name: $"s-{Guid.NewGuid():N}"[..24],
+            ConnectionId: connectionId,
+            ScopeJson: """{"prefix":"docs/"}"""));
+    }
+
+    [Fact]
+    public async Task CreateAsync_NewSource_StartsNeverSyncedAndEnabled()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var source = await NewSourceAsync(sources, connections);
+
+        source.LastSyncStatus.Should().Be(SyncStatus.Never);
+        source.SyncCursor.Should().BeNull();
+        source.LastSyncedAt.Should().BeNull();
+        source.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateSyncStateAsync_AfterSuccessfulSync_PersistsCursor()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var source = await NewSourceAsync(sources, connections);
+        var syncedAt = DateTime.UtcNow;
+
+        await sources.UpdateSyncStateAsync(source.Id, "cursor-abc", SyncStatus.Succeeded, error: null, syncedAt);
+
+        var reloaded = await sources.GetAsync(source.Id);
+        reloaded!.SyncCursor.Should().Be("cursor-abc");
+        reloaded.LastSyncStatus.Should().Be(SyncStatus.Succeeded);
+        reloaded.LastSyncError.Should().BeNull();
+        reloaded.LastSyncedAt.Should().BeCloseTo(syncedAt, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task UpdateSyncStateAsync_WithNullCursor_ClearsItForFullResync()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var source = await NewSourceAsync(sources, connections);
+        await sources.UpdateSyncStateAsync(source.Id, "cursor-abc", SyncStatus.Succeeded, null, DateTime.UtcNow);
+
+        await sources.UpdateSyncStateAsync(source.Id, null, SyncStatus.Failed, "410 Gone", DateTime.UtcNow);
+
+        var reloaded = await sources.GetAsync(source.Id);
+        reloaded!.SyncCursor.Should().BeNull();
+        reloaded.LastSyncStatus.Should().Be(SyncStatus.Failed);
+        reloaded.LastSyncError.Should().Be("410 Gone");
+    }
+
+    [Fact]
+    public async Task CreateAsync_UnknownConnection_Throws()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+
+        Func<Task> act = async () => await sources.CreateAsync(new CreateSourceRequest(
+            Name: $"s-{Guid.NewGuid():N}"[..24],
+            ConnectionId: Guid.NewGuid(),
+            ScopeJson: "{}"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task ListByConnectionAsync_ReturnsOnlyThatConnectionsSources()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        Guid connectionId = await NewConnectionAsync(connections);
+        await sources.CreateAsync(new CreateSourceRequest($"a-{Guid.NewGuid():N}"[..24], connectionId, "{}"));
+        await sources.CreateAsync(new CreateSourceRequest($"b-{Guid.NewGuid():N}"[..24], connectionId, "{}"));
+        await NewSourceAsync(sources, connections); // belongs to a different connection
+
+        var results = await sources.ListByConnectionAsync(connectionId);
+
+        results.Should().HaveCount(2);
+        results.Should().OnlyContain(s => s.ConnectionId == connectionId);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetEnabledFalse_Persists()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var source = await NewSourceAsync(sources, connections);
+
+        await sources.UpdateAsync(source.Id, new UpdateSourceRequest(Enabled: false));
+
+        var reloaded = await sources.GetAsync(source.Id);
+        reloaded!.Enabled.Should().BeFalse();
+    }
+}

--- a/tests/Connapse.Integration.Tests/SourceStoreIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceStoreIntegrationTests.cs
@@ -80,6 +80,78 @@ public class SourceStoreIntegrationTests(SharedWebAppFixture fixture)
     }
 
     [Fact]
+    public async Task TryAdvanceSyncStateAsync_FirstAdvanceFromNullCursor_Succeeds()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var source = await NewSourceAsync(sources, connections);
+
+        bool advanced = await sources.TryAdvanceSyncStateAsync(
+            source.Id, expectedCursor: null, newCursor: "cursor-1", SyncStatus.Succeeded, null, DateTime.UtcNow);
+
+        advanced.Should().BeTrue();
+        (await sources.GetAsync(source.Id))!.SyncCursor.Should().Be("cursor-1");
+    }
+
+    [Fact]
+    public async Task TryAdvanceSyncStateAsync_ReverseCompletionOrder_CannotRegressTheCursor()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var source = await NewSourceAsync(sources, connections);
+
+        // Both syncs read the same starting cursor (null), then B finishes first.
+        await sources.TryAdvanceSyncStateAsync(
+            source.Id, expectedCursor: null, newCursor: "cursor-B", SyncStatus.Succeeded, null, DateTime.UtcNow);
+
+        // A now completes late, still believing the cursor is null. It must not win.
+        bool aWon = await sources.TryAdvanceSyncStateAsync(
+            source.Id, expectedCursor: null, newCursor: "cursor-A", SyncStatus.Succeeded, null, DateTime.UtcNow);
+
+        aWon.Should().BeFalse();
+        (await sources.GetAsync(source.Id))!.SyncCursor.Should().Be("cursor-B");
+    }
+
+    [Fact]
+    public async Task TryAdvanceSyncStateAsync_ChainedAdvances_EachMatchesPriorCursor()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var source = await NewSourceAsync(sources, connections);
+
+        await sources.TryAdvanceSyncStateAsync(source.Id, null, "c1", SyncStatus.Succeeded, null, DateTime.UtcNow);
+        bool second = await sources.TryAdvanceSyncStateAsync(source.Id, "c1", "c2", SyncStatus.Succeeded, null, DateTime.UtcNow);
+
+        second.Should().BeTrue();
+        (await sources.GetAsync(source.Id))!.SyncCursor.Should().Be("c2");
+    }
+
+    [Fact]
+    public async Task UpdateSyncStateAsync_StillResetsUnconditionally_ForFullResync()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var source = await NewSourceAsync(sources, connections);
+        await sources.TryAdvanceSyncStateAsync(source.Id, null, "stale-token", SyncStatus.Succeeded, null, DateTime.UtcNow);
+
+        // A RequiresFullResync response must be able to clear the cursor regardless of its
+        // current value — the compare-and-swap path deliberately does not gate this.
+        await sources.UpdateSyncStateAsync(source.Id, null, SyncStatus.Failed, "410 Gone", DateTime.UtcNow);
+
+        var reloaded = await sources.GetAsync(source.Id);
+        reloaded!.SyncCursor.Should().BeNull();
+        reloaded.LastSyncError.Should().Be("410 Gone");
+    }
+
+    [Fact]
     public async Task CreateAsync_UnknownConnection_Throws()
     {
         await using var scope = fixture.Factory.Services.CreateAsyncScope();


### PR DESCRIPTION
Closes #349. Second of two PRs for Phase 1. **Stacked on #355 — review that first; this PR's diff shows only the store work.**

## What

Adds `PostgresConnectionStore` and `PostgresSourceStore` behind the `IConnectionStore` / `ISourceStore` interfaces, and registers both in DI. Still nothing in the running application reads them.

## Why

Phase 2's backfill needs a stable store API to write through. Landing the stores separately from the schema keeps each PR reviewable and lets the schema merge on its own.

## How

**Secrets are encrypted at rest** via ASP.NET Core DataProtection under the `Connection.v1` purpose, matching the existing `CloudIdentity.v1` pattern in `CloudIdentityService`. The `Connection` read model has no secret property at all — only a `HasSecret` boolean — and a unit test asserts that, so the value cannot leak through an API response by accident.

On update, an omitted secret **leaves the stored one intact** rather than wiping it. Without that, a settings form that doesn't re-send the password field would silently destroy the credential.

`PostgresSourceStore.UpdateSyncStateAsync` persists the sync cursor so incremental sync survives a process restart — the current in-memory snapshot does not. A null cursor is treated as a meaningful clear, not "no change", because that is exactly how a `RequiresFullResync` response (Graph's `HTTP 410 Gone`, Dropbox's `409 reset`) tells us to discard a stale delta token.

Deleting a connection that still has sources throws rather than cascading, backed by `DeleteBehavior.Restrict` at the database level.

### One thing worth a reviewer's opinion

This adds `Microsoft.AspNetCore.DataProtection` to `Connapse.Storage`, which previously had no ASP.NET Core dependency. `Connapse.Identity` solves the same problem with a full `FrameworkReference` to `Microsoft.AspNetCore.App`; I used the targeted package to keep the data layer off the framework. If you'd rather encryption not live in Storage at all, the alternative is an interface in `Connapse.Core` implemented in `Connapse.Web` — happy to refactor.

## Testing

- **All 1029 tests pass, 0 failures** (757 unit + 272 integration).
- 12 new integration tests across the two stores, each written first and confirmed failing before implementation: secret round-trip, no-secret returns null, update preserves an omitted secret, duplicate names rejected, cursor persistence, null-cursor clear, unknown-connection rejection, and connection-scoped listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connection management with creation, updates, deletion, pagination, and connection-scoped source listings.
  * Added secure credential storage and retrieval, with secrets excluded from connection details.
  * Added source management, configurable settings, summaries, and persisted synchronization status.
  * Added safeguards to prevent stale synchronization results from overwriting newer progress.
  * Added clear errors when protected connection credentials cannot be accessed.

* **Bug Fixes**
  * Preserved existing credentials when updating a connection without providing a replacement.
  * Prevented deletion of connections still associated with sources.

* **Tests**
  * Added integration coverage for connection security, source management, synchronization, and concurrency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->