### PR TITLE
feat(mcp): list and search sources with a kind discriminator

### DIFF
--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -43,41 +43,52 @@ public class McpTools
     }
 
     [McpServerTool(Name = "container_list", ReadOnly = true, Idempotent = true),
-     Description("Lists all containers with their descriptions and document counts. Use to discover what containers exist when the target is unknown; if the user already named a container, call `search_knowledge` on it directly instead.")]
+     Description("Lists every searchable knowledge scope with its description and document count. Each entry is either kind=managed (storage Connapse owns, browsable with `list_files`) or kind=source (an external system Connapse mirrors read-only — searchable, but it has no file listing). Use to discover what exists when the target is unknown; if the user already named one, call `search_knowledge` on it directly instead.")]
     public static async Task<string> ContainerList(
         IServiceProvider services,
         CancellationToken ct = default)
     {
         var containerStore = services.GetRequiredService<IContainerStore>();
-        var containers = await containerStore.ListAsync(take: int.MaxValue, ct: ct);
+        var sourceStore = services.GetRequiredService<ISourceStore>();
 
-        if (containers.Count == 0)
+        var containers = await containerStore.ListAsync(take: int.MaxValue, ct: ct);
+        var sources = await sourceStore.ListAsync(take: int.MaxValue, ct: ct);
+
+        // Sources are listed alongside containers so existing agent prompts and the CLI keep
+        // working — a source is simply a searchable scope that happens to be read-only. The
+        // kind field is what lets an agent avoid calling list_files on one.
+        var owners = containers.Select(ToOwner).OfType<SearchableOwner>()
+            .Concat(sources.Select(ToOwner))
+            .ToList();
+
+        if (owners.Count == 0)
             return "No containers found.";
 
         // Conditional TIP: only emit when there's an actual routing decision to make
         // (i.e., more than one container). For a single container the agent has no
         // choice; the TIP would be wasted output tokens.
         var text = "";
-        if (containers.Count > 1)
+        if (owners.Count > 1)
         {
-            text = "TIP: Pick the container whose description best matches the topic, then call `search_knowledge(query=\"...\", containerId=\"<name>\")`.\n\n";
+            text = "TIP: Pick the entry whose description best matches the topic, then call `search_knowledge(query=\"...\", containerId=\"<name>\")`.\n\n";
         }
-        text += $"Found {containers.Count} container(s):\n\n";
-        foreach (var c in containers)
+
+        text += $"Found {owners.Count} knowledge scope(s):\n\n";
+        foreach (var owner in owners)
         {
-            text += $"- {c.Name} ({c.DocumentCount} files)";
-            if (!string.IsNullOrEmpty(c.Description))
-                text += $" — {c.Description}";
+            text += $"- {owner.Name} [{owner.Kind}] ({owner.DocumentCount} files)";
+            if (!string.IsNullOrEmpty(owner.Description))
+                text += $" — {owner.Description}";
             text += "\n";
 
             // Append summary first sentence if available
-            string? firstSentence = TruncateToFirstSentence(c.Summary, maxChars: 120);
+            string? firstSentence = TruncateToFirstSentence(owner.Summary, maxChars: 120);
             if (!string.IsNullOrEmpty(firstSentence))
             {
                 text += $"  Summary: {firstSentence}\n";
             }
 
-            text += $"  ID: {c.Id}\n";
+            text += $"  ID: {owner.Id}\n";
         }
 
         return text.TrimEnd();
@@ -114,7 +125,7 @@ public class McpTools
     public static async Task<string> SearchKnowledge(
         IServiceProvider services,
         [Description("The search query text")] string query,
-        [Description("Container ID or name to search within")] string containerId,
+        [Description("Container or source ID or name to search within")] string containerId,
         [Description("Search mode: Semantic (vector), Keyword (full-text), or Hybrid (both). Default: Hybrid")] string? mode = null,
         [Description("Number of results to return. Default: 10")] int? topK = null,
         [Description("Optional: Filter results to a folder subtree (e.g., '/docs/')")] string? path = null,
@@ -122,9 +133,15 @@ public class McpTools
         CancellationToken ct = default)
     {
         var containerStore = services.GetRequiredService<IContainerStore>();
-        var resolvedId = await ResolveContainerIdAsync(containerId, containerStore, ct);
-        if (resolvedId is null)
+        var sourceStore = services.GetRequiredService<ISourceStore>();
+
+        // Accepts either kind: search is scoped by owner_id, which is the same column
+        // whichever kind owns the document, so a source needs no separate search path.
+        var owner = await ResolveSearchableOwnerAsync(containerId, containerStore, sourceStore, ct);
+        if (owner is null)
             return $"Error: Container '{containerId}' not found.";
+
+        Guid? resolvedId = owner.Id;
 
         if (query.Length > ValidationConstants.MaxQueryLength)
             throw new ArgumentException($"Query must not exceed {ValidationConstants.MaxQueryLength} characters.");
@@ -777,36 +794,51 @@ public class McpTools
     }
 
     [McpServerTool(Name = "container_describe", ReadOnly = true, Idempotent = true),
-     Description("Returns an agent-optimized description of a container: its user-supplied description, auto-generated summary (if available), and document statistics. Use this to understand what a container covers before querying via search_knowledge, or when container_list output is insufficient to choose between containers. The response also echoes the server's tool-routing instructions for clients that don't surface them on connect.")]
+     Description("Returns an agent-optimized description of a knowledge scope — container or source: its description, auto-generated summary (if available), and document statistics. Use this to understand what a scope covers before querying via search_knowledge, or when container_list output is insufficient to choose between them. The response also echoes the server's tool-routing instructions for clients that don't surface them on connect.")]
     public static async Task<string> ContainerDescribe(
         IServiceProvider services,
-        [Description("Container ID (GUID) or name")] string containerId,
+        [Description("Container or source ID (GUID) or name")] string containerId,
         CancellationToken ct = default)
     {
         var containerStore = services.GetRequiredService<IContainerStore>();
-        var resolvedId = await ResolveContainerIdAsync(containerId, containerStore, ct);
-        if (resolvedId is null)
+        var sourceStore = services.GetRequiredService<ISourceStore>();
+
+        var owner = await ResolveSearchableOwnerAsync(containerId, containerStore, sourceStore, ct);
+        if (owner is null)
             return $"Error: Container '{LogSanitizer.Sanitize(containerId)}' not found.";
 
-        var container = await containerStore.GetAsync(resolvedId.Value, ct);
-        if (container is null)
+        Guid? resolvedId = owner.Id;
+
+        var container = owner.IsSource ? null : await containerStore.GetAsync(owner.Id, ct);
+        if (!owner.IsSource && container is null)
             return $"Error: Container '{LogSanitizer.Sanitize(containerId)}' not found.";
 
         var documentStore = services.GetRequiredService<IDocumentStore>();
-        var stats = await documentStore.GetContainerStatsAsync(resolvedId.Value, ct);
+        var stats = await documentStore.GetContainerStatsAsync(owner.Id, ct);
 
-        var text = $"Container: {container.Name}\n";
-        text += $"ID: {container.Id}\n";
-        text += $"Type: {container.ConnectorType}\n";
+        var text = $"{(owner.IsSource ? "Source" : "Container")}: {owner.Name}\n";
+        text += $"ID: {owner.Id}\n";
+        text += $"Kind: {owner.Kind}\n";
 
-        if (!string.IsNullOrWhiteSpace(container.Description))
-            text += $"Description: {container.Description}\n";
-
-        if (!string.IsNullOrWhiteSpace(container.Summary))
+        if (owner.IsSource)
         {
-            text += $"Summary: {container.Summary}\n";
-            text += container.SummaryGeneratedAt.HasValue
-                ? $"Summary generated: {container.SummaryGeneratedAt.Value:u}\n"
+            // Named explicitly so an agent does not waste a call discovering it: a source has
+            // no file listing, by design rather than by omission.
+            text += "Type: external source (read-only; searchable, but `list_files` does not apply)\n";
+        }
+        else
+        {
+            text += $"Type: {container!.ConnectorType}\n";
+        }
+
+        if (!string.IsNullOrWhiteSpace(owner.Description))
+            text += $"Description: {owner.Description}\n";
+
+        if (!string.IsNullOrWhiteSpace(owner.Summary))
+        {
+            text += $"Summary: {owner.Summary}\n";
+            text += container?.SummaryGeneratedAt is { } generatedAt
+                ? $"Summary generated: {generatedAt:u}\n"
                 : "";
         }
         else
@@ -820,7 +852,7 @@ public class McpTools
             text += $"Documents: {stats.DocumentCount}\n";
 
         text += $"Storage: {FormatBytes(stats.TotalSizeBytes)}\n";
-        text += $"Created: {container.CreatedAt:u}";
+        text += $"Created: {owner.CreatedAt:u}";
         text += "\n\n---\nServer instructions:\n" + McpServerConfig.McpServerInstructions;
 
         return text;
@@ -835,6 +867,19 @@ public class McpTools
     };
 
     // Helpers
