### PR TITLE
fix(web): withhold implausibly large deletion sets during source sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ Thumbs.db
 docs/plans/
 docs/v0.2.0-plan.md
 docs/v0.3.0-plan.md
+
+# Subagent-driven-development scratch (ledger, briefs, review packages)
+.superpowers/

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -181,6 +181,8 @@ Two details worth knowing:
 
 The threshold is fixed and not configurable. Small sources are never blocked — losing five of five files applies immediately, since re-ingesting them is cheap.
 
+The guard bounds a single reconcile, not the source's history. A listing that persistently returns just under the threshold — say 9% missing every cycle — never trips it, and the index erodes a little on every sync.
+
 ---
 
 ## Why the split

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -178,6 +178,7 @@ Two details worth knowing:
 
 - **Additions still apply.** A source that trips the guard keeps ingesting, because a safety check that stops a source working is an outage.
 - **Approving re-runs the sync**, it does not replay the earlier list. If the remote recovered in the meantime, nothing is deleted.
+- **Approving is a ceiling, not a licence.** It authorises up to the number you were shown. If the remote degraded further between reading the count and approving it, the larger set is withheld again and needs fresh approval — so a worsening outage cannot have the whole index applied on the strength of a smaller approval.
 
 The threshold is fixed and not configurable. Small sources are never blocked — losing five of five files applies immediately, since re-ingesting them is cheap.
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -168,6 +168,19 @@ Deleting a source removes its indexed documents. The external data is untouched.
 
 Containers have their own `POST /api/containers/{id}/sync`, which reconciles managed storage against the document table. It exists because objects can land in the bucket out of band; it does not talk to any external system.
 
+### Deletions are guarded
+
+A sync reconciles by absence: anything indexed but missing from the remote listing is treated as deleted. That inference is only as good as the listing — and a listing can come back empty *and successful*, from a narrowed bucket policy returning `200 OK` with no keys, or a directory that is temporarily unmounted.
+
+So a reconcile that would delete more than **both 10 documents and 10% of what the source has indexed** applies its additions and **withholds the deletions**, recording how many. The Sources page shows the count to administrators with an "Apply deletions" button.
+
+Two details worth knowing:
+
+- **Additions still apply.** A source that trips the guard keeps ingesting, because a safety check that stops a source working is an outage.
+- **Approving re-runs the sync**, it does not replay the earlier list. If the remote recovered in the meantime, nothing is deleted.
+
+The threshold is fixed and not configurable. Small sources are never blocked — losing five of five files applies immediately, since re-ingesting them is cheap.
+
 ---
 
 ## Why the split

