### PR TITLE
feat(web): add /api/sources with admin-scoped mutations

### DIFF
--- a/src/Connapse.Core/Models/SyncModels.cs
+++ b/src/Connapse.Core/Models/SyncModels.cs
@@ -21,12 +21,19 @@ public record OwnerRef(Guid Id, bool IsSource)
 /// <summary>
 /// Outcome of one sync cycle for one source.
 /// </summary>
+/// <param name="AlreadyRunning">
+/// True when the cycle did nothing because another sync of the same source held the gate.
+/// Distinct from <paramref name="Error"/>: nothing went wrong, the work simply belongs to
+/// the cycle already in flight. A caller that surfaces this to a user should say "in
+/// progress", not "failed".
+/// </param>
 public record SourceSyncResult(
     int Upserted,
     int Deleted,
     bool UsedDeltaPath,
     bool RequiredResync,
-    string? Error);
+    string? Error,
+    bool AlreadyRunning = false);
 
 /// <summary>
 /// Thrown when a reindex would move a document between ownership domains — source to

--- a/src/Connapse.Web/Endpoints/SourceResponse.cs
+++ b/src/Connapse.Web/Endpoints/SourceResponse.cs
@@ -1,0 +1,55 @@
+using Connapse.Core;
+
+namespace Connapse.Web.Endpoints;
+
+/// <summary>
+/// What the API returns for a source.
+/// <para>
+/// Deliberately not the <see cref="Source"/> record. That carries <c>ScopeJson</c>, which
+/// names buckets, prefixes and filesystem subpaths, and <c>SyncCursor</c>, an opaque
+/// provider continuation token — infrastructure detail a reader has no reason to receive,
+/// and the kind of thing that turns a read route into reconnaissance. Serializing the record
+/// directly would hand both out.
+/// </para>
+/// </summary>
+public record SourceResponse(
+    Guid Id,
+    string Name,
+    string? Description,
+    Guid ConnectionId,
+    bool Enabled,
+    SyncStatus LastSyncStatus,
+    DateTime? LastSyncedAt,
+    int? SyncIntervalSeconds,
+    int DocumentCount,
+    string? Summary,
+    DateTime CreatedAt,
+    DateTime UpdatedAt,
+    /// <summary>
+    /// Populated for administrators only. A provider's failure text routinely echoes the
+    /// thing that failed — "Access Denied for bucket payroll-data" — so returning it to
+    /// every reader would give back exactly the infrastructure detail ScopeJson is withheld
+    /// to protect.
+    /// </summary>
+    string? LastSyncError,
+    /// <summary>
+    /// Always "source". Present so a client consuming both this and the container routes can
+    /// tell them apart on a single field, matching the MCP contract.
+    /// </summary>
+    string Kind = "source")
+{
+    public static SourceResponse From(Source source, bool includeDiagnostics) => new(
+        Id: source.Id,
+        Name: source.Name,
+        Description: source.Description,
+        ConnectionId: source.ConnectionId,
+        Enabled: source.Enabled,
+        LastSyncStatus: source.LastSyncStatus,
+        LastSyncedAt: source.LastSyncedAt,
+        SyncIntervalSeconds: source.SyncIntervalSeconds,
+        DocumentCount: source.DocumentCount,
+        Summary: source.Summary,
+        CreatedAt: source.CreatedAt,
+        UpdatedAt: source.UpdatedAt,
+        LastSyncError: includeDiagnostics ? source.LastSyncError : null);
+}