+
+    /// <summary>
+    /// Resolves a name or id to a <b>container</b> only.
+    /// <para>
+    /// Deliberately never resolves a source, and that is load-bearing rather than an
+    /// oversight. Every enumerating and mutating tool routes through this method, so a source
+    /// id handed to <c>list_files</c>, <c>upload_file</c>, or <c>delete_file</c> resolves to
+    /// nothing and the tool reports "not found". Teaching this method about sources would
+    /// silently turn <c>list_files</c> into a file-enumeration route over somebody else's S3
+    /// bucket — the permissions leak epic #348 exists to close. Tools that legitimately
+    /// accept either kind use <see cref="ResolveSearchableOwnerAsync"/> instead.
+    /// </para>
+    /// </summary>
     private static async Task<Guid?> ResolveContainerIdAsync(string nameOrId, IContainerStore store, CancellationToken ct)
     {
         if (Guid.TryParse(nameOrId, out var guid))
@@ -846,6 +891,63 @@ public class McpTools
         var byName = await store.GetByNameAsync(nameOrId.ToLowerInvariant(), ct);
         return byName is not null && Guid.TryParse(byName.Id, out var id) ? id : null;
     }
+
+    /// <summary>
+    /// A knowledge scope that can be searched and described: either a managed container or an
+    /// external source.
+    /// </summary>
+    internal sealed record SearchableOwner(
+        Guid Id, string Name, string Kind, string? Description, string? Summary,
+        int DocumentCount, DateTime CreatedAt)
+    {
+        public const string ManagedKind = "managed";
+        public const string SourceKind = "source";
+
+        public bool IsSource => Kind == SourceKind;
+    }
+
+    /// <summary>
+    /// Resolves a name or id to either a container or a source.
+    /// <para>
+    /// Restricted to the tools where accepting both is the whole point: searching a scope and
+    /// describing one. Listing a source as a searchable scope — its name, kind and summary —
+    /// is not the same as enumerating the documents inside it, and only the former is
+    /// permitted. Containers are checked first so an id collision, however improbable between
+    /// two GUID spaces, resolves to the more restricted kind.
+    /// </para>
+    /// </summary>
+    private static async Task<SearchableOwner?> ResolveSearchableOwnerAsync(
+        string nameOrId, IContainerStore containers, ISourceStore sources, CancellationToken ct)
+    {
+        if (Guid.TryParse(nameOrId, out var guid))
+        {
+            var container = await containers.GetAsync(guid, ct);
+            if (container is not null)
+                return ToOwner(container);
+
+            var source = await sources.GetAsync(guid, ct);
+            return source is not null ? ToOwner(source) : null;
+        }
+
+        string lowered = nameOrId.ToLowerInvariant();
+
+        var byName = await containers.GetByNameAsync(lowered, ct);
+        if (byName is not null)
+            return ToOwner(byName);
+
+        var sourceByName = await sources.GetByNameAsync(lowered, ct);
+        return sourceByName is not null ? ToOwner(sourceByName) : null;
+    }
+
+    private static SearchableOwner? ToOwner(Connapse.Core.Container container) =>
+        Guid.TryParse(container.Id, out var id)
+            ? new SearchableOwner(id, container.Name, SearchableOwner.ManagedKind,
+                container.Description, container.Summary, container.DocumentCount, container.CreatedAt)
+            : null;
+
+    private static SearchableOwner ToOwner(Source source) =>
+        new(source.Id, source.Name, SearchableOwner.SourceKind,
+            source.Description, source.Summary, source.DocumentCount, source.CreatedAt);
 
     private static string? TruncateToFirstSentence(string? text, int maxChars)
     {

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsContainerDescribeTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsContainerDescribeTests.cs
@@ -28,9 +28,15 @@ public class McpToolsContainerDescribeTests
             .GetContainerStatsAsync(ContainerId, Arg.Any<CancellationToken>())
             .Returns(new ContainerStats(12, 12, 0, 0, 300, 2_097_152, new DateTime(2026, 4, 1, 9, 0, 0, DateTimeKind.Utc)));
 
+        // container_describe now accepts a source as well as a container. Left unconfigured
+        // so every lookup misses and these tests keep covering the container path; the
+        // source path is covered in McpSourceKindTests against a real database.
+        var sourceStore = Substitute.For<ISourceStore>();
+
         var services = Substitute.For<IServiceProvider>();
         services.GetService(typeof(IContainerStore)).Returns(_containerStore);
         services.GetService(typeof(IDocumentStore)).Returns(_documentStore);
+        services.GetService(typeof(ISourceStore)).Returns(sourceStore);
         _services = services;
     }
 

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsContainerListTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsContainerListTests.cs
@@ -10,14 +10,23 @@ namespace Connapse.Core.Tests.Mcp;
 public class McpToolsContainerListTests
 {
     private readonly IContainerStore _containerStore;
+    private readonly ISourceStore _sourceStore;
     private readonly IServiceProvider _services;
 
     public McpToolsContainerListTests()
     {
         _containerStore = Substitute.For<IContainerStore>();
 
+        // container_list now lists sources alongside containers. Configured to return none
+        // so these tests keep covering container rendering; source rendering is covered in
+        // McpSourceKindTests against a real database.
+        _sourceStore = Substitute.For<ISourceStore>();
+        _sourceStore.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Source>());
+
         var services = Substitute.For<IServiceProvider>();
         services.GetService(typeof(IContainerStore)).Returns(_containerStore);
+        services.GetService(typeof(ISourceStore)).Returns(_sourceStore);
         _services = services;
     }
 