--- a/docs/research/filesystem-ingestion-2026-08-23.md
+++ b/docs/research/filesystem-ingestion-2026-08-23.md
@@ -1,0 +1,193 @@
+# How should Connapse ingest files from local and remote filesystems?
+
+**Date:** 2026-08-23
+**Status:** Reviewed (adversarial pass applied — see *Corrections after review*)
+**Built on:** no prior corpus material — the Connapse MCP server was not connected to this session, so no corpus pre-check ran.
+
+## Executive summary
+
+**Connapse should stop trying to read filesystems directly and instead read S3-compatible object storage — but this is real work, not a free win.** The current Filesystem connector requires the server process to see a path on its own disk, which is false in Docker and false again on any hosted deployment. S3-compatible endpoints are the only transport surveyed with all four properties Connapse needs at once: authentication with no stored long-lived secret, a complete paginated listing that is an *authoritative* snapshot (so absence genuinely means deleted), pure outbound HTTPS from a container, and scale (a 1,000-key page cap puts 100k objects at ~100 requests).
+
+**The recommendation rests on those correctness properties, not on implementation cost.** An earlier draft of this report claimed Connapse "already has the connector" and the change "costs almost no new code." That was false, and verifying it is what produced this version: `S3ConnectorConfig` exposes only `BucketName`, `Region`, `Prefix` and `RoleArn` — **no endpoint field** — and `S3Connector.CreateS3Client` constructs `new AmazonS3Client(region)` without ever setting `ServiceURL` or `ForcePathStyle`. **Connapse's S3 connector can only talk to real AWS S3 today.** The LocalStack integration test passes only because `LocalStackFixture` sets a *process-wide* `AWS_ENDPOINT_URL_S3` environment variable, which cannot vary per connection and would redirect every S3 connection in the process. Phase 1 is therefore a genuine feature: per-connection endpoint and path-style support, plus web-identity STS.
+
+**What this does not solve, stated plainly: none of the recommended transports reaches a laptop.** S3, SFTP and Graph all require the server to reach the source. A machine behind NAT with only outbound connectivity — which is the original complaint about Docker isolation, generalised — needs a tunnel, a publicly reachable endpoint, or an agent. Running MinIO in front of a folder does not change the direction of the connection. See *What this recommendation does not solve*.
+
+**The most consequential finding is not about transport.** The maintainer proposed letting editors create sources inside admin-created connections. That must not ship until the allowlists are deny-by-default. Connapse *indexes content and makes it searchable*, so an editor choosing a scope inside somebody else's credential converts "the admin holds a broad credential" into "an editor can grep everything that credential can reach." Snowflake — the closest analogue — makes its allowlist a **required** parameter for exactly this reason.
+
+## Research brief
+
+**Question:** What mechanism(s) should Connapse use to ingest files from filesystems the server cannot directly access — local, networked, and remote — given that an admin owns the trust boundary and no long-lived secrets may be stored?
+
+**Sub-questions:**
+1. Server-reachable pull protocols — SFTP/SSH, SMB/CIFS, WebDAV, NFS, S3-compatible.
+2. Push-based agents for machines the server can never reach.
+3. Existing tools — rclone, Syncthing, cloud drive APIs, purpose-built ingestion tools, .NET abstraction libraries.
+4. Trust and delegation — does the connection/source split hold if editors may create sources? Plus safe delete semantics as a cross-cutting concern.
+
+**Out of scope:** S3 and Azure Blob as already-shipped *cloud* connectors; any design requiring stored cloud credentials; Connapse as an OIDC provider; making sources browsable; ingestion pipeline internals. The browser File System Access API was dropped during elicitation because it produces a copy Connapse owns — a container, not a mirror — and therefore answers a different question. It is out of scope rather than rejected on merit.
+
+**Success criteria:** one recommended primary mechanism with a phased path, its security model spelled out, and an explicit rejected-options list with reasons.
+
+## Findings by sub-question
+
+### Sub-question 1 — Server-reachable pull protocols
+
+**Claim: of SFTP, SMB, WebDAV, NFS and S3-compatible, S3-compatible has the best property set for a read-only mirror; NFS is disqualified outright for containerised deployment.**
+
+**S3-compatible endpoints** (MinIO, Ceph, Garage, Backblaze B2, Wasabi) via first-party `AWSSDK.S3`. Change detection is unusually cheap because `ListObjectsV2` returns key, ETag, size and LastModified *in the listing itself* — no per-file stat call. Delete detection is the strongest of the five: a paginated listing that ran to `IsTruncated: false` is an authoritative snapshot, so absence genuinely means deleted. Contrast SFTP or SMB, where a half-failed directory walk is indistinguishable from a mass deletion. **Two caveats the raw comparison hides:** a bucket policy that narrows `ListBucket`, credentials expiring mid-pagination, or versioned buckets with delete markers can all produce a *shorter* listing rather than an error — so "complete listing" must mean "pagination confirmed complete *and* no error at any page," and even then the delete-safety layer below is required. And ETag is not an MD5 for multipart or SSE-KMS objects.
+
+On authentication, MinIO supports `AssumeRoleWithWebIdentity`, exchanging an OIDC JWT for credentials expiring in roughly an hour (primary: MinIO STS docs). **This has an unstated prerequisite worth surfacing: it requires an OIDC issuer, and Connapse is deliberately not one.** The JWT must come from the operator's own identity provider — Keycloak, Entra ID, Auth0 — configured against MinIO. That is an operator prerequisite, not something Connapse supplies. Where no IdP exists, this degrades to a stored access key, which the constraints forbid; the honest fallback is a short-lived key injected as a container secret.
+
+**SFTP** is the viable second. Authentication is the cleanest of any protocol here: an SSH private key mounted as a Docker or Kubernetes secret file, loaded by SSH.NET from a stream, never touching the database. It is fully user-space over outbound TCP/22 — no mounts, no capabilities. The weaknesses are real but tolerable: the protocol has *no* change notification whatsoever, so `SSH_FXP_READDIR` plus mtime/size comparison is the only option, and round-trip cost dominates at scale — 100k files means tens of thousands of round-trips, minutes per scan. Acceptable nightly, painful at a 15-minute poll. Elasticsearch's FSCrawler ssh provider does exactly this and exposes `remove_deleted` (default true), warning that with `index_folders: false` it cannot detect removed folders at all (primary: FSCrawler docs).
+
+**The SSH.NET advisory in Connapse's dependency tree resolves benignly.** `GHSA-q939-rpr3-3284` is CVE-2026-48798, CVSS 7.1 High: a path traversal in `ScpClient.Download()`'s recursive mode where a malicious server returns filenames containing `../`. It affects ≤ 2025.1.0 and is patched in 2026.0.0. It is in the **SCP** client, not SFTP, so an SFTP-only connector never touches the vulnerable code path. (Verified independently against this repository: SSH.NET arrives only transitively via Testcontainers, in the integration test project, and no Connapse code calls SCP.)
+
+**SMB/CIFS** is possible but compromised on the constraint that matters most. SMBLibrary 1.5.7.1 is user-mode — a genuine win, since no kernel mount means no `CAP_SYS_ADMIN` — but it supports **NTLM only**; Kerberos/SPNEGO remains an open issue, not shipped. That forces storing a username and password, directly violating the no-long-lived-secret rule unless scoped to a dedicated read-only service account. It is also LGPL-3.0-or-later, warranting a licence review. SMB2 CHANGE_NOTIFY exists in the protocol and Nextcloud uses it, but Nextcloud's documentation states it "only works reliably on Windows SMB servers due to limitations of linux based SMB servers," and they still fall back to a cron `files:scan`.
+
+**WebDAV wins one dimension outright and is the strongest candidate this report does *not* place in the phased plan.** RFC 6578 `sync-collection` is the only protocol surveyed with a real change feed: the server returns a `DAV:sync-token`, and subsequent REPORTs return only added, changed, and *deleted* member URLs — deletions become explicit events rather than inferred absence, which solves the hardest problem properly. Authentication is good too: bearer tokens or mTLS over HTTPS. **It is excluded on library support, not on protocol merit:** the available .NET clients (`WebDav.Client`, `WebDAVClient`) implement none of `sync-collection`, so the REPORT and token handling would be hand-rolled, and server support is optional so the fallback path (plain PROPFIND, which RFC 6578 §1 says "doesn't scale well") must be built anyway. That is two implementations for one transport. It is a defensible candidate for a later phase and should be reconsidered if a maintained .NET `sync-collection` client appears, or if Nextcloud/ownCloud become a common deployment target.
+
+**NFS should be dropped.** Creating a mount in a non-initial user namespace is disallowed for NFS, requiring `CAP_SYS_ADMIN` or `--privileged` plus host kernel modules (primary: moby#16429, podman#20717). No mature user-space NFS client exists for .NET. It fails the library, authentication, and Docker dimensions simultaneously.
+
+### Sub-question 2 — Push-based agents
+
+**Claim: the architecture is well-understood and convergent, but the distribution cost makes it a second product rather than a feature. This leaves the unreachable-machine case genuinely unsolved — see *What this recommendation does not solve*.**
+
+**Every production agent converges on the same three parts**: a local durable state store, a scanner, and an outbound-only shipper with acknowledged delivery. Filebeat keeps a *registry file* of per-file read offset plus a unique file identifier — explicitly because "the filename and path are not enough to identify a file" — flushes continuously, and resumes from the registry on restart, giving at-least-once and never exactly-once (primary: Elastic docs).
+
+**Dropbox's sync-engine rewrite is the strongest cautionary tale, and its lesson is about the data model, not the transport.** The old engine's failure was that files "lacked a stable identifier that would be preserved across moves," so a move was represented as delete-plus-add; a transient hiccup where "a delete goes through but its corresponding add does not" makes the file vanish everywhere (primary: dropbox.tech). **Stable file IDs rather than paths are the load-bearing decision** for any mirror — and this applies to Connapse's *pull-based* sources just as much as to an agent, which makes it the most transferable finding in this section.
+
+**Enrollment is a solved problem that needs no identity provider.** Elastic Fleet's pattern transfers directly: an admin mints an enrollment token bound to a policy, the agent presents it once, and the server returns a *distinct per-agent* communication API key. Revoking the enrollment token stops new enrollments but already-enrolled agents keep working — so revocation and unenrollment are separate operations, a distinction Tailscale's auth-key docs make just as explicitly. The stolen-laptop answer is therefore: short-lived enrollment token → long-lived per-agent credential → server-side per-agent kill switch. **RFC 8628 device authorization grant is a poor fit** and should be skipped: it explicitly treats devices as public clients that "cannot securely store credentials," and contains no guidance on device credential revocation at all.
+
+**Nobody trusts the filesystem watcher.** All three platform APIs are documented-unreliable: Windows `FileSystemWatcher.InternalBufferSize` defaults to 8 KB and caps at 64 KB, and on overflow "loses track of changes in the directory"; macOS FSEvents coalesces *hierarchically* and can demand a full recursive rescan via `kFSEventStreamEventFlagMustScanSubDirs`; Linux inotify defaults to 8192 watches and fails outright with no fallback when exceeded. Syncthing's resolution is the one to copy — a full rescan hourly *even when the watcher is running*, every minute when it is not. **Treat the watcher as a latency optimisation over an authoritative periodic scan, never as the source of truth.** This finding also applies to the *existing* Filesystem connector, which is watcher-based.
+
+**Distribution cost is the disqualifier.** Native AOT supports the three platforms but each target requires a native toolchain *on that OS*, so a three-platform CI matrix is mandatory; the build image also sets the glibc floor. Signing is a recurring tax: since June 2023 the CA/Browser Forum requires OV code-signing keys on FIPS 140 Level 2 hardware. macOS requires a Developer ID certificate, hardened runtime, notarization and stapling. Auto-update is its own subsystem — Elastic's minimum viable shape is a separate watcher process supervising the new version for ten minutes with automatic rollback. *(One frequently-cited additional cost — that the EV certificate SmartScreen bypass was removed in 2024, leaving no way to avoid cold-start warnings per release — rests on a search summary rather than a Microsoft primary document and should be verified before it informs a decision. The rejection stands on the toolchain and notarization costs without it.)* Note the existing `connapse-cli` distribution route (`dotnet tool install -g`) does not help, since it requires the .NET SDK on the target — fine for developers, wrong for a daemon on a file server.
+
+### Sub-question 3 — Existing tools
+
+**Claim: rclone is MIT rather than MPL, which materially improves its viability; Microsoft Graph is the only cloud-drive API that satisfies the no-stored-credentials rule.**
+
+**rclone's licence was mis-assumed in the brief.** Its `COPYING` is the **MIT License**, not MPL (primary: rclone repo). Bundling the binary or linking `librclone` therefore carries only attribution obligations. Any earlier reasoning that rejected rclone on licence grounds should be revisited.
+
+**`rclone serve s3` is the cheapest breadth play, with a significant caveat.** Pointing Connapse's S3 connector at an rclone S3 endpoint would reach 70+ backends for no new *connector* code — though note it still requires the per-connection endpoint support that Phase 1 adds, since that capability does not exist today. It supports S3v4 auth via `--auth-key` and TLS via `--cert`/`--key`. But the documentation marks it **Experimental**, it is unversioned, and **only mtime is persisted** — other metadata is memory-only. Betting read-only ingestion on an experimental server is the tradeoff to weigh. Credentials need not be stored: rclone accepts configuration entirely via environment variables or inline connection strings, `--config ""` keeps config in memory only, and the azureblob backend supports `env_auth`/`use_msi` for managed identity. rclone has **no change feed** — `sync` is a full listing diff every run.
+
+**Microsoft Graph is the strongest single finding in this sub-question.** `driveItem: delta` returns deleted items with an explicit `deleted` facet and hands back an `@odata.deltaLink` for incremental polling; the documentation states delta is the *only* way to guarantee a complete local representation. Because `Files.Read.All` is an **application** permission, a managed identity's service principal can hold it — client credentials, no secret, no refresh token, **no stored cloud credential**. This is the only cloud-drive candidate satisfying the hard constraint cleanly, and it matches the maintainer's existing Azure managed-identity posture. Caveat: Graph permissions are additive, so granting `Files.Read.All` alongside a narrower `Sites.Selected` defeats the narrower scope.
+
+**Google Drive** has solid delete detection (`changes.list` with `includeRemoved=true`) but a worse credential story — keyless only when running on GCP with an attached service account, otherwise a JSON key file. **Dropbox is not viable under the constraints**: long-lived tokens are deprecated, offline access requires storing a refresh token, and there is no app-only or service-account path.
+
+**Syncthing is the right auth model attached to the wrong problem shape.** Device IDs are certificate fingerprints, so no central identity provider is needed — genuinely aligned with "Connapse is not an OIDC provider" — and `receiveonly` folders exist and behave correctly. But it requires a peer on every source machine, which is an agent by another name, and it is a bidirectional sync engine coerced into read-only ingestion. MPL-2.0, actively maintained. *(Worth noting against the agent rejection: adopting Syncthing is the cheapest way to get agent-shaped reach without building or signing a binary, since the user installs a third-party tool that is already signed and maintained. It remains unrecommended, but it is the strongest fallback if the unreachable-machine case becomes a priority.)*
+
+**The industry answer for the push case is unglamorous: a watched drop folder.** Paperless-ngx consumes from a directory and *moves files out* into its own structure — a drop model, not a mirror, so there is no source-side delete to detect. For the mirror case, FSCrawler's periodic full crawl (`update_rate` default 15m, `remove_deleted` default true) validates list-and-diff as the norm.
+
+**No .NET abstraction library closes the gap.** FluentStorage (MIT, actively maintained) covers S3, Azure Blob/Files/Data Lake, GCP, FTP and SFTP behind one interface — roughly 8–10 backends against rclone's 70+, and no cloud-drive support at all, which is precisely where Connapse's gap is. **No .NET library provides change-feed abstraction; delete detection remains something Connapse must write.**
+
+### Sub-question 4 — Trust, delegation, and safe deletion
+
+**Claim: deny-by-default allowlists are a prerequisite for editor-created sources, not an improvement to schedule afterwards.**
+
+**Snowflake is a near-exact analogue and it made the allowlist mandatory.** `CREATE INTEGRATION` is an account-level privilege held only by ACCOUNTADMIN by default; creating a stage inside one needs only `CREATE STAGE` plus `USAGE` on the integration — a delegable, lower-privileged grant, exactly the shape proposed for Connapse. Crucially `STORAGE_ALLOWED_LOCATIONS` is a **required** parameter — not optional, not empty-means-all — and Snowflake enforces that a stage's URL falls inside it. `STORAGE_BLOCKED_LOCATIONS` exists specifically for the wildcard case (primary: Snowflake docs).
+
+**AWS has a formal name for the risk: `iam:PassRole`, and the confused-deputy problem.** PassRole exists solely to stop a low-privileged principal attaching a high-privileged credential to a resource it controls; AWS guidance is to restrict it to explicit role ARNs and never wildcards. Mapping onto Connapse: **the connection is the passed role, `allowedLocations` is the ARN restriction, and a permissive-when-empty allowlist is `iam:PassRole` on `Resource: "*"`.**
+
+**The dominant attack is exfiltration-into-search, and it is worse than plain read access.** Connapse indexes content and makes it searchable. An editor pointing a source at `/etc`, at a payroll prefix, or at the connection's own credential store converts "the admin holds a broad credential" into "an editor can grep everything that credential can reach." The credential itself never leaks — the *data* does, and search is a lower-friction exfiltration channel than file listing. Three further attacks: an **existence oracle**, since S3 returns 403 versus 404 depending on whether the caller holds `s3:ListBucket`, letting differential error text enumerate buckets the admin's credential can see; **resource exhaustion** via egress charges, embedding spend and index bloat; and **blast-radius laundering**, where an audit trail recording only "connection X read bucket Y" loses which editor chose the scope.
+
+**Counter-evidence from systems that declined to solve this** reinforces the point. Kubernetes documents that anyone who can create a Pod in a namespace can read any Secret in it, and prescribes namespace separation rather than in-boundary delegation. Airflow simply declares DAG authors trusted. HCP Terraform states outright that it cannot prevent a malicious module from exfiltrating sensitive variables. Grafana takes the opposite approach — provisioned datasources are `editable: false`. CVE-2023-40610 shows the escalation shape concretely in Superset.
+
+**Verdict on delegation:** warn-when-empty is tolerable *while sources remain admin-only*, because the admin already holds the credential and no privilege boundary is crossed. The moment an editor can pick the scope, an empty allowlist is unrestricted PassRole. The minimum gate before shipping editor-created sources: allowlist required and non-empty, validated at write time against a canonicalized path, plus a scope preview and per-creator audit.
+
+**On safe deletion, five named safeguards from production systems:**
+
+| Safeguard | System | Specifics |
+|---|---|---|
+| Absolute/percentage delete cap | rclone `--max-delete` | Fatal error, stops the operation. Explicitly framed as protection against "a wrong or inaccessible sync source." |
+| Whole-run abort | Google Cloud Directory Sync | Limits of 0–100% or absolute; on breach **GCDS syncs nothing at all** — deletes and non-deletes alike. |
+| On-by-default threshold | Microsoft Entra Connect Sync | "Prevent accidental deletes" on by default at **500 deletes per export cycle**; on trip the export stops *before deleting any object* and mails an admin. |
+| Health marker before trusting a listing | Syncthing `.stfolder` | A marker directory must be present; if missing the folder is treated as *unhealthy* rather than empty. Cheapest defence against the catastrophic case. |
+| Atomic swap instead of in-place reconcile | Algolia `replaceAllObjects` | Build into a temp index then `moveIndex`; on error the live index is untouched. Cost: record count temporarily doubles. |
+
+**Filebeat's own documentation warns about this exact failure mode**: `clean_removed` "can cause complete file re-reading if shared drives temporarily disconnect," and Elastic advises disabling it in unstable network environments — absence of a file is explicitly treated as untrustworthy evidence.
+
+**Delta APIs shrink the problem but do not remove it.** Microsoft Graph marks deletions with `@removed`, so an empty page means "no changes," never "everything is gone." But delta tokens have **no published TTL** and can be invalidated at any time; the service then returns **HTTP 410 Gone** with `resyncRequired`, forcing full re-enumeration — described in the docs as a normal recovery scenario, not an edge case. The dangerous list-and-diff path therefore still exists; it is merely rarer, and fires on a trigger nobody sees coming.
+
+## Recommendation
+
+**Phase 1 — Per-connection S3 endpoints, with delete safety built in from the start.** Add `ServiceUrl` and `ForcePathStyle` to `S3ConnectorConfig` and thread them through `ConnectorFactory` and the connection form; add `AssumeRoleWithWebIdentity` alongside the existing `AssumeRole`. Replace the LocalStack fixture's process-wide `AWS_ENDPOINT_URL_S3` with per-connection configuration, which is also what makes the test honest. Ship the delete-safety layer in the same phase rather than after it, because this phase already deletes: require pagination confirmed complete with no page error before any reconcile; apply a percentage-or-absolute threshold that **aborts the whole run** GCDS-style rather than partially applying; route deletes to tombstones hidden from search immediately and purged after N days; stamp each successful crawl with a generation counter so "not seen in generation N" is distinguishable from "generation N never completed."
+
+Then document MinIO (or any S3-compatible server) as the supported way to expose a filesystem, and **mark the local-disk Filesystem connector as single-host-only** rather than deleting it — deleting it would strip a working feature from existing single-host users for no gain, and it remains the correct choice when Connapse runs on the same host as the data.
+
+**Phase 2 — SFTP**, with the key mounted as a secret, for genuine remote-disk cases where standing up object storage is not reasonable. Take the SSH.NET 2026.0.0 bump regardless of whether this ships.
+
+**Phase 3 — Microsoft Graph** for OneDrive and SharePoint, using application permissions via managed identity.
+
+**Deferred pending deny-by-default allowlists:** editor-created sources.
+
+**Rejected:** NFS (needs `CAP_SYS_ADMIN`, no .NET client); Dropbox (requires a stored refresh token); a push agent (distribution and signing cost is a second product). **Excluded but defensible, revisit on trigger:** WebDAV (best change feed of any protocol; excluded only on .NET library support); Syncthing (right auth model, wrong shape, but the cheapest route to agent-like reach without shipping a binary); rclone (MIT, viable, gated on accepting an Experimental server on the ingestion path); SMB (gated on LGPL acceptance and a stored NTLM password).
+
+## What this recommendation does not solve
+
+**No transport recommended here reaches a machine the server cannot connect to.** S3, SFTP and Graph are all server-initiated pulls. A laptop or workstation behind NAT, with only outbound connectivity, remains unreachable — and since the question originated in Docker isolation, it is worth being explicit that **running MinIO in front of a folder does not change the direction of the connection.** It solves the *container cannot see the host disk* problem on a single machine; it does not solve *the server is somewhere else entirely*.
+
+For that case the honest options are, in ascending cost: a **tunnel or reverse proxy** exposing an endpoint the server can reach (Tailscale, Cloudflare Tunnel, an SSH reverse tunnel), which moves the problem to network configuration the operator already understands; **Syncthing in `receiveonly` mode** on the server paired with a send-only peer on the machine, which gets agent-shaped reach using a third-party binary the user installs and Connapse never signs; or **building the agent**, whose cost this report argues against but does not argue is unjustifiable if that case becomes the priority.
+
+A fourth non-answer worth naming: **bulk upload**. If the data does not need to stay in sync, uploading a folder into a container is already supported and is not a worse answer merely because it is unglamorous.
+
+## Corrections after review
+
+An adversarial review of the first draft found a load-bearing factual error, since verified directly against this repository and corrected above:
+
+- **The claim that S3-compatible endpoints "already work" was false.** `S3ConnectorConfig` has no endpoint field; `S3Connector.CreateS3Client` never sets `ServiceURL` or `ForcePathStyle`; `AssumeRoleWithWebIdentity` is not implemented (only `AssumeRoleAsync`, which needs base credentials); and the LocalStack test passes only via a process-wide environment variable that cannot vary per connection. The recommendation survived, but its justification changed from *cheapest* to *most correct*, and Phase 1 grew from documentation into a feature.
+- **The original tiebreaker was self-serving.** The first draft resolved a disagreement between two investigations by preferring the option "requiring no new connector code" — a criterion that favours the writer, and which rested on the error above. The tiebreak is now made on correctness properties.
+- **The unreachable-machine case was silently unanswered.** Sub-question 2 asked about machines the server can never reach; the draft rejected the agent and then never acknowledged that every remaining option requires reachability. *What this recommendation does not solve* was added.
+- **Delete safety was mis-phased**, scheduled after a phase that already deletes. It is now inside Phase 1.
+- **WebDAV vanished** — praised as solving the hardest problem, then absent from both the plan and the rejected list. It is now explicitly excluded on library support, with a revisit trigger.
+
+## Conflicts and uncertainties
+
+**Two investigations disagreed on the first move, and the disagreement is real rather than one of emphasis.** The protocol investigation concluded "ship S3-compatible first"; the tools investigation concluded "adopt Microsoft Graph directly, use rclone for breadth." Both are defensible. This report resolves it toward S3 because it serves filesystem-shaped data — which is what the question asked about — while Graph serves cloud-drive-shaped data, a different population. That is a judgement call, and the first draft's stated reason for it (implementation cost) turned out to be factually wrong, which is worth weighing when deciding how much confidence to place in the resolution.
+
+**`rclone serve s3` is simultaneously the cheapest breadth option and the least stable.** Reusing one connector for 70+ backends is genuinely attractive; the server is documented as Experimental, unversioned, and persists only mtime. Unresolved.
+
+**S3's "authoritative listing" property is weaker than a one-line comparison suggests.** Narrowed `ListBucket` permissions, mid-pagination credential expiry, and versioned-bucket delete markers can each shorten a listing without raising an error. This is why the delete-safety layer is inside Phase 1 rather than after it.
+
+**`AssumeRoleWithWebIdentity` requires an OIDC issuer that Connapse deliberately is not.** The keyless-auth claim therefore depends on the operator already running an IdP. Where none exists, this degrades to a short-lived key injected as a secret — still better than a stored long-lived key, but not the clean story the summary implies.
+
+**Two source-quality caveats.** No published formal postmortem of a *search index* wiped by an empty-listing reconcile was found; the evidence comes from file-sync and directory-sync systems, so the transfer is sound by analogy but not directly attested. And the Nextcloud/ownCloud incidents are bug reports rather than formal RCAs.
+
+## Gaps — what we did not find
+
+- **SMBLibrary CHANGE_NOTIFY client support could not be confirmed.** The protocol has it; whether this library exposes it is unverified.
+- **SMB behaviour at 100k files** — no source found.
+- **SSH.NET ssh-agent support** — absence inferred from the library surface, not documented.
+- **rclone `mount` Docker/FUSE requirements** were not verified against primary docs.
+- **The 2024 removal of the EV SmartScreen bypass** rests on a search summary, not a Microsoft primary document.
+- **Delta token TTL for Microsoft Graph is genuinely unpublished**, so resync frequency cannot be planned for — only handled.
+- **No formal postmortem of an index-wipe** as noted above.
+- **LlamaIndex reader licensing and semantics** were not verified.
+- **Cost and latency of tunnelling options** (Tailscale, Cloudflare Tunnel) for the unreachable-machine case were not investigated; that recommendation is directional rather than evidenced.
+
+## Source quality assessment
+
+The synthesis rests predominantly on **primary sources**: protocol specifications and RFCs (RFC 6578, RFC 8628), vendor documentation (AWS IAM, MinIO STS, Microsoft Graph, Snowflake, Elastic, Apple FSEvents, Microsoft Learn), licence files read directly from source repositories, the GitHub Advisory Database, and project issue trackers. The strongest claims — Snowflake's mandatory allowlist, Graph's `@removed` facet and 410 resync behaviour, the platform watcher limits, the Native AOT toolchain constraints — are all primary.
+
+**The claims about Connapse's own code are the highest-confidence in the report**, having been verified by reading the source directly rather than inferred: `S3ConnectorConfig.cs`, `S3Connector.CreateS3Client`, and `LocalStackFixture.InitializeAsync`.
+
+**Secondary sources** carry the confused-deputy framing and some engineering-blog analysis. **The weakest links are listed in Gaps**; none is load-bearing except the SmartScreen claim, and the agent rejection stands without it.
+
+## Sources
+
+**Primary — specifications and standards**
+RFC 6578 (WebDAV sync-collection) · RFC 8628 (OAuth Device Authorization Grant) · draft-ietf-secsh-filexfer · CA/Browser Forum code-signing baseline requirements
+
+**Primary — vendor and project documentation**
+AWS S3 API and IAM PassRole documentation · MinIO STS `AssumeRoleWithWebIdentity` · Microsoft Graph `driveItem: delta` and delta-query overview · Microsoft Entra Connect Sync deletion threshold · Microsoft Learn `FileSystemWatcher.InternalBufferSize` and Native AOT deployment · Apple FSEvents Programming Guide · Snowflake `CREATE STORAGE INTEGRATION` · Elastic Filebeat, Fleet enrollment tokens, elastic-agent upgrades · Datadog Agent architecture · Syncthing FAQ and folder types · rclone (`COPYING`, `sync`, `serve s3`, `rc`, `azureblob`, librclone README) · restic `design.rst` · Paperless-ngx configuration · FSCrawler local-fs documentation · Google Drive `manage-changes` · Dropbox OAuth guide · Grafana provisioning · Kubernetes Secrets concepts · Airflow security model · HCP Terraform security model · Tailscale auth keys · Apple notarization · Algolia `replaceAllObjects` · Google Cloud Directory Sync deletion limits
+
+**Primary — advisories and trackers**
+GHSA-q939-rpr3-3284 / CVE-2026-48798 · CVE-2023-40610 (Superset) · moby#16429 · podman#20717 · nextcloud/desktop#9280, #7831, #8831 · owncloud/client#6322, #2687, #10253 · rclone#959 · SMBLibrary#137 · SSH.NET#100
+
+**Primary — this repository (read directly)**
+`src/Connapse.Storage/Connectors/S3ConnectorConfig.cs` · `src/Connapse.Storage/Connectors/S3Connector.cs` · `tests/Connapse.Integration.Tests/LocalStackFixture.cs`
+
+**Primary — repositories and licences**
+rclone `COPYING` (MIT) · Syncthing `LICENSE` (MPL-2.0) · SMBLibrary (LGPL-3.0-or-later) · FluentStorage (MIT) · Unstructured (Apache-2.0)
+
+**Secondary — engineering analysis**
+Dropbox "Rewriting the heart of our sync engine" · sra.io "An Overview of Deputies in AWS" · Atlassian April 2022 post-incident review · DigiCert 2023 key-storage change notice · kdgregory on S3 403/404 differential responses

--- a/docs/superpowers/plans/2026-08-23-delete-guard.md
+++ b/docs/superpowers/plans/2026-08-23-delete-guard.md
@@ -1,0 +1,758 @@
+﻿# Delete Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a source's index being wiped when its remote listing comes back empty-but-successful, while letting an admin approve a genuine bulk deletion in one action.
+
+**Architecture:** A pure predicate decides whether a computed deletion set is too large to trust. When it trips, `SourceSyncService` applies the upserts, skips the deletions, and records how many were withheld on the source. The Sources page surfaces that count with an admin-only button that re-runs the sync with the guard lifted — recomputing the vanished set rather than replaying a stored one, so a recovered mount deletes nothing.
+
+**Tech Stack:** .NET 10, EF Core + PostgreSQL, Blazor Server, xUnit + FluentAssertions + NSubstitute, Testcontainers.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-sftp-ingestion-and-delete-guard-design.md`
+
+## Global Constraints
+
+- .NET 10, file-scoped namespaces, nullable enabled, implicit usings.
+- Records for DTOs; primary constructors for DI; async all the way (never `.Result`/`.Wait()`).
+- Never use `var` for primitive types.
+- Parameterized SQL only — never string interpolation.
+- Wrap user-controlled values in `LogSanitizer.Sanitize(...)` from `Connapse.Core.Utilities` before logging.
+- Always use `IDbContextFactory<KnowledgeDbContext>` and short-lived contexts: `await using var ctx = await factory.CreateDbContextAsync(ct)`.
+- Tag every test `[Trait("Category", "Unit")]` or `[Trait("Category", "Integration")]`.
+- Test naming: `MethodName_Scenario_ExpectedResult`.
+- Commit style: `<type>: <summary>` — `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `perf:`, `chore:`.
+- Branch: `feature/<issue>-desc`. File the GitHub issue **before** creating the branch.
+- **The threshold is fixed and not configurable.** Do not add settings, options, or per-source config for it.
+- **`SyncStatus` must not gain a member.** Withheld is a count, not a status.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/Connapse.Core/Utilities/DeletionGuard.cs` — the predicate. Core has zero dependencies, and this is pure logic with no I/O.
+- `src/Connapse.Storage/Migrations/<timestamp>_AddSourceWithheldDeletions.cs` — generated.
+- `tests/Connapse.Core.Tests/Sources/DeletionGuardTests.cs`
+- `tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs`
+
+**Modify:**
+- `src/Connapse.Core/Models/SourceModels.cs` — add `WithheldDeletions` to `Source`.
+- `src/Connapse.Storage/Data/Entities/SourceEntity.cs` — add `WithheldDeletions`.
+- `src/Connapse.Storage/Data/KnowledgeDbContext.cs` — map the column (block starts line 494).
+- `src/Connapse.Storage/Sources/PostgresSourceStore.cs` — map it in `MapToModel`; add `UpdateWithheldDeletionsAsync`.
+- `src/Connapse.Core/Interfaces/ISourceStore.cs` — declare `UpdateWithheldDeletionsAsync`.
+- `src/Connapse.Core/Models/SyncModels.cs` — add `WithheldDeletions` to `SourceSyncResult`.
+- `src/Connapse.Web/Services/SourceSyncService.cs` — apply the guard in `SyncViaListAndDiffAsync`; thread an override flag.
+- `src/Connapse.Web/Endpoints/SourceResponse.cs` — expose the count.
+- `src/Connapse.Web/Endpoints/SourcesEndpoints.cs` — accept the override on the sync route.
+- `src/Connapse.Web/Components/Pages/Sources.razor` — surface the count and the button.
+
+---
+
+### Task 1: The deletion guard predicate
+
+**Files:**
+- Create: `src/Connapse.Core/Utilities/DeletionGuard.cs`
+- Test: `tests/Connapse.Core.Tests/Sources/DeletionGuardTests.cs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `public static class DeletionGuard` with `public static bool ShouldWithhold(int vanished, int indexed)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Connapse.Core.Tests/Sources/DeletionGuardTests.cs`:
+
+```csharp
+using Connapse.Core.Utilities;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Sources;
+
+/// <summary>
+/// The boundary this guard draws is the whole of its behaviour, so it is pinned by example
+/// rather than described. Both terms of the rule are load-bearing: a percentage alone fires
+/// constantly on small sources, an absolute alone is meaningless on large ones.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DeletionGuardTests
+{
+    [Theory]
+    // Small sources clean themselves up: re-ingesting five files is cheap, and blocking
+    // them would make the guard fire on ordinary tidying.
+    [InlineData(5, 5, false)]
+    [InlineData(10, 10, false)]
+    // Losing everything from a source big enough to notice is suspicious.
+    [InlineData(15, 15, true)]
+    // Proportionality on large sources: 5% is plausible churn, 50% is not.
+    [InlineData(5_000, 100_000, false)]
+    [InlineData(50_000, 100_000, true)]
+    // Exactly at each bound, so an off-by-one in either term is caught.
+    [InlineData(10, 100, false)]
+    [InlineData(11, 100, true)]
+    // Nothing to delete is never withheld, including on an empty index.
+    [InlineData(0, 0, false)]
+    [InlineData(0, 100, false)]
+    public void ShouldWithhold_AtTheBoundaries_MatchesTheRule(int vanished, int indexed, bool expected)
+    {
+        DeletionGuard.ShouldWithhold(vanished, indexed).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ShouldWithhold_MoreVanishedThanIndexed_DoesNotThrow()
+    {
+        // Not reachable through SyncViaListAndDiffAsync, which derives vanished from the
+        // indexed set — but a predicate that throws on nonsense input would turn a caller
+        // bug into a failed sync rather than a logged oddity.
+        var act = () => DeletionGuard.ShouldWithhold(200, 100);
+
+        act.Should().NotThrow();
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/Connapse.Core.Tests --filter "FullyQualifiedName~DeletionGuardTests"`
+Expected: FAIL — `DeletionGuard` does not exist (compile error `CS0103`).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/Connapse.Core/Utilities/DeletionGuard.cs`:
+
+```csharp
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Decides whether a computed deletion set is too large to trust.
+/// <para>
+/// A reconcile infers deletions from absence: anything indexed but missing from the remote
+/// listing is assumed deleted. That inference is only as good as the listing, and a listing
+/// can come back empty <em>and successful</em> — a narrowed bucket policy returning 200 OK
+/// with zero keys, or a filesystem directory that is temporarily unmounted. Without this
+/// check, one such listing deletes every document the source owns.
+/// </para>
+/// <para>
+/// The rule deliberately does not try to decide whether a deletion is <em>correct</em>. For a
+/// mirror, a wrong deletion is recoverable — the next sync re-ingests it — so what needs
+/// preventing is the catastrophic case, not every false positive.
+/// </para>
+/// </summary>
+public static class DeletionGuard
+{
+    /// <summary>Deletion sets at or below this size are always applied.</summary>
+    /// <remarks>
+    /// A floor rather than a pure percentage: on a five-document source, deleting three is
+    /// 60% and would trip a percentage rule on completely ordinary tidying.
+    /// </remarks>
+    public const int AlwaysAllowedCount = 10;
+
+    /// <summary>Proportion of a source's index above which a deletion set is withheld.</summary>
+    /// <remarks>
+    /// A ceiling rather than a pure count: ten documents out of a hundred thousand is noise,
+    /// and an absolute-only rule would block routine churn on any large source.
+    /// </remarks>
+    public const int WithheldPercent = 10;
+
+    /// <summary>
+    /// True when the deletion set should be withheld pending an administrator's approval.
+    /// Requires <em>both</em> bounds to be exceeded, so neither degenerate case fires.
+    /// </summary>
+    public static bool ShouldWithhold(int vanished, int indexed) =>
+        vanished > AlwaysAllowedCount && vanished > indexed / (100 / WithheldPercent);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/Connapse.Core.Tests --filter "FullyQualifiedName~DeletionGuardTests"`
+Expected: PASS — 10 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Utilities/DeletionGuard.cs tests/Connapse.Core.Tests/Sources/DeletionGuardTests.cs
+git commit -m "feat(core): add the deletion guard predicate"
+```
+
+---
+
+### Task 2: Persist the withheld count
+
+**Files:**
+- Modify: `src/Connapse.Storage/Data/Entities/SourceEntity.cs`
+- Modify: `src/Connapse.Storage/Data/KnowledgeDbContext.cs` (SourceEntity block, from line 494)
+- Modify: `src/Connapse.Core/Models/SourceModels.cs`
+- Modify: `src/Connapse.Storage/Sources/PostgresSourceStore.cs`
+- Modify: `src/Connapse.Core/Interfaces/ISourceStore.cs`
+- Create: migration (generated)
+- Test: `tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `Source.WithheldDeletions` (`int?`); `ISourceStore.UpdateWithheldDeletionsAsync(Guid id, int? withheld, CancellationToken ct = default)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs`:
+
+```csharp
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
+{
+    private static string ShortName(string prefix) => $"{prefix}-{Guid.NewGuid():N}"[..20];
+
+    private async Task<Source> SeedSourceAsync()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+
+        var connection = await connections.CreateAsync(
+            new CreateConnectionRequest(ShortName("conn"), ConnectionProvider.S3, """{"region":"us-east-1"}"""),
+            createdByUserId: null);
+
+        return await sources.CreateAsync(
+            new CreateSourceRequest(ShortName("src"), connection.Id, """{"bucketName":"b"}"""));
+    }
+
+    [Fact]
+    public async Task UpdateWithheldDeletionsAsync_RoundTripsTheCount()
+    {
+        var source = await SeedSourceAsync();
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+
+        (await sources.GetAsync(source.Id))!.WithheldDeletions
+            .Should().BeNull("a source with nothing pending must not claim a count of zero");
+
+        await sources.UpdateWithheldDeletionsAsync(source.Id, 42);
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().Be(42);
+
+        // Clearing must return to null, not zero: the UI distinguishes "nothing pending"
+        // from "a decision was made", and zero would leave the button showing forever.
+        await sources.UpdateWithheldDeletionsAsync(source.Id, null);
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Integration.Tests --filter "FullyQualifiedName~UpdateWithheldDeletionsAsync_RoundTripsTheCount"`
+Expected: FAIL — compile error, `Source` has no `WithheldDeletions` and `ISourceStore` has no `UpdateWithheldDeletionsAsync`.
+
+- [ ] **Step 3: Add the field to the entity**
+
+In `src/Connapse.Storage/Data/Entities/SourceEntity.cs`, after the `SyncIntervalSeconds` line in the `// Sync state` block:
+
+```csharp
+    /// <summary>
+    /// How many deletions the last reconcile declined to apply, or null when none are pending.
+    /// Null rather than zero: the Sources page distinguishes "nothing pending" from "an
+    /// administrator decided", and zero would leave the approval button showing forever.
+    /// </summary>
+    public int? WithheldDeletions { get; set; }
+```
+
+- [ ] **Step 4: Map the column**
+
+In `src/Connapse.Storage/Data/KnowledgeDbContext.cs`, inside the `Entity<SourceEntity>` block, after the `SyncIntervalSeconds` property mapping:
+
+```csharp
+            entity.Property(e => e.WithheldDeletions)
+                .HasColumnName("withheld_deletions");
+```
+
+- [ ] **Step 5: Add the field to the domain record**
+
+In `src/Connapse.Core/Models/SourceModels.cs`, add a parameter to `Source` **at the end of the parameter list**, after `int DocumentCount = 0`:
+
+```csharp
+    int DocumentCount = 0,
+    int? WithheldDeletions = null);
+```
+
+Appending rather than inserting: every positional construction of `Source` in the codebase and tests would otherwise shift.
+
+- [ ] **Step 6: Map it in the store and add the update method**
+
+In `src/Connapse.Storage/Sources/PostgresSourceStore.cs`, in `MapToModel`, after `DocumentCount: documentCount`:
+
+```csharp
+        DocumentCount: documentCount,
+        WithheldDeletions: entity.WithheldDeletions);
+```
+
+Then add the method to the same class:
+
+```csharp
+    public async Task UpdateWithheldDeletionsAsync(Guid id, int? withheld, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var entity = await context.Sources.FirstOrDefaultAsync(s => s.Id == id, ct);
+        if (entity is null) return;
+
+        entity.WithheldDeletions = withheld;
+        entity.UpdatedAt = DateTime.UtcNow;
+        await context.SaveChangesAsync(ct);
+    }
+```
+
+- [ ] **Step 7: Declare it on the interface**
+
+In `src/Connapse.Core/Interfaces/ISourceStore.cs`, next to the other sync-state methods:
+
+```csharp
+    /// <summary>
+    /// Records how many deletions the last reconcile declined to apply, or null to clear.
+    /// Separate from <see cref="UpdateSyncStateAsync"/> because a sync that withholds
+    /// deletions still succeeded — the count is orthogonal to the status, not a variant of it.
+    /// </summary>
+    Task UpdateWithheldDeletionsAsync(Guid id, int? withheld, CancellationToken ct = default);
+```
+
+- [ ] **Step 8: Generate the migration**
+
+```bash
+dotnet ef migrations add AddSourceWithheldDeletions --project src/Connapse.Storage --startup-project src/Connapse.Web
+```
+
+Open the generated `.cs` and confirm it contains exactly one `AddColumn<int>` for `withheld_deletions` on `sources`, nullable, with no default. If it contains anything else, the model has drifted — stop and investigate rather than editing the migration.
+
+Then check `KnowledgeDbContextModelSnapshot.cs`: if `ProductVersion` changed, revert that one line. It reflects the scaffolding tool's runtime rather than the project's EF Core version, and flip-flops between contributors.
+
+- [ ] **Step 9: Run the test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Integration.Tests --filter "FullyQualifiedName~UpdateWithheldDeletionsAsync_RoundTripsTheCount"`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/Connapse.Core/Models/SourceModels.cs src/Connapse.Core/Interfaces/ISourceStore.cs src/Connapse.Storage/Data/Entities/SourceEntity.cs src/Connapse.Storage/Data/KnowledgeDbContext.cs src/Connapse.Storage/Sources/PostgresSourceStore.cs src/Connapse.Storage/Migrations/ tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+git commit -m "feat(storage): persist a source's withheld deletion count"
+```
+
+---
+
+### Task 3: Apply the guard during sync
+
+**Files:**
+- Modify: `src/Connapse.Core/Models/SyncModels.cs`
+- Modify: `src/Connapse.Web/Services/SourceSyncService.cs` (`SyncViaListAndDiffAsync`, from line 206)
+- Test: `tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: `DeletionGuard.ShouldWithhold(int, int)` (Task 1); `ISourceStore.UpdateWithheldDeletionsAsync` (Task 2).
+- Produces: `SourceSyncResult.WithheldDeletions` (`int`); `SourceSyncService.SyncSourceAsync(Source, Connection, CancellationToken, bool applyWithheldDeletions = false)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs`. This is the regression test for the bug — it must fail against current `main`.
+
+```csharp
+    /// <summary>
+    /// A connector whose listing is empty, without erroring — the shape a narrowed bucket
+    /// policy or an unmounted directory actually takes. Before the guard this deleted every
+    /// document the source owned.
+    /// </summary>
+    private sealed class EmptyListingConnector : IConnector
+    {
+        public ConnectorType Type => ConnectorType.S3;
+        public bool SupportsLiveWatch => false;
+        public string ResolveJobPath(string relativePath) => "/" + relativePath.TrimStart('/');
+        public Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<ConnectorFile>>([]);
+        public Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
+            => Task.FromResult<Stream>(new MemoryStream());
+        public Task<bool> ExistsAsync(string path, CancellationToken ct = default) => Task.FromResult(false);
+        public IAsyncEnumerable<ConnectorFileEvent> WatchAsync(CancellationToken ct = default)
+            => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task Sync_ListingCollapsesToEmpty_WithholdsDeletionsAndKeepsDocuments()
+    {
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        var result = await SyncWithConnectorAsync(source, new EmptyListingConnector());
+
+        result.Deleted.Should().Be(0, "an empty listing is not evidence that 40 files were deleted");
+        result.WithheldDeletions.Should().Be(40);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().HaveCount(40);
+
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().Be(40);
+    }
+
+    [Fact]
+    public async Task Sync_WithOverride_AppliesTheWithheldDeletions()
+    {
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        await SyncWithConnectorAsync(source, new EmptyListingConnector());
+        var result = await SyncWithConnectorAsync(source, new EmptyListingConnector(), applyWithheldDeletions: true);
+
+        result.Deleted.Should().Be(40);
+        result.WithheldDeletions.Should().Be(0);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().BeEmpty();
+
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        (await sources.GetAsync(source.Id))!.WithheldDeletions
+            .Should().BeNull("the pending decision is resolved, so the button must stop showing");
+    }
+
+    [Fact]
+    public async Task Sync_SmallDeletionSet_AppliesWithoutWithholding()
+    {
+        // Five of five is below the floor: small sources must stay able to tidy themselves.
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 5);
+
+        var result = await SyncWithConnectorAsync(source, new EmptyListingConnector());
+
+        result.Deleted.Should().Be(5);
+        result.WithheldDeletions.Should().Be(0);
+    }
+```
+
+You will also need two helpers in this class. `SeedDocumentsAsync(Guid sourceId, int count)` inserts `count` source-owned documents — follow the raw-SQL insert pattern in `tests/Connapse.Integration.Tests/OwnerBridgeSchemaTests.cs`, setting `source_id` and leaving `container_id` NULL. `SyncWithConnectorAsync(Source, IConnector, bool applyWithheldDeletions = false)` builds a `SourceSyncService` with a fixed-connector factory — copy `FixedConnectorFactory` from `tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs`, which already exists for exactly this purpose.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/Connapse.Integration.Tests --filter "FullyQualifiedName~DeleteGuardIntegrationTests"`
+Expected: FAIL — `SourceSyncResult` has no `WithheldDeletions`, and `SyncSourceAsync` has no `applyWithheldDeletions` parameter.
+
+- [ ] **Step 3: Add the field to the result record**
+
+In `src/Connapse.Core/Models/SyncModels.cs`:
+
+```csharp
+public record SourceSyncResult(
+    int Upserted,
+    int Deleted,
+    bool UsedDeltaPath,
+    bool RequiredResync,
+    string? Error,
+    bool AlreadyRunning = false,
+    int WithheldDeletions = 0);
+```
+
+- [ ] **Step 4: Apply the guard in the reconcile**
+
+In `src/Connapse.Web/Services/SourceSyncService.cs`, replace the body of `SyncViaListAndDiffAsync` between computing `vanished` and returning:
+
+```csharp
+        var remotePaths = remote.Select(f => f.Path).ToHashSet(StringComparer.Ordinal);
+        var vanished = indexedPaths.Where(p => !remotePaths.Contains(p)).ToList();
+
+        // Upserts apply regardless. A source that trips the guard must keep ingesting new
+        // content, or the safety mechanism becomes the outage it exists to prevent.
+        int upserted = await EnqueueAllAsync(source, remote, context, sp, ct);
+
+        bool withhold = !applyWithheldDeletions
+            && DeletionGuard.ShouldWithhold(vanished.Count, indexedPaths.Count);
+
+        int deleted = 0;
+        if (withhold)
+        {
+            logger.LogWarning(
+                "Source {SourceId} reconcile would delete {Vanished} of {Indexed} document(s); "
+                + "withholding pending administrator approval",
+                source.Id, vanished.Count, indexedPaths.Count);
+        }
+        else
+        {
+            deleted = await DeleteByPathsAsync(source, vanished, context, sp, ct);
+        }
+
+        await sourceStore.UpdateWithheldDeletionsAsync(
+            source.Id, withhold ? vanished.Count : null, ct);
+
+        await sourceStore.UpdateSyncStateAsync(
+            source.Id, source.SyncCursor, SyncStatus.Succeeded, error: null, DateTime.UtcNow, ct);
+
+        return new SourceSyncResult(
+            upserted, deleted, UsedDeltaPath: false, RequiredResync: false, Error: null,
+            WithheldDeletions: withhold ? vanished.Count : 0);
+```
+
+Add `using Connapse.Core.Utilities;` if it is not already present.
+
+- [ ] **Step 5: Thread the override parameter**
+
+Add `bool applyWithheldDeletions = false` as the last parameter of `SyncViaListAndDiffAsync` and of the public `SyncSourceAsync`, passing it through. Do **not** add it to the delta path — the guard does not apply there.
+
+Add this comment above the public method's new parameter:
+
+```csharp
+    /// <param name="applyWithheldDeletions">
+    /// Lifts the deletion guard for this one cycle. The vanished set is recomputed rather
+    /// than replayed from what was withheld earlier, so a source whose remote has recovered
+    /// in the meantime deletes nothing.
+    /// </param>
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `dotnet test tests/Connapse.Integration.Tests --filter "FullyQualifiedName~DeleteGuardIntegrationTests"`
+Expected: PASS — 4 passed.
+
+- [ ] **Step 7: Run the whole suite**
+
+Run: `dotnet test`
+Expected: all pass. `SourceSyncIntegrationTests` exercises the same method and must not regress.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Connapse.Core/Models/SyncModels.cs src/Connapse.Web/Services/SourceSyncService.cs tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+git commit -m "fix(web): withhold implausibly large deletion sets during source sync"
+```
+
+---
+
+### Task 4: Expose the count and the override over REST
+
+**Files:**
+- Modify: `src/Connapse.Web/Endpoints/SourceResponse.cs`
+- Modify: `src/Connapse.Web/Endpoints/SourcesEndpoints.cs` (sync route, from line 190)
+- Test: `tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: `Source.WithheldDeletions` (Task 2); the `applyWithheldDeletions` parameter (Task 3).
+- Produces: `SourceResponse.WithheldDeletions`; `POST /api/sources/{id}/sync?applyWithheldDeletions=true`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `DeleteGuardIntegrationTests.cs`:
+
+```csharp
+    [Fact]
+    public async Task GetSource_AfterWithholding_ReportsTheCount()
+    {
+        var source = await SeedSourceAsync();
+
+        using (var scope = fixture.Factory.Services.CreateScope())
+        {
+            var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+            await sources.UpdateWithheldDeletionsAsync(source.Id, 40);
+        }
+
+        var response = await fixture.AdminClient.GetAsync($"/api/sources/{source.Id}");
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = System.Text.Json.JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("withheldDeletions").GetInt32().Should().Be(40);
+    }
+
+    [Fact]
+    public async Task GetSource_WithNothingWithheld_ReportsNull()
+    {
+        // Null rather than 0, because the page keys the approval button off "is there a
+        // pending decision" — a zero would leave it showing forever.
+        var source = await SeedSourceAsync();
+
+        var response = await fixture.AdminClient.GetAsync($"/api/sources/{source.Id}");
+        var body = await response.Content.ReadAsStringAsync();
+
+        using var doc = System.Text.Json.JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("withheldDeletions").ValueKind
+            .Should().Be(System.Text.Json.JsonValueKind.Null);
+    }
+```
+
+**Note on what these tests do not cover.** `SharedWebAppFixture` exposes only `AdminClient`, so there is no way here to assert that a viewer sees `withheldDeletions` or that a non-admin is refused the override. Both properties hold by construction — the field is mapped unconditionally in `SourceResponse.From` rather than behind `includeDiagnostics`, and the sync route already carries `.RequireAuthorization("RequireAdmin")` — but neither is pinned by a test. Adding a viewer client to the shared fixture is worth doing and is deliberately **not** part of this plan; do not expand scope to chase it.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/Connapse.Integration.Tests --filter "FullyQualifiedName~GetSource_AfterWithholding_ReportsTheCount"`
+Expected: FAIL — `withheldDeletions` is not in the response body.
+
+- [ ] **Step 3: Add the field to the DTO**
+
+In `src/Connapse.Web/Endpoints/SourceResponse.cs`, add a parameter before `string Kind = "source"`:
+
+```csharp
+    /// <summary>
+    /// How many deletions the last reconcile declined to apply, or null when none are pending.
+    /// Unlike <see cref="LastSyncError"/> this is not administrator-only: it is a count, and
+    /// names nothing about the remote's contents or structure.
+    /// </summary>
+    int? WithheldDeletions,
+```
+
+And in `From`, before `LastSyncError`:
+
+```csharp
+        WithheldDeletions: source.WithheldDeletions,
+```
+
+- [ ] **Step 4: Accept the override on the sync route**
+
+In `src/Connapse.Web/Endpoints/SourcesEndpoints.cs`, add to the sync route's parameters:
+
+```csharp
+            [FromQuery] bool applyWithheldDeletions,
+```
+
+Pass it to `SyncSourceAsync`, and make the audit entry distinguish the two cases:
+
+```csharp
+            await auditLogger.LogAsync(
+                applyWithheldDeletions ? "source.deletions_applied" : "source.synced",
+                "source", source.Id.ToString(),
+                new { source.Name, result.Upserted, result.Deleted, result.WithheldDeletions }, ct);
+```
+
+A separate action name so "an administrator approved 40 deletions" is findable in the audit log rather than indistinguishable from an ordinary sync.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet test tests/Connapse.Integration.Tests --filter "FullyQualifiedName~DeleteGuardIntegrationTests"`
+Expected: PASS — 6 passed (four from Task 3, two here).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Connapse.Web/Endpoints/SourceResponse.cs src/Connapse.Web/Endpoints/SourcesEndpoints.cs tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+git commit -m "feat(api): expose withheld deletions and an admin override on source sync"
+```
+
+---
+
+### Task 5: Surface it on the Sources page
+
+**Files:**
+- Modify: `src/Connapse.Web/Components/Pages/Sources.razor`
+
+**Interfaces:**
+- Consumes: `Source.WithheldDeletions` (Task 2); `SyncSourceAsync(..., applyWithheldDeletions)` (Task 3).
+- Produces: nothing consumed by later tasks.
+
+There is no Blazor test harness in this repository, so this task has no automated test. Keep the logic in the page trivial — a conditional row and a call — and rely on Tasks 1–4 for correctness.
+
+- [ ] **Step 1: Add the pending-deletions row**
+
+In `src/Connapse.Web/Components/Pages/Sources.razor`, after the existing `LastSyncStatus == SyncStatus.Failed` row inside the `@foreach`, add:
+
+```razor
+                        @if (source.WithheldDeletions is { } withheld && isAdmin)
+                        {
+                            <tr class="@(source.Enabled ? "" : "opacity-50")">
+                                @* Administrators only, matching the sync-error row: the count
+                                   is harmless, but the action it offers is destructive. *@
+                                <td colspan="7" class="pt-0 border-top-0">
+                                    <div class="alert alert-warning py-2 mb-0 small d-flex align-items-center justify-content-between">
+                                        <span>
+                                            <span class="bi-exclamation-triangle me-1"></span>
+                                            The last sync would have deleted <strong>@withheld</strong> document(s) —
+                                            more than expected, so they were kept. If the source really did lose them, apply the deletions.
+                                        </span>
+                                        <button class="btn btn-sm btn-outline-danger ms-3 text-nowrap"
+                                                @onclick="() => SyncNow(source, applyWithheldDeletions: true)"
+                                                disabled="@(syncing == source.Id)">
+                                            Apply deletions
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+```
+
+- [ ] **Step 2: Thread the flag through the existing handler**
+
+Change `SyncNow`'s signature to `private async Task SyncNow(Source source, bool applyWithheldDeletions = false)`, pass the flag to `SyncService.SyncSourceAsync`, and change the success message so the two cases are distinguishable:
+
+```csharp
+                await AuditLogger.LogAsync(
+                    applyWithheldDeletions ? "source.deletions_applied" : "source.synced",
+                    "source", source.Id.ToString(),
+                    new { source.Name, result.Upserted, result.Deleted });
+
+                Succeed(result.WithheldDeletions > 0
+                    ? $"'{source.Name}' synced — {result.Upserted} queued, {result.WithheldDeletions} deletion(s) withheld."
+                    : $"'{source.Name}' synced — {result.Upserted} queued, {result.Deleted} removed.");
+```
+
+- [ ] **Step 3: Verify it builds**
+
+Run: `dotnet build src/Connapse.Web`
+Expected: Build succeeded, 0 warnings.
+
+- [ ] **Step 4: Manual check**
+
+Start the stack (`docker compose up -d`), create a source, let it index, then make its listing empty — the simplest way is an S3 source pointed at a bucket you then empty. Confirm the warning row appears with the count, that "Apply deletions" removes the documents, and that the row disappears afterwards.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Web/Components/Pages/Sources.razor
+git commit -m "feat(web): surface withheld deletions on the Sources page"
+```
+
+---
+
+### Task 6: Document the guard
+
+**Files:**
+- Modify: `docs/connectors.md`
+
+- [ ] **Step 1: Add the section**
+
+In `docs/connectors.md`, in the **Sync** section after the bullet list:
+
+```markdown
+### Deletions are guarded
+
+A sync reconciles by absence: anything indexed but missing from the remote listing is treated as deleted. That inference is only as good as the listing — and a listing can come back empty *and successful*, from a narrowed bucket policy returning `200 OK` with no keys, or a directory that is temporarily unmounted.
+
+So a reconcile that would delete more than **both 10 documents and 10% of what the source has indexed** applies its additions and **withholds the deletions**, recording how many. The Sources page shows the count to administrators with an "Apply deletions" button.
+
+Two details worth knowing:
+
+- **Additions still apply.** A source that trips the guard keeps ingesting, because a safety check that stops a source working is an outage.
+- **Approving re-runs the sync**, it does not replay the earlier list. If the remote recovered in the meantime, nothing is deleted.
+
+The threshold is fixed and not configurable. Small sources are never blocked — losing five of five files applies immediately, since re-ingesting them is cheap.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/connectors.md
+git commit -m "docs: describe the source deletion guard"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every Part 1 requirement maps to a task: the rule and both bounds (Task 1); `Source.WithheldDeletions` plus its migration (Task 2); list-and-diff-only application, upserts-still-apply, and count-not-status (Task 3); the DTO field and the audited override (Task 4); the admin button (Task 5); the docs (Task 6). The spec's four Part 1 tests all appear — boundaries in Task 1, the empty-listing regression and the override and upserts-still-apply in Task 3.
+
+**Deliberately deferred to Part 2:** everything under SFTP.
+
+**Type consistency.** `WithheldDeletions` is the name on `Source`, `SourceEntity`, `SourceSyncResult` and `SourceResponse`; `withheld_deletions` is the column; `applyWithheldDeletions` is the parameter and query-string name throughout; `DeletionGuard.ShouldWithhold(int, int)` is called only in Task 3 with the signature Task 1 defines.
+
+**One risk called out for the executor.** Task 2 Step 5 appends `WithheldDeletions` to the *end* of the `Source` record's parameter list. `Source` is constructed positionally in several tests; appending keeps those compiling. Do not insert it next to the other sync-state fields, however tidy that looks.

--- a/docs/superpowers/specs/2026-08-23-sftp-ingestion-and-delete-guard-design.md
+++ b/docs/superpowers/specs/2026-08-23-sftp-ingestion-and-delete-guard-design.md
@@ -68,7 +68,11 @@ Instead:
 - `SourceSyncResult.WithheldDeletions` — `int`.
 - `SourceResponse.WithheldDeletions` — visible to any viewer. It is a count, not a path, so unlike `LastSyncError` it leaks nothing about the remote and does not need the admin-only treatment.
 
-**Only the count is stored, never the paths.** The override re-runs the sync with the guard lifted and recomputes the vanished set. This is strictly safer than replaying a stored list: if the mount returned in the meantime, the recomputed set is empty and nothing is deleted. A stored list would delete files that are present again.
+**Only the count is stored, never the paths.** The override re-runs the sync and recomputes the vanished set rather than replaying a stored list: if the mount returned in the meantime, the recomputed set is empty and nothing is deleted, where a stored list would delete files that are present again.
+
+**Corrected after adversarial review — recomputing is not *strictly* safer, and the count is a ceiling.** An earlier draft of this spec claimed recomputing was safer than replaying, full stop. It is safer when the remote **recovered** and more dangerous when it **degraded further**: an administrator shown 40 could have 1,000 applied if the listing worsened between reading the number and pressing the button. So the stored count binds the approval — a recomputed set larger than what was approved is withheld again, and the flag is inert when nothing was withheld, so it cannot lift a guard that never tripped.
+
+Bound by count rather than by path identity, deliberately. The administrator never sees which paths — the page shows a number and a source is never browsable — so the consent being given is "delete what is missing, about this many". Hashing the path set would invalidate approval on ordinary churn and would mean storing path-derived data this design keeps out of the database.
 
 ### Behaviour when the guard trips
 

--- a/docs/superpowers/specs/2026-08-23-sftp-ingestion-and-delete-guard-design.md
+++ b/docs/superpowers/specs/2026-08-23-sftp-ingestion-and-delete-guard-design.md
@@ -1,0 +1,167 @@
+# Design: delete guard and SFTP ingestion
+
+**Date:** 2026-08-23
+**Status:** Approved for planning
+**Research:** `docs/research/filesystem-ingestion-2026-08-23.md`
+
+## Problem
+
+Two problems, one of which is live today.
+
+**The delete guard.** `SourceSyncService.SyncViaListAndDiffAsync` computes the set of indexed paths absent from a remote listing and deletes every one of them, with no check that the listing was trustworthy:
+
+```csharp
+var remotePaths = remote.Select(f => f.Path).ToHashSet(StringComparer.Ordinal);
+var vanished = indexedPaths.Where(p => !remotePaths.Contains(p)).ToList();
+int deleted = await DeleteByPathsAsync(source, vanished, context, sp, ct);
+```
+
+If a listing returns empty but successful, every document for that source is deleted. S3 propagates exceptions mid-pagination, which helps, but a narrowed bucket policy returning `200 OK` with zero keys does not throw — and neither does a filesystem directory that is temporarily unmounted or empty. This affects the S3, Azure and Filesystem sources that already ship.
+
+**Filesystem ingestion is unreachable in the deployments people actually use.** The Filesystem connector requires the server process to see a path on its own disk. In Docker the container filesystem is not the user's; on a hosted deployment there is no shared disk. Bind-mounting host paths is both a security concern and poor UX.
+
+## Decisions taken during brainstorming
+
+| Decision | Choice | Reason |
+|---|---|---|
+| Unreachable machines | Out of scope — operator's problem, documented not coded | Deliberate: Connapse should not hand-hold network reachability |
+| Transport | SFTP | Most common shape of "files on a server somewhere" |
+| SSH key storage | Encrypted in the database via DataProtection | The mechanism already exists; the no-stored-**cloud**-credentials rule is about cloud IAM, not an SSH key for your own box |
+| Host key | Trust on first use, pinned thereafter | Catches the realistic attack — interposition later — without demanding a fingerprint before you can start |
+| Delete safety | Threshold abort only. No tombstones, no generation counter | For a mirror, a wrong deletion is recoverable by re-sync; what needs preventing is the catastrophic case, and a false positive costs re-embedding rather than data |
+| Threshold | Fixed: withhold when vanished exceeds **both** 10 documents and 10% of the source's index | A percentage alone fires constantly on small sources; an absolute alone is meaningless on large ones |
+| Override | Per-source admin button, one shot. Not configurable | Deliberate YAGNI: a config ceiling gets loosened for one event and never tightened again |
+
+## Scope
+
+**In:** the delete guard on the list-and-diff path; an SFTP connection provider and connector; SFTP-specific path confinement; the connection form gaining a credential field for SFTP only; documentation for reaching a local machine over SFTP.
+
+**Out:** tombstones; a generation counter; a configurable threshold; any push/agent mechanism; per-connection S3 endpoints (deferred — see *Deferred work*); credential-source determinism (issue #383, sequenced after this).
+
+**Two issues and at least two PRs, in order.** Part 1 is independently valuable and independently reviewable, and must merge before Part 2 begins — SFTP is list-and-diff, so it is exactly the transport where an unguarded reconcile does the most damage. Part 2 will likely split further under the repo's 300-line convention: the connector and confinement in one PR, the UI and connection-form changes in another.
+
+## Part 1 — The delete guard
+
+Ships first and alone. It fixes shipped behaviour, and SFTP would otherwise be the first transport built on an unsafe foundation.
+
+### The rule
+
+```csharp
+internal static bool ShouldWithholdDeletions(int vanished, int indexed) =>
+    vanished > 10 && vanished > indexed / 10;
+```
+
+Both terms are load-bearing. A 5-document source losing all 5 is not blocked — small sources are cheap to re-ingest and should be allowed to clean themselves up. A 100,000-document source losing 5,000 is not blocked either; losing 50,000 is.
+
+### Where it applies
+
+**The list-and-diff path only.** Delta deletions are *reported* by the provider rather than inferred from absence, so the failure mode the guard exists for does not occur there. More practically, withholding on the delta path would require not advancing the cursor — otherwise those deletions are lost permanently, since a provider will not report the same delta twice — which livelocks the source into reprocessing the same batch every cycle.
+
+The delta path also has no production implementer today, and its 410-resync fallback lands in list-and-diff, which *is* guarded. The risk is covered without the complication.
+
+### State
+
+`SyncStatus` is **unchanged** at `Never/Running/Succeeded/Failed`. A sync that upserted 50 documents and declined to delete 400 genuinely succeeded; an enum cannot express both, and overloading the status is how "withheld" gets treated as failure and stops the source syncing entirely — the outage the guard exists to prevent.
+
+Instead:
+- `Source.WithheldDeletions` — `int?`, null when nothing is pending. **Requires a migration** adding `sources.withheld_deletions` (nullable integer).
+- `SourceSyncResult.WithheldDeletions` — `int`.
+- `SourceResponse.WithheldDeletions` — visible to any viewer. It is a count, not a path, so unlike `LastSyncError` it leaks nothing about the remote and does not need the admin-only treatment.
+
+**Only the count is stored, never the paths.** The override re-runs the sync with the guard lifted and recomputes the vanished set. This is strictly safer than replaying a stored list: if the mount returned in the meantime, the recomputed set is empty and nothing is deleted. A stored list would delete files that are present again.
+
+### Behaviour when the guard trips
+
+Upserts **still apply**. Only deletions are held. A source that trips the guard must keep ingesting new content, or the safety mechanism becomes an outage.
+
+This is a deliberate departure from Google Cloud Directory Sync, which aborts the entire run. Connapse is a mirror for search rather than a directory sync where a partial apply corrupts state, so applying additions while withholding deletions leaves the index strictly more correct than skipping both.
+
+### Override
+
+A flag on the existing admin-only `POST /api/sources/{id}/sync`, and a button on the Sources page shown only when `WithheldDeletions` is non-null and the viewer is an admin. Audited under its own action name so "an admin approved 400 deletions" is distinguishable from an ordinary sync.
+
+### Testing
+
+- Unit tests on `ShouldWithholdDeletions` at boundaries: 10/100, 11/100, 5,000/100,000, 50,000/100,000, 5/5, 0/0.
+- **The regression test that matters:** an integration test seeding a source with documents, making its listing return empty, and asserting the documents are still present and `WithheldDeletions` reports the count. This must fail against current `main`.
+- An integration test that the override applies the deletions.
+- An integration test that upserts still apply on a cycle where deletions are withheld.
+
+## Part 2 — SFTP
+
+### Shape
+
+`ConnectionProvider.Sftp = 5`.
+
+**Connection `ConfigJson`:** `host`, `port` (default 22), `username`, `allowedRoot`, `hostKeyFingerprint` (populated on first connect).
+**Connection `Secret`:** the private key, encrypted by the existing DataProtection machinery.
+**Source `ScopeJson`:** `subPath`, `includePatterns`, `excludePatterns` — **identical to the Filesystem provider**, so `SourceForm`, `SourceScopePreflight` and `SourceScopeSummary` gain a provider case rather than a new branch of logic.
+
+### The passphrase
+
+An encrypted private key needs a passphrase, which is a second secret, and there is one `Secret` field. Store both as a small JSON object inside the existing encrypted blob: one protected value, one decrypt, no schema change.
+
+### Host key verification
+
+**SSH.NET raises `HostKeyReceived` with `CanTrust` defaulting to true** — not handling it is the insecure default, and a mistake here is silent. This must be handled explicitly.
+
+First successful connect records the fingerprint on the connection. Every later connect compares and refuses on mismatch, surfacing as a sync failure naming both the expected and presented fingerprints. The recorded fingerprint is shown on the connection so it can be checked against `ssh-keyscan`. Clearing it re-arms trust-on-first-use, which is how a legitimate server rekey is handled.
+
+### Path confinement — a new implementation, not a reuse
+
+**`PathConfinement` cannot be reused.** It calls `Directory.Exists`, `File.Exists` and `FileSystemInfo.ResolveLinkTarget` — local filesystem I/O. Against a remote path those either return false or resolve something on the *server running Connapse*, silently degrading confinement to a lexical prefix check. That is precisely the bug #365 fixed for local paths, and it would be reintroduced remotely.
+
+SFTP confinement uses the protocol's own `SSH_FXP_REALPATH` via `SftpClient.GetCanonicalPath`, so symlinks resolve **server-side** before the prefix comparison. Same shape as `PathConfinement`, different mechanism, its own tests.
+
+### Listing completeness
+
+The connector must distinguish "I walked everything" from "I walked what I could." A directory it cannot read must **fail the listing**, not silently return fewer files — a quietly-short listing is indistinguishable from a mass deletion to the reconcile, and the delete guard only bounds the damage rather than preventing it. No swallowing per-directory errors during the walk.
+
+### Deliberately not built
+
+- **No tree-walking connection test.** The test button opens a session, verifies the host key, and stats the root. Nothing more.
+- **`SupportsLiveWatch = false`.** SFTP has no change notification. List-and-diff on the normal poll, and at 100k files that is minutes per scan. Documented as a known limit.
+
+### The credential field returns, for SFTP only
+
+[#371](https://github.com/Destrayon/Connapse/pull/371) removed the secret field from the connection form deliberately. It comes back **only when the selected provider is SFTP**. S3 and Azure must continue to have no secret field at all, or the epic's no-stored-cloud-credentials position is quietly reopened. The form is provider-driven the same way the source scope fields are.
+
+### Testing
+
+A Testcontainers SFTP server (`atmoz/sftp`) gives end-to-end coverage the way LocalStack does for S3:
+
+- list and read against a real server;
+- confinement refusal on a `subPath` containing `../`;
+- confinement refusal on a **server-side symlink** pointing outside the root — the case a lexical check would pass;
+- host-key pinning: accept on first connect, refuse after the server's key changes;
+- a source whose remote directory becomes unreadable keeps its documents (ties Parts 1 and 2 together).
+
+## Using SFTP to index a local machine
+
+This is the supported answer to "Connapse in Docker cannot see my files," and it is documentation rather than code.
+
+Enable an SSH server on the host — OpenSSH Server is an optional Windows feature, Remote Login on macOS, sshd on Linux — add a public key to `authorized_keys`, and point an SFTP connection at it. From a Docker Desktop container the host is `host.docker.internal:22`.
+
+Three things the documentation must state, because each costs an hour otherwise:
+
+1. **Windows OpenSSH SFTP presents paths as `/C:/Users/...`** — a leading slash before the drive letter. This affects how `allowedRoot` is written.
+2. **`host.docker.internal` is Docker Desktop only.** A Linux host needs `--add-host=host.docker.internal:host-gateway`; a remote deployment needs the machine's real address, which returns to the reachability question that is the operator's to answer.
+3. **It is list-and-diff on every poll.** Point it at a folder, not a whole drive.
+
+The existing local Filesystem connector is unchanged and remains correct for same-host deployments.
+
+## Deferred work
+
+- **Per-connection S3 endpoints** (MinIO, Ceph, Garage). The S3 connector currently has no endpoint field and can only reach real AWS; the LocalStack test passes only via a process-wide `AWS_ENDPOINT_URL_S3`. Best delete-detection properties of any transport, and worth doing — just not chosen first.
+- **Credential-source determinism** — issue #383.
+- **Editor-created sources** — blocked on deny-by-default allowlists. With an empty allowlist, an editor choosing a scope inside an admin's credential is `iam:PassRole` on `Resource: "*"`, and because Connapse indexes content the result is a query interface over whatever that credential can reach.
+- **Tombstones and a generation counter** — add only if re-ingestion cost proves painful. The generation counter can be added on top of the threshold without redoing it.
+- **WebDAV** — the only surveyed protocol with a real change feed (RFC 6578 `sync-collection`). Excluded on .NET library support, not on merit. Revisit if a maintained client appears.
+
+## Success criteria
+
+1. A source whose remote listing collapses to empty keeps its documents, reports the withheld count, and continues to ingest new content.
+2. An admin can approve the withheld deletions from the Sources page in one action.
+3. An admin can add an SFTP connection and a source inside it entirely from the UI, and index files from a machine the server can reach — including their own, over `host.docker.internal`.
+4. A `subPath` that escapes its `allowedRoot`, whether lexically or through a server-side symlink, is refused.
+5. A changed host key stops the sync rather than being accepted silently.

--- a/src/Connapse.Core/Interfaces/ISourceStore.cs
+++ b/src/Connapse.Core/Interfaces/ISourceStore.cs
@@ -36,6 +36,13 @@ public interface ISourceStore
     /// </summary>
     Task<bool> TryAdvanceSyncStateAsync(Guid id, string? expectedCursor, string? newCursor, SyncStatus status, string? error, DateTime? syncedAt, CancellationToken ct = default);
 
+    /// <summary>
+    /// Records how many deletions the last reconcile declined to apply, or null to clear.
+    /// Separate from <see cref="UpdateSyncStateAsync"/> because a sync that withholds
+    /// deletions still succeeded — the count is orthogonal to the status, not a variant of it.
+    /// </summary>
+    Task UpdateWithheldDeletionsAsync(Guid id, int? withheld, CancellationToken ct = default);
+
     Task<ContainerSettingsOverrides?> GetSettingsOverridesAsync(Guid id, CancellationToken ct = default);
     Task SaveSettingsOverridesAsync(Guid id, ContainerSettingsOverrides overrides, CancellationToken ct = default);
     Task UpdateSummaryAsync(Guid id, string? summary, DateTime? generatedAt, string? docSetHash, CancellationToken ct = default);

--- a/src/Connapse.Core/Models/SourceModels.cs
+++ b/src/Connapse.Core/Models/SourceModels.cs
@@ -20,7 +20,8 @@ public record Source(
     string? Summary = null,
     DateTime? SummaryGeneratedAt = null,
     string? SummaryDocSetHash = null,
-    int DocumentCount = 0);
+    int DocumentCount = 0,
+    int? WithheldDeletions = null);
 
 public record CreateSourceRequest(
     string Name,

--- a/src/Connapse.Core/Models/SyncModels.cs
+++ b/src/Connapse.Core/Models/SyncModels.cs
@@ -33,7 +33,8 @@ public record SourceSyncResult(
     bool UsedDeltaPath,
     bool RequiredResync,
     string? Error,
-    bool AlreadyRunning = false);
+    bool AlreadyRunning = false,
+    int WithheldDeletions = 0);
 
 /// <summary>
 /// Thrown when a reindex would move a document between ownership domains — source to

--- a/src/Connapse.Core/Utilities/DeletionGuard.cs
+++ b/src/Connapse.Core/Utilities/DeletionGuard.cs
@@ -1,0 +1,40 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Decides whether a computed deletion set is too large to trust.
+/// <para>
+/// A reconcile infers deletions from absence: anything indexed but missing from the remote
+/// listing is assumed deleted. That inference is only as good as the listing, and a listing
+/// can come back empty <em>and successful</em> — a narrowed bucket policy returning 200 OK
+/// with zero keys, or a filesystem directory that is temporarily unmounted. Without this
+/// check, one such listing deletes every document the source owns.
+/// </para>
+/// <para>
+/// The rule deliberately does not try to decide whether a deletion is <em>correct</em>. For a
+/// mirror, a wrong deletion is recoverable — the next sync re-ingests it — so what needs
+/// preventing is the catastrophic case, not every false positive.
+/// </para>
+/// </summary>
+public static class DeletionGuard
+{
+    /// <summary>Deletion sets at or below this size are always applied.</summary>
+    /// <remarks>
+    /// A floor rather than a pure percentage: on a five-document source, deleting three is
+    /// 60% and would trip a percentage rule on completely ordinary tidying.
+    /// </remarks>
+    public const int AlwaysAllowedCount = 10;
+
+    /// <summary>Proportion of a source's index above which a deletion set is withheld.</summary>
+    /// <remarks>
+    /// A ceiling rather than a pure count: ten documents out of a hundred thousand is noise,
+    /// and an absolute-only rule would block routine churn on any large source.
+    /// </remarks>
+    public const int WithheldPercent = 10;
+
+    /// <summary>
+    /// True when the deletion set should be withheld pending an administrator's approval.
+    /// Requires <em>both</em> bounds to be exceeded, so neither degenerate case fires.
+    /// </summary>
+    public static bool ShouldWithhold(int vanished, int indexed) =>
+        vanished > AlwaysAllowedCount && vanished > indexed / (100 / WithheldPercent);
+}

--- a/src/Connapse.Storage/Data/Entities/SourceEntity.cs
+++ b/src/Connapse.Storage/Data/Entities/SourceEntity.cs
@@ -19,6 +19,13 @@ public class SourceEntity
     public string? LastSyncError { get; set; }
     public int? SyncIntervalSeconds { get; set; } // null inherits the connection default
 
+    /// <summary>
+    /// How many deletions the last reconcile declined to apply, or null when none are pending.
+    /// Null rather than zero: the Sources page distinguishes "nothing pending" from "an
+    /// administrator decided", and zero would leave the approval button showing forever.
+    /// </summary>
+    public int? WithheldDeletions { get; set; }
+
     // Auto-generated summary (agent-optimized prose for routing)
     public string? Summary { get; set; }
     public DateTime? SummaryGeneratedAt { get; set; }

--- a/src/Connapse.Storage/Data/KnowledgeDbContext.cs
+++ b/src/Connapse.Storage/Data/KnowledgeDbContext.cs
@@ -540,6 +540,9 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
             entity.Property(e => e.SyncIntervalSeconds)
                 .HasColumnName("sync_interval_seconds");
 
+            entity.Property(e => e.WithheldDeletions)
+                .HasColumnName("withheld_deletions");
+
             entity.Property(e => e.Summary)
                 .HasColumnName("summary");
 

--- a/src/Connapse.Storage/Migrations/20260823212530_AddSourceWithheldDeletions.Designer.cs
+++ b/src/Connapse.Storage/Migrations/20260823212530_AddSourceWithheldDeletions.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Connapse.Storage.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -15,13 +16,15 @@ using Pgvector;
 namespace Connapse.Storage.Migrations
 {
     [DbContext(typeof(KnowledgeDbContext))]
-    partial class KnowledgeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260823212530_AddSourceWithheldDeletions")]
+    partial class AddSourceWithheldDeletions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.0")
+                .HasAnnotation("ProductVersion", "10.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.HasPostgresExtension(modelBuilder, "vector");

--- a/src/Connapse.Storage/Migrations/20260823212530_AddSourceWithheldDeletions.cs
+++ b/src/Connapse.Storage/Migrations/20260823212530_AddSourceWithheldDeletions.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Connapse.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSourceWithheldDeletions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "withheld_deletions",
+                table: "sources",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "withheld_deletions",
+                table: "sources");
+        }
+    }
+}

--- a/src/Connapse.Storage/Sources/PostgresSourceStore.cs
+++ b/src/Connapse.Storage/Sources/PostgresSourceStore.cs
@@ -284,5 +284,18 @@ public class PostgresSourceStore(
         Summary: entity.Summary,
         SummaryGeneratedAt: entity.SummaryGeneratedAt,
         SummaryDocSetHash: entity.SummaryDocSetHash,
-        DocumentCount: documentCount);
+        DocumentCount: documentCount,
+        WithheldDeletions: entity.WithheldDeletions);
+
+    public async Task UpdateWithheldDeletionsAsync(Guid id, int? withheld, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var entity = await context.Sources.FirstOrDefaultAsync(s => s.Id == id, ct);
+        if (entity is null) return;
+
+        entity.WithheldDeletions = withheld;
+        entity.UpdatedAt = DateTime.UtcNow;
+        await context.SaveChangesAsync(ct);
+    }
 }

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -145,6 +145,28 @@
                                 </td>
                             </tr>
                         }
