### PR TITLE
feat(storage): bound what a source may be pointed at

### DIFF
--- a/src/Connapse.Core/Models/SourceSecuritySettings.cs
+++ b/src/Connapse.Core/Models/SourceSecuritySettings.cs
@@ -12,7 +12,7 @@ namespace Connapse.Core;
 /// <c>path.repo</c>, which is a static node setting requiring a restart to change.
 /// </para>
 /// </summary>
-public class SourceSecuritySettings
+public record SourceSecuritySettings
 {
     public const string SectionName = "Sources:Security";
 

--- a/src/Connapse.Core/Models/SourceSecuritySettings.cs
+++ b/src/Connapse.Core/Models/SourceSecuritySettings.cs
@@ -1,0 +1,66 @@
+using Connapse.Core.Utilities;
+
+namespace Connapse.Core;
+
+/// <summary>
+/// Bounds what external data a source may be pointed at, independent of who points it.
+/// <para>
+/// Deliberately configuration-only — appsettings, environment, or the deployment's own
+/// config file — and never writable through the API or the settings table. The authority a
+/// filesystem root confers is the same class of thing as a cloud credential, and this project
+/// already refuses to accept those over an API. Elasticsearch takes the same line with
+/// <c>path.repo</c>, which is a static node setting requiring a restart to change.
+/// </para>
+/// </summary>
+public class SourceSecuritySettings
+{
+    public const string SectionName = "Sources:Security";
+
+    /// <summary>
+    /// Directories a filesystem connection's <c>allowedRoot</c> may name. A root must equal
+    /// one of these or sit beneath it.
+    /// <para>
+    /// Empty means unrestricted, which is the pre-existing behaviour and is retained for one
+    /// release so upgrades do not break every filesystem source that #350 backfilled. The
+    /// unrestricted case logs a warning naming each root in use, so an operator can see what
+    /// to configure before it becomes deny-by-default.
+    /// </para>
+    /// </summary>
+    public IReadOnlyList<string> AllowedFilesystemRoots { get; set; } = [];
+
+    /// <summary>
+    /// Decides whether a filesystem root is permitted, resolving links on both sides so a
+    /// symlinked root cannot masquerade as an allowed one.
+    /// </summary>
+    public FilesystemRootDecision EvaluateRoot(string allowedRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(allowedRoot);
+
+        if (AllowedFilesystemRoots.Count == 0)
+            return FilesystemRootDecision.UnrestrictedByConfiguration;
+
+        foreach (string permitted in AllowedFilesystemRoots)
+        {
+            if (string.IsNullOrWhiteSpace(permitted)) continue;
+
+            // ResolveWithin, not a string compare: a root of "/data/link-to-etc" would
+            // otherwise pass by looking like it sits under an allowed "/data".
+            if (PathConfinement.ResolveWithin(permitted, allowedRoot) is not null)
+                return FilesystemRootDecision.Allowed;
+        }
+
+        return FilesystemRootDecision.Denied;
+    }
+}
+
+public enum FilesystemRootDecision
+{
+    /// <summary>The root sits inside a configured entry.</summary>
+    Allowed,
+
+    /// <summary>No allowlist is configured. Permitted, but the caller should warn.</summary>
+    UnrestrictedByConfiguration,
+
+    /// <summary>An allowlist is configured and this root is not covered by it.</summary>
+    Denied
+}

--- a/src/Connapse.Core/Utilities/StorageLocationPolicy.cs
+++ b/src/Connapse.Core/Utilities/StorageLocationPolicy.cs
@@ -1,0 +1,75 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Decides whether a source's storage scope falls inside the locations its connection permits.
+/// <para>
+/// A cloud connection holds only a credential and an endpoint, and the source names its own
+/// bucket or blob container — so without this, anyone who can create a source may point it at
+/// anything the connection's IAM role or managed identity can read, and have it ingested and
+/// made searchable. IAM cannot tell one source from another here, because a single connection
+/// role is shared across every source that uses it.
+/// </para>
+/// <para>
+/// This mirrors Snowflake's <c>STORAGE_ALLOWED_LOCATIONS</c>, where an admin-created storage
+/// integration holds the role ARN and separately limits which buckets a user-created stage may
+/// reference. Snowflake ships it alongside narrow IAM rather than instead of it, and so should
+/// this: the allowlist is application config, while IAM is what actually stops a bug here.
+/// </para>
+/// </summary>
+public static class StorageLocationPolicy
+{
+    /// <summary>
+    /// Evaluates a source's <paramref name="container"/> (an S3 bucket or Azure blob container)
+    /// and optional <paramref name="prefix"/> against the connection's allowed locations.
+    /// </summary>
+    public static StorageLocationDecision Evaluate(
+        IReadOnlyList<string> allowedLocations, string container, string? prefix)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(container);
+
+        var entries = allowedLocations
+            .Where(e => !string.IsNullOrWhiteSpace(e))
+            .ToList();
+
+        if (entries.Count == 0)
+            return StorageLocationDecision.UnrestrictedByConfiguration;
+
+        string candidate = Normalize($"{container}/{prefix?.TrimStart('/') ?? string.Empty}");
+
+        foreach (string entry in entries)
+        {
+            string allowed = Normalize(entry);
+
+            // An entry naming only a bucket permits any prefix within it; an entry naming a
+            // bucket and prefix permits only that subtree. Compared with a trailing slash so
+            // "bucket/docs" cannot admit "bucket/docs-internal" — the same off-by-slash trap
+            // that bites prefix-based filesystem checks.
+            if (candidate.Equals(allowed, StringComparison.Ordinal) ||
+                candidate.StartsWith(allowed.EndsWith('/') ? allowed : allowed + "/", StringComparison.Ordinal))
+            {
+                return StorageLocationDecision.Allowed;
+            }
+        }
+
+        return StorageLocationDecision.Denied;
+    }
+
+    /// <summary>
+    /// Collapses a location to a comparable form. Bucket and container names are
+    /// case-sensitive in both S3 and Azure, so this never changes case.
+    /// </summary>
+    private static string Normalize(string location) =>
+        location.Replace('\\', '/').Trim('/');
+}
+
+public enum StorageLocationDecision
+{
+    /// <summary>The scope falls inside a permitted location.</summary>
+    Allowed,
+
+    /// <summary>The connection lists no locations. Permitted, but the caller should warn.</summary>
+    UnrestrictedByConfiguration,
+
+    /// <summary>The connection lists locations and this scope is not within any of them.</summary>
+    Denied
+}