@@ -46,8 +55,8 @@ public class McpToolsContainerListTests
         var result = await McpTools.ContainerList(_services);
 
         result.Should().NotStartWith("TIP:");
-        result.Should().StartWith("Found 1 container(s):");
-        result.Should().Contain("- only-one (7 files) — The only container");
+        result.Should().StartWith("Found 1 knowledge scope(s):");
+        result.Should().Contain("- only-one [managed] (7 files) — The only container");
     }
 
     [Fact]
@@ -65,14 +74,14 @@ public class McpToolsContainerListTests
 
         result.Should().StartWith("TIP:");
         result.Should().Contain("search_knowledge");
-        result.Should().Contain("Pick the container whose description best matches the topic");
+        result.Should().Contain("Pick the entry whose description best matches the topic");
 
         // Trimmed TIP should NOT contain the v1 "Do NOT enumerate files" phrasing —
         // ServerInstructions Rule 3 covers that now.
         result.Should().NotContain("Do NOT enumerate files");
 
-        result.Should().Contain("- docs (12 files) — Product documentation");
-        result.Should().Contain("- research (5 files) — Customer research");
+        result.Should().Contain("- docs [managed] (12 files) — Product documentation");
+        result.Should().Contain("- research [managed] (5 files) — Customer research");
     }
 
     [Fact]