+
+                        @if (source.WithheldDeletions is { } withheld && isAdmin)
+                        {
+                            <tr class="@(source.Enabled ? "" : "opacity-50")">
+                                @* Administrators only, matching the sync-error row: the count
+                                   is harmless, but the action it offers is destructive. *@
+                                <td colspan="7" class="pt-0 border-top-0">
+                                    <div class="alert alert-warning py-2 mb-0 small d-flex align-items-center justify-content-between">
+                                        <span>
+                                            <span class="bi-exclamation-triangle me-1"></span>
+                                            The last sync would have deleted <strong>@withheld</strong> document(s) —
+                                            more than expected, so they were kept. If the source really did lose them, apply the deletions.
+                                        </span>
+                                        <button class="btn btn-sm btn-outline-danger ms-3 text-nowrap"
+                                                @onclick="() => SyncNow(source, applyWithheldDeletions: true)"
+                                                disabled="@(syncing == source.Id)">
+                                            Apply deletions
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
                     }
                 </tbody>
             </table>
@@ -258,7 +280,7 @@
         builder.CloseElement();
     };
 
-    private async Task SyncNow(Source source)
+    private async Task SyncNow(Source source, bool applyWithheldDeletions = false)
     {
         message = null;
         syncing = source.Id;
@@ -272,7 +294,7 @@
                 return;
             }
 
