### PR TITLE
chore: clear the two standing build warnings

### DIFF
--- a/src/Connapse.Storage/Connectors/ConnectorFactory.cs
+++ b/src/Connapse.Storage/Connectors/ConnectorFactory.cs
@@ -11,7 +11,6 @@ namespace Connapse.Storage.Connectors;
 /// Creates IConnector instances from ContainerEntity configuration.
 /// </summary>
 public class ConnectorFactory(
-    IManagedStorageProvider managedStorageProvider,
     IOptionsMonitor<SourceSecuritySettings> sourceSecurity,
     ILogger<ConnectorFactory> logger) : IConnectorFactory
 {

--- a/tests/Connapse.Core.Tests/CloudScope/CloudScopeServiceTests.cs
+++ b/tests/Connapse.Core.Tests/CloudScope/CloudScopeServiceTests.cs
@@ -58,7 +58,9 @@ public class CloudScopeServiceTests
             Name: "src",
             Description: null,
             ConnectionId: connectionId,
-            ScopeJson: scope,
+            // Matches what the create route stores for a source with no scope, so the tests
+            // that omit one exercise the same value production would hold.
+            ScopeJson: scope ?? "{}",
             CreatedAt: DateTime.UtcNow,
             UpdatedAt: DateTime.UtcNow);
 

--- a/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.Connectors;
@@ -54,7 +54,6 @@ public class SourceConnectorFactoryTests
         monitor.CurrentValue.Returns(settings);
 
         return new ConnectorFactory(
-            Substitute.For<IManagedStorageProvider>(),
             monitor,
             logger ?? NullLogger<ConnectorFactory>.Instance);
     }
@@ -349,3 +348,4 @@ public class SourceConnectorFactoryTests
         name.Should().StartWith("connapse-");
     }
 }
+

--- a/tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj
+++ b/tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj
@@ -12,6 +12,18 @@
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <!--
+      Direct reference purely to lift the transitive SSH.NET that Testcontainers brings in.
+      2024.2.0 carries GHSA-q939-rpr3-3284 (CVE-2026-48798, CVSS 7.1) — a path traversal in
+      ScpClient.Download()'s recursive mode, where a malicious server returns filenames
+      containing "../" and the client writes outside the target directory.
+
+      Nothing here is exposed: SSH.NET is test-only, and no Connapse code calls SCP at all.
+      The reference exists so `dotnet build` stops reporting a high-severity advisory on every
+      run — a standing warning that is not actionable trains people to ignore the ones that are.
+      Remove this once Testcontainers ships a version that references 2026.0.0 or later.
+    -->
+    <PackageReference Include="SSH.NET" Version="2026.0.0" />
     <PackageReference Include="Testcontainers.Azurite" Version="4.3.0" />
     <PackageReference Include="Testcontainers.LocalStack" Version="4.3.0" />
     <PackageReference Include="Testcontainers.Minio" Version="4.3.0" />


### PR DESCRIPTION
Two warnings on every `dotnet build`, both now gone. No behaviour change.

## SSH.NET advisory

`Testcontainers` pulls **SSH.NET 2024.2.0** transitively into the integration test project, and it carries `GHSA-q939-rpr3-3284` (**CVE-2026-48798**, CVSS 7.1 High): a path traversal in `ScpClient.Download()`'s recursive mode, where a malicious server returns filenames containing `../` and the client writes outside the target directory.

**Nothing here is exposed.** SSH.NET is test-only — it never reaches shipped code — and the vulnerable path is the **SCP** client, which no Connapse code calls. So this is hygiene, not a fix.

It is still worth doing, because a standing high-severity advisory that nobody can act on is how people learn to scroll past the ones that matter. A direct `PackageReference` to **2026.0.0** (the patched release) lifts the transitive version. The comment in the csproj says why it exists and when to remove it — once Testcontainers references 2026.0.0 or later itself.

## CS8604 in CloudScopeServiceTests

Mine, introduced in #375. The `MakePair` helper takes `string? scope` and passes it to `Source.ScopeJson`, which is non-nullable. Now `scope ?? "{}"`, which is what `POST /api/sources` actually stores for a source created without one — so the tests that omit a scope exercise the same value production holds, rather than a null that could never occur.

## Verification

`dotnet build` — **0 warnings**, where it previously reported NU1903 and CS8604.
`dotnet test --filter "Category=Unit"` — **837 passed, 0 failed**.

Found while researching filesystem ingestion: one investigation was asked to check whether that advisory was real and fixed upstream, and the answer was yes to both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added administrator tools for creating sources after a connection is configured.
  - Added provider-aware source setup for S3, Azure Blob, and filesystem connections.
  - Added configurable scope fields, include/exclude patterns, and sync intervals.
  - Added pre-creation validation with clear warnings and errors for invalid or restricted locations.
  - Added audit tracking for source creation.

- **Bug Fixes**
  - Improved empty-state guidance when no sources or connections are available.
  - Source scope data is now consistently initialized when no scope is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->