@@ -106,7 +115,7 @@ public class McpToolsContainerListTests
         var result = await McpTools.ContainerList(_services);
 
         result.Should().NotContain("Summary:");
-        result.Should().Contain("- empty (0 files) — Empty container");
+        result.Should().Contain("- empty [managed] (0 files) — Empty container");
         result.Should().Contain("  ID:");
     }
 
@@ -160,11 +169,11 @@ public class McpToolsContainerListTests
 
         var result = await McpTools.ContainerList(_services);
 
-        result.Should().Contain("- docs (10 files) — Product docs");
+        result.Should().Contain("- docs [managed] (10 files) — Product docs");
         result.Should().Contain("  Summary: Complete product documentation.");
-        result.Should().Contain("- research (5 files) — Research papers");
-        result.Should().NotContain("- research (5 files) — Research papers\n  Summary:");
-        result.Should().Contain("- logs (100 files) — System logs");
+        result.Should().Contain("- research [managed] (5 files) — Research papers");
+        result.Should().NotContain("- research [managed] (5 files) — Research papers\n  Summary:");
+        result.Should().Contain("- logs [managed] (100 files) — System logs");
         result.Should().Contain("  Summary: Raw system logs.");
     }
 

--- a/tests/Connapse.Core.Tests/Mcp/McpToolsSearchKnowledgeTests.cs
+++ b/tests/Connapse.Core.Tests/Mcp/McpToolsSearchKnowledgeTests.cs
@@ -29,8 +29,14 @@ public class McpToolsSearchKnowledgeTests
             .GetAsync(ContainerId, Arg.Any<CancellationToken>())
             .Returns(MakeContainer());
 