--- a/src/Connapse.Web/Endpoints/SourcesEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/SourcesEndpoints.cs
@@ -1,0 +1,246 @@
+using System.Text.Json;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Web.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Connapse.Web.Endpoints;
+
+/// <summary>
+/// REST surface for sources — external scopes Connapse mirrors but does not own.
+/// <para>
+/// Two rules shape this file. First, **nothing here returns documents or paths.** There is no
+/// browse route and no document listing: a source is a searchable scope, and enumerating what
+/// is inside one exposes every synced object to any Connapse reader regardless of whether they
+/// could see it in the source system. That leak is the reason epic #348 exists.
+/// </para>
+/// <para>
+/// Second, **mutations require an administrator, not an editor.** Creating a source chooses
+/// what external data gets indexed and made searchable, bounded only by what the connection's
+/// credential can reach — an administrative act rather than a content one. Airbyte reaches the
+/// same conclusion by separating its source-editor role from destination-editor.
+/// </para>
+/// <para>
+/// Connections are deliberately absent entirely. They are the credential boundary and are
+/// configured out of band; see
+/// <c>docs/research/programmatic-source-configuration-safety-2026-08-17.md</c>.
+/// </para>
+/// </summary>
+public static class SourcesEndpoints
+{
+    public static IEndpointRouteBuilder MapSourcesEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/sources").WithTags("Sources");
+
+        // GET /api/sources - List sources (paginated)
+        group.MapGet("/", async (
+            [FromQuery] int? skip,
+            [FromQuery] int? take,
+            [FromServices] ISourceStore sourceStore,
+            [FromServices] IAuthorizationService authorization,
+            HttpContext http,
+            CancellationToken ct) =>
+        {
+            int effectiveSkip = skip ?? 0;
+            int effectiveTake = take ?? 50;
+            var validationError = PaginationValidator.Validate(effectiveSkip, effectiveTake);
+            if (validationError is not null) return validationError;
+
+            var sources = await sourceStore.ListAsync(effectiveSkip, effectiveTake + 1, ct);
+            bool hasMore = sources.Count > effectiveTake;
+            var page = hasMore ? sources.Take(effectiveTake).ToList() : sources;
+
+            bool diagnostics = await IsAdminAsync(authorization, http);
+            var items = page.Select(s => SourceResponse.From(s, diagnostics)).ToList();
+
+            return Results.Ok(new PagedResponse<SourceResponse>(items, items.Count, hasMore));
+        })
+        .WithName("ListSources")
+        .WithDescription("List sources with pagination (?skip=0&take=50). Returns sync state, never a file listing.")
+        .RequireAuthorization("RequireViewer");
+
+        // GET /api/sources/{sourceId}
+        group.MapGet("/{sourceId:guid}", async (
+            Guid sourceId,
+            [FromServices] ISourceStore sourceStore,
+            [FromServices] IAuthorizationService authorization,
+            HttpContext http,
+            CancellationToken ct) =>
+        {
+            var source = await sourceStore.GetAsync(sourceId, ct);
+            if (source is null)
+                return Results.NotFound(new { error = $"Source {sourceId} not found" });
+
+            bool diagnostics = await IsAdminAsync(authorization, http);
+            return Results.Ok(SourceResponse.From(source, diagnostics));
+        })
+        .WithName("GetSource")
+        .WithDescription("Get a source's configuration summary and sync state.")
+        .RequireAuthorization("RequireViewer");
+
+        // POST /api/sources
+        group.MapPost("/", async (
+            [FromBody] CreateSourceApiRequest request,
+            [FromServices] ISourceStore sourceStore,
+            [FromServices] IConnectionStore connectionStore,
+            [FromServices] IAuditLogger auditLogger,
+            CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(request.Name))
+                return Results.BadRequest(new { error = "Source name is required" });
+
+            string name = request.Name.Trim();
+
+            // Checked before anything else touches the database: a source whose connection
+            // does not exist is skipped silently by SourceSyncService, so it would look
+            // created and never sync.
+            var connection = await connectionStore.GetAsync(request.ConnectionId, ct);
+            if (connection is null)
+                return Results.BadRequest(new { error = $"Connection {request.ConnectionId} not found" });
+
+            if (!string.IsNullOrWhiteSpace(request.ScopeJson))
+            {
+                try { JsonDocument.Parse(request.ScopeJson); }
+                catch (JsonException ex)
+                { return Results.BadRequest(new { error = $"Invalid scope JSON: {ex.Message}" }); }
+            }
+
+            var existing = await sourceStore.GetByNameAsync(name, ct);
+            if (existing is not null)
+                return Results.Conflict(new { error = $"Source '{name}' already exists" });
+
+            Source created;
+            try
+            {
+                created = await sourceStore.CreateAsync(
+                    new CreateSourceRequest(
+                        name, request.ConnectionId, request.ScopeJson ?? "{}",
+                        request.Description, request.SyncIntervalSeconds), ct);
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+
+            await auditLogger.LogAsync("source.created", "source", created.Id.ToString(),
+                new { created.Name, created.ConnectionId }, ct);
+
+            return Results.Created($"/api/sources/{created.Id}", SourceResponse.From(created, includeDiagnostics: true));
+        })
+        .WithName("CreateSource")
+        .WithDescription("Create a source inside an existing connection. Administrator only — a source chooses what external data is indexed.")
+        .RequireAuthorization("RequireAdmin");
+
+        // PATCH /api/sources/{sourceId}
+        group.MapPatch("/{sourceId:guid}", async (
+            Guid sourceId,
+            [FromBody] UpdateSourceRequest request,
+            [FromServices] ISourceStore sourceStore,
+            [FromServices] IAuditLogger auditLogger,
+            CancellationToken ct) =>
+        {
+            if (!string.IsNullOrWhiteSpace(request.ScopeJson))
+            {
+                try { JsonDocument.Parse(request.ScopeJson); }
+                catch (JsonException ex)
+                { return Results.BadRequest(new { error = $"Invalid scope JSON: {ex.Message}" }); }
+            }
+
+            var updated = await sourceStore.UpdateAsync(sourceId, request, ct);
+            if (updated is null)
+                return Results.NotFound(new { error = $"Source {sourceId} not found" });
+
+            await auditLogger.LogAsync("source.updated", "source", sourceId.ToString(),
+                new { updated.Name }, ct);
+
+            return Results.Ok(SourceResponse.From(updated, includeDiagnostics: true));
+        })
+        .WithName("UpdateSource")
+        .WithDescription("Update a source's name, description, scope, sync interval, or enabled state.")
+        .RequireAuthorization("RequireAdmin");
+
+        // DELETE /api/sources/{sourceId}
+        group.MapDelete("/{sourceId:guid}", async (
+            Guid sourceId,
+            [FromServices] ISourceStore sourceStore,
+            [FromServices] IAuditLogger auditLogger,
+            CancellationToken ct) =>
+        {
+            var source = await sourceStore.GetAsync(sourceId, ct);
+            if (source is null)
+                return Results.NotFound(new { error = $"Source {sourceId} not found" });
+
+            bool deleted = await sourceStore.DeleteAsync(sourceId, ct);
+            if (!deleted)
+                return Results.NotFound(new { error = $"Source {sourceId} not found" });
+
+            await auditLogger.LogAsync("source.deleted", "source", sourceId.ToString(),
+                new { source.Name }, ct);
+
+            return Results.NoContent();
+        })
+        .WithName("DeleteSource")
+        .WithDescription("Delete a source and its indexed documents. The external data itself is untouched.")
+        .RequireAuthorization("RequireAdmin");
+
+        // POST /api/sources/{sourceId}/sync
+        group.MapPost("/{sourceId:guid}/sync", async (
+            Guid sourceId,
+            [FromServices] ISourceStore sourceStore,
+            [FromServices] IConnectionStore connectionStore,
+            [FromServices] SourceSyncService syncService,
+            [FromServices] IAuditLogger auditLogger,
+            CancellationToken ct) =>
+        {
+            var source = await sourceStore.GetAsync(sourceId, ct);
+            if (source is null)
+                return Results.NotFound(new { error = $"Source {sourceId} not found" });
+
+            if (!source.Enabled)
+                return Results.BadRequest(new { error = $"Source '{source.Name}' is disabled" });
+
+            var connection = await connectionStore.GetAsync(source.ConnectionId, ct);
+            if (connection is null)
+                return Results.BadRequest(new { error = $"Source '{source.Name}' references a missing connection" });
+
+            var result = await syncService.SyncSourceAsync(source, connection, ct);
+
+            await auditLogger.LogAsync("source.synced", "source", sourceId.ToString(),
+                new { source.Name, result.Upserted, result.Deleted }, ct);
+
+            return Results.Ok(new
+            {
+                result.Upserted,
+                result.Deleted,
+                result.UsedDeltaPath,
+                result.RequiredResync,
+                result.Error
+            });
+        })
+        .WithName("SyncSource")
+        .WithDescription("Run one sync cycle for a source immediately, rather than waiting for the next scheduled poll.")
+        .RequireAuthorization("RequireAdmin");
+
+        return app;
+    }
+
+    /// <summary>
+    /// Whether the caller may see diagnostic detail. Reads are open to viewers, but a
+    /// provider's failure text tends to quote the resource that failed, so it is withheld
+    /// from anyone who is not already entitled to know the source's scope.
+    /// </summary>
+    private static async Task<bool> IsAdminAsync(IAuthorizationService authorization, HttpContext http) =>
+        (await authorization.AuthorizeAsync(http.User, "RequireAdmin")).Succeeded;
+}
+
+/// <summary>
+/// Request body for creating a source. Separate from <see cref="CreateSourceRequest"/> so the
+/// wire contract can carry an optional scope while the store's contract requires one.
+/// </summary>
+public record CreateSourceApiRequest(
+    string Name,
+    Guid ConnectionId,
+    string? ScopeJson = null,
+    string? Description = null,
+    int? SyncIntervalSeconds = null);