--- a/src/Connapse.Core/Utilities/StorageLocationPolicy.cs
+++ b/src/Connapse.Core/Utilities/StorageLocationPolicy.cs
@@ -27,12 +27,19 @@ public static class StorageLocationPolicy
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(container);
 
+        // Declaring nothing is the grace path. Declaring entries that are all blank is not:
+        // that is a malformed allowlist, and reading it as "no restrictions" would turn a
+        // typo into an open door. The distinction is between an absent control and a broken
+        // one, and only the first should fail open.
+        if (allowedLocations.Count == 0)
+            return StorageLocationDecision.UnrestrictedByConfiguration;
+
         var entries = allowedLocations
             .Where(e => !string.IsNullOrWhiteSpace(e))
             .ToList();
 
         if (entries.Count == 0)
-            return StorageLocationDecision.UnrestrictedByConfiguration;
+            return StorageLocationDecision.Denied;
 
         string candidate = Normalize($"{container}/{prefix?.TrimStart('/') ?? string.Empty}");
 
@@ -43,9 +50,10 @@ public static class StorageLocationPolicy
             // An entry naming only a bucket permits any prefix within it; an entry naming a
             // bucket and prefix permits only that subtree. Compared with a trailing slash so
             // "bucket/docs" cannot admit "bucket/docs-internal" — the same off-by-slash trap
-            // that bites prefix-based filesystem checks.
+            // that bites prefix-based filesystem checks. Normalize has already stripped any
+            // trailing slash, so the separator is always appended here.
             if (candidate.Equals(allowed, StringComparison.Ordinal) ||
-                candidate.StartsWith(allowed.EndsWith('/') ? allowed : allowed + "/", StringComparison.Ordinal))
+                candidate.StartsWith(allowed + "/", StringComparison.Ordinal))
             {
                 return StorageLocationDecision.Allowed;
             }

--- a/src/Connapse.Storage/Connectors/ConnectorFactory.cs
+++ b/src/Connapse.Storage/Connectors/ConnectorFactory.cs
@@ -10,32 +10,32 @@ namespace Connapse.Storage.Connectors;
 /// <summary>
 /// Creates IConnector instances from ContainerEntity configuration.
 /// </summary>
-public class ConnectorFactory : IConnectorFactory
+public class ConnectorFactory(
+    IManagedStorageProvider managedStorageProvider,
+    IOptionsMonitor<SourceSecuritySettings> sourceSecurity,
+    ILogger<ConnectorFactory> logger) : IConnectorFactory
 {
-    private readonly IManagedStorageProvider _managedStorageProvider;
-    private readonly IOptionsMonitor<SourceSecuritySettings> _sourceSecurity;
-    private readonly ILogger<ConnectorFactory> _logger;
-
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
     };
 