-            var result = await SyncService.SyncSourceAsync(source, connection, CancellationToken.None);
+            var result = await SyncService.SyncSourceAsync(source, connection, CancellationToken.None, applyWithheldDeletions);
 
             if (result.AlreadyRunning)
             {
@@ -285,10 +307,14 @@
             }
             else
             {
-                await AuditLogger.LogAsync("source.synced", "source", source.Id.ToString(),
+                await AuditLogger.LogAsync(
+                    applyWithheldDeletions ? "source.deletions_applied" : "source.synced",
+                    "source", source.Id.ToString(),
                     new { source.Name, result.Upserted, result.Deleted });
 
-                Succeed($"'{source.Name}' synced — {result.Upserted} queued, {result.Deleted} removed.");
+                Succeed(result.WithheldDeletions > 0
+                    ? $"'{source.Name}' synced — {result.Upserted} queued, {result.WithheldDeletions} deletion(s) withheld."
+                    : $"'{source.Name}' synced — {result.Upserted} queued, {result.Deleted} removed.");
             }
 
             await LoadAsync();

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -160,7 +160,7 @@
                                         </span>
                                         <button class="btn btn-sm btn-outline-danger ms-3 text-nowrap"
                                                 @onclick="() => SyncNow(source, applyWithheldDeletions: true)"
-                                                disabled="@(syncing == source.Id)">
+                                                disabled="@(!source.Enabled || syncing == source.Id)">
                                             Apply deletions
                                         </button>
                                     </div>

--- a/src/Connapse.Web/Endpoints/SourceResponse.cs
+++ b/src/Connapse.Web/Endpoints/SourceResponse.cs
@@ -26,6 +26,12 @@ public record SourceResponse(
     DateTime CreatedAt,
     DateTime UpdatedAt,
     /// <summary>
+    /// How many deletions the last reconcile declined to apply, or null when none are pending.
+    /// Unlike <see cref="LastSyncError"/> this is not administrator-only: it is a count, and
+    /// names nothing about the remote's contents or structure.
+    /// </summary>
+    int? WithheldDeletions,
+    /// <summary>
     /// Populated for administrators only. A provider's failure text routinely echoes the
     /// thing that failed — "Access Denied for bucket payroll-data" — so returning it to
     /// every reader would give back exactly the infrastructure detail ScopeJson is withheld
@@ -51,5 +57,6 @@ public record SourceResponse(
         Summary: source.Summary,
         CreatedAt: source.CreatedAt,
         UpdatedAt: source.UpdatedAt,
+        WithheldDeletions: source.WithheldDeletions,
         LastSyncError: includeDiagnostics ? source.LastSyncError : null);
 }

--- a/src/Connapse.Web/Endpoints/SourcesEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/SourcesEndpoints.cs
@@ -193,6 +193,7 @@ public static class SourcesEndpoints
             [FromServices] IConnectionStore connectionStore,
             [FromServices] SourceSyncService syncService,
             [FromServices] IAuditLogger auditLogger,
+            [FromQuery] bool applyWithheldDeletions,
             CancellationToken ct) =>
         {
             var source = await sourceStore.GetAsync(sourceId, ct);
@@ -206,7 +207,7 @@ public static class SourcesEndpoints
             if (connection is null)
                 return Results.BadRequest(new { error = $"Source '{source.Name}' references a missing connection" });
 
-            var result = await syncService.SyncSourceAsync(source, connection, ct);
+            var result = await syncService.SyncSourceAsync(source, connection, ct, applyWithheldDeletions);
 
             // Nothing went wrong — the scheduled cycle got there first. 409 rather than 200
             // so a script driving this does not read "0 upserted" as "nothing to do".
@@ -218,8 +219,10 @@ public static class SourcesEndpoints
                 });
             }
 