--- a/src/Connapse.Web/Endpoints/SourcesEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/SourcesEndpoints.cs
@@ -101,7 +101,8 @@ public static class SourcesEndpoints
 
             if (!string.IsNullOrWhiteSpace(request.ScopeJson))
             {
-                try { JsonDocument.Parse(request.ScopeJson); }
+                // Disposed: JsonDocument rents pooled buffers, and this runs per request.
+                try { using var _ = JsonDocument.Parse(request.ScopeJson); }
                 catch (JsonException ex)
                 { return Results.BadRequest(new { error = $"Invalid scope JSON: {ex.Message}" }); }
             }
@@ -142,7 +143,8 @@ public static class SourcesEndpoints
         {
             if (!string.IsNullOrWhiteSpace(request.ScopeJson))
             {
-                try { JsonDocument.Parse(request.ScopeJson); }
+                // Disposed: JsonDocument rents pooled buffers, and this runs per request.
+                try { using var _ = JsonDocument.Parse(request.ScopeJson); }
                 catch (JsonException ex)
                 { return Results.BadRequest(new { error = $"Invalid scope JSON: {ex.Message}" }); }
             }
@@ -205,6 +207,16 @@ public static class SourcesEndpoints
                 return Results.BadRequest(new { error = $"Source '{source.Name}' references a missing connection" });
 
             var result = await syncService.SyncSourceAsync(source, connection, ct);
+
+            // Nothing went wrong — the scheduled cycle got there first. 409 rather than 200
+            // so a script driving this does not read "0 upserted" as "nothing to do".
+            if (result.AlreadyRunning)
+            {
+                return Results.Conflict(new
+                {
+                    error = $"A sync for source '{source.Name}' is already in progress.",
+                });
+            }
 
             await auditLogger.LogAsync("source.synced", "source", sourceId.ToString(),
                 new { source.Name, result.Upserted, result.Deleted }, ct);

--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -101,9 +101,12 @@ builder.Services.AddHostedService<SourceBackfillHostedService>();
 // Polls every enabled source and reconciles it with its remote. Replaces
 // ConnectorWatcherService, which enumerated containers — after the #350 backfill moved
 // external storage into `sources`, it found nothing and syncing stopped entirely.
-// No longer a singleton: nothing calls into it at runtime, because containers are managed
-// storage only and have no remote to watch.
-builder.Services.AddHostedService<SourceSyncService>();
+//
+// Singleton-as-hosted-service so POST /api/sources/{id}/sync can run one cycle on demand
+// against the same instance. #364 registered it as a plain hosted service on the grounds
+// that nothing called into it at runtime; the sync-now route is that caller.
+builder.Services.AddSingleton<SourceSyncService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<SourceSyncService>());
 
 // Tracks background reindex state so admins can see success/failure via the status endpoint.
 builder.Services.AddSingleton<ReindexStateService>();