+        // search_knowledge now accepts a source id as well as a container id. Left
+        // unconfigured so every source lookup misses and these tests keep covering the
+        // container path; the source path is covered in McpSourceKindTests.
+        var sourceStore = Substitute.For<ISourceStore>();
+
         var services = Substitute.For<IServiceProvider>();
         services.GetService(typeof(IContainerStore)).Returns(_containerStore);
+        services.GetService(typeof(ISourceStore)).Returns(sourceStore);
         services.GetService(typeof(IKnowledgeSearch)).Returns(_searchService);
         services.GetService(typeof(IOptionsMonitor<SearchSettings>)).Returns(_searchSettings);
         _services = services;

--- a/tests/Connapse.Integration.Tests/McpSourceKindTests.cs
+++ b/tests/Connapse.Integration.Tests/McpSourceKindTests.cs
@@ -1,0 +1,172 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Data;
+using Connapse.Web.Mcp;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// The MCP contract for sources: discoverable and searchable, never enumerable.
+/// <para>
+/// The design spec holds two things at once — sources are listed alongside containers so
+/// existing agent prompts keep working, *and* no MCP tool returns a file listing for one.
+/// Satisfying the first without the second is the permissions leak epic #348 exists to close,
+/// so the refusal tests below matter more than the positive ones.
+/// </para>
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class McpSourceKindTests(SharedWebAppFixture fixture)
+{
+    private static string ShortName(string prefix) => $"{prefix}-{Guid.NewGuid():N}"[..20];
+
+    private async Task<Source> SeedSourceAsync(IServiceProvider sp, string? name = null)
+    {
+        var connections = sp.GetRequiredService<IConnectionStore>();
+        var sources = sp.GetRequiredService<ISourceStore>();
+
+        var connection = await connections.CreateAsync(
+            new CreateConnectionRequest(ShortName("conn"), ConnectionProvider.S3, """{"region":"us-east-1"}"""),
+            createdByUserId: null);
+
+        return await sources.CreateAsync(
+            new CreateSourceRequest(name ?? ShortName("src"), connection.Id, """{"bucketName":"b"}"""));
+    }
+
+    private async Task<Container> SeedContainerAsync(IServiceProvider sp)
+    {
+        var containers = sp.GetRequiredService<IContainerStore>();
+        return await containers.CreateAsync(
+            new CreateContainerRequest(ShortName("cnt"), null, ConnectorType.ManagedStorage, null));
+    }
+
+    // ── Discoverable ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ContainerList_IncludesSourcesTaggedWithTheirKind()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var source = await SeedSourceAsync(scope.ServiceProvider);
+        var container = await SeedContainerAsync(scope.ServiceProvider);
+
+        string output = await McpTools.ContainerList(scope.ServiceProvider);
+
+        output.Should().Contain($"{source.Name} [source]");
+        output.Should().Contain($"{container.Name} [managed]",
+            "containers must keep appearing, and the kind is what lets an agent tell them apart");
+    }
+
+    [Fact]
+    public async Task ContainerDescribe_AcceptsASourceAndSaysItHasNoFileListing()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var source = await SeedSourceAsync(scope.ServiceProvider);
+
+        string output = await McpTools.ContainerDescribe(scope.ServiceProvider, source.Id.ToString());
+
+        output.Should().Contain($"Source: {source.Name}");
+        output.Should().Contain("Kind: source");
+        output.Should().Contain("list_files",
+            "an agent should learn the tool does not apply here rather than spending a call finding out");
+    }
+
+    [Fact]
+    public async Task ContainerDescribe_ResolvesASourceByName()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var source = await SeedSourceAsync(scope.ServiceProvider);
+
+        string output = await McpTools.ContainerDescribe(scope.ServiceProvider, source.Name);
+
+        output.Should().Contain("Kind: source");
+    }
+
+    [Fact]
+    public async Task SearchKnowledge_AcceptsASourceId()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var source = await SeedSourceAsync(scope.ServiceProvider);
+
+        // Keyword mode deliberately: the default Hybrid path embeds the query, which would
+        // make this a test of whether Ollama happens to be running rather than of whether a
+        // source id resolves.
+        string output = await McpTools.SearchKnowledge(
+            scope.ServiceProvider, "anything", source.Id.ToString(), mode: "Keyword");
+
+        // The corpus is empty, so this asserts the scope resolved rather than that results
+        // came back — "not found" would mean the resolver rejected the source outright.
+        output.Should().NotContain("not found");
+    }
+
+    // ── Not enumerable ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListFiles_WithASourceId_IsRefused()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var source = await SeedSourceAsync(scope.ServiceProvider);
+
+        // The single most important assertion in this file. list_files routes through
+        // ResolveContainerIdAsync, which never resolves a source; teaching that method about
+        // sources to make search work would silently turn this into a file-enumeration route
+        // over somebody else's S3 bucket.
+        string output = await McpTools.ListFiles(scope.ServiceProvider, source.Id.ToString());
+
+        output.Should().Contain("not found",
+            "a source must be refused outright, not returned as an empty listing");
+    }
+
+    [Fact]
+    public async Task ListFiles_WithASourceName_IsRefused()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var source = await SeedSourceAsync(scope.ServiceProvider);
+
+        string output = await McpTools.ListFiles(scope.ServiceProvider, source.Name);
+
+        output.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task ContainerDelete_WithASourceId_IsRefused()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var source = await SeedSourceAsync(scope.ServiceProvider);
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+
+        string output = await McpTools.ContainerDelete(scope.ServiceProvider, source.Id.ToString());
+
+        output.Should().Contain("not found");
+
+        await using var context = await dbFactory.CreateDbContextAsync();
+        (await context.Sources.AnyAsync(s => s.Id == source.Id))
+            .Should().BeTrue("the source must survive an attempt to delete it as a container");
+    }
+
+    [Fact]
+    public async Task GetDocument_WithASourceId_IsRefused()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var source = await SeedSourceAsync(scope.ServiceProvider);
+
+        string output = await McpTools.GetDocument(
+            scope.ServiceProvider, source.Id.ToString(), fileId: "/anything.md");
+
+        output.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task ContainerStats_WithASourceId_IsRefused()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var source = await SeedSourceAsync(scope.ServiceProvider);
+
+        string output = await McpTools.ContainerStats(scope.ServiceProvider, source.Id.ToString());
+
+        output.Should().Contain("not found");
+    }
+}