-            await auditLogger.LogAsync("source.synced", "source", sourceId.ToString(),
-                new { source.Name, result.Upserted, result.Deleted }, ct);
+            await auditLogger.LogAsync(
+                applyWithheldDeletions ? "source.deletions_applied" : "source.synced",
+                "source", source.Id.ToString(),
+                new { source.Name, result.Upserted, result.Deleted, result.WithheldDeletions }, ct);
 
             return Results.Ok(new
             {

--- a/src/Connapse.Web/Endpoints/SourcesEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/SourcesEndpoints.cs
@@ -193,8 +193,8 @@ public static class SourcesEndpoints
             [FromServices] IConnectionStore connectionStore,
             [FromServices] SourceSyncService syncService,
             [FromServices] IAuditLogger auditLogger,
-            [FromQuery] bool applyWithheldDeletions,
-            CancellationToken ct) =>
+            [FromQuery] bool applyWithheldDeletions = false,
+            CancellationToken ct = default) =>
         {
             var source = await sourceStore.GetAsync(sourceId, ct);
             if (source is null)
@@ -230,7 +230,8 @@ public static class SourcesEndpoints
                 result.Deleted,
                 result.UsedDeltaPath,
                 result.RequiredResync,
-                result.Error
+                result.Error,
+                result.WithheldDeletions
             });
         })
         .WithName("SyncSource")

