### PR TITLE
feat(ingestion): make document ownership explicit and owner-aware

### DIFF
--- a/src/Connapse.Core/Models/IngestionModels.cs
+++ b/src/Connapse.Core/Models/IngestionModels.cs
@@ -8,7 +8,15 @@ public record IngestionOptions(
     string? Path = null,
     ChunkingStrategy Strategy = ChunkingStrategy.Semantic,
     Dictionary<string, string>? Metadata = null,
-    int Generation = 0);
+    int Generation = 0)
+{
+    /// <summary>
+    /// Who will own the ingested document. Preferred over <see cref="ContainerId"/>, which
+    /// cannot express source ownership. When null, ContainerId is used and the owner is
+    /// taken to be a container.
+    /// </summary>
+    public OwnerRef? Owner { get; init; }
+}
 
 public record IngestionResult(
     string DocumentId,

--- a/src/Connapse.Core/Models/SyncModels.cs
+++ b/src/Connapse.Core/Models/SyncModels.cs
@@ -27,3 +27,22 @@ public record SourceSyncResult(
     bool UsedDeltaPath,
     bool RequiredResync,
     string? Error);
+
+/// <summary>
+/// Thrown when a reindex would move a document between ownership domains — source to
+/// container or the reverse. Distinct from ordinary ingestion failures because it must
+/// escape the catch-all that records a "Failed" document: a refused reindex is not the
+/// same as one that went wrong, and conflating them would leave the caller believing the
+/// work failed rather than that it was rejected.
+/// </summary>
+public class DocumentOwnershipChangedException(Guid documentId, OwnerRef existing, OwnerRef attempted)
+    : InvalidOperationException(
+        $"Document {documentId} is owned by {(existing.IsSource ? "source" : "container")} {existing.Id}; " +
+        $"refusing to reindex it as {(attempted.IsSource ? "source" : "container")} {attempted.Id}. " +
+        "Document ownership cannot change.")
+{
+    public Guid DocumentId { get; } = documentId;
+    public OwnerRef ExistingOwner { get; } = existing;
+    public OwnerRef AttemptedOwner { get; } = attempted;
+}
+

--- a/src/Connapse.Core/Models/SyncModels.cs
+++ b/src/Connapse.Core/Models/SyncModels.cs
@@ -1,0 +1,29 @@
+namespace Connapse.Core;
+
+/// <summary>
+/// Identifies who owns a document: a managed container or an external source. Exists so the
+/// ownership decision is made once, at the point the owner is known, rather than by threading
+/// a Guid and a boolean through every layer and hoping each call site pairs them correctly.
+/// <para>
+/// <see cref="ContainerId"/> and <see cref="SourceId"/> are exactly the two columns behind the
+/// ck_documents_single_owner CHECK constraint — precisely one is ever non-null.
+/// </para>
+/// </summary>
+public record OwnerRef(Guid Id, bool IsSource)
+{
+    public static OwnerRef ForContainer(Guid id) => new(id, IsSource: false);
+    public static OwnerRef ForSource(Guid id) => new(id, IsSource: true);
+
+    public Guid? ContainerId => IsSource ? null : Id;
+    public Guid? SourceId => IsSource ? Id : null;
+}
+
+/// <summary>
+/// Outcome of one sync cycle for one source.
+/// </summary>
+public record SourceSyncResult(
+    int Upserted,
+    int Deleted,
+    bool UsedDeltaPath,
+    bool RequiredResync,
+    string? Error);

--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -119,6 +119,18 @@ public class IngestionPipeline : IKnowledgeIngester
             : Guid.NewGuid();
         DocumentEntity? documentEntity = null;
 
+        // Resolve ownership before the try block. Everything below writes through this, so a
+        // source-owned document cannot be recorded against container_id — which would violate
+        // the ck_documents_single_owner CHECK — and no chunk or vector can be written with a
+        // zero owner, which no owner-scoped query would ever match. Deliberately outside the
+        // catch: an ownerless call is a programming error, and failing fast beats recording a
+        // half-written document with a Failed status.
+        var owner = options.Owner
+            ?? (!string.IsNullOrEmpty(options.ContainerId) && Guid.TryParse(options.ContainerId, out var cId)
+                ? OwnerRef.ForContainer(cId)
+                : throw new ArgumentException(
+                    "Ingestion requires an owner: set Owner, or supply a parseable ContainerId.", nameof(options)));
+
         try
         {
             // Handle non-seekable streams (e.g., from MinIO)
@@ -163,10 +175,6 @@ public class IngestionPipeline : IKnowledgeIngester
             metadata[MetadataKeyEmbeddingModel] = embedSettings.Model;
             metadata[MetadataKeyEmbeddingDimensions] = embedSettings.Dimensions.ToString();
 
-            var containerId = !string.IsNullOrEmpty(options.ContainerId) && Guid.TryParse(options.ContainerId, out var cId)
-                ? cId
-                : Guid.Empty;
-
             // Check if document already exists (created eagerly by UploadService)
             documentEntity = await _context.Documents.FindAsync([documentId], ct);
             bool isReindex = documentEntity is not null;
@@ -188,7 +196,8 @@ public class IngestionPipeline : IKnowledgeIngester
             if (documentEntity != null)
             {
                 // Update existing document for reindex
-                documentEntity.ContainerId = containerId;
+                documentEntity.ContainerId = owner.ContainerId;
+                documentEntity.SourceId = owner.SourceId;
                 documentEntity.FileName = options.FileName ?? "unknown";
                 documentEntity.ContentType = options.ContentType;
                 documentEntity.Path = virtualPath;
@@ -202,7 +211,8 @@ public class IngestionPipeline : IKnowledgeIngester
                 documentEntity = new DocumentEntity
                 {
                     Id = documentId,
-                    ContainerId = containerId,
+                    ContainerId = owner.ContainerId,
+                    SourceId = owner.SourceId,
                     FileName = options.FileName ?? "unknown",
                     ContentType = options.ContentType,
                     Path = virtualPath,
@@ -341,7 +351,7 @@ public class IngestionPipeline : IKnowledgeIngester
                 {
                     Id = chunkId,
                     DocumentId = documentEntity.Id,
-                    OwnerId = containerId,
+                    OwnerId = owner.Id,
                     Content = chunkInfo.Content,
                     ChunkIndex = chunkInfo.ChunkIndex,
                     TokenCount = chunkInfo.TokenCount,
@@ -353,7 +363,7 @@ public class IngestionPipeline : IKnowledgeIngester
                 vectorItems.Add((chunkId.ToString(), embeddings[i], new Dictionary<string, string>(chunkInfo.Metadata)
                 {
                     ["documentId"] = documentEntity.Id.ToString(),
-                    ["containerId"] = containerId.ToString(),
+                    ["ownerId"] = owner.Id.ToString(),
                     ["modelId"] = embedSettings.Model,
                     ["ChunkIndex"] = chunkInfo.ChunkIndex.ToString(),
                     ["contentHash"] = EmbeddingCache.ComputeHash(chunkInfo.Content),

--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -195,6 +195,19 @@ public class IngestionPipeline : IKnowledgeIngester
 
             if (documentEntity != null)
             {
+                // Ownership is immutable. Writing both columns from the incoming options would
+                // let a reindex move a document between a source and a container while still
+                // satisfying ck_documents_single_owner — exactly one column stays set, so the
+                // database cannot catch it — silently carrying content across an authorization
+                // boundary. The catch below rethrows this rather than recording a Failed
+                // document, because a refused reindex is not a failed one.
+                var existingOwner = documentEntity.SourceId is Guid existingSourceId
+                    ? OwnerRef.ForSource(existingSourceId)
+                    : OwnerRef.ForContainer(documentEntity.ContainerId!.Value);
+
+                if (existingOwner != owner)
+                    throw new DocumentOwnershipChangedException(documentId, existingOwner, owner);
+
                 // Update existing document for reindex
                 documentEntity.ContainerId = owner.ContainerId;
                 documentEntity.SourceId = owner.SourceId;
@@ -400,6 +413,13 @@ public class IngestionPipeline : IKnowledgeIngester
                 Duration: stopwatch.Elapsed,
                 Warnings: warnings);
         }
+        catch (DocumentOwnershipChangedException)
+        {
+            // Let this escape. Recording a "Failed" document here would tell the caller the
+            // work went wrong rather than that it was refused, and would leave the document
+            // real owner looking broken.
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error during document ingestion");
@@ -461,7 +481,17 @@ public class IngestionPipeline : IKnowledgeIngester
             Document? doc = await _documentStore.GetAsync(documentId, ct)
                 ?? throw new InvalidOperationException(
                     $"IngestByIdAsync: document {documentId} not found and no ContainerId in options");
-            containerId = Guid.Parse(doc.ContainerId);
+
+            // Source-owned documents have an empty ContainerId, so Guid.Parse would throw a
+            // bare FormatException here. Fail with something actionable instead. Re-ingesting
+            // a source document goes through the sync engine, which resolves its connector
+            // from the source's connection rather than from a container.
+            if (string.IsNullOrEmpty(doc.ContainerId) || !Guid.TryParse(doc.ContainerId, out var docContainerId))
+                throw new InvalidOperationException(
+                    $"IngestByIdAsync: document {documentId} is not owned by a container. " +
+                    "Source-owned documents are re-ingested by the source sync engine.");
+
+            containerId = docContainerId;
             virtualPath = doc.Path;
         }
 

--- a/src/Connapse.Storage/Vectors/PgVectorStore.cs
+++ b/src/Connapse.Storage/Vectors/PgVectorStore.cs
@@ -35,7 +35,7 @@ public class PgVectorStore : IVectorStore
     /// <param name="metadata">Metadata containing required keys:
     /// - "documentId": a GUID string identifying the document,
     /// - "modelId": the model identifier string.
-    /// Optionally may contain "containerId" as a GUID string.</param>
+    /// - "ownerId": a GUID string identifying the owning container or source.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <exception cref="ArgumentException">Thrown when:
     /// - <paramref name="id"/> is not a valid GUID,
@@ -70,11 +70,12 @@ public class PgVectorStore : IVectorStore
             throw new ArgumentException("Metadata must contain a 'modelId'", nameof(metadata));
         }
 
-        // Extract containerId from metadata
-        Guid containerId = Guid.Empty;
-        if (metadata.TryGetValue("containerId", out var containerIdStr))
+        // Demand an explicit owner. Defaulting to Guid.Empty here fails silently: the vector
+        // is written, but no owner-scoped query can ever match it, so the content becomes
+        // unreachable rather than visibly broken.
+        if (!metadata.TryGetValue("ownerId", out var ownerIdStr) || !Guid.TryParse(ownerIdStr, out var ownerId))
         {
-            Guid.TryParse(containerIdStr, out containerId);
+            throw new ArgumentException("Metadata must contain a valid 'ownerId'", nameof(metadata));
         }
 
         var existing = await _context.ChunkVectors
@@ -86,7 +87,7 @@ public class PgVectorStore : IVectorStore
             existing.Embedding = new Vector(vector);
             existing.ModelId = modelId;
             existing.DocumentId = documentId;
-            existing.OwnerId = containerId;
+            existing.OwnerId = ownerId;
         }
         else
         {
@@ -95,7 +96,7 @@ public class PgVectorStore : IVectorStore
             {
                 ChunkId = chunkId,
                 DocumentId = documentId,
-                OwnerId = containerId,
+                OwnerId = ownerId,
                 Embedding = new Vector(vector),
                 ModelId = modelId
             };
@@ -121,7 +122,7 @@ public class PgVectorStore : IVectorStore
     /// - Metadata: required and optional metadata for the chunk.
     /// Required metadata keys: "documentId" (GUID string) and "modelId" (string).
     /// Optional metadata keys:
-    /// - "containerId" (GUID string; unparseable or missing defaults to Guid.Empty),
+    /// Also required: "ownerId" (GUID string). Optional keys:
     /// - "contentHash" (string),
     /// - "dimensions" (integer string; used only if parses to an int > 0).
     /// </param>
@@ -135,7 +136,7 @@ public class PgVectorStore : IVectorStore
     /// A list of tuples where each tuple contains:
     /// - Id: a string representation of the chunk GUID.
     /// - Vector: the embedding values for the chunk.
-    /// - Metadata: a dictionary that must include "documentId" (GUID string) and "modelId"; may include "containerId" (GUID string), "contentHash", and "dimensions" (positive integer string).
+    /// - Metadata: a dictionary that must include "documentId" (GUID string), "modelId", and "ownerId" (GUID string); may include "contentHash" and "dimensions" (positive integer string).
     /// </param>
     /// <param name="ct">Cancellation token to cancel the operation.</param>
     /// <exception cref="ArgumentException">
@@ -160,15 +161,17 @@ public class PgVectorStore : IVectorStore
             if (!metadata.TryGetValue("modelId", out var modelId))
                 throw new ArgumentException("Each item's metadata must contain a 'modelId'", nameof(items));
 
-            Guid containerId = Guid.Empty;
-            if (metadata.TryGetValue("containerId", out var containerIdStr))
-                Guid.TryParse(containerIdStr, out containerId);
+            // Demand an explicit owner. Defaulting to Guid.Empty here fails silently: the
+            // vector is written, but no owner-scoped query can ever match it, so the content
+            // is unreachable rather than visibly broken.
+            if (!metadata.TryGetValue("ownerId", out var ownerIdStr) || !Guid.TryParse(ownerIdStr, out var ownerId))
+                throw new ArgumentException("Each item's metadata must contain a valid 'ownerId'", nameof(items));
 
             _context.ChunkVectors.Add(new ChunkVectorEntity
             {
                 ChunkId = chunkId,
                 DocumentId = documentId,
-                OwnerId = containerId,
+                OwnerId = ownerId,
                 Embedding = new Vector(vector),
                 ModelId = modelId,
                 ContentHash = metadata.TryGetValue("contentHash", out var hash) ? hash : null,

--- a/tests/Connapse.Core.Tests/Sync/OwnerRefTests.cs
+++ b/tests/Connapse.Core.Tests/Sync/OwnerRefTests.cs
@@ -1,0 +1,45 @@
+using Connapse.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Sync;
+
+[Trait("Category", "Unit")]
+public class OwnerRefTests
+{
+    [Fact]
+    public void ForContainer_IsNotASource()
+    {
+        var id = Guid.NewGuid();
+
+        var owner = OwnerRef.ForContainer(id);
+
+        owner.Id.Should().Be(id);
+        owner.IsSource.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ForSource_IsASource()
+    {
+        var id = Guid.NewGuid();
+
+        var owner = OwnerRef.ForSource(id);
+
+        owner.Id.Should().Be(id);
+        owner.IsSource.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainerId_And_SourceId_AreMutuallyExclusive()
+    {
+        // These map straight onto the ck_documents_single_owner CHECK: exactly one of the
+        // two columns is set, and this type is what decides which.
+        var container = OwnerRef.ForContainer(Guid.NewGuid());
+        var source = OwnerRef.ForSource(Guid.NewGuid());
+
+        container.ContainerId.Should().NotBeNull();
+        container.SourceId.Should().BeNull();
+        source.ContainerId.Should().BeNull();
+        source.SourceId.Should().NotBeNull();
+    }
+}

--- a/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
@@ -28,6 +28,13 @@ namespace Connapse.Ingestion.Tests.Pipeline;
 [Trait("Category", "Unit")]
 public class IngestionPipelineTests
 {
+    /// <summary>
+    /// These tests predate source ownership and relied on the pipeline defaulting a missing
+    /// container to Guid.Empty. Ingestion now requires an explicit owner, so they declare a
+    /// container one — the ownership itself is not what they are testing.
+    /// </summary>
+    private static readonly Guid TestOwnerId = Guid.NewGuid();
+
     private readonly IKnowledgeFileSystem _fileSystem;
     private readonly IEmbeddingProvider _embeddingProvider;
     private readonly IVectorStore _vectorStore;
@@ -110,7 +117,7 @@ public class IngestionPipelineTests
         var pipeline = CreatePipeline(dbContext);
         var docId = Guid.NewGuid().ToString();
         var stream = new MemoryStream("Test content"u8.ToArray());
-        var options = new IngestionOptions(DocumentId: docId, FileName: "test.txt");
+        var options = new IngestionOptions(DocumentId: docId, FileName: "test.txt") { Owner = OwnerRef.ForContainer(TestOwnerId) };
 
         var result = await pipeline.IngestAsync(stream, options);
 
@@ -123,7 +130,7 @@ public class IngestionPipelineTests
         using var dbContext = CreateInMemoryContext();
         var pipeline = CreatePipeline(dbContext);
         var stream = new MemoryStream("Test content"u8.ToArray());
-        var options = new IngestionOptions(FileName: "test.txt");
+        var options = new IngestionOptions(FileName: "test.txt") { Owner = OwnerRef.ForContainer(TestOwnerId) };
 
         var result = await pipeline.IngestAsync(stream, options);
 
@@ -137,7 +144,7 @@ public class IngestionPipelineTests
         using var dbContext = CreateInMemoryContext();
         var pipeline = CreatePipeline(dbContext);
         var stream = new MemoryStream("Test content"u8.ToArray());
-        var options = new IngestionOptions(FileName: "test.txt");
+        var options = new IngestionOptions(FileName: "test.txt") { Owner = OwnerRef.ForContainer(TestOwnerId) };
 
         var result = await pipeline.IngestAsync(stream, options);
 
@@ -152,7 +159,7 @@ public class IngestionPipelineTests
         using var dbContext = CreateInMemoryContext();
         var pipeline = CreatePipeline(dbContext);
         var stream = new MemoryStream("Test content"u8.ToArray());
-        var options = new IngestionOptions(FileName: "test.txt");
+        var options = new IngestionOptions(FileName: "test.txt") { Owner = OwnerRef.ForContainer(TestOwnerId) };
 
         var result = await pipeline.IngestAsync(stream, options);
 
@@ -166,7 +173,7 @@ public class IngestionPipelineTests
         using var dbContext = CreateInMemoryContext();
         var pipeline = CreatePipeline(dbContext);
         var stream = new MemoryStream("Test content"u8.ToArray());
-        var options = new IngestionOptions(FileName: "test.txt");
+        var options = new IngestionOptions(FileName: "test.txt") { Owner = OwnerRef.ForContainer(TestOwnerId) };
 
         var result = await pipeline.IngestAsync(stream, options);
 
@@ -194,7 +201,7 @@ public class IngestionPipelineTests
         using var dbContext = CreateInMemoryContext();
         var pipeline = CreatePipeline(dbContext);
         var stream = new MemoryStream("Test content"u8.ToArray());
-        var options = new IngestionOptions(FileName: "test.txt");
+        var options = new IngestionOptions(FileName: "test.txt") { Owner = OwnerRef.ForContainer(TestOwnerId) };
 
         await pipeline.IngestAsync(stream, options);
 
@@ -207,7 +214,7 @@ public class IngestionPipelineTests
         using var dbContext = CreateInMemoryContext();
         var pipeline = CreatePipeline(dbContext);
         var stream = new MemoryStream("Test content"u8.ToArray());
-        var options = new IngestionOptions(FileName: "test.xyz");
+        var options = new IngestionOptions(FileName: "test.xyz") { Owner = OwnerRef.ForContainer(TestOwnerId) };
 
         await pipeline.IngestAsync(stream, options);
 
@@ -237,7 +244,7 @@ public class IngestionPipelineTests
         var innerStream = new MemoryStream(data);
         var nonSeekableStream = new NonSeekableStream(innerStream);
 
-        var options = new IngestionOptions(FileName: "test.txt");
+        var options = new IngestionOptions(FileName: "test.txt") { Owner = OwnerRef.ForContainer(TestOwnerId) };
 
         var result = await pipeline.IngestAsync(nonSeekableStream, options);
 

--- a/tests/Connapse.Integration.Tests/SourceIngestionOwnershipTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceIngestionOwnershipTests.cs
@@ -100,4 +100,67 @@ public class SourceIngestionOwnershipTests(SharedWebAppFixture fixture)
 
         await act.Should().ThrowAsync<ArgumentException>();
     }
+
+    [Fact]
+    public async Task Reindex_AttemptingToMoveSourceDocumentToContainer_IsRejected()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        Guid sourceId = await SeedSourceAsync(scope.ServiceProvider);
+        var pipeline = scope.ServiceProvider.GetRequiredService<IKnowledgeIngester>();
+
+        using var first = new MemoryStream("original source-owned content"u8.ToArray());
+        var created = await pipeline.IngestAsync(first, new IngestionOptions(
+            FileName: "move.md", ContentType: "text/markdown", Path: "/move.md")
+        {
+            Owner = OwnerRef.ForSource(sourceId)
+        }, CancellationToken.None);
+
+        // Re-ingesting the same document under a container owner would clear source_id and
+        // set container_id. The CHECK still passes — exactly one column is set — so nothing
+        // at the database level catches it, and the content silently crosses an
+        // authorization boundary.
+        using var second = new MemoryStream("reindexed content"u8.ToArray());
+        Func<Task> act = async () => await pipeline.IngestAsync(second, new IngestionOptions(
+            DocumentId: created.DocumentId, FileName: "move.md", Path: "/move.md")
+        {
+            Owner = OwnerRef.ForContainer(Guid.NewGuid())
+        }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        await using var ctx = await factory.CreateDbContextAsync();
+        var doc = await ctx.Documents.AsNoTracking().SingleAsync(d => d.Id == Guid.Parse(created.DocumentId));
+        doc.SourceId.Should().Be(sourceId, "a rejected reindex must not move the document");
+        doc.ContainerId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Reindex_WithMatchingOwner_Succeeds()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        Guid sourceId = await SeedSourceAsync(scope.ServiceProvider);
+        var pipeline = scope.ServiceProvider.GetRequiredService<IKnowledgeIngester>();
+
+        using var first = new MemoryStream("first revision of the document"u8.ToArray());
+        var created = await pipeline.IngestAsync(first, new IngestionOptions(
+            FileName: "same.md", ContentType: "text/markdown", Path: "/same.md")
+        {
+            Owner = OwnerRef.ForSource(sourceId)
+        }, CancellationToken.None);
+
+        // Same owner is the normal re-sync case and must keep working.
+        using var second = new MemoryStream("second revision of the document"u8.ToArray());
+        await pipeline.IngestAsync(second, new IngestionOptions(
+            DocumentId: created.DocumentId, FileName: "same.md", Path: "/same.md")
+        {
+            Owner = OwnerRef.ForSource(sourceId)
+        }, CancellationToken.None);
+
+        await using var ctx = await factory.CreateDbContextAsync();
+        var doc = await ctx.Documents.AsNoTracking().SingleAsync(d => d.Id == Guid.Parse(created.DocumentId));
+        doc.SourceId.Should().Be(sourceId);
+        doc.ContainerId.Should().BeNull();
+    }
 }

--- a/tests/Connapse.Integration.Tests/SourceIngestionOwnershipTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceIngestionOwnershipTests.cs
@@ -1,0 +1,103 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Pins the two ownership bugs found while planning PR 3b. Before #351, IngestionPipeline
+/// set documents.container_id unconditionally — so ingesting into a source would have
+/// violated the ck_documents_single_owner CHECK — and PgVectorStore defaulted a missing
+/// owner to Guid.Empty, which writes a vector no owner-scoped query can ever match.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class SourceIngestionOwnershipTests(SharedWebAppFixture fixture)
+{
+    private static string ShortName(string p) => $"{p}-{Guid.NewGuid():N}"[..20];
+
+    private static async Task<Guid> SeedSourceAsync(IServiceProvider sp)
+    {
+        var connections = sp.GetRequiredService<IConnectionStore>();
+        var sources = sp.GetRequiredService<ISourceStore>();
+
+        var connection = await connections.CreateAsync(
+            new CreateConnectionRequest(ShortName("c"), ConnectionProvider.S3, """{"region":"us-east-1"}"""),
+            createdByUserId: null);
+
+        var source = await sources.CreateAsync(
+            new CreateSourceRequest(ShortName("s"), connection.Id, """{"bucketName":"b"}"""));
+
+        return source.Id;
+    }
+
+    [Fact]
+    public async Task Ingest_ForSourceOwner_WritesSourceIdNotContainerId()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        Guid sourceId = await SeedSourceAsync(scope.ServiceProvider);
+
+        var pipeline = scope.ServiceProvider.GetRequiredService<IKnowledgeIngester>();
+        using var content = new MemoryStream("owner test content for the source"u8.ToArray());
+
+        await pipeline.IngestAsync(content, new IngestionOptions(
+            FileName: "owned.md",
+            ContentType: "text/markdown",
+            Path: "/owned.md")
+        {
+            Owner = OwnerRef.ForSource(sourceId)
+        }, CancellationToken.None);
+
+        await using var ctx = await factory.CreateDbContextAsync();
+        var doc = await ctx.Documents.AsNoTracking().SingleAsync(d => d.SourceId == sourceId);
+
+        doc.ContainerId.Should().BeNull("the XOR check forbids both owners being set");
+        doc.SourceId.Should().Be(sourceId);
+        doc.OwnerId.Should().Be(sourceId);
+    }
+
+    [Fact]
+    public async Task Ingest_ForSourceOwner_WritesChunksWithSourceOwnerNotEmpty()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        Guid sourceId = await SeedSourceAsync(scope.ServiceProvider);
+
+        var pipeline = scope.ServiceProvider.GetRequiredService<IKnowledgeIngester>();
+        using var content = new MemoryStream("chunk owner content for the source document"u8.ToArray());
+
+        await pipeline.IngestAsync(content, new IngestionOptions(
+            FileName: "chunks.md",
+            ContentType: "text/markdown",
+            Path: "/chunks.md")
+        {
+            Owner = OwnerRef.ForSource(sourceId)
+        }, CancellationToken.None);
+
+        await using var ctx = await factory.CreateDbContextAsync();
+
+        (await ctx.Chunks.AsNoTracking().AnyAsync(c => c.OwnerId == sourceId))
+            .Should().BeTrue("chunks must carry the source as their owner");
+        (await ctx.Chunks.AsNoTracking().AnyAsync(c => c.OwnerId == Guid.Empty))
+            .Should().BeFalse("a zero owner is unreachable by every owner-scoped query");
+    }
+
+    [Fact]
+    public async Task Ingest_WithNoOwnerAndNoContainerId_Throws()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var pipeline = scope.ServiceProvider.GetRequiredService<IKnowledgeIngester>();
+        using var content = new MemoryStream("no owner"u8.ToArray());
+
+        // Failing loudly beats writing a document nobody owns.
+        Func<Task> act = async () => await pipeline.IngestAsync(
+            content, new IngestionOptions(FileName: "orphan.md", Path: "/orphan.md"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+}


### PR DESCRIPTION
Part of #351. First of two PRs for phase 3b. Plan: #362.

## What

Makes ingestion owner-aware, so a document can belong to a source rather than only to a container. Introduces `OwnerRef`, teaches `IngestionPipeline` to write `source_id`, and makes vector upserts demand an explicit owner.

Split out from the sync engine deliberately: these are two standalone bug fixes, and the 700-line `ConnectorWatcherService` rewrite deserves its own review rather than riding behind them.

## Why

Two bugs found while grounding the #362 plan, both of which would bite the moment sources are enumerated:

**1. Ingesting into a source was impossible.** `IngestionPipeline` set `documentEntity.ContainerId` unconditionally and never `SourceId`, so any source-owned document would have violated the `ck_documents_single_owner` CHECK constraint.

**2. Vectors could be written with no owner, silently.** `PgVectorStore` read an optional `containerId` from metadata and defaulted a missing or unparseable value to `Guid.Empty`:

```csharp
Guid containerId = Guid.Empty;
if (metadata.TryGetValue("containerId", out var containerIdStr))
    Guid.TryParse(containerIdStr, out containerId);
```

That is the worse of the two. The write succeeds, but every search path filters on `owner_id`, so a zero-owner vector matches nothing — the content is unreachable rather than visibly broken, and nothing surfaces an error.

## How

`OwnerRef(Guid Id, bool IsSource)` with `ForContainer` / `ForSource` factories, exposing `ContainerId` and `SourceId` that map exactly onto the two columns behind the CHECK constraint. Threading a bare `Guid` plus a boolean would have invited getting the pairing wrong at one call site out of several; one type makes it impossible.

`IngestionOptions` gains `Owner`, preferred over the existing `ContainerId` string, which stays so unrelated callers keep working.

Ownership is resolved **once, above the try block**, and every downstream write goes through it — the document row on both the create and reindex paths, the chunk's `OwnerId`, and the vector metadata key (now `ownerId`, not `containerId`). Above the try deliberately: the pipeline otherwise catches exceptions and records a "Failed" document, so validating inside would half-write a row for what is a programming error.

`PgVectorStore` now throws when `ownerId` is missing or unparseable, in both `UpsertAsync` and `UpsertBatchAsync`. Failing loudly at write time beats discovering it at search time.

## Testing

**1048 tests pass, 0 failures.** New coverage: `OwnerRef`'s mutual exclusivity, a source-owned document writing `source_id` with `container_id` null and `owner_id` matching, chunks carrying the source owner with no `Guid.Empty` present, and an ownerless call throwing rather than silently succeeding.

Eight existing `IngestionPipelineTests` broke because they relied on the old `Guid.Empty` fallback — they test pipeline mechanics like non-seekable streams and document-ID generation, not ownership, so they were **updated** with an explicit container owner rather than deleted. Unlike PR 3a, none of these scenarios became unreachable.

## Still to come in phase 3b

`SourceSyncService` replacing `ConnectorWatcherService` — the fix for external sources not syncing at all since #359. This PR is a prerequisite: the sync engine ingests with `OwnerRef.ForSource(...)`, which does not work until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Ingestion now supports ownership by either a container or a source.
  - Ownership information is preserved on ingested documents, chunks, and vector metadata.
  - Added sync results capturing updates, deletions, delta processing, resynchronization, and errors.

- **Bug Fixes**
  - Prevented ingestion without a valid owner.
  - Ensured source-owned content no longer falls back to an empty or incorrect container identifier.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->