-    public ConnectorFactory(
-        IManagedStorageProvider managedStorageProvider,
-        IOptionsMonitor<SourceSecuritySettings> sourceSecurity,
-        ILogger<ConnectorFactory> logger)
-    {
-        _managedStorageProvider = managedStorageProvider;
-        _sourceSecurity = sourceSecurity;
-        _logger = logger;
-    }
+    /// <summary>
+    /// Scopes already warned about running without an allowlist.
+    /// <para>
+    /// A connector is built on every sync cycle, so warning unconditionally would emit one
+    /// line per source every five minutes — burying the very message an operator needs to
+    /// act on before these become deny-by-default. Keyed on the scope as well as the
+    /// connection, so changing a root or bucket warns again rather than staying silent.
+    /// </para>
+    /// </summary>
+    private readonly HashSet<string> _warnedUnrestricted = [];
 
     public IConnector Create(Container container)
     {
         return container.ConnectorType switch
         {
-            ConnectorType.ManagedStorage => _managedStorageProvider.CreateConnector(container.Id),
+            ConnectorType.ManagedStorage => managedStorageProvider.CreateConnector(container.Id),
             ConnectorType.Filesystem => CreateFilesystemConnector(container),
             ConnectorType.S3 => CreateS3Connector(container),
             ConnectorType.AzureBlob => CreateAzureBlobConnector(container),
@@ -115,6 +115,18 @@ public class ConnectorFactory : IConnectorFactory
             : [];
 
     /// <summary>
+    /// True the first time a given scope is seen, false afterwards. The factory is a
+    /// singleton, so this is shared across every sync cycle for the process's lifetime.
+    /// </summary>
+    private bool ShouldWarn(string key)
+    {
+        lock (_warnedUnrestricted)
+        {
+            return _warnedUnrestricted.Add(key);
+        }
+    }
+
+    /// <summary>
     /// Checks that a source's bucket or blob container falls inside the locations its
     /// connection permits, and returns it.
     /// <para>
@@ -137,13 +149,16 @@ public class ConnectorFactory : IConnectorFactory
                 // Warned rather than refused, matching the filesystem root allowlist: #350
                 // backfilled existing S3 and Azure containers into connections and none of
                 // them declare locations, so enforcing now would break every upgrade.
-                _logger.LogWarning(
-                    "Connection {ConnectionName} declares no allowedLocations, so source "
-                    + "{SourceName} may name any container its credential can reach. It "
-                    + "currently names {Container}.",
-                    LogSanitizer.Sanitize(connectionName),
-                    LogSanitizer.Sanitize(sourceName),
-                    LogSanitizer.Sanitize(container));
+                if (ShouldWarn($"location:{connectionName}:{container}"))
+                {
+                    logger.LogWarning(
+                        "Connection {ConnectionName} declares no allowedLocations, so source "
+                        + "{SourceName} may name any container its credential can reach. It "
+                        + "currently names {Container}.",
+                        LogSanitizer.Sanitize(connectionName),
+                        LogSanitizer.Sanitize(sourceName),
+                        LogSanitizer.Sanitize(container));
+                }
                 return container;
 
             default:
@@ -163,7 +178,7 @@ public class ConnectorFactory : IConnectorFactory
     /// </summary>
     private string RequirePermittedRoot(string allowedRoot, string connectionName)
     {
-        switch (_sourceSecurity.CurrentValue.EvaluateRoot(allowedRoot))
+        switch (sourceSecurity.CurrentValue.EvaluateRoot(allowedRoot))
         {
             case FilesystemRootDecision.Allowed:
                 return allowedRoot;
@@ -173,13 +188,16 @@ public class ConnectorFactory : IConnectorFactory
                 // filesystem containers into connections, so enforcing immediately would
                 // break every upgrade until an operator edited configuration. The warning
                 // names the root so they know what to add.
-                _logger.LogWarning(
-                    "Connection {ConnectionName} uses filesystem root {Root} with no "
-                    + "{SectionName}:AllowedFilesystemRoots configured. Any root is currently "
-                    + "accepted; configure the allowlist to bound this.",
-                    LogSanitizer.Sanitize(connectionName),
-                    LogSanitizer.Sanitize(allowedRoot),
-                    SourceSecuritySettings.SectionName);
+                if (ShouldWarn($"root:{connectionName}:{allowedRoot}"))
+                {
+                    logger.LogWarning(
+                        "Connection {ConnectionName} uses filesystem root {Root} with no "
+                        + "{SectionName}:AllowedFilesystemRoots configured. Any root is currently "
+                        + "accepted; configure the allowlist to bound this.",
+                        LogSanitizer.Sanitize(connectionName),
+                        LogSanitizer.Sanitize(allowedRoot),
+                        SourceSecuritySettings.SectionName);
+                }
                 return allowedRoot;
 
             default:

--- a/src/Connapse.Storage/Connectors/ConnectorFactory.cs
+++ b/src/Connapse.Storage/Connectors/ConnectorFactory.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Connapse.Storage.Connectors;
 
@@ -11,15 +13,22 @@ namespace Connapse.Storage.Connectors;
 public class ConnectorFactory : IConnectorFactory
 {
     private readonly IManagedStorageProvider _managedStorageProvider;
+    private readonly IOptionsMonitor<SourceSecuritySettings> _sourceSecurity;
+    private readonly ILogger<ConnectorFactory> _logger;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
     };
 
-    public ConnectorFactory(IManagedStorageProvider managedStorageProvider)
+    public ConnectorFactory(
+        IManagedStorageProvider managedStorageProvider,
+        IOptionsMonitor<SourceSecuritySettings> sourceSecurity,
+        ILogger<ConnectorFactory> logger)
     {
         _managedStorageProvider = managedStorageProvider;
+        _sourceSecurity = sourceSecurity;
+        _logger = logger;
     }
 
     public IConnector Create(Container container)
@@ -72,9 +81,11 @@ public class ConnectorFactory : IConnectorFactory
             ConnectionProvider.Filesystem => new FilesystemConnector(new FilesystemConnectorConfig
             {
                 RootPath = CombineUnderRoot(
-                    Str(credential, "allowedRoot")
-                        ?? throw new InvalidOperationException(
-                            $"Connection '{connection.Name}' has no allowedRoot."),
+                    RequirePermittedRoot(
+                        Str(credential, "allowedRoot")
+                            ?? throw new InvalidOperationException(
+                                $"Connection '{connection.Name}' has no allowedRoot."),
+                        connection.Name),
                     Str(scope, "subPath"),
                     source.Name),
                 IncludePatterns = Arr(scope, "includePatterns"),
@@ -94,6 +105,42 @@ public class ConnectorFactory : IConnectorFactory
         doc.RootElement.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Array
             ? v.EnumerateArray().Where(e => e.ValueKind == JsonValueKind.String).Select(e => e.GetString()!).ToArray()
             : [];
+
+    /// <summary>
+    /// Checks a connection's allowed root against the deployment's configured allowlist.
+    /// <para>
+    /// The confinement check below stops a source escaping its root; this stops the root
+    /// itself being somewhere it should never be. They are independent: an allowlist does not
+    /// stop a symlink, and link resolution does not stop <c>allowedRoot: "/"</c>.
+    /// </para>
+    /// </summary>
+    private string RequirePermittedRoot(string allowedRoot, string connectionName)
+    {
+        switch (_sourceSecurity.CurrentValue.EvaluateRoot(allowedRoot))
+        {
+            case FilesystemRootDecision.Allowed:
+                return allowedRoot;
+
+            case FilesystemRootDecision.UnrestrictedByConfiguration:
+                // Warned rather than refused, for one release: #350 backfilled existing
+                // filesystem containers into connections, so enforcing immediately would
+                // break every upgrade until an operator edited configuration. The warning
+                // names the root so they know what to add.
+                _logger.LogWarning(
+                    "Connection {ConnectionName} uses filesystem root {Root} with no "
+                    + "{SectionName}:AllowedFilesystemRoots configured. Any root is currently "
+                    + "accepted; configure the allowlist to bound this.",
+                    LogSanitizer.Sanitize(connectionName),
+                    LogSanitizer.Sanitize(allowedRoot),
+                    SourceSecuritySettings.SectionName);
+                return allowedRoot;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Connection '{connectionName}' names filesystem root '{allowedRoot}', which is not "
+                    + $"within any entry of {SourceSecuritySettings.SectionName}:AllowedFilesystemRoots.");
+        }
+    }
 
     /// <summary>
     /// Resolves a source's subPath beneath its connection's allowed root, and verifies the

--- a/src/Connapse.Storage/Connectors/ConnectorFactory.cs
+++ b/src/Connapse.Storage/Connectors/ConnectorFactory.cs
@@ -60,9 +60,13 @@ public class ConnectorFactory : IConnectorFactory
             {
                 Region = Str(credential, "region") ?? "us-east-1",
                 RoleArn = Str(credential, "roleArn"),
-                BucketName = Str(scope, "bucketName")
-                    ?? throw new InvalidOperationException(
-                        $"Source '{source.Name}' has no bucketName in its scope."),
+                BucketName = RequirePermittedLocation(
+                    Arr(credential, "allowedLocations"),
+                    Str(scope, "bucketName")
+                        ?? throw new InvalidOperationException(
+                            $"Source '{source.Name}' has no bucketName in its scope."),
+                    Str(scope, "prefix"),
+                    connection.Name, source.Name),
                 Prefix = Str(scope, "prefix"),
             }),
 
@@ -72,9 +76,13 @@ public class ConnectorFactory : IConnectorFactory
                     ?? throw new InvalidOperationException(
                         $"Connection '{connection.Name}' has no storageAccountName."),
                 ManagedIdentityClientId = Str(credential, "managedIdentityClientId"),
-                ContainerName = Str(scope, "containerName")
-                    ?? throw new InvalidOperationException(
-                        $"Source '{source.Name}' has no containerName in its scope."),
+                ContainerName = RequirePermittedLocation(
+                    Arr(credential, "allowedLocations"),
+                    Str(scope, "containerName")
+                        ?? throw new InvalidOperationException(
+                            $"Source '{source.Name}' has no containerName in its scope."),
+                    Str(scope, "prefix"),
+                    connection.Name, source.Name),
                 Prefix = Str(scope, "prefix"),
             }),
 
@@ -105,6 +113,45 @@ public class ConnectorFactory : IConnectorFactory
         doc.RootElement.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Array
             ? v.EnumerateArray().Where(e => e.ValueKind == JsonValueKind.String).Select(e => e.GetString()!).ToArray()
             : [];
+
+    /// <summary>
+    /// Checks that a source's bucket or blob container falls inside the locations its
+    /// connection permits, and returns it.
+    /// <para>
+    /// The cloud counterpart of <see cref="RequirePermittedRoot"/>. IAM cannot make this
+    /// distinction on its own: one connection role is shared by every source that uses the
+    /// connection, so as far as AWS or Azure is concerned each of those sources is the same
+    /// principal.
+    /// </para>
+    /// </summary>
+    private string RequirePermittedLocation(
+        IReadOnlyList<string> allowedLocations, string container, string? prefix,
+        string connectionName, string sourceName)
+    {
+        switch (StorageLocationPolicy.Evaluate(allowedLocations, container, prefix))
+        {
+            case StorageLocationDecision.Allowed:
+                return container;
+
+            case StorageLocationDecision.UnrestrictedByConfiguration:
+                // Warned rather than refused, matching the filesystem root allowlist: #350
+                // backfilled existing S3 and Azure containers into connections and none of
+                // them declare locations, so enforcing now would break every upgrade.
+                _logger.LogWarning(
+                    "Connection {ConnectionName} declares no allowedLocations, so source "
+                    + "{SourceName} may name any container its credential can reach. It "
+                    + "currently names {Container}.",
+                    LogSanitizer.Sanitize(connectionName),
+                    LogSanitizer.Sanitize(sourceName),
+                    LogSanitizer.Sanitize(container));
+                return container;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Source '{sourceName}' names storage location '{container}/{prefix}', which is not "
+                    + $"within the allowedLocations declared by connection '{connectionName}'.");
+        }
+    }
 
     /// <summary>
     /// Checks a connection's allowed root against the deployment's configured allowlist.

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -165,6 +165,13 @@ public static class ServiceCollectionExtensions
         // Vector model discovery (cross-model search support)
         services.AddScoped<VectorModelDiscovery>();
 
+        // Bounds which filesystem roots a source may be pointed at. Bound from configuration
+        // only — never the settings table — because the authority a root confers is the same
+        // class of thing as a cloud credential, which this project refuses to accept over an
+        // API. See SourceSecuritySettings.
+        services.Configure<SourceSecuritySettings>(
+            configuration.GetSection(SourceSecuritySettings.SectionName));
+
         // Connector factory (singleton — shared S3 client and config must outlive requests)
         services.AddSingleton<ConnectorFactory>();
         services.AddSingleton<IConnectorFactory>(sp => sp.GetRequiredService<ConnectorFactory>());

--- a/src/Connapse.Web/appsettings.json
+++ b/src/Connapse.Web/appsettings.json
@@ -37,6 +37,12 @@
       "RedirectUri": ""
     }
   },