--- a/src/Connapse.Web/Services/SourceSyncService.cs
+++ b/src/Connapse.Web/Services/SourceSyncService.cs
@@ -94,9 +94,11 @@ public class SourceSyncService(
     /// source and reported, so one unreachable provider cannot stall every other source.
     /// </summary>
     /// <param name="applyWithheldDeletions">
-    /// Lifts the deletion guard for this one cycle. The vanished set is recomputed rather
-    /// than replayed from what was withheld earlier, so a source whose remote has recovered
-    /// in the meantime deletes nothing.
+    /// Applies deletions an administrator has already approved. The vanished set is recomputed
+    /// rather than replayed, so a source whose remote recovered in the meantime deletes
+    /// nothing — but it is capped at the count that was withheld, so a remote that degraded
+    /// further cannot have the larger set applied on the strength of the smaller approval.
+    /// Inert when nothing was withheld: the flag cannot lift a guard that never tripped.
     /// </param>
     internal async Task<SourceSyncResult> SyncSourceAsync(
         Source source, Connection connection, CancellationToken ct, bool applyWithheldDeletions = false)
@@ -233,16 +235,44 @@ public class SourceSyncService(
         // content, or the safety mechanism becomes the outage it exists to prevent.
         int upserted = await EnqueueAllAsync(source, remote, context, sp, ct);
 
-        bool withhold = !applyWithheldDeletions
-            && DeletionGuard.ShouldWithhold(vanished.Count, indexedPaths.Count);
+        // An approval authorises the deletion set the administrator was shown a count of, not
+        // whatever the next listing happens to produce. Recomputing stays — a remote that
+        // recovered must still delete nothing — but the recomputed set may not *exceed* what
+        // was approved. Without that ceiling the override is unbounded in precisely the
+        // situation it is most likely to be used: a remote that is still degrading. Approve 40
+        // and the cycle could apply 1,000.
+        //
+        // Bound by count rather than by identity. The administrator never sees which paths —
+        // the page shows a number and a source is never browsable — so the consent being given
+        // is "delete what is missing, about this many", and a count expresses that honestly.
+        // Hashing the path set would invalidate approval on any ordinary churn, and would mean
+        // storing path-derived data this design deliberately keeps out of the database.
+        //
+        // Null when nothing was withheld, so the flag cannot lift a guard that never tripped:
+        // a first-ever sync carrying applyWithheldDeletions=true is still guarded.
+        int? approved = applyWithheldDeletions ? source.WithheldDeletions : null;
+
+        bool withhold = approved is null
+            ? DeletionGuard.ShouldWithhold(vanished.Count, indexedPaths.Count)
+            : vanished.Count > approved.Value;
 
         int deleted = 0;
         if (withhold)
         {
-            logger.LogWarning(
-                "Source {SourceId} reconcile would delete {Vanished} of {Indexed} document(s); "
-                + "withholding pending administrator approval",
-                source.Id, vanished.Count, indexedPaths.Count);
+            if (approved is { } ceiling)
+            {
+                logger.LogWarning(
+                    "Source {SourceId} approval superseded: {Approved} deletion(s) were approved but "
+                    + "the listing now shows {Vanished} of {Indexed}; withholding pending fresh approval",
+                    source.Id, ceiling, vanished.Count, indexedPaths.Count);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "Source {SourceId} reconcile would delete {Vanished} of {Indexed} document(s); "
+                    + "withholding pending administrator approval",
+                    source.Id, vanished.Count, indexedPaths.Count);
+            }
         }
         else
         {

--- a/src/Connapse.Web/Services/SourceSyncService.cs
+++ b/src/Connapse.Web/Services/SourceSyncService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
 using Connapse.Storage.Data;
 using Connapse.Storage.Data.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -92,7 +93,13 @@ public class SourceSyncService(
     /// Runs one sync cycle for one source. Never throws: a remote failure is recorded on the
     /// source and reported, so one unreachable provider cannot stall every other source.
     /// </summary>
-    internal async Task<SourceSyncResult> SyncSourceAsync(Source source, Connection connection, CancellationToken ct)
+    /// <param name="applyWithheldDeletions">
+    /// Lifts the deletion guard for this one cycle. The vanished set is recomputed rather
+    /// than replayed from what was withheld earlier, so a source whose remote has recovered
+    /// in the meantime deletes nothing.
+    /// </param>
+    internal async Task<SourceSyncResult> SyncSourceAsync(
+        Source source, Connection connection, CancellationToken ct, bool applyWithheldDeletions = false)
     {
         if (!source.Enabled)
             return new SourceSyncResult(0, 0, UsedDeltaPath: false, RequiredResync: false, Error: null);
@@ -127,7 +134,8 @@ public class SourceSyncService(
 
             return connector is ISyncCursorConnector cursorConnector
                 ? await SyncViaDeltaAsync(source, cursorConnector, sourceStore, scope.ServiceProvider, ct)
-                : await SyncViaListAndDiffAsync(source, connector, sourceStore, scope.ServiceProvider, ct);
+                : await SyncViaListAndDiffAsync(
+                    source, connector, sourceStore, scope.ServiceProvider, ct, applyWithheldDeletions);
         }
         catch (Exception ex)
         {
@@ -204,7 +212,8 @@ public class SourceSyncService(
     }
 
     private async Task<SourceSyncResult> SyncViaListAndDiffAsync(
-        Source source, IConnector connector, ISourceStore sourceStore, IServiceProvider sp, CancellationToken ct)
+        Source source, IConnector connector, ISourceStore sourceStore, IServiceProvider sp, CancellationToken ct,
+        bool applyWithheldDeletions = false)
     {
         IReadOnlyList<ConnectorFile> remote = await connector.ListFilesAsync(null, ct);
 
@@ -220,15 +229,37 @@ public class SourceSyncService(
         var remotePaths = remote.Select(f => f.Path).ToHashSet(StringComparer.Ordinal);
         var vanished = indexedPaths.Where(p => !remotePaths.Contains(p)).ToList();
 
+        // Upserts apply regardless. A source that trips the guard must keep ingesting new
+        // content, or the safety mechanism becomes the outage it exists to prevent.
         int upserted = await EnqueueAllAsync(source, remote, context, sp, ct);
-        int deleted = await DeleteByPathsAsync(source, vanished, context, sp, ct);
+
+        bool withhold = !applyWithheldDeletions
+            && DeletionGuard.ShouldWithhold(vanished.Count, indexedPaths.Count);
+
+        int deleted = 0;
+        if (withhold)
+        {
+            logger.LogWarning(
+                "Source {SourceId} reconcile would delete {Vanished} of {Indexed} document(s); "
+                + "withholding pending administrator approval",
+                source.Id, vanished.Count, indexedPaths.Count);
+        }
+        else
+        {
+            deleted = await DeleteByPathsAsync(source, vanished, context, sp, ct);
+        }
+
+        await sourceStore.UpdateWithheldDeletionsAsync(
+            source.Id, withhold ? vanished.Count : null, ct);
 
         // No cursor to advance on this path, so record the outcome directly. The stored
         // cursor stays null, which is what marks this source as fallback-synced.
         await sourceStore.UpdateSyncStateAsync(
             source.Id, source.SyncCursor, SyncStatus.Succeeded, error: null, DateTime.UtcNow, ct);
 
-        return new SourceSyncResult(upserted, deleted, UsedDeltaPath: false, RequiredResync: false, Error: null);
+        return new SourceSyncResult(
+            upserted, deleted, UsedDeltaPath: false, RequiredResync: false, Error: null,
+            WithheldDeletions: withhold ? vanished.Count : 0);
     }
 
     /// <summary>

--- a/tests/Connapse.Core.Tests/Sources/DeletionGuardTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/DeletionGuardTests.cs
@@ -1,0 +1,45 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Sources;
+
+/// <summary>
+/// The boundary this guard draws is the whole of its behaviour, so it is pinned by example
+/// rather than described. Both terms of the rule are load-bearing: a percentage alone fires
+/// constantly on small sources, an absolute alone is meaningless on large ones.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DeletionGuardTests
+{
+    [Theory]
+    // Small sources clean themselves up: re-ingesting five files is cheap, and blocking
+    // them would make the guard fire on ordinary tidying.
+    [InlineData(5, 5, false)]
+    [InlineData(10, 10, false)]
+    // Losing everything from a source big enough to notice is suspicious.
+    [InlineData(15, 15, true)]
+    // Proportionality on large sources: 5% is plausible churn, 50% is not.
+    [InlineData(5_000, 100_000, false)]
+    [InlineData(50_000, 100_000, true)]
+    // Exactly at each bound, so an off-by-one in either term is caught.
+    [InlineData(10, 100, false)]
+    [InlineData(11, 100, true)]
+    // Nothing to delete is never withheld, including on an empty index.
+    [InlineData(0, 0, false)]
+    [InlineData(0, 100, false)]
+    public void ShouldWithhold_AtTheBoundaries_MatchesTheRule(int vanished, int indexed, bool expected)
+    {
+        DeletionGuard.ShouldWithhold(vanished, indexed).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ShouldWithhold_MoreVanishedThanIndexed_DoesNotThrow()
+    {
+        // Not reachable through SyncViaListAndDiffAsync, which derives vanished from the
+        // indexed set — but a predicate that throws on nonsense input would turn a caller
+        // bug into a failed sync rather than a logged oddity.
+        var act = () => DeletionGuard.ShouldWithhold(200, 100);
+
+        act.Should().NotThrow();
+    }
+}

--- a/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
@@ -44,9 +44,15 @@ public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
         for (int i = 0; i < count; i++)
         {
             string path = $"/doc-{i}.md";
+
+            // status = 'Ready': these rows represent already-indexed documents, not ones
+            // mid-ingestion. Left at the column's 'Pending' default, HasRemoteChanged's
+            // in-flight check would treat every one of them as already queued and skip it
+            // regardless of remote signature, which would make a reconcile's upsert count
+            // always zero here.
             await context.Database.ExecuteSqlRawAsync(
-                "INSERT INTO documents (id, container_id, source_id, file_name, path, content_hash, size_bytes, created_at) "
-                + "VALUES ({0}, NULL, {1}, {2}, {3}, '', 1, now())",
+                "INSERT INTO documents (id, container_id, source_id, file_name, path, content_hash, size_bytes, status, created_at) "
+                + "VALUES ({0}, NULL, {1}, {2}, {3}, '', 1, 'Ready', now())",
                 Guid.NewGuid(), sourceId, $"doc-{i}.md", path);
         }
     }
@@ -96,6 +102,25 @@ public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
             => throw new NotSupportedException();
     }
 
+    /// <summary>
+    /// A connector whose listing is a fixed, non-empty set of files, following
+    /// <see cref="EmptyListingConnector"/>'s shape. Used where a test needs the remote to
+    /// report specific paths rather than nothing.
+    /// </summary>
+    private sealed class FixedListingConnector(IReadOnlyList<ConnectorFile> files) : IConnector
+    {
+        public ConnectorType Type => ConnectorType.S3;
+        public bool SupportsLiveWatch => false;
+        public string ResolveJobPath(string relativePath) => "/" + relativePath.TrimStart('/');
+        public Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
+            => Task.FromResult(files);
+        public Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
+            => Task.FromResult<Stream>(new MemoryStream());
+        public Task<bool> ExistsAsync(string path, CancellationToken ct = default) => Task.FromResult(false);
+        public IAsyncEnumerable<ConnectorFileEvent> WatchAsync(CancellationToken ct = default)
+            => throw new NotSupportedException();
+    }
+
     [Fact]
     public async Task Sync_ListingCollapsesToEmpty_WithholdsDeletionsAndKeepsDocuments()
     {
@@ -134,6 +159,59 @@ public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
         var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
         (await sources.GetAsync(source.Id))!.WithheldDeletions
             .Should().BeNull("the pending decision is resolved, so the button must stop showing");
+    }
+
+    [Fact]
+    public async Task Sync_WhileWithholding_UpsertsStillApply()
+    {
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        // 5 of the 40 indexed paths are still reported by the remote. The raw-SQL seed above
+        // writes no remote signature metadata, so HasRemoteChanged treats every one of them as
+        // changed and they are re-enqueued — that is what proves upserts still apply here, not
+        // just that the connector returned something. The other 35 paths are absent from the
+        // remote and are what trips the guard.
+        var remoteFiles = Enumerable.Range(0, 5)
+            .Select(i => new ConnectorFile($"/doc-{i}.md", 1, DateTime.UtcNow, "text/markdown"))
+            .ToList();
+
+        var result = await SyncWithConnectorAsync(source, new FixedListingConnector(remoteFiles));
+
+        result.Upserted.Should().Be(5,
+            "a source that trips the guard must keep ingesting new content, or the safety " +
+            "mechanism becomes the outage it exists to prevent");
+        result.Deleted.Should().Be(0);
+        result.WithheldDeletions.Should().Be(35);
+    }
+
+    [Fact]
+    public async Task Sync_WithOverride_AfterRemoteRecovered_RecomputesAndDeletesNothing()
+    {
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        // First cycle: the listing collapses to empty and all 40 are withheld.
+        await SyncWithConnectorAsync(source, new EmptyListingConnector());
+
+        // Second cycle, with the override: the remote has recovered and reports all 40 files
+        // again. An implementation that stored and replayed the vanished set from the first
+        // cycle would delete all 40 here; one that recomputes deletes nothing.
+        var allFiles = Enumerable.Range(0, 40)
+            .Select(i => new ConnectorFile($"/doc-{i}.md", 1, DateTime.UtcNow, "text/markdown"))
+            .ToList();
+
+        var result = await SyncWithConnectorAsync(
+            source, new FixedListingConnector(allFiles), applyWithheldDeletions: true);
+
+        result.Deleted.Should().Be(0,
+            "approving re-runs the sync rather than replaying the earlier list, so a remote " +
+            "that recovered in the meantime must delete nothing");
+        result.WithheldDeletions.Should().Be(0);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().HaveCount(40);
     }
 
     [Fact]

--- a/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
@@ -147,7 +147,13 @@ public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
         await SeedDocumentsAsync(source.Id, count: 40);
 
         await SyncWithConnectorAsync(source, new EmptyListingConnector());
-        var result = await SyncWithConnectorAsync(source, new EmptyListingConnector(), applyWithheldDeletions: true);
+
+        // Reloaded, because the approval path reads the withheld count off the source it is
+        // given and the first cycle only wrote it to the database. Both real callers — the
+        // sync route and the Sources page — load the source immediately before syncing, so
+        // passing the stale object here would test something no caller does.
+        var reloaded = await ReloadAsync(source.Id);
+        var result = await SyncWithConnectorAsync(reloaded, new EmptyListingConnector(), applyWithheldDeletions: true);
 
         result.Deleted.Should().Be(40);
         result.WithheldDeletions.Should().Be(0);
@@ -279,5 +285,96 @@ public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
         using var doc = System.Text.Json.JsonDocument.Parse(body);
         doc.RootElement.GetProperty("withheldDeletions").ValueKind
             .Should().Be(System.Text.Json.JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task Sync_WithOverrideButNothingWithheld_StillAppliesTheGuard()
+    {
+        // The flag must not lift a guard that never tripped. Otherwise a caller passing
+        // applyWithheldDeletions=true on a source's very first sync bypasses the guard
+        // entirely, and nobody ever sees a count to approve.
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        var result = await SyncWithConnectorAsync(
+            source, new EmptyListingConnector(), applyWithheldDeletions: true);
+
+        result.Deleted.Should().Be(0, "no approval exists, so the guard still applies");
+        result.WithheldDeletions.Should().Be(40);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().HaveCount(40);
+    }
+
+    [Fact]
+    public async Task Sync_WithOverride_AfterRemoteDegradedFurther_WithholdsAgain()
+    {
+        // The asymmetry in "recompute rather than replay": recomputing is safer when the
+        // remote recovered, and *more* dangerous when it degraded further. An administrator
+        // shown 20 must not have 40 applied because the listing worsened between reading the
+        // number and pressing the button. The approval is a ceiling, not a licence.
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        // First cycle: half the files are still visible, so 20 vanish and are withheld.
+        var stillPresent = Enumerable.Range(0, 20)
+            .Select(i => new ConnectorFile($"/doc-{i}.md", 1, DateTime.UtcNow, "text/markdown"))
+            .ToList();
+
+        var withheld = await SyncWithConnectorAsync(source, new FixedListingConnector(stillPresent));
+        withheld.WithheldDeletions.Should().Be(20, "20 of 40 vanished, which trips the guard");
+
+        // The administrator approves those 20 — but by the time the cycle runs, the remote has
+        // gone completely dark and all 40 now look deleted.
+        var reloaded = await ReloadAsync(source.Id);
+        var approval = await SyncWithConnectorAsync(
+            reloaded, new EmptyListingConnector(), applyWithheldDeletions: true);
+
+        approval.Deleted.Should().Be(0, "40 exceeds the 20 that were approved");
+        approval.WithheldDeletions.Should().Be(40, "the larger set is re-withheld for fresh approval");
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().HaveCount(40);
+    }
+
+    [Fact]
+    public async Task Sync_WithOverride_AfterRemotePartlyRecovered_AppliesTheSmallerSet()
+    {
+        // The other side of the ceiling: fewer deletions than approved is within what the
+        // administrator sanctioned, so it applies rather than needing a second approval.
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        var withheld = await SyncWithConnectorAsync(source, new EmptyListingConnector());
+        withheld.WithheldDeletions.Should().Be(40);
+
+        var mostReturned = Enumerable.Range(0, 35)
+            .Select(i => new ConnectorFile($"/doc-{i}.md", 1, DateTime.UtcNow, "text/markdown"))
+            .ToList();
+
+        var reloaded = await ReloadAsync(source.Id);
+        var approval = await SyncWithConnectorAsync(
+            reloaded, new FixedListingConnector(mostReturned), applyWithheldDeletions: true);
+
+        approval.Deleted.Should().Be(5, "5 is within the 40 approved");
+        approval.WithheldDeletions.Should().Be(0);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Re-reads a source so its <c>WithheldDeletions</c> reflects the previous cycle. The
+    /// approval path reads that count off the passed-in source, and both real callers load it
+    /// fresh immediately before syncing.
+    /// </summary>
+    private async Task<Source> ReloadAsync(Guid sourceId)
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        return (await sources.GetAsync(sourceId))!;
     }
 }

--- a/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
@@ -1,0 +1,48 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
+{
+    private static string ShortName(string prefix) => $"{prefix}-{Guid.NewGuid():N}"[..20];
+
+    private async Task<Source> SeedSourceAsync()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+
+        var connection = await connections.CreateAsync(
+            new CreateConnectionRequest(ShortName("conn"), ConnectionProvider.S3, """{"region":"us-east-1"}"""),
+            createdByUserId: null);
+
+        return await sources.CreateAsync(
+            new CreateSourceRequest(ShortName("src"), connection.Id, """{"bucketName":"b"}"""));
+    }
+
+    [Fact]
+    public async Task UpdateWithheldDeletionsAsync_RoundTripsTheCount()
+    {
+        var source = await SeedSourceAsync();
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+
+        (await sources.GetAsync(source.Id))!.WithheldDeletions
+            .Should().BeNull("a source with nothing pending must not claim a count of zero");
+
+        await sources.UpdateWithheldDeletionsAsync(source.Id, 42);
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().Be(42);
+
+        // Clearing must return to null, not zero: the UI distinguishes "nothing pending"
+        // from "a decision was made", and zero would leave the button showing forever.
+        await sources.UpdateWithheldDeletionsAsync(source.Id, null);
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().BeNull();
+    }
+}

--- a/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
@@ -168,4 +168,38 @@ public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
         await sources.UpdateWithheldDeletionsAsync(source.Id, null);
         (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().BeNull();
     }
+
+    [Fact]
+    public async Task GetSource_AfterWithholding_ReportsTheCount()
+    {
+        var source = await SeedSourceAsync();
+
+        using (var scope = fixture.Factory.Services.CreateScope())
+        {
+            var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+            await sources.UpdateWithheldDeletionsAsync(source.Id, 40);
+        }
+
+        var response = await fixture.AdminClient.GetAsync($"/api/sources/{source.Id}");
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = System.Text.Json.JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("withheldDeletions").GetInt32().Should().Be(40);
+    }
+
+    [Fact]
+    public async Task GetSource_WithNothingWithheld_ReportsNull()
+    {
+        // Null rather than 0, because the page keys the approval button off "is there a
+        // pending decision" — a zero would leave it showing forever.
+        var source = await SeedSourceAsync();
+
+        var response = await fixture.AdminClient.GetAsync($"/api/sources/{source.Id}");
+        var body = await response.Content.ReadAsStringAsync();
+
+        using var doc = System.Text.Json.JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("withheldDeletions").ValueKind
+            .Should().Be(System.Text.Json.JsonValueKind.Null);
+    }
 }

--- a/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
@@ -1,7 +1,11 @@
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Storage.Data;
+using Connapse.Web.Services;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Connapse.Integration.Tests;
@@ -24,6 +28,125 @@ public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
 
         return await sources.CreateAsync(
             new CreateSourceRequest(ShortName("src"), connection.Id, """{"bucketName":"b"}"""));
+    }
+
+    /// <summary>
+    /// Inserts <paramref name="count"/> source-owned documents directly via SQL, following the
+    /// raw-insert pattern in OwnerBridgeSchemaTests: <c>IDocumentStore.StoreAsync</c> always
+    /// populates <c>container_id</c> and so cannot express a source-owned row.
+    /// </summary>
+    private async Task SeedDocumentsAsync(Guid sourceId, int count)
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var context = await dbFactory.CreateDbContextAsync();
+
+        for (int i = 0; i < count; i++)
+        {
+            string path = $"/doc-{i}.md";
+            await context.Database.ExecuteSqlRawAsync(
+                "INSERT INTO documents (id, container_id, source_id, file_name, path, content_hash, size_bytes, created_at) "
+                + "VALUES ({0}, NULL, {1}, {2}, {3}, '', 1, now())",
+                Guid.NewGuid(), sourceId, $"doc-{i}.md", path);
+        }
+    }
+
+    /// <summary>
+    /// Hands the service a fixed connector, following <c>FixedConnectorFactory</c> in
+    /// SourceSyncIntegrationTests, which exists for exactly this purpose.
+    /// </summary>
+    private sealed class FixedConnectorFactory(IConnector connector) : IConnectorFactory
+    {
+        public IConnector Create(Source source, Connection connection) => connector;
+    }
+
+    private async Task<SourceSyncResult> SyncWithConnectorAsync(
+        Source source, IConnector connector, bool applyWithheldDeletions = false)
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+        var connection = (await connections.GetAsync(source.ConnectionId))!;
+
+        var service = new SourceSyncService(
+            scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>(),
+            new FixedConnectorFactory(connector),
+            scope.ServiceProvider.GetRequiredService<IIngestionQueue>(),
+            scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<SourceSyncService>());
+
+        return await service.SyncSourceAsync(
+            source, connection, CancellationToken.None, applyWithheldDeletions);
+    }
+
+    /// <summary>
+    /// A connector whose listing is empty, without erroring — the shape a narrowed bucket
+    /// policy or an unmounted directory actually takes. Before the guard this deleted every
+    /// document the source owned.
+    /// </summary>
+    private sealed class EmptyListingConnector : IConnector
+    {
+        public ConnectorType Type => ConnectorType.S3;
+        public bool SupportsLiveWatch => false;
+        public string ResolveJobPath(string relativePath) => "/" + relativePath.TrimStart('/');
+        public Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<ConnectorFile>>([]);
+        public Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
+            => Task.FromResult<Stream>(new MemoryStream());
+        public Task<bool> ExistsAsync(string path, CancellationToken ct = default) => Task.FromResult(false);
+        public IAsyncEnumerable<ConnectorFileEvent> WatchAsync(CancellationToken ct = default)
+            => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task Sync_ListingCollapsesToEmpty_WithholdsDeletionsAndKeepsDocuments()
+    {
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        var result = await SyncWithConnectorAsync(source, new EmptyListingConnector());
+
+        result.Deleted.Should().Be(0, "an empty listing is not evidence that 40 files were deleted");
+        result.WithheldDeletions.Should().Be(40);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().HaveCount(40);
+
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().Be(40);
+    }
+
+    [Fact]
+    public async Task Sync_WithOverride_AppliesTheWithheldDeletions()
+    {
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        await SyncWithConnectorAsync(source, new EmptyListingConnector());
+        var result = await SyncWithConnectorAsync(source, new EmptyListingConnector(), applyWithheldDeletions: true);
+
+        result.Deleted.Should().Be(40);
+        result.WithheldDeletions.Should().Be(0);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().BeEmpty();
+
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        (await sources.GetAsync(source.Id))!.WithheldDeletions
+            .Should().BeNull("the pending decision is resolved, so the button must stop showing");
+    }
+
+    [Fact]
+    public async Task Sync_SmallDeletionSet_AppliesWithoutWithholding()
+    {
+        // Five of five is below the floor: small sources must stay able to tidy themselves.
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 5);
+
+        var result = await SyncWithConnectorAsync(source, new EmptyListingConnector());
+
+        result.Deleted.Should().Be(5);
+        result.WithheldDeletions.Should().Be(0);
     }
 
     [Fact]

