### PR TITLE
feat(web): add a create-source form to the Sources page

### DIFF
--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -1,4 +1,4 @@
-@page "/sources"
+﻿@page "/sources"
 @rendermode InteractiveServer
 @attribute [Authorize]
 @using Connapse.Core
@@ -10,6 +10,7 @@
 @inject SourceSyncService SyncService
 @inject IAuditLogger AuditLogger
 @inject AuthenticationStateProvider AuthStateProvider
+@inject SourceScopePreflight Preflight
 
 @*
     Sources — external scopes Connapse mirrors but does not own.
@@ -37,11 +38,27 @@
         </div>
         @if (isAdmin)
         {
-            <a class="btn btn-outline-secondary" href="/settings">
-                <span class="bi-gear me-1"></span> Connections
-            </a>
+            <div class="d-flex gap-2">
+                <a class="btn btn-outline-secondary" href="/settings">
+                    <span class="bi-gear me-1"></span> Connections
+                </a>
+                <button class="btn btn-primary" @onclick="BeginCreate" disabled="@(connections.Count == 0)">
+                    <span class="bi-plus-lg me-1"></span> New source
+                </button>
+            </div>
         }
     </div>
+
+    @if (isAdmin && connections.Count == 0 && !loading)
+    {
+        @* A source only exists inside a connection, so offering the button with nothing to
+           attach it to would open a modal whose first field has no options. *@
+        <div class="alert alert-info">
+            <span class="bi-info-circle me-2"></span>
+            No connections yet. <a href="/settings" class="alert-link">Add one</a> before creating a source —
+            a connection holds the credential, a source picks a scope inside it.
+        </div>
+    }
 
     @if (message is not null)
     {
@@ -63,7 +80,7 @@
                 <p class="text-muted mb-2">No sources yet.</p>
                 <p class="text-muted small mb-0">
                     A source points at a scope inside a connection — a bucket, a blob container, or a
-                    directory. @(isAdmin ? "Add a connection first, then create a source inside it." : "Ask an administrator to add one.")
+                    directory. @(isAdmin ? "Create one to start mirroring it." : "Ask an administrator to add one.")
                 </p>
             </div>
         </div>
@@ -152,6 +169,124 @@
     }
 </div>
 