@@ -353,6 +356,7 @@ api.MapAuthEndpoints();
 api.MapCloudIdentityEndpoints();
 api.MapAgentEndpoints();
 api.MapContainersEndpoints();
+api.MapSourcesEndpoints();
 api.MapDocumentsEndpoints();
 api.MapFoldersEndpoints();
 api.MapSearchEndpoints();

--- a/src/Connapse.Web/Services/SourceSyncService.cs
+++ b/src/Connapse.Web/Services/SourceSyncService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
@@ -30,6 +31,13 @@ public class SourceSyncService(
     ILogger<SourceSyncService> logger) : BackgroundService
 {
     private static readonly TimeSpan DefaultSyncInterval = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// One gate per source, so two cycles for the same source cannot overlap while different
+    /// sources still sync concurrently. Never pruned: the entry is a single semaphore, and a
+    /// source that syncs once is likely to sync again.
+    /// </summary>
+    private readonly ConcurrentDictionary<Guid, SemaphoreSlim> _syncGates = new();
 
     /// <summary>Document metadata keys holding the remote's signature at last ingestion.</summary>
     internal const string RemoteLastModifiedKey = "RemoteLastModified";
@@ -89,6 +97,26 @@ public class SourceSyncService(
         if (!source.Enabled)
             return new SourceSyncResult(0, 0, UsedDeltaPath: false, RequiredResync: false, Error: null);
 
+        // One sync per source at a time. The timer used to be the only caller and ran its
+        // sources sequentially, so overlap was impossible; the sync-now endpoint can now
+        // start a second cycle for a source the timer is already working on. The
+        // compare-and-swap below keeps the cursor safe either way, but two cycles would
+        // still list the same remote twice and enqueue the same files twice — duplicated
+        // embedding work, which costs real money.
+        //
+        // Acquired without waiting: a caller who arrives during an in-flight cycle wants to
+        // hear "already running", not to be blocked behind it.
+        var gate = _syncGates.GetOrAdd(source.Id, _ => new SemaphoreSlim(1, 1));
+        if (!await gate.WaitAsync(0, ct))
+        {
+            logger.LogInformation(
+                "Sync for source {SourceId} ({Name}) is already in progress; skipping this request",
+                source.Id, Sanitize(source.Name));
+
+            return new SourceSyncResult(
+                0, 0, UsedDeltaPath: false, RequiredResync: false, Error: null, AlreadyRunning: true);
+        }
+
         await using var scope = scopeFactory.CreateAsyncScope();
         var sourceStore = scope.ServiceProvider.GetRequiredService<ISourceStore>();
 
@@ -124,6 +152,8 @@ public class SourceSyncService(
             // minutes per source, so skipping this abandons a client per source per cycle —
             // the watcher this replaced disposed here for the same reason.
             if (connector is IDisposable disposable) disposable.Dispose();
+
+            gate.Release();
         }
     }
 

--- a/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
@@ -110,6 +110,35 @@ public class SourceSyncIntegrationTests(SharedWebAppFixture fixture)
             => throw new NotSupportedException();
     }
 