--- a/tests/Connapse.Integration.Tests/SourcesEndpointsTests.cs
+++ b/tests/Connapse.Integration.Tests/SourcesEndpointsTests.cs
@@ -5,8 +5,10 @@ using System.Text.Json;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Identity.Data.Entities;
+using Connapse.Storage.Data;
 using FluentAssertions;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -113,6 +115,35 @@ public class SourcesEndpointsTests(SharedWebAppFixture fixture) : IAsyncLifetime
             name = name ?? ShortName("src"),
             connectionId,
             scopeJson = """{"bucketName":"b","prefix":"team/"}""",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return created.GetProperty("id").GetGuid();
+    }
+
+    /// <summary>
+    /// A filesystem connection rooted at a real local directory, used where a sync test needs
+    /// the route to reach a working connector rather than time out against a fake S3 region.
+    /// </summary>
+    private async Task<Guid> SeedFilesystemConnectionAsync(string rootPath)
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+        string configJson = JsonSerializer.Serialize(new { allowedRoot = rootPath });
+        var connection = await connections.CreateAsync(
+            new CreateConnectionRequest(ShortName("fsconn"), ConnectionProvider.Filesystem, configJson),
+            createdByUserId: null);
+        return connection.Id;
+    }
+
+    private async Task<Guid> CreateFilesystemSourceAsync(Guid connectionId, string? name = null)
+    {
+        var response = await Admin.PostAsJsonAsync("/api/sources", new
+        {
+            name = name ?? ShortName("src"),
+            connectionId,
+            scopeJson = "{}",
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -321,6 +352,85 @@ public class SourcesEndpointsTests(SharedWebAppFixture fixture) : IAsyncLifetime
         var response = await Admin.PostAsync($"/api/sources/{sourceId}/sync", null);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SyncSource_EnabledWithNoQueryString_BindsSuccessfully()
+    {
+        // A non-nullable [FromQuery] parameter with no default makes minimal-API binding fail
+        // before the handler runs, which also produces 400 — the same status the disabled
+        // check above returns. The source here is enabled, so a 400 can only mean binding
+        // failed, unlike the test above where a 400 is ambiguous.
+        string root = Directory.CreateTempSubdirectory("connapse-sync-test-").FullName;
+        try
+        {
+            Guid connectionId = await SeedFilesystemConnectionAsync(root);
+            Guid sourceId = await CreateFilesystemSourceAsync(connectionId);
+
+            var response = await Admin.PostAsync($"/api/sources/{sourceId}/sync", null);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK,
+                "an enabled source with no query string must reach the handler, not fail binding");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SyncSource_ApplyWithheldDeletionsTrue_ReachesTheOverridePathAndReportsWithheldCount()
+    {
+        string root = Directory.CreateTempSubdirectory("connapse-sync-test-").FullName;
+        try
+        {
+            Guid connectionId = await SeedFilesystemConnectionAsync(root);
+            Guid sourceId = await CreateFilesystemSourceAsync(connectionId);
+            await SeedSourceDocumentsAsync(sourceId, count: 40);
+
+            // The directory is empty, so all 40 documents vanish — well past the guard's
+            // threshold — and the default (no query string) call must withhold rather than
+            // delete them.
+            var withheldResponse = await Admin.PostAsync($"/api/sources/{sourceId}/sync", null);
+            withheldResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            var withheldBody = await withheldResponse.Content.ReadFromJsonAsync<JsonElement>();
+            withheldBody.GetProperty("deleted").GetInt32().Should().Be(0);
+            withheldBody.GetProperty("withheldDeletions").GetInt32().Should().Be(40,
+                "the sync response is the one place an admin sees why deletions were withheld");
+
+            // ?applyWithheldDeletions=true must reach the override path and actually apply them.
+            var appliedResponse = await Admin.PostAsync(
+                $"/api/sources/{sourceId}/sync?applyWithheldDeletions=true", null);
+            appliedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            var appliedBody = await appliedResponse.Content.ReadFromJsonAsync<JsonElement>();
+            appliedBody.GetProperty("deleted").GetInt32().Should().Be(40);
+            appliedBody.GetProperty("withheldDeletions").GetInt32().Should().Be(0);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Inserts <paramref name="count"/> source-owned documents directly via SQL, following the
+    /// raw-insert pattern in DeleteGuardIntegrationTests: <c>IDocumentStore.StoreAsync</c>
+    /// always populates <c>container_id</c> and so cannot express a source-owned row.
+    /// </summary>
+    private async Task SeedSourceDocumentsAsync(Guid sourceId, int count)
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var context = await dbFactory.CreateDbContextAsync();
+
+        for (int i = 0; i < count; i++)
+        {
+            string path = $"/doc-{i}.md";
+            await context.Database.ExecuteSqlRawAsync(
+                "INSERT INTO documents (id, container_id, source_id, file_name, path, content_hash, size_bytes, created_at) "
+                + "VALUES ({0}, NULL, {1}, {2}, {3}, '', 1, now())",
+                Guid.NewGuid(), sourceId, $"doc-{i}.md", path);
+        }
     }
 
     // ── No enumeration surface ────────────────────────────────────────────


### PR DESCRIPTION
Closes #384. First PR into the `epic/sftp-ingestion` integration branch — **not** into `main`.

Part 1 of `docs/superpowers/specs/2026-08-23-sftp-ingestion-and-delete-guard-design.md`. Ships on its own because it fixes shipped behaviour, and because SFTP is list-and-diff and would otherwise be built on the unsafe reconcile.

## The bug

`SourceSyncService.SyncViaListAndDiffAsync` deleted every indexed path absent from a remote listing, with no check that the listing was trustworthy. **An empty-but-successful listing deleted the source''s entire index.** S3 propagates exceptions mid-pagination, but a narrowed bucket policy returning `200 OK` with zero keys does not throw — and neither does a filesystem directory that is temporarily unmounted.

**This was verified reproducing, not assumed.** The implementer''s pre-fix run failed to *compile* rather than fail, so the bug was never actually observed. A reviewer then neutralised `DeletionGuard.ShouldWithhold` to return false and watched the test fail with `Expected result.Deleted to be 0 ... but found 40`, then restored it and watched it pass. That experiment is the evidence this PR rests on.

## The guard

```csharp
vanished > 10 && vanished > indexed / 10
```

Both terms are load-bearing. A percentage alone fires constantly on small sources — three of five files is 60%. An absolute alone is meaningless on large ones — ten of a hundred thousand is noise. Requiring both means a five-document source can still tidy itself, and a hundred-thousand-document source is protected proportionally.

Three properties worth stating, each with a test:

- **Additions still apply.** A source that trips the guard keeps ingesting. A safety check that stops a source working is the outage it exists to prevent.
- **Approving recomputes, never replays.** Only the count is stored, never the paths. If the remote recovered in the meantime, the re-run finds the files present and deletes nothing.
- **Withheld is a count, not a `SyncStatus`.** A sync that upserted 50 and declined to delete 400 genuinely succeeded; overloading the status is how "withheld" gets treated as failure.

The threshold is fixed and deliberately not configurable — the only escape is an admin pressing **Apply deletions** on that source.

## What the final review caught that five per-task reviews missed

`[FromQuery] bool applyWithheldDeletions` with no default makes the parameter **required** in minimal APIs, so `POST /api/sources/{id}/sync` returned **400 for every existing caller** — scripts, and `connapse-cli`. The Blazor page was unaffected because it calls the service directly, which is why manual testing missed it.

The one test touching that route asserted `BadRequest` because its source was *disabled*. Binding now failed for an unrelated reason and produced the same status code, so **the test passed vacuously**. The new test uses an enabled source, so a 400 can only mean binding failed.

The same review found that neither "additions still apply" nor "recomputes rather than replays" was pinned by any test — an implementation that returned early before `EnqueueAllAsync`, or one that stored and replayed the vanished paths, would have passed the entire suite. Both now have tests that fail against those wrong implementations.

## Testing

`dotnet test` — **1,156 passed, 0 failed.**

Verified by hand and worth repeating before merge, since the UI has no test harness: index a source, empty its bucket, confirm the amber row and the count; put the files back and press **Apply deletions**, confirming nothing is deleted; and add a file while deletions are withheld, confirming it still ingests.

## Not in this PR

All of SFTP — Part 2 of the spec. Also parked deliberately: the two non-atomic writes in the reconcile (harmless, since approving recomputes), a redundant round-trip when writing null over null, and the delta path, which the guard does not apply to and which has no implementer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)