+@if (form is not null)
+{
+    <div class="modal show d-block" tabindex="-1" style="background: rgba(0,0,0,.5);">
+        <div class="modal-dialog modal-dialog-centered modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">New source</h5>
+                    <button type="button" class="btn-close" @onclick="CancelCreate"></button>
+                </div>
+                <div class="modal-body">
+                    @if (createError is not null)
+                    {
+                        <div class="alert alert-danger py-2 small">
+                            <span class="bi-x-circle me-1"></span> @createError
+                        </div>
+                    }
+                    @if (createWarning is not null)
+                    {
+                        @* Accepted but worth seeing. The allowlists are permissive when empty
+                           today and refuse later, and this is the one moment an operator is
+                           looking at the connection and could narrow it. *@
+                        <div class="alert alert-warning py-2 small">
+                            <span class="bi-exclamation-triangle me-1"></span> @createWarning
+                        </div>
+                    }
+
+                    <div class="mb-3">
+                        <label class="form-label">Connection</label>
+                        <select class="form-select" value="@form.ConnectionId"
+                                @onchange="OnConnectionChanged">
+                            @foreach (var connection in connections)
+                            {
+                                <option value="@connection.Id">@connection.Name (@connection.Provider)</option>
+                            }
+                        </select>
+                        <div class="form-text">
+                            The connection holds the credential. This source picks a scope inside it.
+                        </div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">Name</label>
+                        <input class="form-control" @bind="form.Name" placeholder="company-docs" />
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">Description (optional)</label>
+                        <input class="form-control" @bind="form.Description"
+                               placeholder="What is in here, and who it is for" />
+                    </div>
+
+                    @* Which scope fields exist is decided by the connection's provider, because
+                       the keys ConnectorFactory reads differ per provider and writing the wrong
+                       one produces a source that silently syncs nothing. *@
+                    @if (selectedProvider is ConnectionProvider.S3 or ConnectionProvider.AzureBlob)
+                    {
+                        <div class="mb-3">
+                            <label class="form-label">
+                                @(selectedProvider == ConnectionProvider.S3 ? "Bucket" : "Blob container")
+                            </label>
+                            <input class="form-control font-monospace" @bind="form.Container"
+                                   placeholder="@(selectedProvider == ConnectionProvider.S3 ? "company-knowledge" : "knowledge")" />
+                        </div>
+
+                        <div class="mb-3">
+                            <label class="form-label">Prefix (optional)</label>
+                            <input class="form-control font-monospace" @bind="form.Prefix" placeholder="docs/" />
+                            <div class="form-text">Narrows the source to a subtree. Everything below it is indexed.</div>
+                        </div>
+                    }
+                    else if (selectedProvider is ConnectionProvider.Filesystem)
+                    {
+                        <div class="mb-3">
+                            <label class="form-label">Sub-path (optional)</label>
+                            <input class="form-control font-monospace" @bind="form.SubPath" placeholder="team-a" />
+                            <div class="form-text">
+                                Resolved beneath the connection's allowed root. Leave empty for the root itself.
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label">Include patterns (optional)</label>
+                                <textarea class="form-control font-monospace" rows="3"
+                                          @bind="form.IncludePatterns" placeholder="*.pdf&#10;*.md"></textarea>
+                                <div class="form-text">One per line.</div>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label">Exclude patterns (optional)</label>
+                                <textarea class="form-control font-monospace" rows="3"
+                                          @bind="form.ExcludePatterns" placeholder="*.tmp"></textarea>
+                                <div class="form-text">One per line.</div>
+                            </div>
+                        </div>
+                    }
+
+                    <div class="mb-0">
+                        <label class="form-label">Sync interval in seconds (optional)</label>
+                        <input type="number" class="form-control" min="60" @bind="form.SyncIntervalSeconds"
+                               placeholder="300" />
+                        <div class="form-text">Leave empty to use the configured default.</div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" @onclick="CancelCreate" disabled="@creating">Cancel</button>
+                    <button class="btn btn-primary" @onclick="Create" disabled="@creating">
+                        @if (creating)
+                        {
+                            <span class="spinner-border spinner-border-sm me-1"></span>
+                        }
+                        Create source
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
 @if (pendingDelete is not null)
 {
     <div class="modal show d-block" tabindex="-1" style="background: rgba(0,0,0,.5);">
@@ -182,6 +317,7 @@
 
 @code {
     private List<Source> sources = [];
+    private List<Connection> connections = [];
     private Dictionary<Guid, string> connectionNames = [];
     private bool loading = true;
     private bool isAdmin;
@@ -190,6 +326,14 @@
     private Source? pendingDelete;
     private string? message;
     private bool messageSuccess;
+
+    private SourceForm? form;
+    private bool creating;
+    private string? createError;
+    private string? createWarning;
+
+    private ConnectionProvider? selectedProvider =>
+        connections.FirstOrDefault(c => c.Id == form?.ConnectionId)?.Provider;
 
     protected override async Task OnInitializedAsync()
     {
@@ -206,8 +350,8 @@
         try
         {
             sources = (await SourceStore.ListAsync(take: int.MaxValue)).ToList();
-            connectionNames = (await ConnectionStore.ListAsync(take: int.MaxValue))
-                .ToDictionary(c => c.Id, c => c.Name);
+            connections = (await ConnectionStore.ListAsync(take: int.MaxValue)).ToList();
+            connectionNames = connections.ToDictionary(c => c.Id, c => c.Name);
         }
         catch (Exception ex)
         {
@@ -217,6 +361,7 @@
             // even after a later action succeeds.
             Fail($"Could not load sources: {ex.Message}");
             sources = [];
+            connections = [];
             connectionNames = [];
         }
         finally
@@ -329,6 +474,120 @@
         catch (Exception ex)
         {
             Fail(ex.Message);
+        }
+    }
+
+    private void BeginCreate()
+    {
+        message = null;
+        createError = null;
+        createWarning = null;
+        form = new SourceForm { ConnectionId = connections.First().Id };
+    }
+
+    private void CancelCreate()
+    {
+        form = null;
+        createError = null;
+        createWarning = null;
+    }
+
+    private void OnConnectionChanged(ChangeEventArgs args)
+    {
+        if (form is null) return;
+
+        if (Guid.TryParse(args.Value?.ToString(), out var id))
+            form.ConnectionId = id;
+
+        // The scope fields differ per provider, so anything typed for the previous one is now
+        // meaningless — carrying a bucket name over into a filesystem source would write a key
+        // the connector never reads.
+        form.Container = null;
+        form.Prefix = null;
+        form.SubPath = null;
+        form.IncludePatterns = null;
+        form.ExcludePatterns = null;
+
+        createError = null;
+        createWarning = null;
+    }
+
+    private async Task Create()
+    {
+        if (form is null) return;
+
+        createError = null;
+        createWarning = null;
+
+        var connection = connections.FirstOrDefault(c => c.Id == form.ConnectionId);
+        if (connection is null)
+        {
+            createError = "That connection no longer exists. Reload the page.";
+            return;
+        }
+
+        if (form.Validate(connection.Provider) is { } invalid)
+        {
+            createError = invalid;
+            return;
+        }
+
+        string scopeJson = form.ToScopeJson(connection.Provider);
+
+        // Checked before creating rather than at the first sync. ConnectorFactory re-checks on
+        // every cycle and remains the enforcement point — this exists so a refusal is legible
+        // now instead of surfacing as a failed sync five minutes later.
+        var preflight = Preflight.Check(connection, scopeJson);
+        if (preflight.IsRefused)
+        {
+            createError = preflight.Error;
+            return;
+        }
+
+        creating = true;
+
+        try
+        {
+            var created = await SourceStore.CreateAsync(new CreateSourceRequest(
+                form.Name.Trim(),
+                form.ConnectionId,
+                scopeJson,
+                string.IsNullOrWhiteSpace(form.Description) ? null : form.Description.Trim(),
+                form.SyncIntervalSeconds));
+
+            await AuditLogger.LogAsync("source.created", "source", created.Id.ToString(),
+                new { created.Name, created.ConnectionId });
+
+            form = null;
+            Succeed($"'{created.Name}' created. It will sync on the next cycle, or press Sync now.");
+
+            if (preflight.Warning is not null)
+            {
+                // Survives the modal closing: the operator should still see it.
+                message += " " + preflight.Warning;
+            }
+
+            await LoadAsync();
+        }
+        catch (ArgumentException ex)
+        {
+            // The store validates the name shape and the connection's existence.
+            createError = ex.Message;
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Duplicate name is the expected case here.
+            createError = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            // An exception escaping a Blazor event handler tears down the circuit, so the
+            // operator would see the page die rather than a message.
+            createError = ex.Message;
+        }
+        finally
+        {
+            creating = false;
         }
     }
 

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -532,22 +532,29 @@
             return;
         }
 
-        string scopeJson = form.ToScopeJson(connection.Provider);
-
-        // Checked before creating rather than at the first sync. ConnectorFactory re-checks on
-        // every cycle and remains the enforcement point — this exists so a refusal is legible
-        // now instead of surfacing as a failed sync five minutes later.
-        var preflight = Preflight.Check(connection, scopeJson);
-        if (preflight.IsRefused)
-        {
-            createError = preflight.Error;
-            return;
-        }
-
         creating = true;
 
         try
         {
+            // Inside the try, not above it. Both of these can throw — ToScopeJson refuses a
+            // provider it does not know, and the preflight's filesystem branch rejects a blank
+            // allowed root — and an exception escaping an async event handler tears down the
+            // Blazor circuit, which is the outcome the handlers below exist to prevent.
+            //
+            // Not hypothetical: the moment a provider is added to the enum without a case
+            // here, picking a connection of that kind kills the page instead of saying so.
+            string scopeJson = form.ToScopeJson(connection.Provider);
+
+            // Checked before creating rather than at the first sync. ConnectorFactory re-checks
+            // on every cycle and remains the enforcement point — this exists so a refusal is
+            // legible now instead of surfacing as a failed sync five minutes later.
+            var preflight = Preflight.Check(connection, scopeJson);
+            if (preflight.IsRefused)
+            {
+                createError = preflight.Error;
+                return;
+            }
+
             var created = await SourceStore.CreateAsync(new CreateSourceRequest(
                 form.Name.Trim(),
                 form.ConnectionId,

--- a/src/Connapse.Web/Components/Settings/SourceForm.cs
+++ b/src/Connapse.Web/Components/Settings/SourceForm.cs
@@ -1,0 +1,128 @@
+using System.Text.Json.Nodes;
+using Connapse.Core;
+
+namespace Connapse.Web.Components.Settings;
+
+/// <summary>
+/// The editable shape of a new source, flattened out of the provider-specific scope JSON it is
+/// stored as.
+/// <para>
+/// A plain record rather than logic inside the Razor component, for the same reason as
+/// <see cref="ConnectionForm"/>: this is where a mistyped key silently becomes a source that
+/// points at nothing, or at the wrong bucket, and the component itself has no test harness in
+/// this repository. The keys written here must match the ones
+/// <c>ConnectorFactory.Create(Source, Connection)</c> reads, so they are asserted in tests
+/// rather than trusted.
+/// </para>
+/// </summary>
+public sealed record SourceForm
+{
+    public string Name { get; set; } = "";
+    public string? Description { get; set; }
+    public Guid ConnectionId { get; set; }
+
+    /// <summary>S3 bucket, or Azure blob container. Which one is decided by the connection.</summary>
+    public string? Container { get; set; }
+
+    /// <summary>Cloud only. Narrows the source to a subtree of the bucket or container.</summary>
+    public string? Prefix { get; set; }
+
+    /// <summary>Filesystem only. Resolved beneath the connection's allowed root.</summary>
+    public string? SubPath { get; set; }
+
+    /// <summary>Newline-separated in the UI; an array in the stored JSON.</summary>
+    public string? IncludePatterns { get; set; }
+
+    /// <summary>Newline-separated in the UI; an array in the stored JSON.</summary>
+    public string? ExcludePatterns { get; set; }
+
+    /// <summary>Null means "use the configured default" rather than "never sync".</summary>
+    public int? SyncIntervalSeconds { get; set; }
+
+    /// <summary>
+    /// Builds the scope JSON for a connection's provider. Only the keys that provider reads are
+    /// emitted — writing a <c>bucketName</c> into a filesystem scope would be silently ignored
+    /// at sync time, which is worse than being rejected.
+    /// </summary>
+    public string ToScopeJson(ConnectionProvider provider)
+    {
+        var node = new JsonObject();
+
+        switch (provider)
+        {
+            case ConnectionProvider.S3:
+                node["bucketName"] = Container?.Trim() ?? "";
+                if (!Blank(Prefix)) node["prefix"] = Prefix!.Trim();
+                break;
+
+            case ConnectionProvider.AzureBlob:
+                node["containerName"] = Container?.Trim() ?? "";
+                if (!Blank(Prefix)) node["prefix"] = Prefix!.Trim();
+                break;
+
+            case ConnectionProvider.Filesystem:
+                // Always present, and empty means the root itself. ConnectorFactory treats a
+                // blank subPath as "the allowed root", so this is a meaningful value rather
+                // than a missing one.
+                node["subPath"] = SubPath?.Trim() ?? "";
+                AddPatterns(node, "includePatterns", IncludePatterns);
+                AddPatterns(node, "excludePatterns", ExcludePatterns);
+                break;
+
+            default:
+                throw new NotSupportedException($"Unknown connection provider: {provider}");
+        }
+
+        return node.ToJsonString();
+    }
+
+    /// <summary>
+    /// Field-level validation. Returns the first problem, or null when the form is well formed.
+    /// <para>
+    /// Deliberately does not check the connection's allowlist — that is
+    /// <see cref="Connapse.Web.Services.SourceScopePreflight"/>, which needs deployment
+    /// configuration this record does not have.
+    /// </para>
+    /// </summary>
+    public string? Validate(ConnectionProvider provider)
+    {
+        if (Blank(Name))
+            return "A source name is required.";
+
+        if (ConnectionId == Guid.Empty)
+            return "Choose a connection for this source.";
+
+        if (provider is ConnectionProvider.S3 && Blank(Container))
+            return "A bucket name is required.";
+
+        if (provider is ConnectionProvider.AzureBlob && Blank(Container))
+            return "A blob container name is required.";
+
+        if (SyncIntervalSeconds is { } interval && interval < 60)
+            return "Sync interval must be at least 60 seconds.";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Splits a newline- or comma-separated textarea into entries, dropping blanks. Shared shape
+    /// with the connection form's allowed-locations field so the two behave the same way.
+    /// </summary>
+    internal static List<string> ParsePatterns(string? raw) =>
+        string.IsNullOrWhiteSpace(raw)
+            ? []
+            : raw.Split(['\n', '\r', ','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                 .ToList();
+
+    private static void AddPatterns(JsonObject node, string name, string? raw)
+    {
+        var values = ParsePatterns(raw);
+        if (values.Count == 0) return;
+
+        var array = new JsonArray();
+        foreach (string value in values) array.Add(value);
+        node[name] = array;
+    }
+
+    private static bool Blank(string? value) => string.IsNullOrWhiteSpace(value);
+}

--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -142,6 +142,11 @@ if (allowAnonDiscovery)
 
 builder.Services.AddMemoryCache();
 builder.Services.AddScoped<ICloudScopeService, CloudScopeService>();
+
+// Pre-flight for the Sources create form. Not an enforcement point — ConnectorFactory
+// re-checks the same policy on every sync cycle, which is what catches an allowlist narrowed
+// after a source already exists.
+builder.Services.AddScoped<SourceScopePreflight>();
 builder.Services.AddScoped<IUploadService, UploadService>();
 
 builder.Services.AddConnapseStorage(builder.Configuration);

--- a/src/Connapse.Web/Services/SourceScopePreflight.cs
+++ b/src/Connapse.Web/Services/SourceScopePreflight.cs
@@ -1,0 +1,175 @@
+using System.Text.Json.Nodes;
+using Connapse.Core;
+using Connapse.Core.Utilities;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Web.Services;
+
+/// <summary>
+/// Answers "would this scope be allowed?" before a source is created, so an operator sees the
+/// refusal in the form instead of discovering it as a failed sync five minutes later.
+/// <para>
+/// <strong>This is not the enforcement point.</strong> <c>ConnectorFactory.Create(Source,
+/// Connection)</c> is, and it re-checks on every sync cycle — which matters because a
+/// connection's allowlist can be narrowed after a source already exists. This class exists so
+/// the common case fails early and legibly; removing it would cost clarity, not safety.
+/// </para>
+/// <para>
+/// It calls the same primitives the factory calls — <see cref="StorageLocationPolicy"/> and
+/// <see cref="SourceSecuritySettings.EvaluateRoot"/> — rather than restating the rules, because
+/// two implementations of an allowlist will drift and the copy that drifts is the one nobody
+/// re-reads.
+/// </para>
+/// </summary>
+public class SourceScopePreflight(IOptionsMonitor<SourceSecuritySettings> sourceSecurity)
+{
+    /// <summary>
+    /// Evaluates the scope against its connection.
+    /// <para>
+    /// Deliberately does not touch the network. A bucket that is allowed but unreachable is a
+    /// credential problem, and reporting it here would block creating a perfectly valid source
+    /// whenever the environment happens to be missing its cloud session.
+    /// </para>
+    /// </summary>
+    public ScopePreflightResult Check(Connection connection, string scopeJson)
+    {
+        JsonObject? credential = Parse(connection.ConfigJson);
+        JsonObject? scope = Parse(scopeJson);
+
+        if (scope is null)
+            return ScopePreflightResult.Refuse("The scope could not be read as JSON.");
+
+        return connection.Provider switch
+        {
+            ConnectionProvider.S3 => CheckLocation(credential, scope, "bucketName", "bucket", connection.Name),
+            ConnectionProvider.AzureBlob => CheckLocation(credential, scope, "containerName", "blob container", connection.Name),
+            ConnectionProvider.Filesystem => CheckRoot(credential, scope, connection.Name),
+            _ => ScopePreflightResult.Refuse(
+                $"Connection '{connection.Name}' uses a provider this form does not understand.")
+        };
+    }
+
+    private static ScopePreflightResult CheckLocation(
+        JsonObject? credential, JsonObject scope, string scopeKey, string noun, string connectionName)
+    {
+        string? container = Str(scope, scopeKey);
+        if (string.IsNullOrWhiteSpace(container))
+            return ScopePreflightResult.Refuse($"A {noun} name is required.");
+
+        var allowed = StringArray(credential, "allowedLocations");
+        string? prefix = Str(scope, "prefix");
+
+        return StorageLocationPolicy.Evaluate(allowed, container, prefix) switch
+        {
+            StorageLocationDecision.Allowed => ScopePreflightResult.Allowed,
+
+            // Accepted, matching the factory rather than second-guessing it: a connection that
+            // declares no locations is permitted for one release, because #350 backfilled
+            // connections that declare none. Surfaced as a warning because this is the one
+            // moment an operator is looking at the connection and could narrow it — the sync-time
+            // equivalent is a log line nobody reads.
+            StorageLocationDecision.UnrestrictedByConfiguration => ScopePreflightResult.Warn(
+                $"Connection '{connectionName}' declares no allowed locations, so a source may name "
+                + "any bucket its credential can reach. This becomes an error in a future release."),
+
+            _ => ScopePreflightResult.Refuse(
+                $"'{Join(container, prefix)}' is outside the locations connection '{connectionName}' permits.")
+        };
+    }
+
+    private ScopePreflightResult CheckRoot(JsonObject? credential, JsonObject scope, string connectionName)
+    {
+        string? allowedRoot = Str(credential, "allowedRoot");
+        if (string.IsNullOrWhiteSpace(allowedRoot))
+            return ScopePreflightResult.Refuse($"Connection '{connectionName}' has no allowed root configured.");
+
+        var rootDecision = sourceSecurity.CurrentValue.EvaluateRoot(allowedRoot);
+        if (rootDecision is FilesystemRootDecision.Denied)
+        {
+            return ScopePreflightResult.Refuse(
+                $"Connection '{connectionName}' names a root outside "
+                + $"{SourceSecuritySettings.SectionName}:AllowedFilesystemRoots.");
+        }
+
+        string? subPath = Str(scope, "subPath");
+
+        // The same call the factory makes. Resolves links on every segment, so a subPath
+        // pointing through a junction is refused here rather than at the first sync.
+        if (!string.IsNullOrWhiteSpace(subPath) && PathConfinement.CombineWithin(allowedRoot, subPath) is null)
+        {
+            return ScopePreflightResult.Refuse(
+                $"'{subPath}' resolves outside the root connection '{connectionName}' allows.");
+        }
+
+        return rootDecision is FilesystemRootDecision.UnrestrictedByConfiguration
+            ? ScopePreflightResult.Warn(
+                $"No {SourceSecuritySettings.SectionName}:AllowedFilesystemRoots is configured, so "
+                + $"connection '{connectionName}' may use any root. This becomes an error in a future release.")
+            : ScopePreflightResult.Allowed;
+    }
+
+    private static string Join(string container, string? prefix) =>
+        string.IsNullOrWhiteSpace(prefix)
+            ? container
+            : $"{container.TrimEnd('/')}/{prefix.Trim('/')}";
+
+    private static JsonObject? Parse(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+
+        try { return JsonNode.Parse(json)?.AsObject(); }
+        catch (Exception ex) when (ex is System.Text.Json.JsonException or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private static string? Str(JsonObject? node, string name) =>
+        node?[name] is JsonValue value && value.TryGetValue<string>(out var s) && !string.IsNullOrWhiteSpace(s)
+            ? s
+            : null;
+
+    /// <summary>
+    /// Reads a JSON string array, mirroring <c>ConnectorFactory</c>'s reader exactly.
+    /// <para>
+    /// <strong>Blank entries are kept.</strong> <see cref="StorageLocationPolicy"/> draws a
+    /// deliberate line between "declared nothing" (fail open, for one release) and "declared
+    /// only blanks" (a malformed allowlist, refused). Filtering blanks here collapses the
+    /// second into the first and turns a typo into an open door — which is the exact hole the
+    /// policy's own comment warns about.
+    /// </para>
+    /// <para>
+    /// Non-string elements are skipped rather than throwing: a stored array holding a number is
+    /// a bad config, not a reason to break the form.
+    /// </para>
+    /// </summary>
+    private static List<string> StringArray(JsonObject? node, string name)
+    {
+        var values = new List<string>();
+        if (node?[name] is not JsonArray array) return values;
+
+        foreach (var element in array)
+        {
+            if (element is JsonValue value && value.TryGetValue<string>(out var text))
+                values.Add(text);
+        }
+
+        return values;
+    }
+}
+
+/// <summary>
+/// The outcome of a pre-flight check. <c>Warning</c> is distinct from <c>Error</c> on purpose:
+/// the permissive-when-empty allowlists accept the source today and will refuse it later, so an
+/// operator needs to see that without being blocked by it.
+/// </summary>
+public sealed record ScopePreflightResult(string? Error, string? Warning)
+{
+    public static readonly ScopePreflightResult Allowed = new(null, null);
+
+    public static ScopePreflightResult Refuse(string error) => new(error, null);
+
+    public static ScopePreflightResult Warn(string warning) => new(null, warning);
+
+    public bool IsRefused => Error is not null;
+}

--- a/src/Connapse.Web/Services/SourceScopePreflight.cs
+++ b/src/Connapse.Web/Services/SourceScopePreflight.cs
@@ -39,6 +39,17 @@ public class SourceScopePreflight(IOptionsMonitor<SourceSecuritySettings> source
         if (scope is null)
             return ScopePreflightResult.Refuse("The scope could not be read as JSON.");
 
+        // Blank and malformed both parse to null, and they must not mean the same thing here.
+        // Blank is fine — ConnectorFactory reads it as "{}" — but malformed makes the factory
+        // throw on the first sync, while an empty credential looks to the check below like a
+        // connection declaring no allowlist, which is merely a warning. Preflight would then
+        // wave through a source that cannot possibly work, which is the one thing it exists
+        // to prevent.
+        if (credential is null && !string.IsNullOrWhiteSpace(connection.ConfigJson))
+            return ScopePreflightResult.Refuse(
+                $"Connection '{connection.Name}' has configuration that is not valid JSON, so no "
+                + "source using it can sync. Re-save the connection to repair it.");
+
         return connection.Provider switch
         {
             ConnectionProvider.S3 => CheckLocation(credential, scope, "bucketName", "bucket", connection.Name),

--- a/tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using Connapse.Core;
+using Connapse.Web.Components.Settings;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Sources;
+
+/// <summary>
+/// The scope keys this form writes must be the ones <c>ConnectorFactory.Create(Source,
+/// Connection)</c> reads. Nothing enforces that at compile time — a mistyped key produces a
+/// source that is created successfully and then syncs nothing at all, which is the failure this
+/// file exists to catch.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SourceFormTests
+{
+    private static SourceForm Filled() => new()
+    {
+        Name = "company-docs",
+        ConnectionId = Guid.NewGuid(),
+        Container = "company-knowledge",
+        Prefix = "docs/",
+        SubPath = "team-a",
+        IncludePatterns = "*.pdf\n*.md",
+        ExcludePatterns = "*.tmp",
+    };
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public void ToScopeJson_S3_WritesBucketNameNotContainerName()
+    {
+        var scope = Parse(Filled().ToScopeJson(ConnectionProvider.S3));
+
+        scope.GetProperty("bucketName").GetString().Should().Be("company-knowledge");
+        scope.GetProperty("prefix").GetString().Should().Be("docs/");
+
+        // The Azure key must not leak into an S3 scope: the connector reads one or the other,
+        // so a stray key is silently ignored rather than rejected.
+        scope.TryGetProperty("containerName", out _).Should().BeFalse();
+        scope.TryGetProperty("subPath", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToScopeJson_AzureBlob_WritesContainerNameNotBucketName()
+    {
+        var scope = Parse(Filled().ToScopeJson(ConnectionProvider.AzureBlob));
+
+        scope.GetProperty("containerName").GetString().Should().Be("company-knowledge");
+        scope.GetProperty("prefix").GetString().Should().Be("docs/");
+        scope.TryGetProperty("bucketName", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToScopeJson_Filesystem_WritesSubPathAndPatternsAsArrays()
+    {
+        var scope = Parse(Filled().ToScopeJson(ConnectionProvider.Filesystem));
+
+        scope.GetProperty("subPath").GetString().Should().Be("team-a");
+
+        scope.GetProperty("includePatterns").EnumerateArray()
+            .Select(e => e.GetString()).Should().BeEquivalentTo(["*.pdf", "*.md"]);
+        scope.GetProperty("excludePatterns").EnumerateArray()
+            .Select(e => e.GetString()).Should().BeEquivalentTo(["*.tmp"]);
+
+        // A bucket typed before the provider was switched must not survive into the scope.
+        scope.TryGetProperty("bucketName", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToScopeJson_FilesystemWithNoSubPath_StillWritesTheKeyAsEmpty()
+    {
+        // Empty means "the allowed root itself" to ConnectorFactory, which is a real choice
+        // rather than a missing value — omitting the key entirely would mean the same thing
+        // today but relies on the connector's null handling rather than saying so.
+        var scope = Parse(new SourceForm { Name = "n" }.ToScopeJson(ConnectionProvider.Filesystem));
+
+        scope.GetProperty("subPath").GetString().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToScopeJson_BlankPrefix_IsOmittedRatherThanWrittenEmpty()
+    {
+        // An empty prefix and no prefix mean the same thing to the connector, but writing
+        // "prefix": "" makes the stored scope look deliberately narrowed when it is not.
+        var form = new SourceForm { Name = "n", Container = "b", Prefix = "   " };
+
+        Parse(form.ToScopeJson(ConnectionProvider.S3))
+            .TryGetProperty("prefix", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToScopeJson_TrimsWhitespaceAroundValues()
+    {
+        var form = new SourceForm { Name = "n", Container = "  bucket  ", Prefix = "  docs/  " };
+        var scope = Parse(form.ToScopeJson(ConnectionProvider.S3));
+
+        scope.GetProperty("bucketName").GetString().Should().Be("bucket");
+        scope.GetProperty("prefix").GetString().Should().Be("docs/");
+    }
+
+    [Theory]
+    [InlineData("*.pdf\n*.md", 2)]
+    [InlineData("*.pdf, *.md", 2)]
+    [InlineData("*.pdf\r\n\r\n*.md", 2)]
+    [InlineData("   ", 0)]
+    [InlineData(null, 0)]
+    public void ParsePatterns_HandlesTheSeparatorsAnOperatorActuallyTypes(string? raw, int expected)
+    {
+        SourceForm.ParsePatterns(raw).Should().HaveCount(expected);
+    }
+
+    [Fact]
+    public void Validate_MissingName_IsRejected()
+    {
+        var form = new SourceForm { ConnectionId = Guid.NewGuid(), Container = "b" };
+        form.Validate(ConnectionProvider.S3).Should().Contain("name");
+    }
+
+    [Fact]
+    public void Validate_MissingConnection_IsRejected()
+    {
+        var form = new SourceForm { Name = "n", Container = "b" };
+        form.Validate(ConnectionProvider.S3).Should().Contain("connection");
+    }
+
+    [Theory]
+    [InlineData(ConnectionProvider.S3, "bucket")]
+    [InlineData(ConnectionProvider.AzureBlob, "container")]
+    public void Validate_CloudProviderWithoutAContainer_IsRejected(ConnectionProvider provider, string noun)
+    {
+        var form = new SourceForm { Name = "n", ConnectionId = Guid.NewGuid() };
+        form.Validate(provider).Should().Contain(noun);
+    }
+
+    [Fact]
+    public void Validate_FilesystemWithoutASubPath_IsAccepted()
+    {
+        // Unlike a bucket, an empty sub-path is meaningful: it selects the connection's root.
+        var form = new SourceForm { Name = "n", ConnectionId = Guid.NewGuid() };
+        form.Validate(ConnectionProvider.Filesystem).Should().BeNull();
+    }
+
+    [Fact]
+    public void Validate_SyncIntervalBelowAMinute_IsRejected()
+    {
+        var form = new SourceForm
+        {
+            Name = "n", ConnectionId = Guid.NewGuid(), Container = "b", SyncIntervalSeconds = 30
+        };
+
+        form.Validate(ConnectionProvider.S3).Should().Contain("60");
+    }
+
+    [Fact]
+    public void Validate_NoSyncInterval_IsAccepted()
+    {
+        // Null means "use the configured default", not "never sync".
+        var form = new SourceForm { Name = "n", ConnectionId = Guid.NewGuid(), Container = "b" };
+        form.Validate(ConnectionProvider.S3).Should().BeNull();
+    }
+}

--- a/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
@@ -1,0 +1,204 @@
+using Connapse.Core;
+using Connapse.Web.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Connapse.Core.Tests.Sources;
+
+/// <summary>
+/// The pre-flight check is a UX affordance, not a security boundary — <c>ConnectorFactory</c>
+/// re-checks the same policy on every sync cycle. What these tests pin is that it gives the
+/// <em>same answer</em> as the factory would, because a pre-check that disagrees with the real
+/// one is worse than none: it either blocks a valid source or promises one that will fail.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SourceScopePreflightTests
+{
+    private static SourceScopePreflight Build(params string[] allowedFilesystemRoots)
+    {
+        var monitor = Substitute.For<IOptionsMonitor<SourceSecuritySettings>>();
+        monitor.CurrentValue.Returns(new SourceSecuritySettings
+        {
+            AllowedFilesystemRoots = allowedFilesystemRoots
+        });
+
+        return new SourceScopePreflight(monitor);
+    }
+
+    private static Connection Conn(ConnectionProvider provider, string? configJson) => new(
+        Id: Guid.NewGuid(),
+        Name: "conn",
+        Provider: provider,
+        ConfigJson: configJson,
+        CreatedByUserId: null,
+        CreatedAt: DateTime.UtcNow,
+        UpdatedAt: DateTime.UtcNow);
+
+    [Fact]
+    public void Check_S3BucketInsideAllowedLocations_IsAllowed()
+    {
+        var connection = Conn(ConnectionProvider.S3, """{"allowedLocations":["company-knowledge"]}""");
+
+        var result = Build().Check(connection, """{"bucketName":"company-knowledge"}""");
+
+        result.IsRefused.Should().BeFalse();
+        result.Warning.Should().BeNull();
+    }
+
+    [Fact]
+    public void Check_S3BucketOutsideAllowedLocations_IsRefusedNamingTheScope()
+    {
+        var connection = Conn(ConnectionProvider.S3, """{"allowedLocations":["company-knowledge"]}""");
+
+        var result = Build().Check(connection, """{"bucketName":"payroll-data"}""");
+
+        result.IsRefused.Should().BeTrue();
+        // The operator needs to know which of the two things is wrong — what they typed, or
+        // what the connection permits.
+        result.Error.Should().Contain("payroll-data").And.Contain("conn");
+    }
+
+    [Fact]
+    public void Check_NoAllowedLocations_IsAcceptedWithAWarning()
+    {
+        // Matches ConnectorFactory, which warns and proceeds: #350 backfilled connections that
+        // declare no locations, so refusing here would block every upgraded deployment.
+        var connection = Conn(ConnectionProvider.S3, """{"region":"us-east-1"}""");
+
+        var result = Build().Check(connection, """{"bucketName":"anything"}""");
+
+        result.IsRefused.Should().BeFalse();
+        result.Warning.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Check_AllowedLocationsPresentButAllBlank_IsRefused()
+    {
+        // A malformed allowlist is not an absent one. Reading it as "no restrictions" would
+        // turn a typo into an open door, which is the distinction StorageLocationPolicy draws.
+        var connection = Conn(ConnectionProvider.S3, """{"allowedLocations":["","   "]}""");
+
+        var result = Build().Check(connection, """{"bucketName":"anything"}""");
+
+        result.IsRefused.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Check_AzureContainerOutsideAllowedLocations_IsRefused()
+    {
+        var connection = Conn(ConnectionProvider.AzureBlob,
+            """{"storageAccountName":"acct","allowedLocations":["knowledge"]}""");
+
+        Build().Check(connection, """{"containerName":"secrets"}""").IsRefused.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Check_MissingContainerName_IsRefusedBeforeThePolicyRuns()
+    {
+        // StorageLocationPolicy.Evaluate throws on a blank container, so the guard has to come
+        // first — otherwise a half-filled form takes the page down instead of showing an error.
+        var connection = Conn(ConnectionProvider.S3, """{"allowedLocations":["b"]}""");
+
+        var act = () => Build().Check(connection, "{}");
+
+        act.Should().NotThrow();
+        Build().Check(connection, "{}").IsRefused.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Check_UnparseableScope_IsRefusedRatherThanThrowing()
+    {
+        var connection = Conn(ConnectionProvider.S3, """{"allowedLocations":["b"]}""");
+
+        Build().Check(connection, "not json").IsRefused.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Check_AllowedLocationsHoldingANonString_DoesNotThrow()
+    {
+        // A stored array with a number in it is a bad config, not a reason to break the form.
+        var connection = Conn(ConnectionProvider.S3, """{"allowedLocations":["ok",42]}""");
+
+        var act = () => Build().Check(connection, """{"bucketName":"ok"}""");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Check_FilesystemWithoutAnAllowedRoot_IsRefused()
+    {
+        var connection = Conn(ConnectionProvider.Filesystem, "{}");
+
+        Build().Check(connection, """{"subPath":"a"}""").IsRefused.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Check_FilesystemSubPathEscapingTheRoot_IsRefused()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"preflight-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var connection = Conn(ConnectionProvider.Filesystem,
+                $$"""{"allowedRoot":{{System.Text.Json.JsonSerializer.Serialize(root)}}}""");
+
+            var result = Build(root).Check(connection, """{"subPath":"../../etc"}""");
+
+            result.IsRefused.Should().BeTrue();
+            result.Error.Should().Contain("outside");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Check_FilesystemRootOutsideTheDeploymentAllowlist_IsRefused()
+    {
+        string permitted = Path.Combine(Path.GetTempPath(), $"permitted-{Guid.NewGuid():N}");
+        string other = Path.Combine(Path.GetTempPath(), $"other-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(permitted);
+        Directory.CreateDirectory(other);
+
+        try
+        {
+            var connection = Conn(ConnectionProvider.Filesystem,
+                $$"""{"allowedRoot":{{System.Text.Json.JsonSerializer.Serialize(other)}}}""");
+
+            var result = Build(permitted).Check(connection, """{"subPath":""}""");
+
+            result.IsRefused.Should().BeTrue();
+            result.Error.Should().Contain(SourceSecuritySettings.SectionName);
+        }
+        finally
+        {
+            Directory.Delete(permitted, recursive: true);
+            Directory.Delete(other, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Check_FilesystemWithNoDeploymentAllowlist_IsAcceptedWithAWarning()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"unbounded-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var connection = Conn(ConnectionProvider.Filesystem,
+                $$"""{"allowedRoot":{{System.Text.Json.JsonSerializer.Serialize(root)}}}""");
+
+            var result = Build().Check(connection, """{"subPath":""}""");
+
+            result.IsRefused.Should().BeFalse();
+            result.Warning.Should().Contain(SourceSecuritySettings.SectionName);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
@@ -201,4 +201,39 @@ public class SourceScopePreflightTests
             Directory.Delete(root, recursive: true);
         }
     }
+    // ── Malformed connection configuration ─────────────────────────────────
+
+    /// <summary>
+    /// Blank and malformed both parse to null, and conflating them defeats the point of
+    /// preflighting at all: ConnectorFactory throws on malformed JSON at the first sync, while
+    /// an empty credential reads here as "declares no allowlist", which is only a warning. The
+    /// source would be accepted and then never work.
+    /// </summary>
+    [Theory]
+    [InlineData(ConnectionProvider.S3, """{"bucketName":"b"}""")]
+    [InlineData(ConnectionProvider.AzureBlob, """{"containerName":"c"}""")]
+    [InlineData(ConnectionProvider.Filesystem, """{"subPath":"docs"}""")]
+    public void Check_MalformedConnectionConfig_IsRefused(ConnectionProvider provider, string scope)
+    {
+        var result = Build().Check(Conn(provider, "{not valid json"), scope);
+
+        result.IsRefused.Should().BeTrue();
+        result.Error.Should().Contain("not valid JSON");
+    }
+
+    /// <summary>
+    /// Blank must keep its meaning. The factory reads a blank config as "{}", so preflight has
+    /// to agree — refusing here would block connections that work perfectly well.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Check_BlankConnectionConfig_IsNotTreatedAsMalformed(string? configJson)
+    {
+        var result = Build().Check(Conn(ConnectionProvider.S3, configJson), """{"bucketName":"b"}""");
+
+        result.IsRefused.Should().BeFalse(
+            "the connector factory reads a blank config as an empty object, and preflight must match");
+    }
 }


### PR DESCRIPTION
Closes #379.

Found while checking whether the connector feature was ready to actually set up: you can create a **connection** in the UI, then land on the Sources page and find no way to point it at anything. `POST /api/sources` was the only path. Connections got a full CRUD tab in #371; sources got the read half only.

**940 insertions** — about 300 of markup and logic, the rest tests.

## The form is provider-driven, not generic

Which scope fields exist is decided by the selected connection's provider:

| Provider | Fields |
|---|---|
| S3 | `bucketName` (required), `prefix` |
| AzureBlob | `containerName` (required), `prefix` |
| Filesystem | `subPath`, `includePatterns`, `excludePatterns` |

This is the part worth being careful about. `ConnectorFactory` reads a different key per provider and ignores the rest, so writing `bucketName` into a filesystem scope produces a source that is **created successfully and then syncs nothing** — no error anywhere. Changing the connection therefore clears the scope fields rather than carrying them over, and `SourceForm.ToScopeJson` emits only the keys that provider actually reads.

`SourceForm` is a plain record rather than logic in the component, for the same reason `ConnectionForm` is: Razor components have no test harness in this repository, and this is exactly where a mistyped key goes unnoticed. The tests assert both that the right key is present *and* that the other provider's key is absent.

## Pre-flight, and what it deliberately is not

`SourceScopePreflight` checks the scope against the connection's `allowedLocations` / `allowedRoot` before the source is created, so `payroll-data is outside the locations connection 'prod' permits` appears in the form rather than as a failed sync five minutes later. The API doesn't do this today — it validates that the scope is *parseable* JSON and leaves the allowlist to sync time.

Three things about how it's built:

**It is not an enforcement point, and says so.** `ConnectorFactory` re-checks on every sync cycle, which is what catches an allowlist narrowed *after* a source already exists. Removing the pre-flight would cost clarity, not safety.

**It calls the same primitives rather than restating the rules** — `StorageLocationPolicy.Evaluate` and `SourceSecuritySettings.EvaluateRoot`, including `PathConfinement.CombineWithin` for filesystem sub-paths, so a `subPath` pointing through a junction is refused here too. Two implementations of an allowlist will drift, and the copy that drifts is the one nobody re-reads.

**It doesn't touch the network.** A bucket that is allowed but unreachable is a credential problem; reporting it here would block creating a valid source whenever the environment happens to be missing its cloud session. It also avoids `S3Connector`'s blocking STS call in its constructor.

Warnings are separate from errors, because the permissive-when-empty allowlists **accept the source today and will refuse it in a future release**. The operator is looking right at the connection at that moment — it is the one point where they'd plausibly go narrow it. The sync-time equivalent is a log line nobody reads.

## A bug my own test caught

The first version of `StringArray` filtered blank entries out of `allowedLocations` before handing them to `StorageLocationPolicy`. That quietly destroyed the distinction the policy exists to draw:

- `allowedLocations` **absent** → fail open, for one release, because #350 backfilled connections that declare none.
- `allowedLocations: ["", "  "]` → **refused**, because a malformed allowlist is not an absent one.

Pre-filtering collapsed the second into the first, turning a typo into an open door — the exact hole `StorageLocationPolicy`'s own comment warns about. `Check_AllowedLocationsPresentButAllBlank_IsRefused` failed, which is how I found it. The reader now mirrors `ConnectorFactory`'s exactly: keep every JSON string including empties, skip non-strings.

## Testing

`dotnet test` — **838 unit + 328 integration, 0 failed.**

The 30 new unit tests cover the scope-key mapping per provider (including that the other provider's key is absent), pattern parsing across the separators an operator actually types, and every pre-flight decision — allowed, outside-the-allowlist, no-allowlist-warns, all-blank-refused, unparseable scope, a non-string in the array, filesystem root outside the deployment allowlist, and a sub-path escaping its root.

No integration test for the modal itself: the Razor component has no harness here, which is precisely why the logic lives in two testable classes instead of in the page.

## Not in scope

Editing a source's scope after creation. Sources can already be enabled, disabled and deleted; re-pointing one at a different bucket is a separate question, because the documents already indexed under it would then claim to come from somewhere they didn't.

## Worth a manual pass

The modal has no automated coverage. With a connection configured: create an S3 source and confirm the bucket field appears; switch the connection to a filesystem one and confirm the scope fields swap and clear; try a bucket outside `allowedLocations` and confirm the refusal names it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added source creation from the Sources page for S3, Azure Blob, and filesystem connections.
  - Added provider-specific fields for containers, prefixes, subpaths, patterns, and sync intervals.
  - Added validation and preflight checks to identify unsafe or invalid source locations before creation.
  - Added warnings and clear error messages for unsupported, incomplete, or restricted configurations.
  - Source creation is disabled until a connection is available, with updated empty-state guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->