+    /// <summary>A connector that blocks inside ListFilesAsync until released.</summary>
+    private sealed class BlockingConnector : IConnector
+    {
+        private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Completes once the connector is inside the remote call.</summary>
+        public Task Entered => _entered.Task;
+
+        public void Release() => _release.TrySetResult();
+
+        public ConnectorType Type => ConnectorType.S3;
+        public bool SupportsLiveWatch => false;
+
+        public async Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
+        {
+            _entered.TrySetResult();
+            await _release.Task;
+            return [];
+        }
+
+        public Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
+            => Task.FromResult<Stream>(new MemoryStream());
+        public Task<bool> ExistsAsync(string path, CancellationToken ct = default) => Task.FromResult(true);
+        public string ResolveJobPath(string relativePath) => relativePath;
+        public IAsyncEnumerable<ConnectorFileEvent> WatchAsync(CancellationToken ct = default)
+            => throw new NotSupportedException();
+    }
+
     /// <summary>A connector whose remote calls fail.</summary>
     private sealed class ThrowingConnector : IConnector
     {
@@ -414,6 +443,64 @@ public class SourceSyncIntegrationTests(SharedWebAppFixture fixture)
 
         result.Error.Should().NotBeNull();
         connector.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SyncSourceAsync_WhileAnotherCycleIsRunning_ReportsAlreadyRunning()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+
+        var connector = new BlockingConnector();
+        var service = BuildService(scope.ServiceProvider, connector);
+
+        // The timer was once the only caller and ran sources sequentially, so overlap could
+        // not happen. The sync-now endpoint can start a second cycle for a source the timer
+        // already holds — two cycles would list the same remote twice and enqueue the same
+        // files twice, which is duplicated embedding work rather than a correctness bug, but
+        // a costly one.
+        var firstCycle = service.SyncSourceAsync(source, connection, CancellationToken.None);
+        await connector.Entered; // the first cycle is now inside the remote call
+
+        var second = await service.SyncSourceAsync(source, connection, CancellationToken.None);
+
+        second.AlreadyRunning.Should().BeTrue();
+        second.Error.Should().BeNull("nothing went wrong — the work belongs to the cycle in flight");
+
+        connector.Release();
+        (await firstCycle).AlreadyRunning.Should().BeFalse("the first cycle held the gate and ran");
+    }
+
+    [Fact]
+    public async Task SyncSourceAsync_AfterACycleCompletes_TheGateIsReleased()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+
+        var service = BuildService(scope.ServiceProvider, new FakeListConnector());
+
+        await service.SyncSourceAsync(source, connection, CancellationToken.None);
+        var second = await service.SyncSourceAsync(source, connection, CancellationToken.None);
+
+        // A gate that is never released would wedge the source permanently after one cycle.
+        second.AlreadyRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SyncSourceAsync_WhenTheRemoteThrows_TheGateIsStillReleased()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+
+        var service = BuildService(scope.ServiceProvider, new ThrowingConnector());
+
+        await service.SyncSourceAsync(source, connection, CancellationToken.None);
+        var second = await service.SyncSourceAsync(source, connection, CancellationToken.None);
+
+        // The failure path is where a missed release would hurt most: an unreachable remote
+        // is exactly when cycles repeat.
+        second.AlreadyRunning.Should().BeFalse();
+        second.Error.Should().NotBeNull();
     }
 
     [Fact]

--- a/tests/Connapse.Integration.Tests/SourcesEndpointsTests.cs
+++ b/tests/Connapse.Integration.Tests/SourcesEndpointsTests.cs
@@ -307,6 +307,10 @@ public class SourcesEndpointsTests(SharedWebAppFixture fixture) : IAsyncLifetime
             .Should().Be(HttpStatusCode.NotFound);
     }
 