### PR DESCRIPTION
Closes #351. Completes phase 3c and, with it, phase 3.

Sources have been syncable since #364 and manageable over REST since #368, but invisible to agents. This makes them discoverable and searchable through MCP — without making them enumerable.

## The resolver split is the point

`ResolveContainerIdAsync` stays **container-only**, and that is load-bearing rather than an oversight. Every enumerating and mutating tool routes through it, which is why `list_files`, `get_document`, `container_stats`, `container_delete`, `upload_file`, and `delete_file` already refuse a source id today.

Teaching *that* method about sources — the obvious way to make search work — would have silently turned `list_files` into a file-enumeration route over somebody else's S3 bucket. That is precisely the permissions leak epic #348 exists to close, and it would have shipped looking like a feature. Tools that legitimately accept either kind use a separate `ResolveSearchableOwnerAsync`.

Containers are checked before sources so an id collision between the two GUID spaces, however improbable, resolves to the more restricted kind.

## What changed

- **`container_list`** lists containers and sources together, each tagged `kind=managed` or `kind=source`
- **`search_knowledge`** accepts a source id or name. No separate search path was needed — search is already scoped by `owner_id`, which is the same column whichever kind owns the document
- **`container_describe`** accepts a source and states outright that it has no file listing, so an agent learns that rather than spending a call discovering it

