### PR TITLE
feat(web): add the Sources tab

### DIFF
--- a/src/Connapse.Web/Components/Layout/NavMenu.razor
+++ b/src/Connapse.Web/Components/Layout/NavMenu.razor
@@ -18,6 +18,15 @@
                     </NavLink>
                 </div>
 
+                @* Sources sits beside Files rather than under Settings: managed storage and
+                   mirrored external systems are peers, and the split between them is the
+                   distinction this nav is meant to make legible. *@
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="sources">
+                        <span class="nav-icon bi-cloud-arrow-down" aria-hidden="true"></span> Sources
+                    </NavLink>
+                </div>
+
                 <div class="nav-item px-3">
                     <NavLink class="nav-link" href="search">
                         <span class="nav-icon bi-search" aria-hidden="true"></span> Search

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -1,0 +1,370 @@
+@page "/sources"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using Connapse.Core
+@using Connapse.Core.Interfaces
+
+@using Connapse.Web.Services
+@inject ISourceStore SourceStore
+@inject IConnectionStore ConnectionStore
+@inject SourceSyncService SyncService
+@inject IAuditLogger AuditLogger
+@inject AuthenticationStateProvider AuthStateProvider
+
+@*
+    Sources — external scopes Connapse mirrors but does not own.
+
+    This page shows what each source is *doing*, never what is *inside* it. There is no file
+    list, no path, and no document name anywhere on it, and that is the point of the whole
+    epic rather than an omission: the file tree exposed every synced object to any Connapse
+    user regardless of what they could see in the source system, which is a far wider surface
+    than search results, and search already passes through CloudScopeService.
+
+    The aggregate document count is the one exception, accepted during design as a weak signal
+    in exchange for the page being useful at all.
+*@
+
+<PageTitle>Sources - Connapse</PageTitle>
+
+<div class="container-fluid py-4">
+    <div class="d-flex justify-content-between align-items-start mb-4">
+        <div>
+            <h1 class="mb-1"><span class="bi-cloud-arrow-down me-2"></span>Sources</h1>
+            <p class="text-muted mb-0">
+                External systems Connapse keeps in step with. Their contents are searchable but not
+                browsable — Connapse mirrors this data, it does not own it.
+            </p>
+        </div>
+        @if (isAdmin)
+        {
+            <a class="btn btn-outline-secondary" href="/settings">
+                <span class="bi-gear me-1"></span> Connections
+            </a>
+        }
+    </div>
+
+    @if (message is not null)
+    {
+        <div class="alert @(messageSuccess ? "alert-success" : "alert-danger") alert-dismissible fade show" role="alert">
+            <span class="@(messageSuccess ? "bi-check-circle" : "bi-x-circle") me-2"></span>
+            @message
+            <button type="button" class="btn-close" @onclick="() => message = null"></button>
+        </div>
+    }
+
+    @if (loading)
+    {
+        <div class="text-muted"><span class="spinner-border spinner-border-sm me-2"></span>Loading sources…</div>
+    }
+    else if (sources.Count == 0)
+    {
+        <div class="card">
+            <div class="card-body text-center py-5">
+                <p class="text-muted mb-2">No sources yet.</p>
+                <p class="text-muted small mb-0">
+                    A source points at a scope inside a connection — a bucket, a blob container, or a
+                    directory. @(isAdmin ? "Add a connection first, then create a source inside it." : "Ask an administrator to add one.")
+                </p>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table align-middle">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Connection</th>
+                        <th>Scope</th>
+                        <th>Documents</th>
+                        <th>Last sync</th>
+                        <th>Status</th>
+                        @if (isAdmin)
+                        {
+                            <th class="text-end">Actions</th>
+                        }
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var source in sources)
+                    {
+                        <tr class="@(source.Enabled ? "" : "opacity-50")">
+                            <td>
+                                <div class="fw-medium">@source.Name</div>
+                                @if (!string.IsNullOrWhiteSpace(source.Description))
+                                {
+                                    <div class="small text-muted">@source.Description</div>
+                                }
+                            </td>
+                            <td class="small">@ConnectionName(source.ConnectionId)</td>
+                            @* The scope names a bucket or directory, which is infrastructure rather
+                               than content. Shown because an operator needs to know what a source
+                               points at; it is never a listing of what is inside. *@
+                            <td class="small text-muted font-monospace">@DescribeScope(source)</td>
+                            <td>@source.DocumentCount</td>
+                            <td class="small text-muted">@FormatLastSync(source)</td>
+                            <td>@StatusBadge(source)</td>
+                            @if (isAdmin)
+                            {
+                                <td class="text-end text-nowrap">
+                                    <button class="btn btn-sm btn-outline-primary me-1"
+                                            @onclick="() => SyncNow(source)"
+                                            disabled="@(!source.Enabled || syncing == source.Id)">
+                                        @if (syncing == source.Id)
+                                        {
+                                            <span class="spinner-border spinner-border-sm"></span>
+                                        }
+                                        else
+                                        {
+                                            <span class="bi-arrow-repeat"></span>
+                                        }
+                                        <span class="ms-1">Sync</span>
+                                    </button>
+                                    <button class="btn btn-sm btn-outline-secondary me-1" @onclick="() => ToggleEnabled(source)">
+                                        @(source.Enabled ? "Disable" : "Enable")
+                                    </button>
+                                    <button class="btn btn-sm btn-outline-danger" @onclick="() => ConfirmDelete(source)">
+                                        Delete
+                                    </button>
+                                </td>
+                            }
+                        </tr>
+
+                        @if (source.LastSyncStatus == SyncStatus.Failed && !string.IsNullOrWhiteSpace(source.LastSyncError) && isAdmin)
+                        {
+                            <tr class="@(source.Enabled ? "" : "opacity-50")">
+                                @* Administrators only: a provider's failure text routinely quotes the
+                                   resource that failed, which is the same infrastructure detail the
+                                   API withholds from non-admin readers. *@
+                                <td colspan="7" class="pt-0 border-top-0">
+                                    <div class="alert alert-danger py-2 mb-0 small">
+                                        <span class="bi-exclamation-triangle me-1"></span>
+                                        @source.LastSyncError
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</div>
+
+@if (pendingDelete is not null)
+{
+    <div class="modal show d-block" tabindex="-1" style="background: rgba(0,0,0,.5);">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Delete source</h5>
+                    <button type="button" class="btn-close" @onclick="() => pendingDelete = null"></button>
+                </div>
+                <div class="modal-body">
+                    <p>
+                        Delete <strong>@pendingDelete.Name</strong> and its
+                        @pendingDelete.DocumentCount indexed document(s)?
+                    </p>
+                    <p class="text-muted small mb-0">
+                        The data in the external system is untouched — only what Connapse indexed
+                        from it is removed. Re-creating the source will sync it again.
+                    </p>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" @onclick="() => pendingDelete = null">Cancel</button>
+                    <button class="btn btn-danger" @onclick="Delete">Delete source</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private List<Source> sources = [];
+    private Dictionary<Guid, string> connectionNames = [];
+    private bool loading = true;
+    private bool isAdmin;
+
+    private Guid? syncing;
+    private Source? pendingDelete;
+    private string? message;
+    private bool messageSuccess;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        isAdmin = authState.User.IsInRole("Owner") || authState.User.IsInRole("Admin");
+
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+
+        sources = (await SourceStore.ListAsync(take: int.MaxValue)).ToList();
+        connectionNames = (await ConnectionStore.ListAsync(take: int.MaxValue))
+            .ToDictionary(c => c.Id, c => c.Name);
+
+        loading = false;
+    }
+
+    private string ConnectionName(Guid connectionId) =>
+        connectionNames.TryGetValue(connectionId, out var name)
+            ? name
+            // The FK makes this unreachable through normal deletion, but a source whose
+            // connection vanished is skipped silently by the sync service — worth naming
+            // rather than rendering a blank cell.
+            : "(missing connection)";
+
+    private static string DescribeScope(Source source) =>
+        SourceScopeSummary.Describe(source.ScopeJson) ?? "—";
+
+    private static string FormatLastSync(Source source) =>
+        source.LastSyncedAt is { } at
+            ? $"{at:u}"
+            : "Never";
+
+    private static RenderFragment StatusBadge(Source source) => builder =>
+    {
+        (string css, string text) = source switch
+        {
+            { Enabled: false } => ("text-bg-secondary", "Disabled"),
+            { LastSyncStatus: SyncStatus.Succeeded } => ("text-bg-success", "Synced"),
+            { LastSyncStatus: SyncStatus.Failed } => ("text-bg-danger", "Failed"),
+            { LastSyncStatus: SyncStatus.Running } => ("text-bg-info", "Syncing"),
+            _ => ("text-bg-light", "Never synced"),
+        };
+
+        builder.OpenElement(0, "span");
+        builder.AddAttribute(1, "class", $"badge {css}");
+        builder.AddContent(2, text);
+        builder.CloseElement();
+    };
+
+    private async Task SyncNow(Source source)
+    {
+        message = null;
+        syncing = source.Id;
+
+        try
+        {
+            var connection = await ConnectionStore.GetAsync(source.ConnectionId);
+            if (connection is null)
+            {
+                Fail($"'{source.Name}' references a connection that no longer exists.");
+                return;
+            }
+
+            var result = await SyncService.SyncSourceAsync(source, connection, CancellationToken.None);
+
+            if (result.AlreadyRunning)
+            {
+                // Not a failure: the scheduled cycle got there first.
+                Warn($"A sync for '{source.Name}' is already in progress.");
+            }
+            else if (result.Error is not null)
+            {
+                Fail($"Sync failed for '{source.Name}': {result.Error}");
+            }
+            else
+            {
+                await AuditLogger.LogAsync("source.synced", "source", source.Id.ToString(),
+                    new { source.Name, result.Upserted, result.Deleted });
+
+                Succeed($"'{source.Name}' synced — {result.Upserted} queued, {result.Deleted} removed.");
+            }
+
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            // An exception escaping a Blazor event handler tears down the circuit, so the
+            // operator would see the page die rather than a message.
+            Fail(ex.Message);
+        }
+        finally
+        {
+            syncing = null;
+        }
+    }
+
+    private async Task ToggleEnabled(Source source)
+    {
+        message = null;
+
+        try
+        {
+            var updated = await SourceStore.UpdateAsync(source.Id, new UpdateSourceRequest(Enabled: !source.Enabled));
+            if (updated is null)
+            {
+                Fail($"'{source.Name}' no longer exists — it was deleted elsewhere.");
+            }
+            else
+            {
+                await AuditLogger.LogAsync("source.updated", "source", source.Id.ToString(),
+                    new { source.Name, updated.Enabled });
+
+                Succeed($"'{source.Name}' {(updated.Enabled ? "enabled" : "disabled")}.");
+            }
+
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Fail(ex.Message);
+        }
+    }
+
+    private void ConfirmDelete(Source source) => pendingDelete = source;
+
+    private async Task Delete()
+    {
+        if (pendingDelete is null) return;
+
+        var source = pendingDelete;
+        pendingDelete = null;
+        message = null;
+
+        try
+        {
+            bool deleted = await SourceStore.DeleteAsync(source.Id);
+            if (deleted)
+            {
+                await AuditLogger.LogAsync("source.deleted", "source", source.Id.ToString(),
+                    new { source.Name });
+
+                Succeed($"'{source.Name}' deleted. The external data is untouched.");
+            }
+            else
+            {
+                Fail($"'{source.Name}' no longer exists — it was deleted elsewhere.");
+            }
+
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Fail(ex.Message);
+        }
+    }
+
+    private void Succeed(string text)
+    {
+        messageSuccess = true;
+        message = text;
+    }
+
+    private void Warn(string text)
+    {
+        messageSuccess = true;
+        message = text;
+    }
+
+    private void Fail(string text)
+    {
+        messageSuccess = false;
+        message = text;
+    }
+}

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -203,11 +203,26 @@
     {
         loading = true;
 
-        sources = (await SourceStore.ListAsync(take: int.MaxValue)).ToList();
-        connectionNames = (await ConnectionStore.ListAsync(take: int.MaxValue))
-            .ToDictionary(c => c.Id, c => c.Name);
-
-        loading = false;
+        try
+        {
+            sources = (await SourceStore.ListAsync(take: int.MaxValue)).ToList();
+            connectionNames = (await ConnectionStore.ListAsync(take: int.MaxValue))
+                .ToDictionary(c => c.Id, c => c.Name);
+        }
+        catch (Exception ex)
+        {
+            // Two failure modes to close, not one. Uncaught from OnInitializedAsync this tears
+            // down the circuit and the operator watches the page die; and without the finally
+            // below, a throw leaves `loading` true forever, so the page sits on its spinner
+            // even after a later action succeeds.
+            Fail($"Could not load sources: {ex.Message}");
+            sources = [];
+            connectionNames = [];
+        }
+        finally
+        {
+            loading = false;
+        }
     }
 
     private string ConnectionName(Guid connectionId) =>

--- a/src/Connapse.Web/Services/SourceScopeSummary.cs
+++ b/src/Connapse.Web/Services/SourceScopeSummary.cs
@@ -1,0 +1,98 @@
+using System.Text.Json.Nodes;
+
+namespace Connapse.Web.Services;
+
+/// <summary>
+/// Renders a source's scope JSON as one short human-readable line for the Sources tab.
+/// <para>
+/// A scope names a bucket, blob container, or directory — infrastructure, not content. An
+/// operator needs to see what a source points at to recognise it; what is *inside* that scope
+/// is never shown, which is the distinction the whole connector/source split rests on.
+/// </para>
+/// <para>
+/// Note this is a UI concern only. The REST surface deliberately omits <c>ScopeJson</c>
+/// entirely, because a reader over the API has no equivalent need and the detail is useful for
+/// reconnaissance.
+/// </para>
+/// </summary>
+public static class SourceScopeSummary
+{
+    /// <summary>
+    /// Summarizes the scope, or returns null when there is nothing meaningful to show. Never
+    /// throws: a scope that cannot be parsed is a display problem, not a reason to fail the page.
+    /// </summary>
+    public static string? Describe(string? scopeJson)
+    {
+        if (string.IsNullOrWhiteSpace(scopeJson)) return null;
+
+        JsonObject? node;
+        try
+        {
+            node = JsonNode.Parse(scopeJson)?.AsObject();
+        }
+        catch (Exception ex) when (ex is System.Text.Json.JsonException or InvalidOperationException)
+        {
+            return null;
+        }
+
+        if (node is null) return null;
+
+        // The container-ish key differs per provider, and only one is ever present.
+        string? container = Str(node, "bucketName") ?? Str(node, "containerName");
+        string? prefix = Str(node, "prefix");
+        string? subPath = Str(node, "subPath");
+
+        string? scope = container is not null
+            ? Join(container, prefix)
+            : subPath;
+
+        if (scope is null) return null;
+
+        // Patterns change what a source picks up as much as the path does, so an operator
+        // comparing two sources on the same directory needs to see them.
+        string? patterns = Patterns(node);
+        return patterns is null ? scope : $"{scope} ({patterns})";
+    }
+
+    private static string Join(string container, string? prefix) =>
+        string.IsNullOrWhiteSpace(prefix)
+            ? container
+            : $"{container.TrimEnd('/')}/{prefix.Trim('/')}";
+
+    private static string? Patterns(JsonObject node)
+    {
+        var include = StringArray(node, "includePatterns");
+        var exclude = StringArray(node, "excludePatterns");
+
+        var parts = new List<string>();
+        if (include.Count > 0) parts.Add(string.Join(", ", include));
+        if (exclude.Count > 0) parts.Add("excluding " + string.Join(", ", exclude));
+
+        return parts.Count == 0 ? null : string.Join("; ", parts);
+    }
+
+    private static List<string> StringArray(JsonObject node, string name)
+    {
+        var values = new List<string>();
+        if (node[name] is not JsonArray arr) return values;
+
+        // TryGetValue rather than GetValue: a stored array holding a number would otherwise
+        // throw out of a display helper and take the page down over cosmetic detail.
+        foreach (var element in arr)
+        {
+            if (element is JsonValue value
+                && value.TryGetValue<string>(out var text)
+                && !string.IsNullOrWhiteSpace(text))
+            {
+                values.Add(text);
+            }
+        }
+
+        return values;
+    }
+
+    private static string? Str(JsonObject node, string name) =>
+        node[name] is JsonValue value && value.TryGetValue<string>(out var s) && !string.IsNullOrWhiteSpace(s)
+            ? s
+            : null;
+}

--- a/tests/Connapse.Core.Tests/Web/SourceScopeSummaryTests.cs
+++ b/tests/Connapse.Core.Tests/Web/SourceScopeSummaryTests.cs
@@ -1,0 +1,112 @@
+using Connapse.Web.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Web;
+
+/// <summary>
+/// The one-line scope description shown on the Sources tab.
+/// <para>
+/// It names <em>where</em> a source points — a bucket, container, or directory — and never what
+/// is inside it. That line is the boundary this page is built around, so the tests below pin
+/// both halves: the scope renders, and nothing resembling content does.
+/// </para>
+/// </summary>
+[Trait("Category", "Unit")]
+public class SourceScopeSummaryTests
+{
+    [Fact]
+    public void Describe_S3Scope_ShowsBucketAndPrefix()
+    {
+        SourceScopeSummary.Describe("""{"bucketName":"docs-bucket","prefix":"team/2026/"}""")
+            .Should().Be("docs-bucket/team/2026");
+    }
+
+    [Fact]
+    public void Describe_S3ScopeWithoutPrefix_ShowsJustTheBucket()
+    {
+        SourceScopeSummary.Describe("""{"bucketName":"docs-bucket"}""")
+            .Should().Be("docs-bucket");
+    }
+
+    [Fact]
+    public void Describe_AzureScope_ShowsContainerAndPrefix()
+    {
+        SourceScopeSummary.Describe("""{"containerName":"blobs","prefix":"reports/"}""")
+            .Should().Be("blobs/reports");
+    }
+
+    [Fact]
+    public void Describe_FilesystemScope_ShowsTheSubPath()
+    {
+        SourceScopeSummary.Describe("""{"subPath":"team/docs"}""")
+            .Should().Be("team/docs");
+    }
+
+    [Fact]
+    public void Describe_IncludesPatterns_BecauseTheyChangeWhatIsPickedUp()
+    {
+        // Two sources on the same directory with different patterns are different sources; the
+        // operator needs to be able to tell them apart.
+        SourceScopeSummary.Describe("""{"subPath":"team","includePatterns":["*.md","*.txt"]}""")
+            .Should().Be("team (*.md, *.txt)");
+    }
+
+    [Fact]
+    public void Describe_ShowsExclusionsSeparately()
+    {
+        SourceScopeSummary.Describe("""{"subPath":"team","excludePatterns":["*.tmp"]}""")
+            .Should().Be("team (excluding *.tmp)");
+    }
+
+    // ── Never throws, never guesses ───────────────────────────────────
+
+    [Fact]
+    public void Describe_MalformedJson_ReturnsNull()
+    {
+        // A display helper that throws takes the whole page down over cosmetic detail.
+        SourceScopeSummary.Describe("{not valid json").Should().BeNull();
+    }
+
+    [Fact]
+    public void Describe_NonStringPatternEntries_AreSkipped()
+    {
+        SourceScopeSummary.Describe("""{"subPath":"team","includePatterns":["*.md",42,null]}""")
+            .Should().Be("team (*.md)");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{}")]
+    public void Describe_NothingMeaningful_ReturnsNull(string? scopeJson)
+    {
+        SourceScopeSummary.Describe(scopeJson).Should().BeNull();
+    }
+
+    [Fact]
+    public void Describe_JsonArrayRatherThanObject_ReturnsNull()
+    {
+        SourceScopeSummary.Describe("""["not","an","object"]""").Should().BeNull();
+    }
+
+    // ── The boundary ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Describe_NeverSurfacesDocumentDetail()
+    {
+        // A scope blob could carry anything. Only the keys that name the scope itself are read,
+        // so a stray document list in stored config cannot leak onto the page — the Sources tab
+        // showing file names is precisely the leak this epic exists to close.
+        string scope = """
+            {"bucketName":"docs","prefix":"team/","documents":["salary-review.pdf"],"lastFile":"secret.txt"}
+            """;
+
+        var described = SourceScopeSummary.Describe(scope);
+
+        described.Should().Be("docs/team");
+        described.Should().NotContain("salary-review");
+        described.Should().NotContain("secret.txt");
+    }
+}


### PR DESCRIPTION
Part of #352. Task 4b of phase 4. Independent of #371 — branched off `main`, touches no file that PR touches.

Sources have been syncable since #364 and manageable over REST since #368. This is the first place an operator can see them in the product.

## What the page deliberately does not have

No file list, no path, no document name. That absence *is* the feature: the file tree exposed every synced object to any Connapse user regardless of what they could see in the source system, which is a far wider surface than search results — and search already passes through `CloudScopeService`.

The aggregate document count is the one exception, accepted during design as a weak signal in exchange for the page being useful at all.

## Authorization

Reads are open to any authenticated user; **sync, enable/disable, and delete are admin-only**, matching `/api/sources`.

The last sync error is admin-only too. A provider's failure text routinely quotes the resource that failed — `Access Denied for bucket payroll-secrets` — which is the same infrastructure detail the API withholds from non-admin readers. Showing it to everyone here would undo that.

## Scope rendering is a separate class

`SourceScopeSummary` renders the one-line "where does this point" cell. It is a separate class rather than logic inside the component so it can be tested — this repository has no component test harness, and adding one would be a larger change than the feature.

It reads **only** the keys that name the scope (`bucketName`, `containerName`, `prefix`, `subPath`, and the patterns). A test pins that a stored config carrying stray keys like `documents` or `lastFile` cannot put document detail on the page — the Sources tab showing file names is precisely the leak this epic exists to close, and it would be an easy one to introduce later by rendering the scope blob more generously.

It also skips non-string pattern entries rather than throwing: a display helper that throws takes the whole page down over cosmetic detail.

## Two smaller decisions

**Sources sits beside Files in the nav**, not under Settings. Managed storage and mirrored external systems are peers, and that split is exactly what the navigation should make legible. Connections stay in Settings, since those are configuration rather than content.

**Sync-now duplicates the endpoint's sequence** rather than calling the REST API from the server. Blazor Server and REST are two genuine front doors, and having the page authenticate against its own API would be worse. It shares the per-source gate added in #368, so a manual sync during a scheduled cycle reports "already in progress" rather than starting a second one.

## Testing

`dotnet test` — **1149 passed, 0 failed.** 14 new tests on the scope summarizer.

The page itself has no automated coverage, for the harness reason above. Worth a manual pass: confirm a viewer sees no action buttons and no error text, confirm sync-now reports rather than throws when the remote is unreachable, and confirm the delete dialog states the external data is untouched.

## Next

4c is the one that closes #352: Home simplification, removing the Filesystem write flags, the search facet — and the test that makes "no external connector reachable through the file browser" an enforced property rather than a stated goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Sources page for viewing external source details, scope summaries, document counts, and synchronization status.
  * Administrators can sync, enable or disable, and delete sources with confirmation and status feedback.
  * Added a Sources link to the navigation menu.
  * Non-administrators can view source information in read-only mode.
  * Added clear summaries for storage locations, paths, inclusion patterns, and exclusions.

* **Bug Fixes**
  * Improved handling of invalid or incomplete source scope data without displaying errors or document details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->