### PR TITLE
fix(web): correct cloud identity copy that implied it grants storage access

### DIFF
--- a/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
+++ b/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
@@ -34,8 +34,9 @@
         <h2 class="h5 mb-0">Cloud Identities</h2>
     </div>
     <p class="text-muted small mb-4">
-        Link your cloud provider accounts to access S3 and Azure Blob Storage containers with your own permissions.
-        Only identity metadata is stored — no access keys or tokens.
+        Link your cloud accounts so search results from an S3 or Azure Blob source are narrowed to
+        what your own cloud permissions allow. Only identity metadata is stored — no access keys or
+        tokens, and linking does not grant Connapse access to your storage.
     </p>
 
     <div class="row g-3">
@@ -128,7 +129,8 @@
                     else
                     {
                         <p class="text-muted small mb-0">
-                            Sign in with your AWS IAM Identity Center account to access S3 containers with your own permissions.
+                            Sign in with AWS IAM Identity Center so results from S3 sources are limited to the
+                            accounts your SSO identity covers.
                         </p>
                     }
                 </div>
@@ -238,7 +240,8 @@
                     else
                     {
                         <p class="text-muted small mb-0">
-                            Connect your Azure identity to access Blob Storage containers with your own RBAC permissions.
+                            Connect your Azure identity so results from Blob Storage sources are limited by your
+                            own RBAC permissions.
                         </p>
                     }
                 </div>


### PR DESCRIPTION
No behaviour change — three sentences of UI copy.

## The problem

**Profile > Integrations** said:

> Link your cloud provider accounts to access S3 and Azure Blob Storage containers with your own permissions.

That reads as though linking an account is what connects Connapse to your storage. It is not, and the difference is security-relevant: an operator can reasonably conclude no further credential setup is needed, then wonder why every sync fails.

## What linking actually does

A linked identity stores `CloudIdentityData(PrincipalArn, AccountId, ObjectId, TenantId, DisplayName)` — identifiers, **no token and no credential**. It flows into exactly one place, `ICloudIdentityProvider.DiscoverScopesAsync`, which decides *which results that user may see*. It never reaches `S3Connector` or `AzureBlobConnector`.

Reading a bucket uses the process's own ambient credential chain — the AWS default chain or `DefaultAzureCredential` — which is the no-stored-keys rule working as intended. The two are unrelated:

| | Who it is for | What it does |
|---|---|---|
| Profile > Integrations | Each user | Narrows search results — cloud scope |
| Connection credentials | The Connapse process | Actually reads the bucket |

## The change

The three affected strings now say results are *narrowed by* your permissions rather than that access is *granted by* the link, and the header adds the explicit negative — linking does not grant Connapse access to your storage. The negative earns its place: the old sentence's most natural reading was the wrong one, so correcting the positive claim alone would still leave a reader unsure.

The `Settings > AWS SSO` and `Azure AD` tabs are untouched. They configure the issuer, region and OAuth client so user linking can happen at all, which is a third thing again, and their copy does not claim otherwise.

Found while checking whether the connector feature was ready for a first setup, and reading the code to confirm what a linked identity is actually used for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)