### PR TITLE
docs: rewrite connector documentation for the connection/source model

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The MCP server exposes:
 
 > **Full reference:** See [docs/mcp-tools.md](docs/mcp-tools.md) for parameter tables, return formats, error cases, and usage examples.
 
-> **Write guards**: Amazon S3 and Azure Blob Storage containers are read-only (synced from source). Filesystem containers respect per-container permission flags. Upload and delete tools will return an error for containers that block writes.
+> **Containers and sources**: `container_list` tags each scope `managed` or `source`. A **source** is an external system Connapse mirrors read-only — searchable, but never browsable and never writable. `list_files` and every write tool resolve containers only; pass a source id and they report it as not found. See [docs/connectors.md](docs/connectors.md).
 
 <details>
 <summary><strong>Example prompts</strong> — what to ask your agent</summary>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,4 @@
-# API Reference
+﻿# API Reference
 
 > Part of [Connapse](https://github.com/Destrayon/Connapse) — open-source AI knowledge management platform.
 
@@ -492,7 +492,7 @@ When an agent authenticates via API key, it receives two implicit scopes. These 
 | Scope | Grants |
 |-------|--------|
 | `knowledge:read` | Search and read documents across all containers via MCP |
-| `agent:ingest` | Upload and delete files via MCP (subject to connector write guards) |
+| `agent:ingest` | Upload and delete files in containers via MCP |
 
 Agents have **unrestricted access to all containers** in the system. There is no per-container access control for agent API keys.
 
@@ -503,7 +503,7 @@ Agents interact with Connapse through the MCP endpoint (`POST /mcp`). All 11 MCP
 #### What agents can do
 
 - Create, list, and delete containers (via MCP)
-- Upload and delete files, subject to connector write guards (via MCP)
+- Upload and delete files in containers (via MCP)
 - Search across any container (via MCP)
 - List files and retrieve document content (via MCP)
 
@@ -534,25 +534,17 @@ All container endpoints require authentication. RBAC rules:
 ```json
 {
   "name": "my-project",
-  "description": "Project knowledge base",
-  "connectorType": "MinIO",
-  "connectorConfig": null
+  "description": "Project knowledge base"
 }
 ```
 
 **Fields**:
 - `name` (required): lowercase alphanumeric + hyphens, 2-128 chars, globally unique
 - `description` (optional): Container description
-- `connectorType` (optional, default: `MinIO`): `MinIO` (Managed Storage — MinIO by default, overridable per deployment) | `Filesystem` | `S3` | `AzureBlob`
-- `connectorConfig` (conditional): JSON string with connector-specific config
 
-**Connector Config Requirements**:
-| Connector | Required Fields | Example |
-|-----------|----------------|---------|
-| MinIO | None (global config) | — |
-| Filesystem | `rootPath` | `{"rootPath":"C:\\docs"}` |
-| S3 | `bucketName`, `region` | `{"bucketName":"docs","region":"us-east-1"}` |
-| AzureBlob | `storageAccountName`, `containerName` | `{"storageAccountName":"acct","containerName":"docs"}` |
+A container is always managed storage — Connapse's own backend, configured globally under Settings > Storage. There is no connector to choose. To index an external system, create a connection and a source instead: see [Sources](#sources) and [connectors.md](connectors.md).
+
+> **Changed in v0.4.0.** `connectorType` and `connectorConfig` were removed. A request that still sends them is accepted, the fields are ignored, and a managed container is created — the response carries no connector field back.
 
 **Response** (201 Created):
 ```json
@@ -560,7 +552,6 @@ All container endpoints require authentication. RBAC rules:
   "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "name": "my-project",
   "description": "Project knowledge base",
-  "connectorType": "MinIO",
   "documentCount": 0,
   "createdAt": "2026-02-26T10:00:00Z",
   "updatedAt": "2026-02-26T10:00:00Z"
@@ -583,7 +574,6 @@ All container endpoints require authentication. RBAC rules:
       "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
       "name": "my-project",
       "description": "Project knowledge base",
-      "connectorType": "MinIO",
       "documentCount": 42,
       "createdAt": "2026-02-26T10:00:00Z",
       "updatedAt": "2026-02-26T10:00:00Z"
@@ -625,7 +615,6 @@ All container endpoints require authentication. RBAC rules:
 {
   "containerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "containerName": "my-project",
-  "connectorType": "MinIO",
   "documents": {
     "total": 42,
     "ready": 40,
@@ -681,7 +670,7 @@ Upload one or more files into a container.
 - Files stream directly to MinIO (not buffered in memory)
 - Ingestion is asynchronous — track progress via SignalR or poll the file endpoint
 - Duplicate filenames in the same folder auto-increment: `file (1).pdf`, `file (2).pdf`
-- **Write guard**: S3 and AzureBlob containers block uploads (read-only). Filesystem containers respect the `allowUpload` flag. Returns `400` with `{ "error": "write_denied" }` when blocked. See [connectors.md — Write Guards](connectors.md#write-guards).
+- **Containers only**: a source id returns `404`. Sources mirror somebody else's system and are never written to through Connapse. See [connectors.md](connectors.md).
 
 ---
 
@@ -770,7 +759,7 @@ Returns whether the file needs reindexing and the reason.
 
 Cascade deletes chunks, vectors, and removes the file from MinIO.
 
-**Write guard**: S3 and AzureBlob containers block deletes. Filesystem containers respect the `allowDelete` flag. Returns `400` with `{ "error": "write_denied" }` when blocked. See [connectors.md — Write Guards](connectors.md#write-guards).
+**Containers only**: a source id returns `404`.
 
 **Response** (204 No Content)
 
@@ -787,7 +776,7 @@ Cascade deletes chunks, vectors, and removes the file from MinIO.
 { "path": "/docs/2026/" }
 ```
 
-**Write guard**: S3 and AzureBlob containers block folder creation. Filesystem containers respect the `allowCreateFolder` flag. Returns `400` with `{ "error": "write_denied" }` when blocked.
+**Containers only**: a source id returns `404`. A source has no folder tree to add to.
 
 **Response** (200 OK): Returns `Folder` object.
 
@@ -799,7 +788,7 @@ Cascade deletes chunks, vectors, and removes the file from MinIO.
 
 Cascade deletes all nested files, subfolders, chunks, vectors, and MinIO objects.
 
-**Write guard**: S3 and AzureBlob containers block folder deletion. Filesystem containers respect the `allowDelete` flag. Returns `400` with `{ "error": "write_denied" }` when blocked.
+**Containers only**: a source id returns `404`.
 
 **Response** (204 No Content)
 
@@ -1044,19 +1033,11 @@ Connapse exposes an MCP server for AI agent integration.
 - `bulk_delete` `fileIds` is a JSON array of document ID strings: `["id1","id2"]`.
 - `get_document` `fileId` accepts either a document UUID or a virtual path (e.g., `/docs/readme.md`).
 
-### Write Guards
+### What is writable
 
-Write operations (`upload_file`, `bulk_upload`, `delete_file`, `bulk_delete`) are subject to container write guards:
+Write tools (`container_create`, `container_delete`, `upload_file`, `bulk_upload`, `delete_file`, `bulk_delete`) resolve **containers only**.
 
-| Connector Type | Upload | Delete | Notes |
-|---------------|--------|--------|-------|
-| **Managed Storage** | Allowed | Allowed | Default connector (`MinIO` wire value); full read/write |
-| **InMemory** | Allowed | Allowed | Ephemeral storage |
-| **Filesystem** | Configurable | Configurable | Per-container `allowUpload`/`allowDelete` flags (default: allowed) |
-| **S3** | Blocked | Blocked | Read-only; files are synced from the source bucket |
-| **AzureBlob** | Blocked | Blocked | Read-only; files are synced from the source container |
-
-When a write is blocked, the tool returns an error message explaining why (e.g., "S3 containers are read-only. Files are synced from the source.").
+There is no permission table any more: only the managed-storage connector implements `IWritableConnector`, so a source is incapable of being written to rather than blocked at runtime. Passing a source id returns `Error: Container '<id>' not found.` — the same answer as an id that does not exist.
 
 ### bulk_upload
 
@@ -1113,7 +1094,7 @@ Failures:
 - All files share a single batch ID for tracking
 - Uses `Semantic` chunking strategy
 - Intermediate folders are created automatically
-- Subject to [write guards](#write-guards)
+- Containers only — see [What is writable](#what-is-writable)
 
 ---
 
@@ -1158,7 +1139,7 @@ Failures:
 - Files not found or belonging to a different container are reported as failures
 - Storage deletion failures are non-fatal warnings (DB record is still removed)
 - Does not clean up empty parent folders
-- Subject to [write guards](#write-guards)
+- Containers only — see [What is writable](#what-is-writable)
 
 ---
 
@@ -1199,47 +1180,95 @@ All API errors follow RFC 7807 Problem Details format.
 
 ---
 
-## Container Connector Endpoints (v0.3.0)
+## Sources
 
-### Test Connector Connection
+Base path: `/api/sources`
 
-Test a cloud connector configuration before creating a container.
+A **source** is an external system Connapse mirrors read-only — an S3 bucket, an Azure Blob container, or a filesystem directory. It is searchable but never browsable and never writable. See [connectors.md](connectors.md) for the connection/source model.
 
-**Endpoint**: `POST /api/containers/test-connection`
+**Connections have no REST surface.** They hold the credential boundary and are managed in Settings > Connections by administrators only. Sources are scoped inside a connection an administrator already approved, which is why they do have routes.
+
+| Method | Route | Role |
+|--------|-------|------|
+| GET | `/api/sources` | Viewer |
+| GET | `/api/sources/{id}` | Viewer |
+| POST | `/api/sources` | **Admin** |
+| PATCH | `/api/sources/{id}` | **Admin** |
+| DELETE | `/api/sources/{id}` | **Admin** |
+| POST | `/api/sources/{id}/sync` | **Admin** |
+
+### Create Source
+
+**Endpoint**: `POST /api/sources`
 
 **Request Body**:
 ```json
 {
-  "connectorType": "S3",
-  "connectorConfig": "{\"bucketName\":\"docs\",\"region\":\"us-east-1\"}",
-  "timeoutSeconds": 15
+  "name": "company-docs",
+  "description": "Shared reference material",
+  "connectionId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "scopeJson": "{\"bucketName\":\"company-knowledge\",\"prefix\":\"docs/\"}"
 }
 ```
 
-**Response** (200 OK):
+Scope keys by provider:
+
+| Provider | Keys |
+|----------|------|
+| S3 | `bucketName`, `prefix` |
+| AzureBlob | `containerName`, `prefix` |
+| Filesystem | `subPath`, `includePatterns`, `excludePatterns` |
+
+The scope must fall inside the `allowedLocations` or `allowedRoot` its connection declares, or creation fails.
+
+### Source Response
+
 ```json
 {
-  "success": true,
-  "message": "Connected successfully",
-  "details": { "bucketName": "docs", "region": "us-east-1", "objectsFound": 3 },
-  "elapsed": "00:00:01.234"
+  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "name": "company-docs",
+  "description": "Shared reference material",
+  "connectionId": "8a1b...",
+  "enabled": true,
+  "lastSyncStatus": "Succeeded",
+  "lastSyncedAt": "2026-02-26T10:05:00Z",
+  "syncIntervalSeconds": 300,
+  "documentCount": 128,
+  "summary": null,
+  "lastSyncError": null,
+  "createdAt": "2026-02-26T10:00:00Z",
+  "updatedAt": "2026-02-26T10:05:00Z",
+  "kind": "source"
 }
 ```
 
-**Supported connectors**: S3, AzureBlob, Managed Storage (wire value: `MinIO`).
+**Two fields are withheld deliberately.** `scopeJson` names buckets, prefixes, and filesystem subpaths, and `syncCursor` is an opaque provider continuation token — returning either would turn a read route into reconnaissance. `lastSyncError` is populated **for administrators only**, because a provider's failure text routinely echoes what failed (`Access Denied for bucket payroll-data`).
+
+`kind` is always `"source"`, so a client consuming both these and the container routes can tell them apart on one field. It matches the MCP contract.
+
+### Sync a Source
+
+**Endpoint**: `POST /api/sources/{id}/sync`
+
+Runs one reconciliation cycle immediately rather than waiting for the next scheduled poll. A source already syncing is reported as such rather than queued.
+
+### Delete a Source
+
+**Endpoint**: `DELETE /api/sources/{id}`
+
+Removes the source and its indexed documents. **The external data is untouched.**
 
 ---
 
+## Container Connector Endpoints
+
 ### Sync Container
 
-Trigger an on-demand sync for cloud containers.
+Reconcile a container's managed storage against the document table. Lists stored objects, compares to the database, and enqueues anything new or unfinished — useful when objects have landed in the bucket out of band.
 
 **Endpoint**: `POST /api/containers/{id}/sync`
 
-**Notes**:
-- Returns 400 for Filesystem ("live watch is enough")
-- Returns 404 for non-existent containers
-- Cloud scope enforcement: user must have a linked identity for the container's cloud provider
+**Auth**: Editor minimum
 
 **Response** (200 OK):
 ```json
@@ -1250,6 +1279,8 @@ Trigger an on-demand sync for cloud containers.
   "skippedCount": 37
 }
 ```
+
+> **Changed in v0.4.0.** `POST /api/containers/test-connection` was removed — it validated connector config before creating a container, which no longer happens. Connection testing lives in Settings > Connections. This route also no longer talks to any external system: external syncing is `POST /api/sources/{id}/sync`.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1483,5 +1483,6 @@ Auth endpoints are under `/api/v1/auth/` and `/api/v1/agents/`. Container endpoi
 ## References
 
 - [architecture.md](architecture.md) — System architecture and design
+- [connectors.md](connectors.md) — Connections, sources, and containers
 - [deployment.md](deployment.md) — Deployment and configuration
-- [.claude/state/api-surface.md](../.claude/state/api-surface.md) — Internal interface documentation
+- [mcp-tools.md](mcp-tools.md) — Tool reference for agents

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,14 +155,24 @@ All swappable implementations are defined as interfaces in `Connapse.Core` or `C
 All domain types live in the `Connapse.Core` namespace (files in `Models/` folder):
 
 ```csharp
-// Containers & Storage
-enum ConnectorType { MinIO = 0, Filesystem = 1, S3 = 3, AzureBlob = 4 } // MinIO = 0 is the Managed Storage type — value kept for backwards compatibility
-record Container(string Id, string Name, string? Description, ConnectorType ConnectorType,
-    string? ConnectorConfig, DateTime CreatedAt, DateTime UpdatedAt, int DocumentCount);
+// Containers — Connapse's own storage. Browsable and writable; no connector to choose,
+// because managed storage is what a container is.
+record Container(string Id, string Name, string? Description,
+    DateTime CreatedAt, DateTime UpdatedAt, int DocumentCount);
 record ContainerSettingsOverrides { ChunkingSettings? Chunking, EmbeddingSettings? Embedding,
     SearchSettings? Search, UploadSettings? Upload };
-record CreateContainerRequest(string Name, string? Description,
-    ConnectorType? ConnectorType, string? ConnectorConfig);
+record CreateContainerRequest(string Name, string? Description);
+
+// Connections & Sources — somebody else's storage, mirrored read-only. A connection holds
+// the credential and what it may reach; a source names a scope within one. See connectors.md.
+enum ConnectionProvider { Filesystem = 1, S3 = 3, AzureBlob = 4 }
+record Connection(Guid Id, string Name, ConnectionProvider Provider, string? ConfigJson,
+    Guid? CreatedByUserId, DateTime CreatedAt, DateTime UpdatedAt, bool HasSecret, int SourceCount);
+record Source(Guid Id, string Name, string? Description, Guid ConnectionId, string? ScopeJson, ...);
+
+// ConnectorType is the connector's own self-description (IConnector.Type), not a container
+// column — those were dropped in #353.
+enum ConnectorType { ManagedStorage = 0, Filesystem = 1, S3 = 3, AzureBlob = 4 }
 record Folder(string Id, string ContainerId, string Path, DateTime CreatedAt);
 record Document(string Id, string ContainerId, string FileName, string? ContentType, string Path,
     long SizeBytes, DateTime CreatedAt, Dictionary<string, string> Metadata);
@@ -736,16 +746,21 @@ A **Container** is a logical knowledge base; a **Connector** is the storage tech
 
 ### IConnector Interface
 
-All connectors implement `IConnector`: `ReadFileAsync`, `WriteFileAsync`, `DeleteFileAsync`, `ListFilesAsync`, `ExistsAsync`, `WatchAsync`. Paths are virtual (`/docs/file.pdf`), not filesystem-absolute.
+All connectors implement `IConnector`: `ReadFileAsync`, `ListFilesAsync`, `ExistsAsync`, `ResolveJobPath`, `WatchAsync`. Paths are virtual (`/docs/file.pdf`), not filesystem-absolute.
 
-### ConnectorWatcherService
+`IConnector` has **no write surface**. Writes live on `IWritableConnector`, which only the managed-storage connector implements — so a source is incapable of being written to rather than told not to at runtime. That is why `ContainerWriteGuard` no longer exists.
 
-`BackgroundService` (Singleton + HostedService) that manages all container watching:
+### SourceSyncService
 
-- **Filesystem**: `FileSystemWatcher` with 750ms debounce, 5-min rescan safety net
-- **Cloud (S3/AzureBlob/MinIO)**: 5-min `PeriodicTimer` polling, in-memory snapshot for change detection
-- First poll: detects creates + deletes; subsequent polls: also detects LastModified/SizeBytes changes
-- New remote files pre-registered as "Pending" in DB before ingestion starts (immediate UI feedback)
+`BackgroundService` (Singleton + HostedService) that polls every enabled source and reconciles it against its remote. It replaced `ConnectorWatcherService`, which enumerated *containers* — once external storage moved into `sources`, that service matched nothing and syncing had silently stopped.
+
+- **Interval** 5 minutes by default, overridable per source
+- **Change detection** compares remote last-modified and size, stored on the document so a restart does not re-ingest everything
+- **One cycle at a time per source** — a source already syncing is skipped rather than queued, so a slow remote cannot stack cycles
+- **Cursors advance by compare-and-swap**, so a cycle racing a configuration change cannot overwrite newer state
+- New remote files are pre-registered as "Pending" before ingestion starts, for immediate UI feedback
+
+Registered as a singleton *and* a hosted service, so `POST /api/sources/{id}/sync` can run one cycle on demand against the same instance.
 
 ### Per-Container Settings
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -1,351 +1,197 @@
-# Connectors
+# Connections, Sources, and Containers
 
 > Part of [Connapse](https://github.com/Destrayon/Connapse) — open-source AI knowledge management platform.
 
-Connapse uses **Connectors** to interface with different storage backends. A **Container** is a logical knowledge base; a **Connector** is the technology that backs it.
+Connapse keeps two kinds of storage apart, because they answer to different owners.
 
-## Connector Types
+| | **Container** | **Source** |
+|---|---|---|
+| Whose data | Connapse's own | Somebody else's |
+| Browsable | Yes — full file tree | No |
+| Writable | Yes — upload, delete, create folders | Never |
+| Searchable | Yes | Yes |
+| Created by | Any editor | Administrators only |
+| Backed by | Managed storage | A **connection** to S3, Azure Blob, or a filesystem |
 
-| Type | Config Required | Live Watch | Sync | Use Case |
-|------|----------------|------------|------|----------|
-| **Managed Storage** | No (global) | Polling (5 min) | Yes | Default — provider-abstracted storage (MinIO by default, overridable per deployment) |
-| **Filesystem** | `rootPath` | FileSystemWatcher | No (auto) | Local directories, shared drives |
-| **S3** | `bucketName`, `region` | Polling (5 min) | Yes | AWS S3 buckets (IAM-only) |
-| **AzureBlob** | `storageAccountName`, `containerName` | Polling (5 min) | Yes | Azure Blob Storage (managed identity) |
+A **connection** is the third piece: an administrator registers one credential and endpoint, and any number of sources point at scopes within it. One connection to an AWS account, many sources naming different buckets.
+
+This split replaced a single `Container` type carrying a `connectorType` column. If you are looking for that column, or for `ContainerWriteGuard`, or for per-container upload permission flags, they were removed in [#348](https://github.com/Destrayon/Connapse/issues/348) — see [Why the split](#why-the-split) at the end.
 
 ---
 
-## Managed Storage (default)
+## Containers
 
-Managed Storage is the default connector. It uses an `IManagedStorageProvider` abstraction — backed by MinIO by default, and overridable per deployment. No per-container configuration is needed; the backing store is configured globally.
+A container is Connapse's own storage, provided through an `IManagedStorageProvider` abstraction — MinIO by default, overridable per deployment. There is nothing to configure per container; the backing store is configured globally under **Settings > Storage**.
 
-The enum value remains `MinIO = 0` for backwards compatibility.
-
-**How it works:**
-- Requests route through `IManagedStorageProvider`, which dispatches to the active backend (MinIO or an override)
-- Files are stored with per-container key prefixes in a shared instance
-- Background polling detects remote changes every 5 minutes
-
-**Setup:**
-1. MinIO runs automatically via Docker (development) or is configured in `appsettings.json`
-2. Global settings: Settings > Storage > MinIO endpoint, access key, secret key
-3. Create a container with no connector type specified (defaults to Managed Storage)
-
-**API:**
 ```http
 POST /api/containers
-{ "name": "my-knowledge-base" }
+{ "name": "my-knowledge-base", "description": "optional" }
 ```
+
+That is the whole request. A container has no connector to choose, because managed storage is what a container *is*.
+
+Deleting a container deletes its stored objects, so it must be empty first.
 
 ---
 
-## Filesystem
+## Connections
 
-The Filesystem connector watches a local directory for changes in real time using `FileSystemWatcher`.
+A connection holds **how to authenticate** and **what the credential is allowed to reach**. It never holds a bucket name — that is the source's job.
 
-**Configuration:**
+Connections are created and edited in **Settings > Connections**, by administrators, in the UI only. There is no REST route for them, and that is deliberate: see [Why connections are UI-only](#why-connections-are-ui-only).
+
+### No stored cloud credentials
+
+There is no secret field on a connection form, because Connapse does not accept pasted cloud keys.
+
+- **S3** authenticates through the AWS default credential chain — an instance profile, an IRSA role, or an SSO session. `roleArn` optionally names a role to assume on top of that.
+- **Azure Blob** authenticates through `DefaultAzureCredential` — a managed identity, a workload identity, or a developer sign-in. `managedIdentityClientId` optionally selects a specific user-assigned identity.
+- **Filesystem** has no credential at all; it runs as whatever account the server runs as.
+
+The consequence worth internalising: **rotating credentials is an operation you perform in AWS or Azure, and Connapse needs no involvement.** There is nothing stored here to rotate.
+
+### Configuration by provider
+
+**S3**
+
 ```json
 {
-  "rootPath": "C:\\Documents\\Knowledge",
-  "includePatterns": ["*.pdf", "*.docx", "*.md"],
-  "excludePatterns": ["*.tmp", "~*"],
-  "allowDelete": true,
-  "allowUpload": true,
-  "allowCreateFolder": true
-}
-```
-
-| Field | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `rootPath` | Yes | — | Absolute path to the watched directory |
-| `includePatterns` | No | `[]` (all files) | Glob patterns for files to include |
-| `excludePatterns` | No | `[]` | Glob patterns for files to exclude |
-| `allowDelete` | No | `true` | Allow deleting files through the UI |
-| `allowUpload` | No | `true` | Allow uploading files through the UI |
-| `allowCreateFolder` | No | `true` | Allow creating folders through the UI |
-
-**How live watch works:**
-1. `FileSystemWatcher` monitors the root path for Created, Changed, Deleted, Renamed events
-2. Events are debounced with a **750ms** quiet period (prevents duplicate processing)
-3. New external files are automatically ingested; UI uploads are skipped (the upload endpoint owns them)
-4. Changed files are re-ingested unless already Pending/Queued/Processing
-5. Deleted files have their documents and chunks removed from the database
-6. Renamed files reuse the original document ID (avoids unique constraint issues)
-7. A full rescan runs every **5 minutes** as a safety net
-
-**Glob matching:** Patterns match against filename only (not full path). Supports `*` (any characters) and `?` (single character). Case-insensitive.
-
-**API:**
-```http
-POST /api/containers
-{
-  "name": "local-docs",
-  "connectorType": "Filesystem",
-  "connectorConfig": "{\"rootPath\":\"C:\\\\Documents\\\\Knowledge\"}"
-}
-```
-
-> **Note:** Filesystem containers do not support manual sync — the live watcher handles everything automatically.
-
----
-
-## S3
-
-The S3 connector reads from AWS S3 buckets using IAM credentials only — no access keys are stored.
-
-**Configuration:**
-```json
-{
-  "bucketName": "company-knowledge",
   "region": "us-east-1",
-  "prefix": "docs/",
-  "roleArn": "arn:aws:iam::123456789012:role/ConnaspseReader"
+  "roleArn": "arn:aws:iam::123456789012:role/ConnapseReader",
+  "allowedLocations": ["company-knowledge", "shared-docs/public/"]
 }
 ```
 
-| Field | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `bucketName` | Yes | — | S3 bucket name |
-| `region` | Yes | `us-east-1` | AWS region |
-| `prefix` | No | — | Key prefix to scope access within the bucket |
-| `roleArn` | No | — | IAM role ARN for cross-account access via STS AssumeRole |
+**Azure Blob**
 
-**Authentication:** Uses `DefaultAWSCredentials` — IAM roles, environment variables, or instance profiles. No stored access keys.
-
-**How sync works:**
-- Background polling every **5 minutes** compares remote files against the database
-- First poll detects creates and deletes
-- Subsequent polls also detect changes (LastModified/SizeBytes differences)
-- New files are pre-registered as "Pending" in the database (visible in UI immediately)
-- On-demand sync available via `POST /api/containers/{id}/sync`
-
-**Cross-account access:** Set `roleArn` to assume a role in another AWS account. The connector uses STS `AssumeRole` to get temporary credentials.
-
-**API:**
-```http
-POST /api/containers
-{
-  "name": "s3-knowledge",
-  "connectorType": "S3",
-  "connectorConfig": "{\"bucketName\":\"company-knowledge\",\"region\":\"us-east-1\"}"
-}
-```
-
-**Test before creating:**
-```http
-POST /api/containers/test-connection
-{
-  "connectorType": "S3",
-  "connectorConfig": "{\"bucketName\":\"company-knowledge\",\"region\":\"us-east-1\"}",
-  "timeoutSeconds": 15
-}
-```
-
----
-
-## Azure Blob
-
-The Azure Blob connector reads from Azure Blob Storage containers using managed identity — no connection strings stored.
-
-**Configuration:**
 ```json
 {
   "storageAccountName": "companydata",
-  "containerName": "knowledge",
-  "prefix": "docs/",
-  "managedIdentityClientId": "12345678-1234-1234-1234-123456789012"
+  "managedIdentityClientId": "00000000-0000-0000-0000-000000000000",
+  "allowedLocations": ["knowledge", "archive/2026/"]
 }
 ```
 
-| Field | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `storageAccountName` | Yes | — | Azure Storage account name |
-| `containerName` | Yes | — | Blob container name |
-| `prefix` | No | — | Blob prefix to scope access |
-| `managedIdentityClientId` | No | — | Client ID for user-assigned managed identity |
-
-**Authentication:** Uses `DefaultAzureCredential` — managed identity, Azure CLI, environment variables. For user-assigned managed identities, set `managedIdentityClientId`.
-
-**How sync works:** Same as S3 — 5-minute background polling + on-demand sync endpoint.
-
-**API:**
-```http
-POST /api/containers
-{
-  "name": "azure-knowledge",
-  "connectorType": "AzureBlob",
-  "connectorConfig": "{\"storageAccountName\":\"companydata\",\"containerName\":\"knowledge\"}"
-}
-```
-
-**Test before creating:**
-```http
-POST /api/containers/test-connection
-{
-  "connectorType": "AzureBlob",
-  "connectorConfig": "{\"storageAccountName\":\"companydata\",\"containerName\":\"knowledge\"}",
-  "timeoutSeconds": 15
-}
-```
-
-> **Note:** `DefaultAzureCredential` tries multiple authentication methods sequentially, so the first connection test may take longer than expected.
-
----
-
-## Write Guards
-
-Write operations (upload, delete, create folder) are subject to **container write guards** enforced by `ContainerWriteGuard`. This applies consistently across both the REST API and MCP tools.
-
-### Permissions by Connector Type
-
-| Connector Type | Upload | Delete | Create Folder | Notes |
-|---------------|--------|--------|---------------|-------|
-| **Managed Storage** | Allowed | Allowed | Allowed | Default connector; full read/write |
-| **InMemory** | Allowed | Allowed | Allowed | Ephemeral storage |
-| **Filesystem** | Configurable | Configurable | Configurable | Per-container flags (default: allowed) |
-| **S3** | Blocked | Blocked | Blocked | Read-only; files are synced from the source bucket |
-| **AzureBlob** | Blocked | Blocked | Blocked | Read-only; files are synced from the source container |
-
-### Filesystem Permission Flags
-
-Filesystem containers support three per-container permission flags in their connector config:
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `allowUpload` | `true` | Allow uploading files through the API/UI |
-| `allowDelete` | `true` | Allow deleting files through the API/UI |
-| `allowCreateFolder` | `true` | Allow creating folders through the API/UI |
-
-Set these to `false` to make a Filesystem container partially or fully read-only:
+**Filesystem**
 
 ```json
 {
-  "rootPath": "C:\\Documents\\Knowledge",
-  "allowUpload": false,
-  "allowDelete": false,
-  "allowCreateFolder": false
+  "allowedRoot": "/srv/knowledge"
 }
 ```
 
-### Error Responses
+### The two allowlists
 
-When a write operation is blocked:
+`allowedLocations` and `allowedRoot` bound what any source using the connection may be pointed at. They exist because **IAM cannot make this distinction on its own**: every source sharing a connection presents the same principal to AWS or Azure, so as far as the cloud provider is concerned they are indistinguishable. The allowlist is the only place that difference can be expressed.
 
-- **REST API**: Returns `400 Bad Request` with `{ "error": "write_denied", "message": "..." }`
-- **MCP**: Returns an error message as plain text (e.g., `"Error: S3 containers are read-only. Files are synced from the source."`)
+A location may name a whole container (`company-knowledge`) or a container and prefix (`shared-docs/public/`). A prefix entry permits only sources at or below it.
 
-### Affected Endpoints
+**Currently permissive when empty.** A connection declaring no allowlist warns once per scope and is accepted, because [#350](https://github.com/Destrayon/Connapse/issues/350) backfilled existing containers into connections and none of them declare one. This becomes deny-by-default before connections are ever creatable programmatically. A connection declaring entries that are *all blank* is denied, not treated as unconfigured.
 
-| Endpoint | Operation |
-|----------|-----------|
-| `POST /api/containers/{id}/files` | Upload |
-| `DELETE /api/containers/{id}/files/{fileId}` | Delete |
-| `POST /api/containers/{id}/folders` | CreateFolder |
-| `DELETE /api/containers/{id}/folders` | Delete |
-| MCP `upload_file` / `bulk_upload` | Upload |
-| MCP `delete_file` / `bulk_delete` | Delete |
+Deployments can bound `allowedRoot` further with `Sources:Security:AllowedFilesystemRoots`. When configured, the Connections tab renders the root as a dropdown rather than a free-text field.
 
----
-
-## Per-Container Settings
-
-Each container can override global settings for chunking, embedding, search, and upload.
-
-**Override hierarchy** (highest priority wins):
-1. Container-specific overrides
-2. Global database settings
-3. Application defaults
-
-**Endpoints:**
-```http
-GET  /api/containers/{id}/settings   # Current overrides (null = using global)
-PUT  /api/containers/{id}/settings   # Save overrides
-```
-
-**Example — override embedding model for one container:**
 ```json
-PUT /api/containers/{id}/settings
 {
-  "embedding": {
-    "provider": "OpenAI",
-    "model": "text-embedding-3-small",
-    "dimensions": 1536
+  "Sources": {
+    "Security": {
+      "AllowedFilesystemRoots": ["/srv/knowledge", "/mnt/shared"]
+    }
   }
 }
 ```
 
-**Override categories:**
-- `chunking` — Strategy, chunk size, overlap
-- `embedding` — Provider, model, dimensions
-- `search` — Mode, TopK, cross-model settings
-- `upload` — Max file size, allowed types
+The two checks are independent and both are needed: an allowlist does not stop a symlink, and link resolution does not stop `allowedRoot: "/"`.
 
-> **Warning:** Changing the embedding model for a container that already has indexed documents will cause search quality degradation until all documents are re-embedded. Use the reindex endpoint to trigger re-embedding.
+### Filesystem confinement
+
+A filesystem source's `subPath` is resolved beneath its connection's `allowedRoot`, and the result is verified to still be inside it — resolving links on **every path segment**, not just the leaf.
+
+This is deliberate and was a real vulnerability ([#365](https://github.com/Destrayon/Connapse/issues/365)). `Path.GetFullPath` is purely lexical: it never touches the filesystem, so a junction or symlink sitting *inside* the allowed root passed the old prefix check and the connector then walked straight through it to the target. On Windows, creating a junction needs no elevation.
+
+Two limits an operator has to handle outside Connapse, because no path check can reach them:
+
+- **Bind mounts and hard links** are invisible to link resolution — the resolved path genuinely *is* inside the root.
+- **Time-of-check/time-of-use.** A path verified as inside the root can be replaced before it is opened; the fix needs an anchored open with per-platform interop, which .NET has no cross-platform primitive for.
+
+Run the server under a low-privilege account, and keep configuration and the DataProtection key ring outside every configured root.
 
 ---
 
-## Connection Testing
+## Sources
 
-Test cloud connector configurations before creating a container:
+A source names **what to index** inside a connection.
 
 ```http
-POST /api/containers/test-connection
+POST /api/sources
 {
-  "connectorType": "S3",
-  "connectorConfig": "{ ... }",
-  "timeoutSeconds": 15
+  "name": "company-docs",
+  "connectionId": "…",
+  "scopeJson": "{\"bucketName\":\"company-knowledge\",\"prefix\":\"docs/\"}"
 }
 ```
 
-**Response:**
-```json
-{
-  "success": true,
-  "message": "Connected successfully",
-  "details": {
-    "bucketName": "company-knowledge",
-    "region": "us-east-1",
-    "objectsFound": 3,
-    "hasMore": true
-  },
-  "elapsed": "00:00:01.234"
-}
-```
+Scope keys by provider:
 
-**Supported connectors:** S3, AzureBlob, Managed Storage (MinIO). Filesystem doesn't need connection tests.
+| Provider | Keys |
+|---|---|
+| S3 | `bucketName`, `prefix` |
+| Azure Blob | `containerName`, `prefix` |
+| Filesystem | `subPath`, `includePatterns`, `excludePatterns` |
 
-**What gets tested:**
-- **S3:** `ListObjectsV2` with MaxKeys=5 — verifies bucket exists and credentials have read access
-- **AzureBlob:** `GetBlobsAsync` with limit of 5 — verifies container exists and identity has access
-- **Managed Storage (MinIO):** `ListBuckets` + bucket existence check — verifies endpoint and credentials
+### API
+
+| Method | Route | Role |
+|---|---|---|
+| GET | `/api/sources` | Viewer |
+| GET | `/api/sources/{id}` | Viewer |
+| POST | `/api/sources` | **Admin** |
+| PATCH | `/api/sources/{id}` | **Admin** |
+| DELETE | `/api/sources/{id}` | **Admin** |
+| POST | `/api/sources/{id}/sync` | **Admin** |
+
+Reads are viewer-level; every mutation is administrator-only, because a source chooses what external data gets indexed.
+
+**The response never contains the scope.** `scopeJson` names buckets, prefixes, and filesystem subpaths, and `syncCursor` is an opaque provider continuation token. Returning either would turn a read route into reconnaissance. `lastSyncError` is administrator-only for the same reason — a provider's failure text routinely echoes what failed, as in `Access Denied for bucket payroll-data`.
+
+Deleting a source removes its indexed documents. The external data is untouched.
+
+### Sync
+
+`SourceSyncService` polls every enabled source and reconciles it against its remote. It replaced `ConnectorWatcherService`, which enumerated *containers* — after external storage moved into `sources`, that service matched nothing and syncing had silently stopped.
+
+- **Default interval** 5 minutes, overridable per source with `syncIntervalSeconds`.
+- **Change detection** compares the remote's last-modified time and size, stored on the document so a restart does not re-ingest everything.
+- **One cycle at a time per source.** A source already syncing is skipped rather than queued, so a slow remote cannot stack cycles.
+- **Cursors advance by compare-and-swap**, so a cycle that raced with a configuration change cannot overwrite the newer state.
+
+`POST /api/sources/{id}/sync` runs one cycle immediately instead of waiting for the next poll.
+
+Containers have their own `POST /api/containers/{id}/sync`, which reconciles managed storage against the document table. It exists because objects can land in the bucket out of band; it does not talk to any external system.
 
 ---
 
-## Background Sync
+## Why the split
 
-The `ConnectorWatcherService` manages file change detection for all containers.
+Three problems, all of them presentation problems:
 
-**Filesystem containers:** Real-time `FileSystemWatcher` with 750ms debounce + 5-minute rescan safety net.
+1. **Rendering an S3 bucket as a browsable folder tree implied ownership Connapse does not have.** A file tree with an upload button says "this is yours."
+2. **The tree exposed every synced object to any Connapse user**, regardless of what they could see in the source system — a far wider surface than search results.
+3. **Synced buckets competed with real containers in one list**, so "where does this file live?" had no consistent answer.
 
-**Cloud containers (S3, AzureBlob, Managed Storage):** 5-minute polling loop that:
-1. Lists all remote files via `ListFilesAsync`
-2. Compares against database documents and an in-memory snapshot
-3. Detects creates, deletes, and changes (after first poll)
-4. Pre-registers new files as "Pending" in the database
-5. Enqueues ingestion jobs for new/changed files
-6. Removes deleted documents from the database
+Write capability is now a **type guarantee** rather than a runtime check: only the managed-storage connector implements `IWritableConnector`, so a source is *incapable* of being written to. `ContainerWriteGuard` and the per-container permission flags were deleted because there is no longer a runtime decision for them to make.
 
-**On-demand sync:** `POST /api/containers/{id}/sync` triggers an immediate sync for cloud containers. Returns:
-```json
-{
-  "batchId": "abc123",
-  "totalFiles": 42,
-  "enqueuedCount": 5,
-  "skippedCount": 37,
-  "message": "Sync complete: 5 enqueued, 37 skipped"
-}
-```
+## Why connections are UI-only
 
-**Startup behavior:**
-- Existing Filesystem containers start watching automatically
-- Existing cloud containers start polling automatically
+Sources have admin-scoped REST routes so infrastructure-as-code still works. Connections do not, and the asymmetry is intentional.
+
+A connection is the credential boundary. Creating one programmatically means an API call can introduce a new principal for Connapse to authenticate as — and today the allowlists that would bound it are permissive when empty. Until they are deny-by-default, an unconstrained root is only reachable by an administrator sitting in the admin UI, which is a materially smaller surface than a token.
+
+A source, by contrast, can only ever name a scope *within* a connection an administrator already approved.
+
+---
+
+## Related
+
+- [Architecture](architecture.md) — where these types live in the layer graph
+- [API reference](api.md) — full request and response shapes
+- [MCP tools](mcp-tools.md) — how sources and containers appear to agents

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,4 +1,4 @@
-# MCP Tools Reference
+﻿# MCP Tools Reference
 
 Connapse exposes 11 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) server at `/mcp`. All tools require authentication — see [Using with Claude (MCP)](../README.md#using-with-claude-mcp) for setup.
 
@@ -52,7 +52,7 @@ ID: <uuid>
 
 ## container_list
 
-List all containers with document counts. Use to discover available knowledge bases before searching.
+Lists every searchable knowledge scope. Use to discover what exists when the target is unknown; if the user already named one, call `search_knowledge` on it directly.
 
 ### Parameters
 
@@ -61,13 +61,28 @@ None.
 ### Return Format
 
 ```
-Found 2 container(s):
+Found 3 knowledge scope(s):
 
-- my-docs (15 files) — Project documentation
+- my-docs [managed] (15 files) — Project documentation
   ID: <uuid>
-- research (8 files) — Research papers
+- research [managed] (8 files) — Research papers
+  ID: <uuid>
+- company-docs [source] (128 files) — Shared reference material
   ID: <uuid>
 ```
+
+### The `kind` discriminator
+
+Every entry is one of two kinds:
+
+| Kind | What it is | `list_files` |
+|------|-----------|--------------|
+| `managed` | Storage Connapse owns | Works |
+| `source` | An external system Connapse mirrors read-only | **Does not apply** |
+
+Both are searchable, and `search_knowledge` accepts either — search is scoped by owner id, which is the same column whichever kind owns the document.
+
+`list_files` is container-only by design, not by omission. A source has no file listing because enumerating one would list every synced object out of somebody else's system to any Connapse reader, regardless of what they can see in the source system itself. Reading `kind` before calling `list_files` saves a wasted call.
 
 Returns `No containers found.` when empty.
 
@@ -83,7 +98,7 @@ None.
 
 ## container_delete
 
-Delete a container. MinIO containers must be emptied first. Filesystem/S3/Azure files are not deleted — only the index is removed.
+Delete a container. It must be emptied first, because deleting one deletes its stored files. External sources are not containers and cannot be deleted here — use `DELETE /api/sources/{id}`.
 
 ### Parameters
 
@@ -100,7 +115,7 @@ Container '<name>' deleted.
 ### Error Cases
 
 - `Error: Container '<id>' not found.`
-- `Error: Container '<id>' is not empty. Delete all files first.` (MinIO only)
+- `Error: Container '<id>' is not empty. Delete all files first.`
 
 ### Usage Example
 
@@ -122,7 +137,6 @@ Get container statistics: document counts, chunk count, storage size, and embedd
 
 ```
 Container: my-docs
-Type: MinIO
 Documents: 15
 Chunks: 342
 Storage: 2.4 MB
@@ -181,7 +195,7 @@ The file will be parsed, chunked, and embedded in the background.
 - `Error: Provide either 'content' (base64) or 'textContent' (raw text).`
 - `Error: Container '<id>' not found.`
 - `Error: 'content' must be valid base64-encoded data.`
-- Write guard errors for read-only containers (S3, AzureBlob)
+- `Error: Container '<id>' not found.` for a source id — write tools resolve containers only
 
 ### Usage Example
 
@@ -331,7 +345,7 @@ File 'readme.md' (ID: <uuid>) deleted from database, but the backing storage fil
 
 - `Error: Container '<id>' not found.`
 - `Error: File '<id>' not found in this container.`
-- Write guard errors for read-only containers (S3, AzureBlob)
+- `Error: Container '<id>' not found.` for a source id — write tools resolve containers only
 
 ### Usage Example
 
@@ -446,19 +460,15 @@ Returns `No results found.` when no matches.
 
 ---
 
-## Write Guards
+## What is writable
 
-Write operations (`upload_file`, `bulk_upload`, `delete_file`, `bulk_delete`) are subject to per-connector permissions:
+Write operations — `container_create`, `container_delete`, `upload_file`, `bulk_upload`, `delete_file`, `bulk_delete` — apply to **containers only**.
 
-| Connector | Upload | Delete | Notes |
-|-----------|--------|--------|-------|
-| MinIO | Yes | Yes | Full read/write access |
-| InMemory | Yes | Yes | Full read/write access |
-| Filesystem | Configurable | Configurable | Per-container `allowUpload` / `allowDelete` flags (default: allowed) |
-| S3 | No | No | Read-only — synced from source |
-| AzureBlob | No | No | Read-only — synced from source |
+There is no permission table any more, because there is no runtime decision left to make. Only the managed-storage connector implements `IWritableConnector`, so a source is *incapable* of being written to rather than told not to at runtime. The per-connector permission flags and `ContainerWriteGuard` that used to be documented here were removed with the connector columns they read.
 
-Write tools return a descriptive error when the container's connector blocks the operation.
+The practical consequence for an agent: **every write tool resolves containers only.** Passing a source id returns `Error: Container '<id>' not found.` — the same answer as an id that does not exist, because as far as these tools are concerned it is not a container.
+
+Read tools split differently: `search_knowledge` and `container_describe` accept either kind, `list_files` and `get_document` accept containers only. `container_list` tells you which is which via `kind`.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-21-connector-source-split-phase-5.md
+++ b/docs/superpowers/plans/2026-08-21-connector-source-split-phase-5.md
@@ -73,4 +73,9 @@ searchable through MCP alone, unscoped. Filed separately rather than fixed insid
   which is the migration proving it ran).
 - **2026-08-21** — Phase 5 split out: `docs/connectors.md` is a document about the old model and
   needs rewriting rather than patching, so it ships as a stacked docs PR rather than pushing this
-  one further past the 300-line convention. Next action: open the code PR, then the docs branch.
+  one further past the 300-line convention.
+- **2026-08-21** — Both PRs open. #375 (code, closes #353) targets `main`; #377 (docs, closes #376,
+  filed for the untracked doc debt) is stacked on it. `connectors.md` rewritten as
+  "Connections, Sources, and Containers"; `api.md` gains a Sources section; `architecture.md` and
+  `mcp-tools.md` updated; one README line. Verified no reference to a deleted component survives
+  outside sentences that describe it as removed. **Epic #348 is complete pending review.**


### PR DESCRIPTION
Closes #376. The last piece of epic #348.

**Stacked on [#375](https://github.com/Destrayon/Connapse/pull/375)** — merge that first, or this diff will show its code changes too.

**254 insertions, 352 deletions.** Mostly removal, like the code PR it follows.

## connectors.md is rewritten, not patched

The document was organised around the thing that was deleted. Its section list was Connector Types → Managed Storage → Filesystem → S3 → Azure Blob → Write Guards → Permissions by Connector Type → Filesystem Permission Flags. Every one of those describes a container choosing a connector, which is no longer a decision anybody makes.

It is now **Connections, Sources, and Containers**, opening with the table that answers the question a reader actually arrives with — whose data is this, and what can I do to it:

| | Container | Source |
|---|---|---|
| Whose data | Connapse's own | Somebody else's |
| Browsable | Yes | No |
| Writable | Yes | Never |

Things it now says that were not written down anywhere:

- **Why the allowlists exist at all.** IAM cannot distinguish two sources sharing a connection — they present the same principal — so `allowedLocations` is the only place that difference can be expressed. Without this, the allowlist reads as belt-and-braces rather than the only available control.
- **What rotating a credential means here**: nothing, because there is nothing stored. That follows from the no-stored-keys rule but is worth stating as the operational consequence.
- **The two confinement limits no path check can reach** — bind mounts and hard links (the resolved path genuinely *is* inside the root), and TOCTOU (no cross-platform anchored-open primitive in .NET) — with the deployment advice that actually addresses them: low-privilege account, config and key ring outside every configured root.
- **Why connections are UI-only and sources are not.** The asymmetry looks arbitrary until you see that a connection introduces a principal while a source can only name a scope inside one an administrator already approved.

The removed pieces get one line pointing at #348 rather than silence, so someone arriving from an old bookmark learns where `ContainerWriteGuard` went instead of concluding the docs are wrong.

## api.md

- **New Sources section** covering all six routes, the admin/viewer split, and — the part worth reading — *why two fields are absent from the response*. `scopeJson` names buckets and subpaths, `syncCursor` is a provider continuation token, and `lastSyncError` is admin-only because provider failure text echoes what failed (`Access Denied for bucket payroll-data`).
- `POST /api/containers/test-connection` removed, with a "Changed in v0.4.0" note rather than a silent deletion.
- `POST /api/containers/{id}/sync` re-described: it reconciles managed storage now, and no longer talks to any external system.
- Create-container request and response examples lose `connectorType`/`connectorConfig`, with a note that a stale client sending them gets a managed container and no connector field back — so it cannot conclude its request was honoured.
- The write-guard table is replaced by a statement of the type guarantee. Four per-endpoint "Write guard: S3 and AzureBlob block…" notes become "Containers only: a source id returns 404."

## architecture.md

The `Container` record loses its connector fields and gains `Connection`/`Source` alongside it. `ConnectorType` stays with a comment explaining it is `IConnector.Type` — the connector's self-description — not a container column, since that distinction is exactly what a reader will trip over.

`ConnectorWatcherService` becomes `SourceSyncService`, keeping the sentence about *why* it was replaced: the old service enumerated containers, so once external storage moved to `sources` it matched nothing and syncing had silently stopped. That is the kind of failure worth leaving a marker for.

## mcp-tools.md

`container_list` documents the `kind` discriminator with a table of what each kind supports, and states that `list_files` is container-only **by design rather than omission** — enumerating a source would list every synced object out of somebody else's system to any reader. An agent that reads `kind` first saves a wasted call.

`container_delete` and `container_stats` lose their MinIO/Filesystem/S3/Azure phrasing. The Write Guards table becomes "What is writable", which explains that there is no permission table any more because there is no runtime decision left: only managed storage implements `IWritableConnector`.

## README

One line. The write-guards note becomes a containers-and-sources note, since that is what an agent operator needs to know before their first `list_files` call.

## Verification

No code changed, so there is nothing to test. What I did check: `ConnectorWatcherService`, `ContainerWriteGuard`, `connector_type`, `connector_config`, `allowUpload`/`allowDelete`/`allowCreateFolder`, `write_denied`, and `/api/containers/test-connection` now appear across `README.md` and `docs/` **only** in sentences that deliberately describe them as removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External storage is now represented as read-only sources, while containers provide managed, writable storage.
  * Added source management, permissions, scoped responses, and synchronization documentation.
  * Source search remains available, while browsing and write operations are restricted.

* **Bug Fixes**
  * Source identifiers are correctly rejected by container-only operations.
  * Container creation and statistics no longer expose legacy connector details.
  * Database migrations remove obsolete connector fields while preserving existing data.

* **Documentation**
  * Updated API, architecture, connector, MCP, and setup documentation for the managed-storage and source model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->