+  "Sources": {
+    "Security": {
+      "//AllowedFilesystemRoots": "Directories a filesystem connection's allowedRoot may name; a root must equal one of these or sit beneath it. Empty means unrestricted, which is retained for one release so upgrades keep working, and logs a warning naming each root in use. Configuration only — never settable through the API or the settings table, because the authority a root confers is the same class of thing as a cloud credential.",
+      "AllowedFilesystemRoots": []
+    }
+  },
   "Knowledge": {
     "Chunking": {
       "Strategy": "Semantic",

--- a/tests/Connapse.Core.Tests/Connectors/ConnectorFactoryTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/ConnectorFactoryTests.cs
@@ -21,7 +21,16 @@ public class ConnectorFactoryTests
         var managedStorageProvider = Substitute.For<IManagedStorageProvider>();
         managedStorageProvider.CreateConnector(Arg.Any<string>())
             .Returns(ci => Substitute.For<IConnector>());
-        _factory = new ConnectorFactory(managedStorageProvider);
+
+        // No allowlist configured: these tests cover container-path construction, which
+        // predates the source allowlist and is unaffected by it.
+        var sourceSecurity = Substitute.For<IOptionsMonitor<SourceSecuritySettings>>();
+        sourceSecurity.CurrentValue.Returns(new SourceSecuritySettings());
+
+        _factory = new ConnectorFactory(
+            managedStorageProvider,
+            sourceSecurity,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ConnectorFactory>.Instance);
     }
 
     [Fact]

--- a/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
@@ -1,7 +1,10 @@
+using System.Text.Json;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.Connectors;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
 
@@ -15,8 +18,23 @@ namespace Connapse.Core.Tests.Connectors;
 [Trait("Category", "Unit")]
 public class SourceConnectorFactoryTests
 {
-    private readonly IConnectorFactory _factory =
-        new ConnectorFactory(Substitute.For<IManagedStorageProvider>());
+    private readonly IConnectorFactory _factory = BuildFactory(new SourceSecuritySettings());
+
+    /// <summary>
+    /// Builds a factory with the given source-security policy. Defaults to no configured
+    /// allowlist, which is the unrestricted-with-a-warning path, so these tests keep covering
+    /// recombination rather than the allowlist.
+    /// </summary>
+    private static ConnectorFactory BuildFactory(SourceSecuritySettings settings)
+    {
+        var monitor = Substitute.For<IOptionsMonitor<SourceSecuritySettings>>();
+        monitor.CurrentValue.Returns(settings);
+
+        return new ConnectorFactory(
+            Substitute.For<IManagedStorageProvider>(),
+            monitor,
+            NullLogger<ConnectorFactory>.Instance);
+    }
 
     private static Connection MakeConnection(ConnectionProvider provider, string config, Guid? id = null) => new(
         Id: id ?? Guid.NewGuid(),
@@ -129,6 +147,64 @@ public class SourceConnectorFactoryTests
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*outside*");
+    }
+
+    [Fact]
+    public void Create_FilesystemRootOutsideTheAllowlist_Throws()
+    {
+        // The allowlist bounds what the root itself may be. Link resolution bounds where a
+        // source may reach from there. Neither substitutes for the other: this is the control
+        // that stops allowedRoot: "/".
+        var factory = BuildFactory(new SourceSecuritySettings
+        {
+            AllowedFilesystemRoots = [Path.Combine(Path.GetTempPath(), "connapse-permitted")]
+        });
+
+        var connection = MakeConnection(ConnectionProvider.Filesystem, """{"allowedRoot":"/"}""");
+        var source = MakeSource(connection.Id, "{}");
+
+        Action act = () => factory.Create(source, connection);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*AllowedFilesystemRoots*");
+    }
+
+    [Fact]
+    public void Create_FilesystemRootInsideTheAllowlist_IsAccepted()
+    {
+        string permitted = Path.Combine(Path.GetTempPath(), $"connapse-allow-{Guid.NewGuid():N}");
+        string root = Path.Combine(permitted, "team");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var factory = BuildFactory(new SourceSecuritySettings { AllowedFilesystemRoots = [permitted] });
+
+            // A root nested inside a permitted entry is allowed — operators configure the
+            // parent once rather than enumerating every source directory.
+            var connection = MakeConnection(ConnectionProvider.Filesystem, $$"""{"allowedRoot":{{JsonSerializer.Serialize(root)}}}""");
+            var source = MakeSource(connection.Id, "{}");
+
+            factory.Create(source, connection).Type.Should().Be(ConnectorType.Filesystem);
+        }
+        finally
+        {
+            Directory.Delete(permitted, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Create_FilesystemRootWithNoAllowlistConfigured_IsAcceptedForNow()
+    {
+        // Deliberately permissive for one release: #350 backfilled existing filesystem
+        // containers into connections, so enforcing immediately would break every upgrade
+        // until an operator edited configuration. The factory logs a warning naming the root.
+        var factory = BuildFactory(new SourceSecuritySettings());
+
+        var connection = MakeConnection(ConnectionProvider.Filesystem, """{"allowedRoot":"/data"}""");
+        var source = MakeSource(connection.Id, "{}");
+
+        factory.Create(source, connection).Type.Should().Be(ConnectorType.Filesystem);
     }
 
     [Fact]

--- a/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
@@ -150,6 +150,57 @@ public class SourceConnectorFactoryTests
     }
 
     [Fact]
+    public void Create_S3SourceNamingABucketOutsideAllowedLocations_Throws()
+    {
+        // The connection's IAM role can read both buckets — this allowlist is the only thing
+        // distinguishing them, because every source on the connection is the same AWS principal.
+        var connection = MakeConnection(ConnectionProvider.S3,
+            """{"region":"eu-west-1","allowedLocations":["docs-bucket"]}""");
+        var source = MakeSource(connection.Id, """{"bucketName":"payroll-bucket"}""");
+
+        Action act = () => _factory.Create(source, connection);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*allowedLocations*");
+    }
+
+    [Fact]
+    public void Create_S3SourceInsideAllowedLocations_IsAccepted()
+    {
+        var connection = MakeConnection(ConnectionProvider.S3,
+            """{"region":"eu-west-1","allowedLocations":["docs-bucket/team"]}""");
+        var source = MakeSource(connection.Id, """{"bucketName":"docs-bucket","prefix":"team/2026/"}""");
+
+        var connector = (S3Connector)_factory.Create(source, connection);
+
+        connector.Config.BucketName.Should().Be("docs-bucket");
+    }
+
+    [Fact]
+    public void Create_AzureSourceNamingAContainerOutsideAllowedLocations_Throws()
+    {
+        var connection = MakeConnection(ConnectionProvider.AzureBlob,
+            """{"storageAccountName":"acct","allowedLocations":["public-docs"]}""");
+        var source = MakeSource(connection.Id, """{"containerName":"hr-private"}""");
+
+        Action act = () => _factory.Create(source, connection);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*allowedLocations*");
+    }
+
+    [Fact]
+    public void Create_CloudSourceWithNoAllowedLocations_IsAcceptedForNow()
+    {
+        // Same one-release grace as the filesystem root allowlist: #350 backfilled existing
+        // cloud containers into connections that declare no locations.
+        var connection = MakeConnection(ConnectionProvider.S3, """{"region":"eu-west-1"}""");
+        var source = MakeSource(connection.Id, """{"bucketName":"anything"}""");
+
+        _factory.Create(source, connection).Type.Should().Be(ConnectorType.S3);
+    }
+
+    [Fact]
     public void Create_FilesystemRootOutsideTheAllowlist_Throws()
     {
         // The allowlist bounds what the root itself may be. Link resolution bounds where a

--- a/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
@@ -3,6 +3,7 @@ using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.Connectors;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -21,11 +22,33 @@ public class SourceConnectorFactoryTests
     private readonly IConnectorFactory _factory = BuildFactory(new SourceSecuritySettings());
 
     /// <summary>
+    /// Captures log entries so the grace-path warning can be asserted. Written by hand rather
+    /// than substituted because ILogger.Log is generic, which makes the mock-based assertion
+    /// far harder to read than the thing it is checking.
+    /// </summary>
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+
+        public IEnumerable<string> Warnings =>
+            Entries.Where(e => e.Level == LogLevel.Warning).Select(e => e.Message);
+    }
+
+    /// <summary>
     /// Builds a factory with the given source-security policy. Defaults to no configured
     /// allowlist, which is the unrestricted-with-a-warning path, so these tests keep covering
     /// recombination rather than the allowlist.
     /// </summary>
-    private static ConnectorFactory BuildFactory(SourceSecuritySettings settings)
+    private static ConnectorFactory BuildFactory(
+        SourceSecuritySettings settings, ILogger<ConnectorFactory>? logger = null)
     {
         var monitor = Substitute.For<IOptionsMonitor<SourceSecuritySettings>>();
         monitor.CurrentValue.Returns(settings);
@@ -33,7 +56,7 @@ public class SourceConnectorFactoryTests
         return new ConnectorFactory(
             Substitute.For<IManagedStorageProvider>(),
             monitor,
-            NullLogger<ConnectorFactory>.Instance);
+            logger ?? NullLogger<ConnectorFactory>.Instance);
     }
 
     private static Connection MakeConnection(ConnectionProvider provider, string config, Guid? id = null) => new(
@@ -190,14 +213,54 @@ public class SourceConnectorFactoryTests
     }
 
     [Fact]
-    public void Create_CloudSourceWithNoAllowedLocations_IsAcceptedForNow()
+    public void Create_CloudSourceWithNoAllowedLocations_IsAcceptedAndWarns()
     {
         // Same one-release grace as the filesystem root allowlist: #350 backfilled existing
-        // cloud containers into connections that declare no locations.
+        // cloud containers into connections that declare no locations. The warning is
+        // asserted because it is the only signal an operator gets before this becomes
+        // deny-by-default — silently permitting would be indistinguishable from working.
+        var logger = new RecordingLogger<ConnectorFactory>();
+        var factory = BuildFactory(new SourceSecuritySettings(), logger);
+
         var connection = MakeConnection(ConnectionProvider.S3, """{"region":"eu-west-1"}""");
         var source = MakeSource(connection.Id, """{"bucketName":"anything"}""");
 
-        _factory.Create(source, connection).Type.Should().Be(ConnectorType.S3);
+        factory.Create(source, connection).Type.Should().Be(ConnectorType.S3);
+
+        logger.Warnings.Should().ContainSingle()
+            .Which.Should().Contain("anything", "the warning must name the container so an operator knows what to allowlist");
+    }
+
+    [Fact]
+    public void Create_RepeatedCyclesOverTheSameScope_WarnOnlyOnce()
+    {
+        // A connector is built every sync cycle. Warning each time would emit one line per
+        // source every five minutes and bury the message it exists to deliver.
+        var logger = new RecordingLogger<ConnectorFactory>();
+        var factory = BuildFactory(new SourceSecuritySettings(), logger);
+
+        var connection = MakeConnection(ConnectionProvider.S3, """{"region":"eu-west-1"}""");
+        var source = MakeSource(connection.Id, """{"bucketName":"anything"}""");
+
+        factory.Create(source, connection);
+        factory.Create(source, connection);
+        factory.Create(source, connection);
+
+        logger.Warnings.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Create_DifferentScopesOnTheSameConnection_EachWarn()
+    {
+        // Deduplication must not hide a second unrestricted bucket behind the first.
+        var logger = new RecordingLogger<ConnectorFactory>();
+        var factory = BuildFactory(new SourceSecuritySettings(), logger);
+
+        var connection = MakeConnection(ConnectionProvider.S3, """{"region":"eu-west-1"}""");
+        factory.Create(MakeSource(connection.Id, """{"bucketName":"first"}"""), connection);
+        factory.Create(MakeSource(connection.Id, """{"bucketName":"second"}"""), connection);
+
+        logger.Warnings.Should().HaveCount(2);
     }
 
     [Fact]
@@ -245,17 +308,22 @@ public class SourceConnectorFactoryTests
     }
 
     [Fact]
-    public void Create_FilesystemRootWithNoAllowlistConfigured_IsAcceptedForNow()
+    public void Create_FilesystemRootWithNoAllowlistConfigured_IsAcceptedAndWarns()
     {
         // Deliberately permissive for one release: #350 backfilled existing filesystem
         // containers into connections, so enforcing immediately would break every upgrade
-        // until an operator edited configuration. The factory logs a warning naming the root.
-        var factory = BuildFactory(new SourceSecuritySettings());
+        // until an operator edited configuration.
+        var logger = new RecordingLogger<ConnectorFactory>();
+        var factory = BuildFactory(new SourceSecuritySettings(), logger);
 
         var connection = MakeConnection(ConnectionProvider.Filesystem, """{"allowedRoot":"/data"}""");
         var source = MakeSource(connection.Id, "{}");
 
         factory.Create(source, connection).Type.Should().Be(ConnectorType.Filesystem);
+
+        logger.Warnings.Should().ContainSingle()
+            .Which.Should().Contain("AllowedFilesystemRoots",
+                "the warning must name the setting an operator has to configure");
     }
 
     [Fact]

--- a/tests/Connapse.Core.Tests/Utilities/SourceSecuritySettingsTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SourceSecuritySettingsTests.cs
@@ -1,0 +1,94 @@
+using Connapse.Core;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+/// <summary>
+/// The filesystem root allowlist, and proof that it actually loads from configuration.
+/// <para>
+/// The binding test is the point of this file. This allowlist is only reachable through
+/// configuration binding, so if binding silently produced an empty list the control would be
+/// off and every deployment would take the permissive grace path without anyone noticing —
+/// the failure is invisible precisely because "no roots configured" is a legitimate state.
+/// </para>
+/// </summary>
+[Trait("Category", "Unit")]
+public class SourceSecuritySettingsTests
+{
+    private static SourceSecuritySettings Bind(params (string Key, string Value)[] values)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values.Select(v =>
+                new KeyValuePair<string, string?>(v.Key, v.Value)))
+            .Build();
+
+        return configuration.GetSection(SourceSecuritySettings.SectionName)
+            .Get<SourceSecuritySettings>() ?? new SourceSecuritySettings();
+    }
+
+    [Fact]
+    public void AllowedFilesystemRoots_BindsFromConfiguration()
+    {
+        var settings = Bind(
+            ("Sources:Security:AllowedFilesystemRoots:0", "/data/docs"),
+            ("Sources:Security:AllowedFilesystemRoots:1", "/mnt/share"));
+
+        settings.AllowedFilesystemRoots.Should().BeEquivalentTo(["/data/docs", "/mnt/share"]);
+    }
+
+    [Fact]
+    public void AllowedFilesystemRoots_AbsentFromConfiguration_IsEmpty()
+    {
+        Bind().AllowedFilesystemRoots.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EvaluateRoot_WithNoAllowlist_IsUnrestricted()
+    {
+        new SourceSecuritySettings().EvaluateRoot("/anything")
+            .Should().Be(FilesystemRootDecision.UnrestrictedByConfiguration);
+    }
+
+    [Fact]
+    public void EvaluateRoot_RootOutsideEveryEntry_IsDenied()
+    {
+        var settings = new SourceSecuritySettings
+        {
+            AllowedFilesystemRoots = [Path.Combine(Path.GetTempPath(), "permitted")]
+        };
+
+        settings.EvaluateRoot(Path.Combine(Path.GetTempPath(), "elsewhere"))
+            .Should().Be(FilesystemRootDecision.Denied);
+    }
+
+    [Fact]
+    public void EvaluateRoot_RootBeneathAnEntry_IsAllowed()
+    {
+        string permitted = Path.Combine(Path.GetTempPath(), $"connapse-eval-{Guid.NewGuid():N}");
+        string nested = Path.Combine(permitted, "team");
+        Directory.CreateDirectory(nested);
+
+        try
+        {
+            var settings = new SourceSecuritySettings { AllowedFilesystemRoots = [permitted] };
+
+            settings.EvaluateRoot(nested).Should().Be(FilesystemRootDecision.Allowed);
+        }
+        finally
+        {
+            Directory.Delete(permitted, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void EvaluateRoot_AllEntriesBlank_IsDenied()
+    {
+        // Matches StorageLocationPolicy: a malformed allowlist is not an absent one, so it
+        // must not fall through to the permissive path.
+        var settings = new SourceSecuritySettings { AllowedFilesystemRoots = ["", "   "] };
+
+        settings.EvaluateRoot("/anything").Should().Be(FilesystemRootDecision.Denied);
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/StorageLocationPolicyTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/StorageLocationPolicyTests.cs
@@ -1,0 +1,111 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+/// <summary>
+/// Bounds which bucket or blob container a source may name inside a connection whose
+/// credential may reach many of them.
+/// </summary>
+[Trait("Category", "Unit")]
+public class StorageLocationPolicyTests
+{
+    [Fact]
+    public void Evaluate_NoLocationsConfigured_IsUnrestricted()
+    {
+        // Permissive for one release: #350 backfilled existing S3 and Azure containers into
+        // connections, none of which declare locations, so denying immediately would break
+        // every upgrade.
+        StorageLocationPolicy.Evaluate([], "any-bucket", null)
+            .Should().Be(StorageLocationDecision.UnrestrictedByConfiguration);
+    }
+
+    [Fact]
+    public void Evaluate_BucketOnlyEntry_PermitsAnyPrefixWithin()
+    {
+        StorageLocationPolicy.Evaluate(["docs-bucket"], "docs-bucket", "team/reports/")
+            .Should().Be(StorageLocationDecision.Allowed);
+    }
+
+    [Fact]
+    public void Evaluate_BucketOnlyEntry_DeniesADifferentBucket()
+    {
+        // The case that matters: the connection's role can read both, and only this stops a
+        // source naming the one it should not.
+        StorageLocationPolicy.Evaluate(["docs-bucket"], "payroll-bucket", null)
+            .Should().Be(StorageLocationDecision.Denied);
+    }
+
+    [Fact]
+    public void Evaluate_PrefixedEntry_PermitsThatSubtree()
+    {
+        StorageLocationPolicy.Evaluate(["shared/docs"], "shared", "docs/2026/")
+            .Should().Be(StorageLocationDecision.Allowed);
+    }
+
+    [Fact]
+    public void Evaluate_PrefixedEntry_DeniesOutsideTheSubtree()
+    {
+        StorageLocationPolicy.Evaluate(["shared/docs"], "shared", "payroll/")
+            .Should().Be(StorageLocationDecision.Denied);
+    }
+
+    [Fact]
+    public void Evaluate_SiblingPrefixSharingAName_IsDenied()
+    {
+        // "docs-internal" starts with "docs" as a string but is a different subtree — the
+        // off-by-slash trap that breaks prefix comparisons.
+        StorageLocationPolicy.Evaluate(["shared/docs"], "shared", "docs-internal/")
+            .Should().Be(StorageLocationDecision.Denied);
+    }
+
+    [Fact]
+    public void Evaluate_SiblingBucketSharingAName_IsDenied()
+    {
+        StorageLocationPolicy.Evaluate(["docs"], "docs-internal", null)
+            .Should().Be(StorageLocationDecision.Denied);
+    }
+
+    [Fact]
+    public void Evaluate_ExactBucketWithNoPrefix_IsAllowed()
+    {
+        StorageLocationPolicy.Evaluate(["docs-bucket"], "docs-bucket", null)
+            .Should().Be(StorageLocationDecision.Allowed);
+    }
+
+    [Fact]
+    public void Evaluate_IsCaseSensitive()
+    {
+        // S3 bucket names and Azure container names are both case-sensitive, so matching
+        // loosely would admit a name that is not the same resource.
+        StorageLocationPolicy.Evaluate(["Docs"], "docs", null)
+            .Should().Be(StorageLocationDecision.Denied);
+    }
+
+    [Fact]
+    public void Evaluate_LeadingAndTrailingSlashes_DoNotChangeTheDecision()
+    {
+        StorageLocationPolicy.Evaluate(["/shared/docs/"], "shared", "/docs/2026")
+            .Should().Be(StorageLocationDecision.Allowed);
+    }
+
+    [Fact]
+    public void Evaluate_MultipleEntries_MatchesAny()
+    {
+        StorageLocationPolicy.Evaluate(["a-bucket", "b-bucket/docs"], "b-bucket", "docs/x/")
+            .Should().Be(StorageLocationDecision.Allowed);
+    }
+
+    [Fact]
+    public void Evaluate_BlankEntriesAreIgnoredButDoNotMakeItUnrestricted()
+    {
+        // A list of blanks must not read as "nothing configured" and silently permit
+        // everything — that would turn a typo into an open door.
+        StorageLocationPolicy.Evaluate(["  ", ""], "any-bucket", null)
+            .Should().Be(StorageLocationDecision.UnrestrictedByConfiguration);
+
+        StorageLocationPolicy.Evaluate(["", "docs"], "payroll", null)
+            .Should().Be(StorageLocationDecision.Denied);
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/StorageLocationPolicyTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/StorageLocationPolicyTests.cs
@@ -75,7 +75,7 @@ public class StorageLocationPolicyTests
     }
 
     [Fact]
-    public void Evaluate_IsCaseSensitive()
+    public void Evaluate_LocationDifferingOnlyByCase_IsDenied()
     {
         // S3 bucket names and Azure container names are both case-sensitive, so matching
         // loosely would admit a name that is not the same resource.
@@ -98,14 +98,22 @@ public class StorageLocationPolicyTests
     }
 
     [Fact]
-    public void Evaluate_BlankEntriesAreIgnoredButDoNotMakeItUnrestricted()
+    public void Evaluate_AllEntriesBlank_IsDenied()
     {
-        // A list of blanks must not read as "nothing configured" and silently permit
-        // everything — that would turn a typo into an open door.
+        // A malformed allowlist is not an absent one. Reading a list of blanks as "nothing
+        // configured" would let a typo silently permit everything — only a genuinely empty
+        // list takes the grace path.
         StorageLocationPolicy.Evaluate(["  ", ""], "any-bucket", null)
-            .Should().Be(StorageLocationDecision.UnrestrictedByConfiguration);
+            .Should().Be(StorageLocationDecision.Denied);
+    }
 
+    [Fact]
+    public void Evaluate_BlankEntryAlongsideRealOnes_IsIgnored()
+    {
         StorageLocationPolicy.Evaluate(["", "docs"], "payroll", null)
             .Should().Be(StorageLocationDecision.Denied);
+
+        StorageLocationPolicy.Evaluate(["", "docs"], "docs", null)
+            .Should().Be(StorageLocationDecision.Allowed);
     }
 }


### PR DESCRIPTION
Part of #351.

Bounds what a source may be pointed at, on both sides: a configured allowlist of filesystem roots, and a per-connection allowlist of cloud storage locations. Together these are the precondition for exposing source creation over REST at all — without them, "create a source" is "read anything the deployment's credentials can reach, and make it searchable."

Background and prior art: `docs/research/programmatic-source-configuration-safety-2026-08-17.md`.

## `Sources:Security:AllowedFilesystemRoots` — deployment configuration

A connection's `allowedRoot` must equal a configured entry or sit beneath it. Configuration only, never the settings table: the authority a filesystem root confers is the same class of thing as a cloud credential, and this project already refuses to accept those over an API. Elasticsearch takes the same line with `path.repo`, a static node setting its API cannot change.

This is what stops `allowedRoot: "/"`. It is independent of the link resolution in #366 and neither substitutes for the other — an allowlist does not stop a symlink, and resolving links does not stop a root pointing at the whole disk. Root matching resolves links on both sides, so `/data/link-to-etc` cannot pass by appearing to sit under a permitted `/data`.

## `allowedLocations` — per-connection, for S3 and Azure Blob

A source's bucket or blob container plus prefix must fall inside one of the entries its connection declares.

**IAM cannot make this distinction.** One connection role is shared by every source using that connection, so to AWS or Azure they are the same principal. Snowflake reaches the same conclusion with `STORAGE_ALLOWED_LOCATIONS` on a storage integration — shipped alongside narrow IAM, not instead of it. Databricks Unity Catalog splits the same way, separating a storage credential from external locations.

Worth recording why this is not done with AWS session policies, which looked like the more elegant answer: they apply only when `roleArn` is set, cap at 2 KB, and **have no Azure equivalent** — managed-identity tokens cannot be narrowed at request time. They cannot provide a uniform boundary across both clouds. Still worth adding opportunistically on the assume-role path later, where they would convert an application bug into an AWS-side denial.

Matching rules: an entry naming only a bucket permits any prefix within it; one naming a bucket and prefix permits only that subtree. Comparison is case-sensitive, because S3 bucket names and Azure container names both are, and a separator is appended before prefix-matching so `bucket/docs` cannot admit `bucket/docs-internal` — the off-by-slash trap that breaks prefix comparisons.

## Both enforce at the factory

`ConnectorFactory.Create(source, connection)` is the single point every source connector is built through, so a future endpoint that forgets to validate cannot bypass either check.

## Upgrade behaviour — deliberately permissive for one release

An empty allowlist permits and logs a warning naming the root or container in use. #350 backfilled existing Filesystem, S3, and Azure containers into connections, and none of them declare either allowlist, so enforcing immediately would break every upgrade until an operator edited configuration. The warning tells them what to add. Both become deny-by-default in a later release.

This is a deliberate softening of the research's "absent means deny" recommendation. It is defensible because connections remain Admin-UI-only, so an unconstrained root or location is not remotely reachable today — but it must be tightened before, or together with, any programmatic connection creation.

## Testing

`dotnet test` — **1099 passed, 0 failed.** 16 new tests: 12 on the location policy (bucket-only entries, prefixed subtrees, sibling-name rejection on both bucket and prefix, case sensitivity, slash normalization, and that a list of blank entries does not read as "unconfigured"), and 4 at the factory covering both clouds plus the grace path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable security restrictions for filesystem roots used by sources.
  * Added storage-location allowlists for cloud containers, buckets, and prefixes.
  * Added clear allowed, denied, and unrestricted validation outcomes.
  * Unrestricted configurations remain supported with warning notifications, issued only once per connection and location.

* **Configuration**
  * Added the `Sources.Security` section for managing permitted filesystem roots.

* **Tests**
  * Added coverage for location matching, path boundaries, normalization, case sensitivity, warning behavior, and security enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->