+    // The per-source gate itself is covered deterministically in SourceSyncIntegrationTests,
+    // where a connector can be made to block. Racing two HTTP requests here would pass or
+    // fail on timing.
+
     [Fact]
     public async Task SyncSource_WhenDisabled_IsRejected()
     {
@@ -322,7 +326,7 @@ public class SourcesEndpointsTests(SharedWebAppFixture fixture) : IAsyncLifetime
     // ── No enumeration surface ────────────────────────────────────────────
 
     [Fact]
-    public async Task NoBrowseOrDocumentRouteExistsForASource()
+    public async Task GetSource_EnumerationRoutes_AreNotFound()
     {
         Guid connectionId = await SeedConnectionAsync();
         Guid sourceId = await CreateSourceAsync(connectionId);

--- a/tests/Connapse.Integration.Tests/SourcesEndpointsTests.cs
+++ b/tests/Connapse.Integration.Tests/SourcesEndpointsTests.cs
@@ -1,0 +1,356 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Identity.Data.Entities;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// The <c>/api/sources</c> surface.
+/// <para>
+/// Two properties matter more than the CRUD: responses must never carry the source's scope,
+/// and mutations must require an administrator rather than an editor. Both are asserted
+/// negatively — the absence of a field, the refusal of a role — because a later refactor that
+/// serializes the record directly, or copies the container endpoints' authorization, would
+/// otherwise pass every positive test.
+/// </para>
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class SourcesEndpointsTests(SharedWebAppFixture fixture) : IAsyncLifetime
+{
+    private const string EditorEmail = "editor@sources-tests.connapse.io";
+    private const string EditorPassword = "EditorSrcTest1!";
+    private const string ViewerEmail = "viewer@sources-tests.connapse.io";
+    private const string ViewerPassword = "ViewerSrcTest1!";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private HttpClient _editorClient = null!;
+    private HttpClient _viewerClient = null!;
+
+    private HttpClient Admin => fixture.AdminClient;
+
+    public async Task InitializeAsync()
+    {
+        await SeedUserAsync(EditorEmail, EditorPassword, "Editor");
+        await SeedUserAsync(ViewerEmail, ViewerPassword, "Viewer");
+        _editorClient = await ClientForAsync(EditorEmail, EditorPassword);
+        _viewerClient = await ClientForAsync(ViewerEmail, ViewerPassword);
+    }
+
+    public Task DisposeAsync()
+    {
+        _editorClient.Dispose();
+        _viewerClient.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task SeedUserAsync(string email, string password, string role)
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ConnapseUser>>();
+
+        if (await userManager.FindByEmailAsync(email) is not null) return;
+
+        var user = new ConnapseUser
+        {
+            UserName = email,
+            Email = email,
+            EmailConfirmed = true,
+            DisplayName = email,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        var result = await userManager.CreateAsync(user, password);
+        result.Succeeded.Should().BeTrue(
+            because: string.Join(", ", result.Errors.Select(e => e.Description)));
+        await userManager.AddToRoleAsync(user, role);
+    }
+
+    private async Task<HttpClient> ClientForAsync(string email, string password)
+    {
+        using var anon = fixture.Factory.CreateClient();
+        var response = await anon.PostAsJsonAsync("/api/v1/auth/token", new { email, password });
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var token = await response.Content.ReadFromJsonAsync<TokenPayload>(JsonOptions);
+
+        var client = fixture.Factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token!.AccessToken);
+        return client;
+    }
+
+    private sealed record TokenPayload(string AccessToken);
+
+    private static string ShortName(string prefix) => $"{prefix}-{Guid.NewGuid():N}"[..20];
+
+    /// <summary>Creates a connection directly, since there is no REST route to create one.</summary>
+    private async Task<Guid> SeedConnectionAsync()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+        var connection = await connections.CreateAsync(
+            new CreateConnectionRequest(ShortName("conn"), ConnectionProvider.S3, """{"region":"us-east-1"}"""),
+            createdByUserId: null);
+        return connection.Id;
+    }
+
+    private async Task<Guid> CreateSourceAsync(Guid connectionId, string? name = null)
+    {
+        var response = await Admin.PostAsJsonAsync("/api/sources", new
+        {
+            name = name ?? ShortName("src"),
+            connectionId,
+            scopeJson = """{"bucketName":"b","prefix":"team/"}""",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return created.GetProperty("id").GetGuid();
+    }
+
+    // ── The scope must never come back ────────────────────────────────────
+
+    [Fact]
+    public async Task GetSource_ResponseOmitsScopeAndCursor()
+    {
+        Guid connectionId = await SeedConnectionAsync();
+        Guid sourceId = await CreateSourceAsync(connectionId);
+
+        var response = await Admin.GetAsync($"/api/sources/{sourceId}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string body = await response.Content.ReadAsStringAsync();
+
+        // Positive first, so the negatives below cannot pass on an empty or error body.
+        body.Should().Contain("\"kind\":\"source\"");
+        body.Should().Contain("lastSyncStatus");
+
+        // Asserted on the raw body rather than a deserialized DTO: deserializing into
+        // SourceResponse would drop unexpected fields silently, which is exactly the
+        // regression this guards against.
+        body.Should().NotContain("scopeJson", "the scope names buckets and paths");
+        body.Should().NotContain("bucketName", "the scope's contents must not leak either");
+        body.Should().NotContain("syncCursor", "a provider continuation token is not the caller's business");
+    }
+
+    [Fact]
+    public async Task ListSources_ResponseOmitsScope()
+    {
+        Guid connectionId = await SeedConnectionAsync();
+        await CreateSourceAsync(connectionId);
+
+        var response = await Admin.GetAsync("/api/sources?take=50");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string body = await response.Content.ReadAsStringAsync();
+
+        body.Should().Contain("\"kind\":\"source\"", "the listing must actually contain a source");
+        body.Should().NotContain("scopeJson");
+        body.Should().NotContain("bucketName");
+    }
+
+    [Fact]
+    public async Task GetSource_AsViewer_OmitsTheSyncErrorDetail()
+    {
+        Guid connectionId = await SeedConnectionAsync();
+        Guid sourceId = await CreateSourceAsync(connectionId);
+
+        // A provider's failure text routinely quotes the resource that failed, so handing it
+        // to every reader would give back the infrastructure detail scopeJson is withheld to
+        // protect.
+        using (var scope = fixture.Factory.Services.CreateScope())
+        {
+            var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+            await sources.UpdateSyncStateAsync(
+                sourceId, null, SyncStatus.Failed,
+                "Access Denied for bucket payroll-secrets", DateTime.UtcNow);
+        }
+
+        var asViewer = await _viewerClient.GetAsync($"/api/sources/{sourceId}");
+        asViewer.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await asViewer.Content.ReadAsStringAsync())
+            .Should().NotContain("payroll-secrets");
+
+        var asAdmin = await Admin.GetAsync($"/api/sources/{sourceId}");
+        (await asAdmin.Content.ReadAsStringAsync())
+            .Should().Contain("payroll-secrets", "an administrator needs the failure reason");
+    }
+
+    // ── Mutations are administrator-only ──────────────────────────────────
+
+    [Fact]
+    public async Task CreateSource_AsEditor_IsForbidden()
+    {
+        Guid connectionId = await SeedConnectionAsync();
+
+        var response = await _editorClient.PostAsJsonAsync("/api/sources", new
+        {
+            name = ShortName("src"),
+            connectionId,
+            scopeJson = "{}",
+        });
+
+        // Editor is enough to manage container content, but choosing what external data gets
+        // indexed is an administrative act.
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task DeleteSource_AsEditor_IsForbidden()
+    {
+        Guid connectionId = await SeedConnectionAsync();
+        Guid sourceId = await CreateSourceAsync(connectionId);
+
+        var response = await _editorClient.DeleteAsync($"/api/sources/{sourceId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ListSources_AsViewer_IsAllowed()
+    {
+        var response = await _viewerClient.GetAsync("/api/sources");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ── CRUD ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateSource_WithUnknownConnection_IsRejected()
+    {
+        // A source whose connection does not exist is skipped silently by the sync service,
+        // so it would look created and never sync.
+        var response = await Admin.PostAsJsonAsync("/api/sources", new
+        {
+            name = ShortName("src"),
+            connectionId = Guid.NewGuid(),
+            scopeJson = "{}",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task CreateSource_WithMalformedScopeJson_IsRejected()
+    {
+        Guid connectionId = await SeedConnectionAsync();
+
+        var response = await Admin.PostAsJsonAsync("/api/sources", new
+        {
+            name = ShortName("src"),
+            connectionId,
+            scopeJson = "{not valid json",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task CreateSource_DuplicateName_IsConflict()
+    {
+        Guid connectionId = await SeedConnectionAsync();
+        string name = ShortName("dup");
+        await CreateSourceAsync(connectionId, name);
+
+        var response = await Admin.PostAsJsonAsync("/api/sources", new
+        {
+            name,
+            connectionId,
+            scopeJson = "{}",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task UpdateSource_DisablesIt()
+    {
+        Guid connectionId = await SeedConnectionAsync();
+        Guid sourceId = await CreateSourceAsync(connectionId);
+
+        var response = await Admin.PatchAsJsonAsync($"/api/sources/{sourceId}", new { enabled = false });
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var updated = await response.Content.ReadFromJsonAsync<JsonElement>();
+        updated.GetProperty("enabled").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteSource_ThenGet_IsNotFound()
+    {
+        Guid connectionId = await SeedConnectionAsync();
+        Guid sourceId = await CreateSourceAsync(connectionId);
+
+        (await Admin.DeleteAsync($"/api/sources/{sourceId}")).StatusCode
+            .Should().Be(HttpStatusCode.NoContent);
+        (await Admin.GetAsync($"/api/sources/{sourceId}")).StatusCode
+            .Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetSource_UnknownId_IsNotFound()
+    {
+        (await Admin.GetAsync($"/api/sources/{Guid.NewGuid()}")).StatusCode
+            .Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task SyncSource_WhenDisabled_IsRejected()
+    {
+        Guid connectionId = await SeedConnectionAsync();
+        Guid sourceId = await CreateSourceAsync(connectionId);
+        await Admin.PatchAsJsonAsync($"/api/sources/{sourceId}", new { enabled = false });
+
+        var response = await Admin.PostAsync($"/api/sources/{sourceId}/sync", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ── No enumeration surface ────────────────────────────────────────────
+
+    [Fact]
+    public async Task NoBrowseOrDocumentRouteExistsForASource()
+    {
+        Guid connectionId = await SeedConnectionAsync();
+        Guid sourceId = await CreateSourceAsync(connectionId);
+
+        // The whole point of the source/container split: a source is a searchable scope, not
+        // a browsable folder tree. These must not quietly start working.
+        foreach (string path in new[]
+                 {
+                     $"/api/sources/{sourceId}/documents",
+                     $"/api/sources/{sourceId}/browse",
+                     $"/api/sources/{sourceId}/files",
+                 })
+        {
+            var response = await Admin.GetAsync(path);
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound, $"{path} must not exist");
+        }
+    }
+
+    [Fact]
+    public async Task SourceId_OnTheContainerDocumentRoute_IsRejected()
+    {
+        Guid connectionId = await SeedConnectionAsync();
+        Guid sourceId = await CreateSourceAsync(connectionId);
+
+        // Container routes validate that the id is a container before touching documents, so
+        // a source id must 404 rather than enumerate the source through the other surface.
+        var response = await Admin.GetAsync($"/api/containers/{sourceId}/documents");
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.NotFound, HttpStatusCode.BadRequest);
+    }
+}


### PR DESCRIPTION
Part of #351. Task 1 of phase 3c.

Sources have been syncable and searchable since #364 but reachable only through the database. This adds `GET /api/sources`, `GET /api/sources/{id}`, `POST`, `PATCH`, `DELETE`, and `POST /api/sources/{id}/sync`.

## What is deliberately absent

**Nothing returns documents or paths.** No browse route, no document listing. A source is a searchable *scope*; enumerating one exposes every synced object to any Connapse reader regardless of what they could see in the source system — the leak epic #348 exists to close. A test pins that `/documents`, `/browse`, and `/files` stay 404, and another that a source id on the container document route is refused rather than quietly enumerating through the other surface.

**Connections have no REST surface.** They are the credential and filesystem-root boundary, configured out of band and managed in Admin Settings. Rationale and prior art: `docs/research/programmatic-source-configuration-safety-2026-08-17.md`.

## Two decisions that differ from the container endpoints

**Mutations require `RequireAdmin`, not `RequireEditor`.** Creating a source chooses what external data gets indexed and made searchable, bounded only by whatever the connection's credential can reach. That is an administrative act, not a content one. Airbyte separates its source-editor role from destination-editor for the same reason. Copying the container endpoints' authorization here would have been the easy mistake, so the tests assert an Editor is *forbidden* rather than only that an Admin succeeds.

**Responses use a `SourceResponse` DTO, never the `Source` record.** The record carries `ScopeJson` — naming buckets, prefixes, and filesystem subpaths — and `SyncCursor`, an opaque provider continuation token. Serializing it directly hands both to any reader. The tests assert their absence against the **raw response body** rather than a deserialized DTO, because deserializing into `SourceResponse` would silently drop an unexpected field and pass. Positive assertions run first so an empty or error body cannot satisfy the negatives.

## `LastSyncError` is administrator-only

Worth calling out because it is not obvious. Reads are open to viewers, but a provider's failure text routinely quotes the resource that failed — `Access Denied for bucket payroll-secrets` — so returning it to every reader would give back exactly the infrastructure detail `ScopeJson` is withheld to protect. The test asserts a viewer does not see the bucket name and an administrator does.

## One reversal

`SourceSyncService` returns to singleton registration so the sync-now route can drive the same instance. #364 registered it as a plain hosted service on the explicit grounds that nothing called into it at runtime; this route is that caller, so the reasoning no longer holds.

## Testing

`dotnet test` — **1110 passed, 0 failed.** 15 new integration tests covering scope omission on both list and detail, the viewer/admin split on sync errors, Editor being forbidden from create and delete, Viewer being allowed to list, unknown-connection and malformed-scope rejection, duplicate-name conflict, update, delete, sync-when-disabled, and the absent enumeration routes.

Still to come in phase 3c: the MCP `kind` discriminator, which needs a second id resolver so `list_files` stays container-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API endpoints to list, view, create, update, delete, and manually sync sources.
  * Added source configuration options for scope, description, and sync intervals.
  * Added role-based access controls, with diagnostic details restricted to administrators.
  * Added validation for connections, duplicate names, malformed settings, and disabled-source syncing.

* **Bug Fixes**
  * Prevented source scope, cursors, and documents from being exposed through read responses.
  * Prevented overlapping syncs for the same source and now return a conflict when one is already running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->