## Tests assert refusal, not emptiness

Nine integration tests against a real database. The refusal cases matter more than the positive ones: `list_files` is checked by both id and name, and `container_delete` is checked to leave the source still present afterwards. Each asserts an explicit refusal rather than an empty result — an empty listing today would become a real listing the moment someone "fixed" the resolver, and the test would keep passing.

## Output change worth reviewing

`container_list` entries now carry `[managed]` or `[source]`, and the header and tip say "knowledge scope" instead of "container". Once the list holds both kinds, calling them all containers contradicts both the tags and the tool description an agent reads. Four existing tests were updated for the new text. This is agent-facing output, so flagging it explicitly rather than burying it.

## Testing

`dotnet test` — **1135 passed, 0 failed.**

Two notes from the run. My change initially broke 26 existing MCP unit tests, whose stub service providers did not register `ISourceStore`; those are fixed by adding an unconfigured substitute, so they keep covering the container path while `McpSourceKindTests` covers sources against a real database. Separately, 21 integration tests were failing on an Ollama connection error — the container had exited hours earlier, unrelated to this change. Restarted it and confirmed the full suite green.

## After this

Phase 3 is done. Remaining for the epic: Phase 4 (#352 — Sources tab, Connections settings, Home simplification), which is the phase that actually fixes the three problems for users, and Phase 5 (#353 — remove the compatibility shims), which must land in v0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External sources can now be discovered alongside managed containers.
  * Search and description tools support external sources by ID or name.
  * Listings identify whether each knowledge scope is managed or external.
  * Source descriptions clearly indicate read-only behavior and unavailable container-specific details.

* **Bug Fixes**
  * Container-only actions now correctly refuse external source identifiers, protecting source data from unsupported operations.

* **Tests**
  * Added coverage for source discovery, search, descriptions, and operation restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->