### PR TITLE
fix(storage): resolve links before confining a filesystem source to its root

### DIFF
--- a/docs/research/programmatic-source-configuration-safety-2026-08-17.md
+++ b/docs/research/programmatic-source-configuration-safety-2026-08-17.md
@@ -1,0 +1,191 @@
+# How should Connapse safely allow external data-source configuration to be created programmatically?
+
+**Date:** 2026-08-17
+**Status:** Reviewed
+**Built on:** no prior corpus material (Connapse MCP was not available in this session; `docs/research/highest-value-connectors-2026-08-13.md` covers connector selection, not authorization)
+
+## Executive summary
+
+Connapse should expose source creation over REST behind an admin role, keep connection creation out of the API entirely, and put nothing that mutates configuration on MCP. Infrastructure-as-Code is preserved because the thing IaC needs to declare — sources — stays API-creatable; the credential boundary that IaC should *not* be able to invent stays file- and admin-only. This is the shape Grafana, Snowflake, Databricks, and Kubernetes all converged on independently: the object that names a credential is created through a lower-trust channel than the credential itself.
+
+Two server-side constraints must exist regardless of which surface is enabled. First, `allowedRoot` must be selected from a configured allowlist rather than supplied by a caller, matching Elasticsearch `path.repo`. Second — and this is a live defect in already-merged code, not a design question — Connapse's filesystem path confinement is **empirically bypassable by a directory junction**, verified during this research against the exact .NET APIs the product uses.
+
+The most significant correction to the team's prior thinking: AWS session policies, which looked like the elegant answer to bucket scoping, cannot be the primary control. They apply only when `roleArn` is set and have **no Azure equivalent**, so they cannot provide a uniform boundary across both clouds.
+
+## Research brief
+
+**Question:** How should a self-hosted RAG platform allow external data-source configuration to be created programmatically (REST/CLI, for IaC) without turning that capability into a security hole?
+
+**Sub-questions investigated:**
+1. What patterns do comparable self-hosted products use to reconcile IaC with programmatic data-source creation?
+2. Is "allowlist roots in config, select by reference via API" the established answer for filesystem-root authority scopes, and what are its failure modes?
+3. How do these systems separate "declare configuration" from "activate/grant authority"?
+4. What is best practice for exposing mutating tools on an MCP server given prompt-injection risk from ingested content?
+5. How do products constrain which buckets a scope may name, when the credential itself is broad?
+
+**Out of scope:** Connapse UI design; the Phase 4 Sources/Connections screens; regulatory compliance; multi-tenant SaaS tenancy models (Connapse is self-hosted, single-org).
+
+**Success criteria:** A per-surface recommendation (Admin UI / REST+CLI / MCP) for connections vs sources, the server-side constraints required regardless of surface, and an IaC story that does not weaken the boundary.
+
+## Findings by sub-question
+
+### 1. IaC patterns in comparable self-hosted products
+
+**Claim: the established pattern is channel-scoped authority — the file/config channel can create objects the HTTP API cannot.**
+
+Grafana is the clearest precedent and the closest analogue to Connapse. Datasources are provisioned from YAML in `provisioning/datasources/`, read at startup, with version control as the stated motivation. The security-relevant part is the asymmetry: a provisioned datasource carries `editable` (default false), surfacing as `readOnly`, and **`readOnly` cannot be set through the HTTP API at all**. Grafana PR #19006 ignores the field on create/update with the explicit rationale that "one should not be able to create a readonly data source via the API." The filesystem is treated as the high-trust channel because writing it already implies host access. [primary]
+
+That boundary has leaked in practice — Grafana issue #32556 reports a `PUT` on a provisioned datasource flipping `readOnly` back to false. Worth noting as evidence that this pattern needs test coverage, not merely intent. [primary, single issue]
+
+Grafana does expose `POST /api/datasources`, gated by a `datasources:create` permission. The OSS default role mapping for that permission was not confirmed. [primary for the permission name; unverified for the default role]
+
+Airbyte takes the opposite approach — full creation over its public API, with the guardrail in RBAC granularity rather than channel. It has a **Source editor** role distinct from Destination editor, explicitly so teams can start syncing "without being able to reconfigure the destinations they write to." Reading data and writing data are separate privileges. Its Terraform provider is Speakeasy-generated directly from the OpenAPI spec, adding no separate authority model. [primary]
+
+Kubernetes states the underlying principle most directly: permission to create a workload "implicitly grants access to many other resources… such as Secrets, ConfigMaps, and PersistentVolumes that can be mounted." Generalized to CRDs, **create-rights on a custom resource are equivalent to the controller's rights over whatever that resource can name** — the exact confused-deputy shape Connapse has, where the sync service holds the credential and the source names the target. The `secretRef` pattern splits this: the declarative object *references* a credential it cannot read. [primary]
+
+Vault treats mount creation as admin-tier via `sys/mounts/*`. Whether the `sudo` capability is strictly required versus defensively included in the canonical admin policy could not be confirmed. [mixed: "admin-tier" solid, "sudo-required" unverified]
+
+**Terraform support does force a write endpoint to exist** — a provider needs full CRUD plus stable IDs for drift detection, confirmed by both Airbyte (provider generated from API) and Grafana (provider works only against `/api/datasources`, not provisioning files). What it does *not* force is that the endpoint be reachable by ordinary tokens. [secondary, inferential]
+
+### 2. Filesystem root allowlisting, and why it is necessary but not sufficient
+
+**Claim: config-file allowlisting of filesystem roots is established practice, but it is blast-radius control, not confinement — every product using it still had traversal CVEs inside the allowlisted root.**
+
+Elasticsearch `path.repo` is the canonical case: a **static** node setting listing filesystem paths usable for snapshot repositories, where each repository location "must resolve to a path under one of these entries." It is not settable via API; changing it requires a rolling restart. The snapshot API then selects a repository by location *under* an allowlisted root — precisely the "API selects among configured roots by reference" shape. OpenSearch inherits it verbatim. [primary]
+
+PHP `open_basedir` is the same shape and ships with a warning Connapse should internalize: it "is just an extra safety net, that is in no way comprehensive, and can therefore not be relied upon when security is needed." It also documents the exact trap — it "specifies a directory name, not a prefix," so `/www/` must not match `/www-files/`. Notably, PHP **resolves symlinks before the check** and disables the realpath cache to do so. [primary] MySQL `secure_file_priv` follows the same startup-only pattern. [secondary]
+
+The cautionary cases matter as much as the pattern. **CVE-2015-5531** (Elasticsearch ≤1.6.0) was an unauthenticated arbitrary file read where `path.repo` being configured was a *precondition* of the exploit rather than a defense — traversal happened relative to the allowlisted root. **CVE-2021-43798** (Grafana 8.x) was a pre-auth arbitrary file read caused by string-joining a plugin id onto a base directory with no canonicalization, introduced by a refactor. The nginx `alias` off-by-slash class (`location /images` + `alias /var/www/img/` → `/images../` escapes) is the canonical form of prefix-based confinement failure. [primary]
+
+**Residual attacks against Connapse's current `Path.GetFullPath` + `StartsWith(root + separator)` check:**
+
+- **Symlinks and junctions — confirmed exploitable, see below.** `Path.GetFullPath` is purely lexical and does not dereference reparse points. Java's `getCanonicalPath` does resolve symlinks; .NET requires `FileSystemInfo.ResolveLinkTarget(returnFinalTarget: true)` explicitly. (CWE-59) [primary, and empirically verified here]
+- **Bind mounts and hardlinks — not fixable by canonicalization.** The resolved path genuinely *is* beneath the root; there is no string to inspect. Only OS-level controls help: read-only bind mounts, a dedicated low-privilege service account, and not co-locating the app's own config or DataProtection key ring anywhere reachable. [primary]
+- **TOCTOU (CWE-367).** Connapse validates the root once at config time, then a background service walks it every five minutes for the life of the process. A directory swapped for a symlink after validation wins. Atomic resolution at open time is the only real fix — Linux `openat2` with `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS`; on .NET, re-resolve per file and refuse reparse points during enumeration. [primary]
+- **Comparison correctness.** `root + separator` fixes the nginx class, but the comparison must be `OrdinalIgnoreCase` on Windows/macOS and ordinal on Linux, and `\\?\` device paths, UNC shares, trailing dots or spaces, and NTFS alternate data streams (`file::$DATA`) need rejecting before normalization. [primary]
+
+**Empirical verification performed during this research.** Against .NET 7.6.4 on Windows, using the exact APIs in `ConnectorFactory.CombineUnderRoot` and `FilesystemConnector`:
+
+| Step | Result |
+|---|---|
+| `mklink /J root\escape secret\` (no elevation required) | Junction created |
+| `Path.GetFullPath(root\escape)` | Stays lexically under root — junction not resolved |
+| `combined.StartsWith(rootFull + separator)` | **True — the guard passes** |
+| `Directory.EnumerateFiles(root, "*", AllDirectories)` | **Returns `root\escape\keyring.txt`** — content from outside the root |
+
+Both halves fail: the guard admits the path, and the walk reads through it. `FilesystemConnector.cs:79` uses the bare `SearchOption.AllDirectories` overload with no `EnumerationOptions`, so nothing skips reparse points.
+
+### 3. Separating "declare" from "activate"
+
+**Claim: three distinct separations appear across the products studied, and none of them is dry-run or approval workflow.**
+
+1. **Channel-scoped authority** (Grafana): the filesystem is high-trust; the API structurally cannot produce the protected object shape.
+2. **Reference, not embed** (Kubernetes `secretRef`, Vault mounts): the declarative object names a credential it cannot read. This maps almost exactly onto the existing Connapse connection/source split — a source declares `connectionId` and a prefix, never a `roleArn`.
+3. **Split the verb** (Airbyte source-editor vs destination-editor; Vault sudo vs read): creating a *scope inside* an existing credential boundary is a materially smaller privilege than creating the boundary, and all four products treat it as a separate grant.
+
+Notably, **none of the four products gates on dry-run, approval, or two-person rules.** That pattern lives in the Git pull request, not in the product. For a GitOps workflow, the PR review *is* the approval step — which means the product's job is to make the declarative artifact reviewable, not to build an approval engine. [primary/secondary]
+
+### 4. Mutating tools on an MCP server
+
+**Claim: read-only MCP is a strong default rather than a formal consensus, but every relevant guidance converges against putting configuration mutation on an agent-reachable surface.**
+
+The MCP specification (rev 2025-06-18) states hosts "**must** obtain explicit user consent before invoking any tool" and that "tools represent arbitrary code execution and must be treated with appropriate caution" — while conceding the spec "cannot enforce these security principles at the protocol level." Consent is a *host* obligation, so a server relying on it is relying on a control it does not own. [primary]
+
+The Security Best Practices page names **Scope Minimization** explicitly, listing "treating claimed scopes in token as sufficient without server-side authorization logic" as a common mistake. That is precisely Connapse's current state: `/mcp` has a single transport-level `RequireAgent` gate with no per-tool role checks, so any agent token that can call one tool can call all of them. [primary]
+
+`readOnlyHint` and `destructiveHint` annotations exist as a risk vocabulary, but the official MCP blog (16 Mar 2026) is explicit that hints "are not enforcement mechanisms." [primary]
+
+Willison's **lethal trifecta** — private data access, untrusted content, external communication — applies with unusual directness here: a RAG server *is* leg two by construction, since ingested documents are attacker-influenceable text delivered into the model's context. Adding a source-creation tool is worse than a pure exfiltration channel, because injected text could point a new source at an arbitrary path, making the config surface both an exfiltration channel and a corpus-poisoning channel. [secondary — domain-expert blog, 16 Jun 2025]
+
+Documented incidents: **GitHub MCP** (Invariant Labs, 26 May 2025) — a malicious public issue drives the agent to read private repos and exfiltrate via a PR, which the researchers called architectural rather than a code bug; **Atlassian MCP** (Cato Networks, 19 Jun 2025) — an external support ticket carries the injection, executed with internal privileges; **Supabase MCP** (General Analysis, ~6 Jul 2025) — support-ticket injection plus a `service_role` key bypassing RLS, where the vendor's own mitigation was a `--read-only` flag. Asana's June 2025 cross-tenant leak was a tenant-isolation bug, **not** prompt injection, and should not be cited as one. [secondary/tertiary]
+
+The two vendors hit hardest — Supabase and GitHub — both shipped read-only modes as the fix. No authoritative document states flatly that configuration-mutating operations must never be agent-reachable; the strongest support is the spec's consent requirement combined with scope minimization. [uncertainty flagged]
+
+### 5. Constraining which bucket a source may name
+
+**Claim: declare an allowed bucket/prefix list on the connection, backed by narrowly-scoped IAM — the allowlist is layered on top of a scoped credential, never a substitute for one.**
+
+**Snowflake's storage integration is a near-exact precedent for the Connapse object model.** An admin-created integration holds the role ARN, and `STORAGE_ALLOWED_LOCATIONS` "explicitly limits external stages that use the integration to reference one or more storage locations (i.e. S3 bucket, GCS bucket, or Azure container)." A user-created stage's URL must fall inside that list. Snowflake shipped this *in addition to* the IAM role, not instead of it. [primary] Databricks Unity Catalog is the same shape with different nouns — a storage *credential* separated from external *locations*, where ordinary users are granted the location, not the credential. [primary]
+
+The managed RAG analogues do **not** do this: Bedrock Knowledge Bases, Kendra, and Glue crawlers all rely on the IAM role as the entire boundary, with a per-data-source role scoped to one bucket. Bedrock's inclusion prefix is convenience, not security. [primary]
+
+That difference is the crux, and it is what makes the allowlist necessary rather than redundant for Connapse: **those are managed services where each data source gets its own role, whereas Connapse shares one connection role across many user-created sources.** IAM alone therefore cannot distinguish one Connapse source from another.
+
+**On session policies — the correction to the team's prior hypothesis.** Session policies passed to `AssumeRole` are mechanically sound: the resulting permissions are the *intersection* of role policy and session policy, so they can only restrict. But two limits disqualify them as the primary control. They apply **only when `roleArn` is set** — with ambient credentials and no assume-role there is nothing to attach one to. And **Azure has no equivalent**: managed-identity tokens cannot be narrowed at request time, leaving RBAC assignment scope as the only lever, with container-level `Storage Blob Data Reader` as Microsoft's recommended granularity. Inline session policies also cap at 2,048 characters. They remain worth using opportunistically on the AWS assume-role path, where they convert an application bug into an AWS-side denial. [primary]
+
+`ExternalId` solves a *different* problem — cross-account confused deputy where another tenant supplies someone else's role ARN. For a self-hosted single-org deployment assuming a role in the same account, it adds little. [primary]
+
+## Recommendation
+
+**Per surface:**
+
+| | Admin UI | REST / CLI | MCP |
+|---|---|---|---|
+| **Connections** (credential + root boundary) | Read + edit of pre-declared entries | **Read-only** | **Read-only** |
+| **Sources** (scope inside a connection) | Full | **Full, admin-scoped role** | **Read-only** |
+
+Connections come from configuration — appsettings/env, or a provisioning file — following Grafana's channel-scoped model and Elasticsearch's static `path.repo`. Sources are API-creatable because a source is a *reference* to a credential it cannot read, which is the Kubernetes `secretRef` shape, and because that is what IaC actually needs to declare. Split the verb per Airbyte: creating a source is a separate, lesser grant than creating a connection.
+
+**Server-side constraints required regardless of surface:**
+
+1. **`allowedRoot` selected by reference from a configured allowlist**, never supplied by a caller.
+2. **Refuse reparse points during enumeration**, and re-resolve per file rather than trusting a one-time config-time check. The allowlist stops `allowedRoot: "/"`; it does not stop a symlink.
+3. **`allowedLocations` on the connection** — a list of `bucket[/prefix]` or `container[/prefix]` validated on source create/update. Absent means deny, not allow-all.
+4. **Keep IAM/RBAC narrow as the enforcing floor.** The allowlist is application config; IAM is what actually stops an application bug.
+5. **Per-tool authorization on MCP**, not a single transport gate.
+
+**IaC story:** sources are declarable in version control and applied through the admin-scoped REST API, so Terraform or a CLI apply works normally. Connections — the credential boundary — are declared in the deployment's own configuration, which the operator already version-controls alongside their compose file or Helm values. The Git pull request is the approval step, exactly as it is for the four products studied. Nothing about this requires the product to build a dry-run or approval engine.
+
+## Conflicts and uncertainties
+
+- **Managed RAG services contradict the recommendation.** Bedrock Knowledge Bases and Kendra use IAM as the sole boundary with no app-level allowlist, while Snowflake and Databricks add one. This is resolved by the per-data-source-role distinction rather than being a genuine disagreement, but it rests on that reasoning rather than on a source stating it directly.
+- **No product was found that constrains bucket naming purely in app config with no IAM scoping.** The allowlist is always layered on a scoped credential. Confidence high; treat app-level allowlisting as defense in depth, never the only control.
+- **No authoritative source says configuration mutation must never be agent-reachable.** The recommendation to keep it off MCP is an inference from the consent requirement, scope minimization, and vendor responses to real incidents.
+- **Vault's `sudo` requirement for enabling a secrets engine is unverified** — the concepts page and the `/sys/mounts` API page disagree in emphasis.
+- **Grafana's OSS default role for `datasources:create` is unconfirmed.**
+
+## Gaps — what we did not find
+
+- Elasticsearch/Logstash S3 input and Azure AI Search blob indexer were not verified; both are believed to follow the Kendra pattern but this is unconfirmed.
+- No data on how often the Grafana `readOnly` bypass (issue #32556) was exploited in practice, or whether it is fixed.
+- No peer-reviewed work was located on prompt-injection-driven configuration mutation specifically; the evidence is vendor advisories and security-researcher writeups.
+- The empirical junction test was run on Windows only. The equivalent POSIX symlink behaviour for .NET on Linux was not tested, though `Path.GetFullPath` is lexical on all platforms so the guard bypass is expected to be identical.
+
+## Source quality assessment
+
+The core recommendation rests on primary sources: official documentation for Grafana, Airbyte, Kubernetes, Vault, Elasticsearch, PHP, Snowflake, Databricks, AWS, and Azure, plus the MCP specification, plus NVD/CVE entries. The MCP threat analysis leans more on secondary sources — a domain-expert blog and security-vendor writeups — because the incident record is where the evidence lives; these are marked inline. The single most consequential finding, the junction bypass, was verified empirically against the product's own APIs rather than taken from any source.
+
+## Sources
+
+**Primary**
+- Grafana provisioning: https://grafana.com/docs/grafana/latest/administration/provisioning/
+- grafana/grafana PR #19006: https://github.com/grafana/grafana/pull/19006
+- grafana/grafana issue #32556: https://github.com/grafana/grafana/issues/32556
+- Grafana datasource HTTP API: https://grafana.com/docs/grafana/latest/developers/http_api/data_source/
+- Airbyte API access: https://docs.airbyte.com/platform/using-airbyte/configuring-api-access
+- Airbyte RBAC: https://docs.airbyte.com/platform/access-management/rbac
+- Kubernetes RBAC good practices: https://kubernetes.io/docs/concepts/security/rbac-good-practices/
+- Vault policies: https://developer.hashicorp.com/vault/docs/concepts/policies
+- Elasticsearch fs repository settings: https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/fs-repository-settings
+- PHP open_basedir: https://www.php.net/manual/en/ini.core.php#ini.open-basedir
+- CVE-2015-5531: https://nvd.nist.gov/vuln/detail/CVE-2015-5531
+- MCP specification 2025-06-18: https://modelcontextprotocol.io/specification/2025-06-18/index
+- MCP Security Best Practices: https://modelcontextprotocol.io/specification/draft/basic/security_best_practices
+- MCP tool annotations blog (16 Mar 2026): https://blog.modelcontextprotocol.io/posts/2026-03-16-tool-annotations/
+- Snowflake CREATE STORAGE INTEGRATION: https://docs.snowflake.com/en/sql-reference/sql/create-storage-integration
+- Databricks Unity Catalog cloud storage: https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage/
+- Bedrock Knowledge Bases permissions: https://docs.aws.amazon.com/bedrock/latest/userguide/kb-permissions.html
+- Kendra IAM roles: https://docs.aws.amazon.com/kendra/latest/dg/iam-roles.html
+- AWS AssumeRole session policies: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_assumerole.html
+- AWS confused deputy: https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+- Azure role assignment for blob data access: https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access
+- OWASP MCP Security Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+- SEI CERT FIO16-J: https://cmu-sei.github.io/secure-coding-standards/sei-cert-oracle-coding-standard-for-java/rules/input-output-fio/fio16-j
+
+**Secondary**
+- Willison, the lethal trifecta (16 Jun 2025): https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/
+- Willison, Supabase MCP (6 Jul 2025): https://simonwillison.net/2025/Jul/6/supabase-mcp-lethal-trifecta/
+- Invariant Labs, GitHub MCP (26 May 2025): https://invariantlabs.ai/blog/mcp-github-vulnerability
+- Cato CTRL, Atlassian MCP (19 Jun 2025): https://www.catonetworks.com/blog/cato-ctrl-poc-attack-targeting-atlassians-mcp/
+- General Analysis, Supabase MCP: https://generalanalysis.com/blog/supabase-mcp-blog
+- Elastic advisory CVE-2015-5531: https://discuss.elastic.co/t/elasticsearch-directory-traversal-vulnerability-cve-2015-5531/25737

--- a/docs/research/programmatic-source-configuration-safety-2026-08-17.md
+++ b/docs/research/programmatic-source-configuration-safety-2026-08-17.md
@@ -64,7 +64,7 @@ The cautionary cases matter as much as the pattern. **CVE-2015-5531** (Elasticse
 - **TOCTOU (CWE-367).** Connapse validates the root once at config time, then a background service walks it every five minutes for the life of the process. A directory swapped for a symlink after validation wins. Atomic resolution at open time is the only real fix — Linux `openat2` with `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS`; on .NET, re-resolve per file and refuse reparse points during enumeration. [primary]
 - **Comparison correctness.** `root + separator` fixes the nginx class, but the comparison must be `OrdinalIgnoreCase` on Windows/macOS and ordinal on Linux, and `\\?\` device paths, UNC shares, trailing dots or spaces, and NTFS alternate data streams (`file::$DATA`) need rejecting before normalization. [primary]
 
-**Empirical verification performed during this research.** Against .NET 7.6.4 on Windows, using the exact APIs in `ConnectorFactory.CombineUnderRoot` and `FilesystemConnector`:
+**Empirical verification performed during this research, against the code as it stood before the fix.** Run on Windows against .NET 10.0.303 (`dotnet --version`), using the exact APIs then in `ConnectorFactory.CombineUnderRoot` and `FilesystemConnector`:
 
 | Step | Result |
 |---|---|
@@ -73,7 +73,9 @@ The cautionary cases matter as much as the pattern. **CVE-2015-5531** (Elasticse
 | `combined.StartsWith(rootFull + separator)` | **True — the guard passes** |
 | `Directory.EnumerateFiles(root, "*", AllDirectories)` | **Returns `root\escape\keyring.txt`** — content from outside the root |
 
-Both halves fail: the guard admits the path, and the walk reads through it. `FilesystemConnector.cs:79` uses the bare `SearchOption.AllDirectories` overload with no `EnumerationOptions`, so nothing skips reparse points.
+Both halves failed: the guard admitted the path, and the walk read through it. `FilesystemConnector` used the bare `SearchOption.AllDirectories` overload with no `EnumerationOptions`, so nothing skipped reparse points.
+
+Fixed in #366: enumeration now sets `AttributesToSkip = FileAttributes.ReparsePoint` and re-confines each entry, and confinement resolves links on every path segment. The residual gaps below — TOCTOU, bind mounts, hard links — are unchanged by that fix and remain live.
 
 ### 3. Separating "declare" from "activate"
 
@@ -169,6 +171,8 @@ The core recommendation rests on primary sources: official documentation for Gra
 - Elasticsearch fs repository settings: https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/fs-repository-settings
 - PHP open_basedir: https://www.php.net/manual/en/ini.core.php#ini.open-basedir
 - CVE-2015-5531: https://nvd.nist.gov/vuln/detail/CVE-2015-5531
+- CVE-2021-43798: https://nvd.nist.gov/vuln/detail/CVE-2021-43798
+- Grafana security advisory GHSA-8pjx-jj86-j47p (CVE-2021-43798): https://github.com/grafana/grafana/security/advisories/GHSA-8pjx-jj86-j47p
 - MCP specification 2025-06-18: https://modelcontextprotocol.io/specification/2025-06-18/index
 - MCP Security Best Practices: https://modelcontextprotocol.io/specification/draft/basic/security_best_practices
 - MCP tool annotations blog (16 Mar 2026): https://blog.modelcontextprotocol.io/posts/2026-03-16-tool-annotations/

--- a/docs/superpowers/plans/2026-08-17-connector-source-split-phase-3c.md
+++ b/docs/superpowers/plans/2026-08-17-connector-source-split-phase-3c.md
@@ -34,13 +34,23 @@ that satisfies one and not the other is a failure, so the tests have to pin both
 `DELETE /api/sources/{id}`, and `POST /api/sources/{id}/sync` to force a cycle.
 
 Deliberately absent: anything returning documents or paths. No `/api/sources/{id}/documents`, no
-`/api/sources/{id}/browse`. `GET /api/sources/{id}` returns the scope and its sync state — name,
-description, connection, enabled, last sync status, last error, last synced at — and never the
-`ScopeJson` credentials-adjacent detail beyond what the source itself declares.
+`/api/sources/{id}/browse`.
 
-Authorization matches the container endpoints: `RequireViewer` to read, `RequireEditor` to
-mutate. Creation and update validate that the named connection exists, because a source pointing
-at a missing connection is skipped silently by the sync service.
+**Responses use dedicated DTOs, never the `Source` record.** `Source` carries `ScopeJson`, which
+names buckets, prefixes, and filesystem subpaths — infrastructure detail a viewer has no reason
+to receive, and the kind of thing that turns a read route into reconnaissance. The DTO exposes
+id, name, description, connection id, enabled, and sync state. Tests assert the *absence* of
+`ScopeJson` rather than the presence of the wanted fields, because a later refactor that starts
+serializing the record directly would otherwise pass silently.
+
+Authorization is **not** copied from the container endpoints. Reads take `RequireViewer`;
+mutations take `RequireAdmin`, not `RequireEditor`. Creating a source chooses what external data
+gets indexed and made searchable, bounded only by whatever the connection's credential can reach
+— an administrative act. Airbyte reaches the same conclusion by splitting source-editor from
+destination-editor rather than treating them as one grant.
+
+Creation and update validate that the named connection exists, because a source pointing at a
+missing connection is skipped silently by the sync service.
 
 **Done when:** all six routes exist, are registered in `Program.cs`, and integration tests cover
 each — including that a source id passed to a container document route is rejected.
@@ -78,6 +88,13 @@ The Sources tab, the Connections settings screen, and Home simplification are Ph
 Removing the Filesystem write flags is deferred there too — it touches 10+ sites in
 `FileBrowser.razor`. Dropping `containers.connector_type`/`connector_config` is Phase 5 (#353).
 
-Whether `/api/connections` needs REST routes is an open question for Phase 4: the Blazor UI can
-use `IConnectionStore` directly, and the issue scopes 3c to sources only. Flagging rather than
-deciding it here.
+**Mutating `/api/connections` routes are out of scope — decided, not deferred.** Connections are
+the credential and filesystem-root boundary, and this project already refuses to accept cloud
+credentials over an API; a filesystem `allowedRoot` confers the same class of authority. They are
+configured out of band and managed in Admin Settings, which is the channel-scoped model Grafana
+uses, where the provisioning file can create datasources the HTTP API deliberately cannot.
+Read-only connection routes are fine if Phase 4 wants them for the UI.
+
+Any later proposal to add connection mutation over REST, CLI, or MCP reopens this security
+review rather than being an incremental addition — recorded here so it cannot arrive as one.
+Background: `docs/research/programmatic-source-configuration-safety-2026-08-17.md`.

--- a/docs/superpowers/plans/2026-08-17-connector-source-split-phase-3c.md
+++ b/docs/superpowers/plans/2026-08-17-connector-source-split-phase-3c.md
@@ -1,0 +1,83 @@
+# Phase 3c — `/api/sources` endpoints and the MCP `kind` discriminator
+
+Part of #351 (Phase 3 of epic #348). Follows 3a (#361) and 3b (#364).
+
+## Where this picks up
+
+Sources exist, sync themselves, and own documents. Nothing outside the sync engine can see them:
+there is no `SourcesEndpoints`, no `MapSourcesEndpoints` registration, and no `kind` field
+anywhere in `McpTools`. An operator can only reach a source through the database.
+
+## The contract this phase implements
+
+From the design spec:
+
+> Sources are listed alongside containers in the MCP and REST contracts. `container_list` and
+> `search_knowledge` continue to accept any owner id, with a `kind` field in the response
+> distinguishing managed from source.
+
+and, in the same breath, the limit on that:
+
+> Listing a source as a searchable *scope* — its name, kind, and summary — is not the same as
+> enumerating the documents inside it. No REST or MCP endpoint returns a file listing for a
+> source, and `list_files` remains container-only.
+
+Those two together are the whole phase. The first is what stops this being a breaking change for
+existing agents and the CLI; the second is the permissions leak the epic exists to close. A change
+that satisfies one and not the other is a failure, so the tests have to pin both directions.
+
+## Task 1 — `/api/sources`
+
+**Goal:** an operator can manage sources over REST without touching the database.
+
+`GET /api/sources`, `GET /api/sources/{id}`, `POST /api/sources`, `PATCH /api/sources/{id}`,
+`DELETE /api/sources/{id}`, and `POST /api/sources/{id}/sync` to force a cycle.
+
+Deliberately absent: anything returning documents or paths. No `/api/sources/{id}/documents`, no
+`/api/sources/{id}/browse`. `GET /api/sources/{id}` returns the scope and its sync state — name,
+description, connection, enabled, last sync status, last error, last synced at — and never the
+`ScopeJson` credentials-adjacent detail beyond what the source itself declares.
+
+Authorization matches the container endpoints: `RequireViewer` to read, `RequireEditor` to
+mutate. Creation and update validate that the named connection exists, because a source pointing
+at a missing connection is skipped silently by the sync service.
+
+**Done when:** all six routes exist, are registered in `Program.cs`, and integration tests cover
+each — including that a source id passed to a container document route is rejected.
+
+## Task 2 — `kind` on the MCP surface
+
+**Goal:** an agent discovers sources and can search them, without gaining a way to enumerate them.
+
+- `container_list` lists containers and sources together, each carrying `kind: managed | source`.
+- `search_knowledge` resolves a source id or name as well as a container's.
+- `container_describe` accepts a source, reporting its scope and sync state.
+
+The id resolver is the crux. `ResolveContainerIdAsync` today checks only `IContainerStore`, which
+is exactly why `list_files` rejects a source id already. Adding source resolution to *that* method
+would silently open `list_files` too. A second resolver is needed instead, used only by the tools
+that may accept either kind.
+
+**Done when:** an agent can list and search a source, `list_files` and every mutating tool still
+refuse one, and tests assert both.
+
+## Task 3 — Prove the boundary holds
+
+**Goal:** the no-enumeration rule is enforced by tests, not by convention.
+
+One test per surface that must refuse a source id: `list_files`, `container_delete`,
+`upload_file`, `delete_file`, and the REST document/folder routes. Each asserts a refusal, not
+merely an empty result — an empty listing today would become a real listing the moment someone
+"fixes" the resolver.
+
+**Done when:** every enumeration and mutation surface has a test pinning its refusal.
+
+## Not in this phase
+
+The Sources tab, the Connections settings screen, and Home simplification are Phase 4 (#352).
+Removing the Filesystem write flags is deferred there too — it touches 10+ sites in
+`FileBrowser.razor`. Dropping `containers.connector_type`/`connector_config` is Phase 5 (#353).
+
+Whether `/api/connections` needs REST routes is an open question for Phase 4: the Blazor UI can
+use `IConnectionStore` directly, and the issue scopes 3c to sources only. Flagging rather than
+deciding it here.

--- a/src/Connapse.Core/Utilities/PathConfinement.cs
+++ b/src/Connapse.Core/Utilities/PathConfinement.cs
@@ -21,12 +21,19 @@ namespace Connapse.Core.Utilities;
 public static class PathConfinement
 {
     /// <summary>
-    /// Path comparison follows the filesystem, not the language: NTFS and APFS are
-    /// case-insensitive, ext4 is not. Comparing ordinally on Windows would let
-    /// <c>C:\Data\x</c> read as outside <c>C:\data</c>.
+    /// Case-insensitive only on Windows, where NTFS is reliably case-insensitive and an
+    /// ordinal comparison would wrongly read <c>C:\Data\x</c> as outside <c>C:\data</c>.
+    /// <para>
+    /// Everywhere else this compares ordinally, macOS included. APFS is case-insensitive by
+    /// default but can be formatted case-sensitive, and on such a volume <c>/Data</c> and
+    /// <c>/data</c> are genuinely different directories — matching them loosely would admit
+    /// one as being inside the other. The failure modes are not symmetric: comparing too
+    /// strictly rejects a legitimate path, which is visible and fixable, while comparing too
+    /// loosely admits a path that escapes the root, which is silent.
+    /// </para>
     /// </summary>
     private static readonly StringComparison PathComparison =
-        OperatingSystem.IsLinux() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
     /// <summary>
     /// Returns the fully resolved <paramref name="candidate"/> when it lies inside
@@ -38,8 +45,25 @@ public static class PathConfinement
         ArgumentException.ThrowIfNullOrWhiteSpace(root);
         ArgumentNullException.ThrowIfNull(candidate);
 
-        string rootFull = ResolveLinks(Path.GetFullPath(root));
-        string candidateFull = ResolveLinks(Path.GetFullPath(candidate));
+        string? rootFull;
+        string? candidateFull;
+
+        try
+        {
+            rootFull = ResolveLinks(Path.GetFullPath(root));
+            candidateFull = ResolveLinks(Path.GetFullPath(candidate));
+        }
+        catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            // Path.GetFullPath rejects malformed input. A path we cannot even normalize is
+            // not a path we can vouch for.
+            return null;
+        }
+
+        // Either side failing to resolve means the comparison would be against an unverified
+        // string, so refuse rather than guess.
+        if (rootFull is null || candidateFull is null)
+            return null;
 
         return IsWithin(rootFull, candidateFull) ? candidateFull : null;
     }
@@ -116,8 +140,12 @@ public static class PathConfinement
     /// A path that does not exist resolves as far as its existing ancestors allow — a root may
     /// legitimately be configured before it is created.
     /// </para>
+    /// <para>
+    /// Returns null when resolution fails. Callers must treat that as "outside every root":
+    /// a path we cannot resolve is a path we cannot vouch for.
+    /// </para>
     /// </summary>
-    private static string ResolveLinks(string fullPath)
+    private static string? ResolveLinks(string fullPath)
     {
         try
         {
@@ -127,7 +155,11 @@ public static class PathConfinement
             if (string.IsNullOrEmpty(parent) || parent == fullPath)
                 return fullPath;
 
-            string here = Path.Combine(ResolveLinks(parent), Path.GetFileName(fullPath));
+            string? resolvedParent = ResolveLinks(parent);
+            if (resolvedParent is null)
+                return null;
+
+            string here = Path.Combine(resolvedParent, Path.GetFileName(fullPath));
 
             if (Directory.Exists(here))
                 return new DirectoryInfo(here).ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? here;
@@ -140,9 +172,9 @@ public static class PathConfinement
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             // A path we cannot resolve is a path we cannot vouch for. Returning it unchanged
-            // would let the caller's containment check pass on an unverified string, so hand
-            // back a value that cannot be inside any root instead.
-            return Path.Combine(fullPath, "\u0000unresolvable");
+            // would let the caller's containment check pass on an unverified string, so the
+            // caller is forced to refuse it instead.
+            return null;
         }
     }
 }

--- a/src/Connapse.Core/Utilities/PathConfinement.cs
+++ b/src/Connapse.Core/Utilities/PathConfinement.cs
@@ -1,0 +1,148 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Confines a path beneath a root directory, for connectors that mirror a local filesystem.
+/// <para>
+/// The root is a security boundary an administrator configured: a source may name a subpath
+/// inside it and must not be able to reach past it. Getting this right needs more than
+/// <see cref="Path.GetFullPath(string)"/>, which is purely lexical and never touches the
+/// filesystem — so it silently admits a symlink or NTFS junction that points elsewhere
+/// (CWE-59). PHP's <c>open_basedir</c> resolves links before its check for the same reason,
+/// and Java's <c>getCanonicalPath</c> does it as a matter of course; .NET requires
+/// <see cref="FileSystemInfo.ResolveLinkTarget(bool)"/> explicitly.
+/// </para>
+/// <para>
+/// What this cannot defend against: bind mounts and hard links, where the resolved path
+/// genuinely is beneath the root and there is no string left to inspect. Those need a
+/// low-privilege service account and a deployment that keeps the application's own
+/// configuration and DataProtection key ring outside every configured root.
+/// </para>
+/// </summary>
+public static class PathConfinement
+{
+    /// <summary>
+    /// Path comparison follows the filesystem, not the language: NTFS and APFS are
+    /// case-insensitive, ext4 is not. Comparing ordinally on Windows would let
+    /// <c>C:\Data\x</c> read as outside <c>C:\data</c>.
+    /// </summary>
+    private static readonly StringComparison PathComparison =
+        OperatingSystem.IsLinux() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+    /// <summary>
+    /// Returns the fully resolved <paramref name="candidate"/> when it lies inside
+    /// <paramref name="root"/>, or null when it escapes. Both are resolved through any
+    /// symlinks before comparison.
+    /// </summary>
+    public static string? ResolveWithin(string root, string candidate)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(root);
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        string rootFull = ResolveLinks(Path.GetFullPath(root));
+        string candidateFull = ResolveLinks(Path.GetFullPath(candidate));
+
+        return IsWithin(rootFull, candidateFull) ? candidateFull : null;
+    }
+
+    /// <summary>
+    /// Combines <paramref name="relative"/> beneath <paramref name="root"/> and confines the
+    /// result. A rooted <paramref name="relative"/> is rejected rather than honoured:
+    /// <see cref="Path.Combine(string, string)"/> discards the first argument entirely when
+    /// the second is absolute, so treating it as a path under the root would silently hand
+    /// back somewhere else on disk.
+    /// </summary>
+    public static string? CombineWithin(string root, string relative)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(root);
+        ArgumentNullException.ThrowIfNull(relative);
+
+        if (Path.IsPathRooted(relative))
+            return null;
+
+        return ResolveWithin(root, Path.Combine(Path.GetFullPath(root), relative.TrimStart('/', '\\')));
+    }
+
+    /// <summary>
+    /// True when <paramref name="fullCandidate"/> is <paramref name="fullRoot"/> itself or
+    /// sits beneath it. Both arguments must already be fully resolved.
+    /// </summary>
+    public static bool IsWithin(string fullRoot, string fullCandidate)
+    {
+        // Compared with a trailing separator, so a sibling sharing a name prefix cannot pass:
+        // "/data-other" starts with "/data" as a string but is not inside it. This is the
+        // nginx `alias` off-by-slash bug, and it is the most common way this check is written
+        // wrong.
+        string rootWithSep = fullRoot.EndsWith(Path.DirectorySeparatorChar)
+            ? fullRoot
+            : fullRoot + Path.DirectorySeparatorChar;
+
+        return fullCandidate.Equals(fullRoot.TrimEnd(Path.DirectorySeparatorChar), PathComparison)
+            || fullCandidate.StartsWith(rootWithSep, PathComparison);
+    }
+
+    /// <summary>
+    /// True when the entry is a symlink, junction, or other reparse point. Enumeration must
+    /// skip these rather than descend through them.
+    /// </summary>
+    public static bool IsLink(string path)
+    {
+        try
+        {
+            var info = Directory.Exists(path)
+                ? new DirectoryInfo(path)
+                : (FileSystemInfo)new FileInfo(path);
+
+            return info.LinkTarget is not null
+                || info.Attributes.HasFlag(FileAttributes.ReparsePoint);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Unreadable means untrustworthy: refuse it rather than assume it is ordinary.
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Walks every link on the path back to its final target, resolving ancestors before the
+    /// leaf.
+    /// <para>
+    /// Resolving only the leaf is not enough, and this is the subtle half of the bug: in
+    /// <c>/root/link-to-elsewhere/keyring.txt</c> the file itself is not a link, so asking it
+    /// for a link target returns nothing and the path looks contained. Only its parent gives
+    /// the escape away. Each ancestor is therefore resolved first and the remainder rebuilt
+    /// on top of the result.
+    /// </para>
+    /// <para>
+    /// A path that does not exist resolves as far as its existing ancestors allow — a root may
+    /// legitimately be configured before it is created.
+    /// </para>
+    /// </summary>
+    private static string ResolveLinks(string fullPath)
+    {
+        try
+        {
+            string? parent = Path.GetDirectoryName(fullPath);
+
+            // A filesystem root (C:\ or /) has no parent left to resolve.
+            if (string.IsNullOrEmpty(parent) || parent == fullPath)
+                return fullPath;
+
+            string here = Path.Combine(ResolveLinks(parent), Path.GetFileName(fullPath));
+
+            if (Directory.Exists(here))
+                return new DirectoryInfo(here).ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? here;
+
+            if (File.Exists(here))
+                return new FileInfo(here).ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? here;
+
+            return here;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // A path we cannot resolve is a path we cannot vouch for. Returning it unchanged
+            // would let the caller's containment check pass on an unverified string, so hand
+            // back a value that cannot be inside any root instead.
+            return Path.Combine(fullPath, "\u0000unresolvable");
+        }
+    }
+}

--- a/src/Connapse.Storage/Connectors/ConnectorFactory.cs
+++ b/src/Connapse.Storage/Connectors/ConnectorFactory.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
 
 namespace Connapse.Storage.Connectors;
 
@@ -102,24 +103,15 @@ public class ConnectorFactory : IConnectorFactory
     private static string CombineUnderRoot(string allowedRoot, string? subPath, string sourceName)
     {
         if (string.IsNullOrWhiteSpace(subPath))
-            return allowedRoot;
+            return Path.GetFullPath(allowedRoot);
 
-        string rootFull = Path.GetFullPath(allowedRoot);
-        string combined = Path.GetFullPath(Path.Combine(rootFull, subPath));
-
-        // Compare with a trailing separator so "/data-other" cannot pass as being under "/data".
-        string rootWithSep = rootFull.EndsWith(Path.DirectorySeparatorChar)
-            ? rootFull
-            : rootFull + Path.DirectorySeparatorChar;
-
-        if (!combined.Equals(rootFull, StringComparison.Ordinal) &&
-            !combined.StartsWith(rootWithSep, StringComparison.Ordinal))
-        {
-            throw new InvalidOperationException(
+        // Delegated rather than compared here (#365). The previous check was Path.GetFullPath
+        // plus StartsWith, which is purely lexical: a junction inside the allowed root passed
+        // it, and the connector then walked straight through to the target. PathConfinement
+        // resolves links on every path segment before comparing.
+        return PathConfinement.CombineWithin(allowedRoot, subPath)
+            ?? throw new InvalidOperationException(
                 $"Source '{sourceName}' resolves to a path outside its connection's allowed root '{allowedRoot}'.");
-        }
-
-        return combined;
     }
 
     private static S3Connector CreateS3Connector(Container container)

--- a/src/Connapse.Storage/Connectors/FilesystemConnector.cs
+++ b/src/Connapse.Storage/Connectors/FilesystemConnector.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Channels;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
 
 namespace Connapse.Storage.Connectors;
 
@@ -76,8 +77,27 @@ public class FilesystemConnector : IConnector
             return Task.FromResult<IReadOnlyList<ConnectorFile>>([]);
 
         var files = new List<ConnectorFile>();
-        foreach (var filePath in Directory.EnumerateFiles(rootDir, "*", SearchOption.AllDirectories))
+
+        // Reparse points are skipped rather than followed (#365). The bare
+        // SearchOption.AllDirectories overload descends through junctions and symlinks, so a
+        // link planted inside the root pulled its target's contents into the index. Each entry
+        // is also re-confined below rather than trusted from the walk: the root was validated
+        // once at construction, but this runs every sync cycle for the life of the process,
+        // and a directory swapped for a link in between would otherwise win (CWE-367).
+        var options = new EnumerationOptions
         {
+            RecurseSubdirectories = true,
+            AttributesToSkip = FileAttributes.ReparsePoint,
+            IgnoreInaccessible = true,
+        };
+
+        string confinementRoot = _config.RootPath;
+
+        foreach (var filePath in Directory.EnumerateFiles(rootDir, "*", options))
+        {
+            if (PathConfinement.ResolveWithin(confinementRoot, filePath) is null)
+                continue;
+
             var fileName = Path.GetFileName(filePath);
 
             if (_config.IncludePatterns.Count > 0 && !_config.IncludePatterns.Any(p => MatchesGlob(fileName, p)))
@@ -160,19 +180,17 @@ public class FilesystemConnector : IConnector
 
     private string GetFullPath(string path)
     {
-        // If already absolute and not under RootPath, use as-is (for watcher events)
-        if (Path.IsPathRooted(path))
-            return path;
+        // An absolute path used to be returned unchecked, "for watcher events" — which meant
+        // any caller handing in a rooted path read straight past the root. Watcher events are
+        // now confined like everything else: they originate inside the root, so a genuine one
+        // still resolves, and one that does not is exactly what this must refuse (#365).
+        string? resolved = Path.IsPathRooted(path)
+            ? PathConfinement.ResolveWithin(_config.RootPath, path)
+            : PathConfinement.CombineWithin(_config.RootPath, path);
 
-        var fullPath = Path.GetFullPath(Path.Combine(_config.RootPath, path.TrimStart('/', '\\')));
-
-        // Prevent path traversal — resolved path must stay within the connector's root
-        var rootFull = Path.GetFullPath(_config.RootPath);
-        if (!fullPath.StartsWith(rootFull, StringComparison.OrdinalIgnoreCase))
-            throw new UnauthorizedAccessException(
+        return resolved
+            ?? throw new UnauthorizedAccessException(
                 $"Path '{path}' resolves outside the connector root directory.");
-
-        return fullPath;
     }
 
     private static bool MatchesGlob(string fileName, string pattern)

--- a/tests/Connapse.Core.Tests/Connectors/FilesystemConfinementTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/FilesystemConfinementTests.cs
@@ -1,0 +1,138 @@
+using System.Runtime.InteropServices;
+using Connapse.Core;
+using Connapse.Storage.Connectors;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Connectors;
+
+/// <summary>
+/// End-to-end confinement of <see cref="FilesystemConnector"/> (#365).
+/// <para>
+/// PathConfinementTests cover the helper in isolation; these pin the connector itself, which
+/// is where the leak actually happened — the guard admitted a junction and
+/// <c>Directory.EnumerateFiles(.., SearchOption.AllDirectories)</c> then read through it.
+/// </para>
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class FilesystemConfinementTests : IDisposable
+{
+    private readonly string _base = Path.Combine(
+        Path.GetTempPath(), $"connapse-fsguard-{Guid.NewGuid():N}");
+
+    private readonly string _root;
+    private readonly string _outside;
+
+    public FilesystemConfinementTests()
+    {
+        _root = Path.Combine(_base, "root");
+        _outside = Path.Combine(_base, "outside");
+        Directory.CreateDirectory(_root);
+        Directory.CreateDirectory(_outside);
+
+        File.WriteAllText(Path.Combine(_root, "legitimate.md"), "indexable");
+        File.WriteAllText(Path.Combine(_outside, "keyring.txt"), "SECRET-KEYRING-CONTENT");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            foreach (var dir in Directory.GetDirectories(_root))
+            {
+                var info = new DirectoryInfo(dir);
+                if (info.LinkTarget is not null || info.Attributes.HasFlag(FileAttributes.ReparsePoint))
+                    Directory.Delete(dir);
+            }
+        }
+
+        try { Directory.Delete(_base, recursive: true); } catch (IOException) { }
+    }
+
+    private static bool TryCreateDirectoryLink(string linkPath, string targetPath)
+    {
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe",
+                    $"/c mklink /J \"{linkPath}\" \"{targetPath}\"")
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                };
+                using var proc = System.Diagnostics.Process.Start(psi);
+                proc!.WaitForExit(10_000);
+                return proc.ExitCode == 0 && Directory.Exists(linkPath);
+            }
+
+            Directory.CreateSymbolicLink(linkPath, targetPath);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private FilesystemConnector Connector() =>
+        new(new FilesystemConnectorConfig { RootPath = _root });
+
+    [Fact]
+    public async Task ListFilesAsync_DoesNotDescendThroughALink()
+    {
+        string link = Path.Combine(_root, "escape");
+        if (!TryCreateDirectoryLink(link, _outside))
+            return; // platform will not create links unprivileged
+
+        var files = await Connector().ListFilesAsync();
+
+        files.Select(f => Path.GetFileName(f.Path))
+            .Should().NotContain("keyring.txt", "a link out of the root must not be indexed");
+        files.Should().ContainSingle(f => Path.GetFileName(f.Path) == "legitimate.md",
+            "ordinary files inside the root must still be listed");
+    }
+
+    [Fact]
+    public async Task ReadFileAsync_ThroughALink_IsRefused()
+    {
+        string link = Path.Combine(_root, "escape");
+        if (!TryCreateDirectoryLink(link, _outside))
+            return;
+
+        var act = async () => await Connector().ReadFileAsync("escape/keyring.txt");
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ReadFileAsync_AbsolutePathOutsideRoot_IsRefused()
+    {
+        // This used to return early for any rooted path, "for watcher events", handing back
+        // whatever was asked for with no containment check at all.
+        string outsideFile = Path.Combine(_outside, "keyring.txt");
+
+        var act = async () => await Connector().ReadFileAsync(outsideFile);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ReadFileAsync_OrdinaryFileInsideRoot_StillWorks()
+    {
+        // The guard must not be so strict it breaks the normal path.
+        using var stream = await Connector().ReadFileAsync("legitimate.md");
+        using var reader = new StreamReader(stream);
+
+        (await reader.ReadToEndAsync()).Should().Be("indexable");
+    }
+
+    [Fact]
+    public async Task ReadFileAsync_DotDotTraversal_IsRefused()
+    {
+        var act = async () => await Connector().ReadFileAsync("../outside/keyring.txt");
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/PathConfinementTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/PathConfinementTests.cs
@@ -1,0 +1,162 @@
+using System.Runtime.InteropServices;
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+/// <summary>
+/// Confinement of a source's subpath beneath its connection's allowed root (#365).
+/// <para>
+/// The bug these pin: the original check was <c>Path.GetFullPath</c> plus a
+/// <c>StartsWith</c>, which is purely lexical. A junction inside the root passed it, and the
+/// connector's recursive walk then read straight through to the target — verified against
+/// .NET before the fix.
+/// </para>
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class PathConfinementTests : IDisposable
+{
+    private readonly string _base = Path.Combine(
+        Path.GetTempPath(), $"connapse-confine-{Guid.NewGuid():N}");
+
+    private readonly string _root;
+    private readonly string _outside;
+
+    public PathConfinementTests()
+    {
+        _root = Path.Combine(_base, "root");
+        _outside = Path.Combine(_base, "outside");
+        Directory.CreateDirectory(_root);
+        Directory.CreateDirectory(_outside);
+        File.WriteAllText(Path.Combine(_outside, "keyring.txt"), "SECRET");
+    }
+
+    public void Dispose()
+    {
+        // Remove any directory links before deleting the tree, so cleanup cannot follow one
+        // out of the temp directory and delete the target.
+        if (Directory.Exists(_root))
+        {
+            foreach (var dir in Directory.GetDirectories(_root))
+            {
+                if (new DirectoryInfo(dir).LinkTarget is not null ||
+                    new DirectoryInfo(dir).Attributes.HasFlag(FileAttributes.ReparsePoint))
+                {
+                    Directory.Delete(dir);
+                }
+            }
+        }
+
+        try { Directory.Delete(_base, recursive: true); } catch (IOException) { }
+    }
+
+    /// <summary>
+    /// Creates a directory link, returning false when the platform will not allow it without
+    /// elevation. Windows permits junctions unprivileged but not symlinks; Unix permits
+    /// symlinks.
+    /// </summary>
+    private static bool TryCreateDirectoryLink(string linkPath, string targetPath)
+    {
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe",
+                    $"/c mklink /J \"{linkPath}\" \"{targetPath}\"")
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                };
+                using var proc = System.Diagnostics.Process.Start(psi);
+                proc!.WaitForExit(10_000);
+                return proc.ExitCode == 0 && Directory.Exists(linkPath);
+            }
+
+            Directory.CreateSymbolicLink(linkPath, targetPath);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    [Fact]
+    public void CombineWithin_OrdinarySubPath_IsAllowed()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "team"));
+
+        string? result = PathConfinement.CombineWithin(_root, "team");
+
+        result.Should().NotBeNull();
+        result.Should().StartWith(Path.GetFullPath(_root));
+    }
+
+    [Fact]
+    public void CombineWithin_DotDotEscape_IsRejected()
+    {
+        PathConfinement.CombineWithin(_root, "../outside").Should().BeNull();
+    }
+
+    [Fact]
+    public void CombineWithin_AbsolutePath_IsRejected()
+    {
+        // Path.Combine discards its first argument when the second is rooted, so honouring an
+        // absolute "relative" path would hand back somewhere else on disk entirely. The
+        // connector's own GetFullPath had exactly this hole, returning early for rooted paths.
+        PathConfinement.CombineWithin(_root, _outside).Should().BeNull();
+    }
+
+    [Fact]
+    public void IsWithin_SiblingSharingANamePrefix_IsRejected()
+    {
+        // "/data-other" starts with "/data" as a string but is not inside it. This is the
+        // nginx `alias` off-by-slash bug.
+        string root = Path.Combine(_base, "data");
+        string sibling = Path.Combine(_base, "data-other");
+
+        PathConfinement.IsWithin(root, sibling).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsWithin_RootItself_IsAllowed()
+    {
+        PathConfinement.IsWithin(_root, _root).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ResolveWithin_LinkInsideRootPointingOut_IsRejected()
+    {
+        string link = Path.Combine(_root, "escape");
+        if (!TryCreateDirectoryLink(link, _outside))
+            return; // platform will not create links unprivileged; nothing to assert
+
+        // The reported bug: Path.GetFullPath leaves this lexically under the root, so the old
+        // StartsWith check returned true and the walk read the target's contents.
+        PathConfinement.ResolveWithin(_root, link).Should().BeNull();
+        PathConfinement.ResolveWithin(_root, Path.Combine(link, "keyring.txt")).Should().BeNull();
+    }
+
+    [Fact]
+    public void CombineWithin_SubPathThroughALink_IsRejected()
+    {
+        string link = Path.Combine(_root, "escape");
+        if (!TryCreateDirectoryLink(link, _outside))
+            return;
+
+        PathConfinement.CombineWithin(_root, "escape/keyring.txt").Should().BeNull();
+    }
+
+    [Fact]
+    public void IsLink_DetectsADirectoryLink()
+    {
+        string link = Path.Combine(_root, "escape");
+        if (!TryCreateDirectoryLink(link, _outside))
+            return;
+
+        PathConfinement.IsLink(link).Should().BeTrue();
+        PathConfinement.IsLink(_root).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Closes #365.

Filesystem source confinement was bypassable by a symlink or NTFS junction. `Path.GetFullPath` is purely lexical — it never touches the filesystem — so it does not resolve reparse points. A junction inside an allowed root passed the guard, and `Directory.EnumerateFiles(.., SearchOption.AllDirectories)` then descended through it.

Impact: anything the service account could read became ingestible, chunked, embedded, and retrievable through search and the MCP server — including `appsettings.json` and the DataProtection key ring that decrypts stored connection secrets.

Verified on Windows against .NET 10.0.303 before the fix, against the exact APIs in use:

| Step | Result |
|---|---|
| `mklink /J root\escape secret\` (**no elevation required**) | Junction created |
| `Path.GetFullPath(root\escape)` | Not resolved — stays lexically under root |
| `combined.StartsWith(rootFull + separator)` | **True — guard passes** |
| `Directory.EnumerateFiles(root, "*", AllDirectories)` | **Returns `root\escape\keyring.txt`** |

Both halves failed: the guard admitted the path and the walk read through it.

## Two further holes found while fixing it

Both in the same method, and the first is arguably worse than the reported bug since it needs no filesystem setup at all:

- **`GetFullPath` returned any rooted path unchecked**, with the comment "for watcher events". Any caller passing an absolute path read straight past the root with no containment check. Watcher events originate inside the root and still resolve; ones that do not are exactly what this must refuse.
- **The prefix comparison had no trailing separator**, so `/data-other` passed as being inside `/data` — the nginx `alias` off-by-slash bug.

## The fix

New `PathConfinement` helper in `Connapse.Core.Utilities`, used by both `ConnectorFactory.CombineUnderRoot` and `FilesystemConnector.GetFullPath`:

- Resolves links on **every path segment, not just the leaf**. This is the subtle half: in `/root/link/keyring.txt` the file itself is not a link, so asking it for a link target returns nothing and the path looks contained — only the parent gives the escape away. My first attempt resolved only the leaf and the tests caught it.
- Compares with a trailing separator, and case-insensitively only on Windows. APFS is case-insensitive by default but can be formatted case-sensitive, so macOS is treated as case-sensitive: comparing too strictly rejects a legitimate path, which is visible, while comparing too loosely admits an escape, which is silent.
- Rejects rooted input to `CombineWithin` outright, since `Path.Combine` discards its first argument when the second is absolute.
- Returns null when a path cannot be resolved, so the caller refuses it rather than comparing an unverified string.

Enumeration now sets `AttributesToSkip = FileAttributes.ReparsePoint` and re-confines each entry rather than trusting the one-time check at construction — the walk runs every sync cycle for the life of the process, so a directory swapped for a link in between would otherwise win (CWE-367).

## Not fixed, deliberately

Bind mounts and hard links are out of reach of any string check: the resolved path genuinely *is* beneath the root, so there is nothing left to inspect. Those need a low-privilege service account and a deployment that keeps the application's own config and key ring outside every configured root. Noted on #365 for the deployment docs.

The `allowedRoot` allowlist — constraining what the root itself may be, following Elasticsearch's static `path.repo` — is **not** in this PR. It belongs with the connection-configuration work in phase 3c of #351. The allowlist stops `allowedRoot: "/"`; it does not stop a symlink. Both controls are needed and they are independent.

## Testing

`dotnet test` — **1080 passed, 0 failed.** 13 new tests: 8 on the helper, 5 end-to-end on the connector, covering link escape, path-through-a-link, absolute-path bypass, `..` traversal, sibling-prefix, and that ordinary reads inside the root still work. Link-creation tests self-skip on platforms that will not create links unprivileged.

Background and prior art: `docs/research/programmatic-source-configuration-safety-2026-08-17.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened filesystem access controls to prevent directory traversal, absolute-path escapes, sibling-prefix bypasses, and symlink or junction-based escapes.
  * Filesystem listings now skip unsafe links and validate discovered paths before access.
  * Valid paths within the configured root continue to work as expected.

* **Documentation**
  * Added research and implementation plans covering source management, access restrictions, credential activation, MCP behavior, cloud storage boundaries, and infrastructure-as-code workflows.

* **Tests**
  * Added cross-platform coverage for path confinement, link handling, traversal rejection, and valid in-root access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->