### PR TITLE
feat(web): SFTP connection form, host-key display, and docs

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -47,6 +47,7 @@ There is no secret field on a connection form, because Connapse does not accept 
 - **S3** authenticates through the AWS default credential chain — an instance profile, an IRSA role, or an SSO session. `roleArn` optionally names a role to assume on top of that.
 - **Azure Blob** authenticates through `DefaultAzureCredential` — a managed identity, a workload identity, or a developer sign-in. `managedIdentityClientId` optionally selects a specific user-assigned identity.
 - **Filesystem** has no credential at all; it runs as whatever account the server runs as.
+- **SFTP** is the one exception, and it is a narrow one: an SSH private key, encrypted at rest with the same DataProtection machinery everything else uses. The rule this does not break is about **cloud identities** — an AWS access key or an Azure secret is a credential a cloud provider already offers a better answer for, and Connapse refuses to be the worse one. An SSH key for a machine you run has no such alternative.
 
 The consequence worth internalising: **rotating credentials is an operation you perform in AWS or Azure, and Connapse needs no involvement.** There is nothing stored here to rotate.
 
@@ -79,6 +80,20 @@ The consequence worth internalising: **rotating credentials is an operation you 
   "allowedRoot": "/srv/knowledge"
 }
 ```
+
+**SFTP**
+
+```json
+{
+  "host": "files.example.com",
+  "port": 22,
+  "username": "connapse",
+  "allowedRoot": "/srv/knowledge",
+  "hostKeyFingerprint": "SHA256:…"
+}
+```
+
+`hostKeyFingerprint` is not typed. Connapse records it on the first successful connection and refuses every later one that does not match — see [Host keys](#host-keys).
 
 ### The two allowlists
 
@@ -115,6 +130,35 @@ Two limits an operator has to handle outside Connapse, because no path check can
 
 Run the server under a low-privilege account, and keep configuration and the DataProtection key ring outside every configured root.
 
+### SFTP confinement
+
+An SFTP source's `subPath` is confined the same way, with one difference that matters: **resolution happens on the server.**
+
+`allowedRoot` names a directory on a machine that is not the one running Connapse, so resolving it locally would answer a question about the wrong filesystem — and answer it permissively, because a remote path almost never exists locally and a link check that finds nothing reports no link. That degrades confinement to a string-prefix comparison, which is exactly the bug [#365](https://github.com/Destrayon/Connapse/issues/365) fixed for local paths.
+
+So SFTP paths are canonicalised through the protocol's own `SSH_FXP_REALPATH`, and `..` segments and symlinks collapse where they actually mean something before the comparison.
+
+Two related rules:
+
+- **Symlinks are stepped over during the walk, never followed.** A link inside the root whose target is outside it would otherwise pull that target into the index.
+- **A directory that cannot be read fails the whole sync**, rather than contributing nothing to the listing. This matters more than it looks: to the reconcile, a listing that quietly omits a subtree is indistinguishable from every file in it having been deleted. The [deletion guard](#deletions-are-guarded) bounds that damage, but it should not have to.
+
+`allowedRoot` for SFTP is **not** checked against `Sources:Security:AllowedFilesystemRoots`. That setting names directories on the server's own disk; an SFTP root names one on somebody else's.
+
+### Host keys
+
+SSH's protection against somebody else answering on your server's address is the host key, and it only helps if a changed key is noticed.
+
+Connapse **trusts the first key it sees and pins it.** Every later connection compares against the stored fingerprint and refuses on mismatch, naming both keys. The fingerprint is shown on the connection in the format `ssh-keygen` prints, so it can be checked against the server directly:
+
+```bash
+ssh-keyscan files.example.com | ssh-keygen -lf -
+```
+
+Trust-on-first-use does not authenticate the *first* connection — that is its standing trade-off, and the reason the fingerprint is displayed rather than hidden. What it does catch is the realistic case: an address that has been working for months starts answering with a different key.
+
+**If you rekey the server yourself**, syncing stops with a mismatch error. Clear the recorded fingerprint on the connection — the "Forget" control beside it — and the next connection pins the new key.
+
 ---
 
 ## Sources
@@ -137,6 +181,7 @@ Scope keys by provider:
 | S3 | `bucketName`, `prefix` |
 | Azure Blob | `containerName`, `prefix` |
 | Filesystem | `subPath`, `includePatterns`, `excludePatterns` |
+| SFTP | `subPath`, `includePatterns`, `excludePatterns` |
 
 ### API
 
@@ -185,6 +230,25 @@ The threshold is fixed and not configurable. Small sources are never blocked —
 The guard bounds a single reconcile, not the source's history. A listing that persistently returns just under the threshold — say 9% missing every cycle — never trips it, and the index erodes a little on every sync.
 
 ---
+
+## Indexing files on your own machine
+
+The Filesystem connector needs the server process to see a path on its own disk. In Docker the container's filesystem is not yours, and on a hosted deployment there is no shared disk at all — so "point Connapse at my Documents folder" has no answer through that connector.
+
+SFTP is the answer. Run an SSH server on the machine holding the files and let Connapse connect to it.
+
+1. **Enable an SSH server.** OpenSSH Server is an optional feature on Windows, Remote Login on macOS, `sshd` on Linux.
+2. **Add a public key** to that account's `authorized_keys`, and give Connapse the matching private key.
+3. **Create an SFTP connection** under Settings → Connections, pointing at the machine with an `allowedRoot` of the folder you want reachable.
+4. **Create a source** on that connection naming a `subPath` within it.
+
+Three things worth knowing before you spend an hour on them:
+
+- **Windows OpenSSH presents paths with a leading slash before the drive letter** — `/C:/Users/you/Documents`, not `C:\Users\you\Documents`. Write `allowedRoot` that way.
+- **`host.docker.internal` is Docker Desktop only.** From a container on Docker Desktop, that name reaches the host. On a Linux host, add `--add-host=host.docker.internal:host-gateway`. On a remote deployment it does not apply at all — the server needs a real address it can reach, and making the machine reachable is your problem, not Connapse's.
+- **It is list-and-diff on every poll.** SFTP has no change notification, so each cycle walks the tree. Point a source at a folder, not a whole drive; at a hundred thousand files a scan is minutes.
+
+The Filesystem connector is unchanged and remains the better choice when the server genuinely does share a disk with the data — it is cheaper and it supports live watching.
 
 ## Why the split
 

--- a/docs/research/docker-local-filesystem-access-2026-08-23.md
+++ b/docs/research/docker-local-filesystem-access-2026-08-23.md
@@ -1,0 +1,175 @@
+# How should Connapse in Docker reach files on the operator's own machine?
+
+**Date:** 2026-08-23
+**Status:** Complete
+**Supersedes nothing.** Narrows a question [the earlier report](filesystem-ingestion-2026-08-23.md) answered under an assumption that no longer holds.
+
+## Why this is a second report
+
+The earlier research asked *"which pull protocol should Connapse speak?"* and recommended SFTP for the local case. That framing had already ruled out mounting the host's disk into the container — brainstorming rejected bind mounts as "a security concern and poor UX" before any research began, so every option surveyed was a network protocol by construction.
+
+The new constraint — **everything must be configurable in the UI** — makes that exclusion worth re-testing rather than inheriting. A protocol needs a server and a credential set up per connection, forever. A mount is configured once and then never again. Against a "no terminal" requirement those trade in opposite directions, so the answer can change.
+
+## The hard constraint
+
+**A container's filesystem namespace is fixed when the container is created.** Adding a bind mount to a running container means stopping it, removing it, and creating a new one with the full mount set ([docker/cli#5328](https://github.com/docker/cli/issues/5328), [moby#11105](https://github.com/moby/moby/issues/11105)). This is a property of how containers work, not a Docker limitation awaiting a feature.
+
+**Docker Desktop does not expose host drives automatically.** Verified directly: `docker run --rm alpine ls /` on this machine shows no `/host_mnt` and no host paths. Drive sharing in Docker Desktop settings makes a path *mountable*, not mounted.
+
+So no application running inside a container can grant itself access to a host path it was not given. Every solution is one of four families.
+
+## The four families
+
+### 1. Mount once at deployment, choose paths in the UI
+
+Mount a broad host path read-only when the container is created; afterwards every source is configured in the UI within it.
+
+This is what comparable self-hosted products do, and [Immich's external library flow](https://oneuptime.com/blog/post/2026-03-20-photo-gallery-portainer/view) is the closest match to Connapse's model: uncomment an optional bind mount, then add the path in the admin panel and scan. [Paperless-ngx](https://docs.paperless-ngx.com/setup/) is the same shape — the consumption directory is a compose volume, and everything else is application configuration.
+
+It maps onto Connapse's existing split without inventing anything:
+
+| Layer | Who sets it | Connapse concept |
+|---|---|---|
+| What the container can see at all | Deployment, once | the bind mount |
+| Which roots an admin may name | `Sources:Security:AllowedFilesystemRoots` | connection `allowedRoot` |
+| Which subtree gets indexed | Admin, in the UI, any number of times | source `subPath` |
+
+**Cost:** one line in `docker-compose.yml` and a `docker compose up -d`. No new code, no credential of any kind, no server on the host.
+
+### 2. Speak a network protocol to a server on the host
+
+SFTP, SMB, or WebDAV. Nothing in the container's configuration changes; the host runs a server and Connapse authenticates to it.
+
+Covered in depth by the earlier report. The relevant update is what is **already true on this machine** (all verified directly):
+
+| | Status |
+|---|---|
+| `sshd` service | **Running**, automatic start |
+| `Subsystem sftp` | **Configured** (`sftp-server.exe`) |
+| `PubkeyAuthentication` | **yes** |
+| `authorized_keys` | **Present**, both user and administrators paths |
+| Port 22 from a container | **Open** via `host.docker.internal` |
+| `LanmanServer` (SMB) | **Running**, shares `C$`, `D$`, `ADMIN$` |
+| Port 445 from a container | **Open** |
+
+SFTP is therefore about one step from working here: generate a key pair and add the public half to `authorized_keys`. [#392](https://github.com/Destrayon/Connapse/issues/392) removes the terminal from the first half of that.
+
+**SMB is worse here despite being equally reachable.** The shares that exist are `C$` and `D$`, which are administrative shares — reaching them means storing a Windows *administrator* password. SMBLibrary is also NTLM-only and LGPL-3.0. Trading an SSH key scoped to one account for an administrator password is a clear downgrade.
+
+### 3. Push from the host to Connapse
+
+An agent, a sync tool, or the existing upload UI. The earlier report rejected a purpose-built agent on distribution and signing cost, and that stands.
+
+Worth noting the honest zero-infrastructure member of this family: **Connapse already accepts uploads into managed containers through the UI.** That is fully UI-driven with nothing to install. It is copy-in rather than sync — files do not track changes on disk — but for a fixed corpus it is the shortest path that exists today.
+
+### 4. Do not run Connapse in a container
+
+If Connapse runs natively on the machine holding the files, the Filesystem connector works with real paths. No mount, no server, no credential, no key.
+
+This deserves stating plainly because the entire problem is an artefact of the deployment choice. For a single-user local install it is the simplest answer available, and it is the one configuration where "point it at a folder" needs nothing else at all.
+
+## The tempting answer, and why it is wrong
+
+The obvious way to make mounts UI-configurable is to give Connapse the Docker socket so it can recreate its own container with new mounts.
+
+**Do not do this under any circumstances.** Access to `/var/run/docker.sock` is [root-equivalent on the host](https://www.netdata.cloud/guides/docker/docker-socket-security/): anything that can talk to the daemon can create a container that mounts `/` and execute as root. Mounting the socket read-only does not help, because the restriction is on the filesystem handle and not on the API it exposes.
+
+The mount boundary exists to stop a compromised Connapse reading arbitrary host files. Handing Connapse the ability to move that boundary hands it root on the machine — strictly worse than the exposure it was meant to bound. **This is the principled reason the mount stays a deployment concern: it is the one decision the application must not be able to make about itself.**
+
+## Recommendation
+
+**For the local case, mount once and read-only. For the remote case, SFTP.** They are not competitors; they answer different questions.
+
+The "everything in the UI" requirement is satisfied in the sense that matters: **all recurring work is in the UI.** Adding a source, changing a subpath, adding a second folder inside the mount, excluding a pattern — every one of those is a UI action. What remains outside is a single line set once at install, and it is outside precisely because it is the security boundary.
+
+Concretely, mount the profile rather than a whole drive:
+
+```yaml
+    volumes:
+      - appdata:/app/appdata
+      - C:/Users/Diviel:/mnt/host:ro
+```
+
+`:ro` costs nothing, since Connapse never writes to a source, and removes an entire class of accident. Then set `Sources:Security:AllowedFilesystemRoots` to `/mnt/host` so the allowlist and the mount agree, and every connection is bounded twice.
+
+**SFTP is still worth finishing**, and not as a consolation. It is the only option in the list that works when the files are on a machine Connapse does not share hardware with — a NAS, a work laptop, a hosted deployment — and on this machine it is one paste away from working.
+
+## What Connapse should change
+
+1. **Ship the bind mount commented out in `docker-compose.yml`**, with the target path and `:ro` already written, exactly as Immich does. This turns the one-time step from "know that this is possible and write it correctly" into "uncomment a line". Filed as [#393](https://github.com/Destrayon/Connapse/issues/393).
+2. **Say this in `docs/connectors.md`.** The document currently explains that the Filesystem connector needs a shared disk without telling anyone how to arrange one.
+3. **Finish [#392](https://github.com/Destrayon/Connapse/issues/392)** so the SFTP path needs no terminal either.
+
+## Addendum — optimising for operator setup cost
+
+The first pass asked what *works*. This pass asks what costs the operator least, which turns out to have a different answer, because the browser is a route none of the four families covers.
+
+### The category has not solved this, and says so out loud
+
+[AnythingLLM](https://docs.anythingllm.com/installation-docker/overview) is the closest comparable product, and it ships **two builds**: a desktop app — one-click, single-user, direct filesystem access, no configuration — and a Docker build for teams that adds roles and access control. The split is not accidental. Their Docker users have been asking for exactly this since at least [#1873](https://github.com/Mintplex-Labs/anything-llm/issues/1873) and [#4877](https://github.com/Mintplex-Labs/anything-llm/issues/4877) (watch folders), and the community answer is a [third-party Python sync script](https://github.com/dastra/anythingllm-document-sync).
+
+The instructive one is [#3640](https://github.com/Mintplex-Labs/anything-llm/issues/3640): a user who **already mounted their NAS into the container** and still could not use it, because the UI offered no way to point at an existing directory. Their native sync feature watches individual files and [cannot watch a directory at all](https://docs.anythingllm.com/beta-preview/active-features/live-document-sync).
+
+**Connapse is ahead of this, not behind it.** The connection/source split already expresses "here is a root, index this subtree of it" — the exact thing #3640 wanted and could not find. What is missing is only the mount, and the documentation for it.
+
+### The route none of the four families covers: the browser
+
+The container cannot see the host's disk, but **the operator's browser can**, and it is already talking to Connapse.
+
+**`<input type="file" webkitdirectory>`** lets a user pick a whole folder from a native dialog; the browser then hands over every file beneath it, with the relative path on each as `webkitRelativePath`. It reached [Baseline in 2025](https://caniuse.com/input-file-directory) and works in Chrome, Edge, Firefox, and Safari 11.1+ — everything except iOS Safari. There is no permission API, no flag, and nothing to install.
+
+**Setup cost: none.** Not "one line in a compose file" — actually none. The operator opens Connapse, clicks a button, picks a folder.
+
+Connapse is most of the way there already and does not know it. `wwwroot/js/fileDrop.js` uploads via `fetch()` and `FormData`, which is the right shape — but it reads `e.dataTransfer.files`, so **dropping a folder does not work today**. Directory drops need `webkitGetAsEntry()` and a recursive walk; folder *picking* needs the attribute above. Both are small, and both feed the upload path that already exists.
+
+**What it does not do is stay in sync.** This is an import, into a managed container, and refreshing means importing again. That is a real limitation and it is also the honest shape of the thing: once the bytes are uploaded, Connapse owns them, which is exactly what a container is. It suits "index my documents" and does not suit "mirror a folder that changes".
+
+Practical ceiling: this is a browser upload, so a few thousand files is comfortable and a hundred thousand is not.
+
+### The File System Access API, and why not
+
+[`showDirectoryPicker()`](https://developer.chrome.com/docs/capabilities/web-apis/file-system-access) is the more powerful version — a directory handle that can be stored in IndexedDB and re-used, with [persistent permissions since Chrome 122](https://developer.chrome.com/blog/persistent-permissions-for-the-file-system-access-api) that survive a browser restart. It would allow genuine re-sync with no setup.
+
+**It is the wrong fit anyway, for a reason that has nothing to do with browser support.** Connapse syncs from a background service on a timer. A directory handle only lives in a page — so a source backed by one can only reconcile while somebody has the tab open, and Chrome auto-revokes on tab backgrounding besides. A "source" that silently stops syncing when you close the tab is worse than an import that never claimed to.
+
+It is also Chromium-only (no Firefox, no Safari), where `webkitdirectory` is Baseline. More work, narrower support, and a sync model that does not match the product.
+
+### Revised recommendation
+
+Three answers for three shapes of need, and the cheapest one covers most people:
+
+| Need | Answer | Operator setup |
+|---|---|---|
+| "Get my documents in" | **Folder upload in the browser** | **None** |
+| "Mirror a folder that keeps changing" | Bind mount, read-only | One line, once |
+| "Files are on another machine" | SFTP | SSH server + key |
+| Single machine, no Docker wanted | Native install | None; connector works as-is |
+
+**Build the folder upload.** It is the smallest change of the four, it needs nothing from the user, it works in every desktop browser, and it reuses an upload path that already exists. Filed as [#394](https://github.com/Destrayon/Connapse/issues/394).
+
+The mount stays the answer for continuous sync and should be [shipped commented-out](https://github.com/Destrayon/Connapse/issues/393) so it is an uncomment rather than a thing to know. SFTP stays the answer for another machine. And AnythingLLM's split is worth taking seriously as positioning: **Docker is the deployment for teams and servers; a single user indexing their own laptop has a simpler option, and Connapse should say so rather than making them fight the container.**
+
+## What this does not solve
+
+- **Files on a machine that is off, asleep, or behind NAT.** Unchanged from the earlier report, and still deliberately the operator's problem.
+- **A mount is as broad as you make it.** Mounting `C:/` gives every source in Connapse a potential view of the whole drive, bounded only by `AllowedFilesystemRoots`. The narrower the mount, the less the allowlist has to carry.
+- **Changing which folder is mounted still requires a container recreate.** Choosing a *sub*path does not. Mount broadly enough that the sub-path choice is the one you actually make.
+
+## Verification log
+
+Everything asserted about this machine was checked rather than assumed:
+
+- `docker run --rm alpine ls /` — no host paths, no `/host_mnt`.
+- `nc -z host.docker.internal 22 / 445 / 139` from a container — 22 open, 445 open, 139 closed.
+- `Get-Service sshd, LanmanServer` — both Running, both Automatic.
+- `Get-SmbShare` — `ADMIN$`, `C$`, `D$`, `IPC$`.
+- `sshd_config` — `PubkeyAuthentication yes`, `Subsystem sftp sftp-server.exe`, `PasswordAuthentication yes`, administrators override present.
+- `authorized_keys` present at both the user and administrators locations.
+
+## Sources
+
+- [docker/cli#5328](https://github.com/docker/cli/issues/5328), [moby#11105](https://github.com/moby/moby/issues/11105) — mounts cannot be added to a running container
+- [Docker bind mounts documentation](https://docs.docker.com/engine/storage/bind-mounts.md)
+- [Docker socket security](https://www.netdata.cloud/guides/docker/docker-socket-security/), [The Dangers of Docker.sock](https://raesene.github.io/blog/2016/03/06/The-Dangers-Of-Docker.sock/)
+- [Paperless-ngx setup](https://docs.paperless-ngx.com/setup/), [Immich external libraries via Portainer](https://oneuptime.com/blog/post/2026-03-20-photo-gallery-portainer/view)
+- [Earlier report: filesystem ingestion](filesystem-ingestion-2026-08-23.md) — protocol comparison, SMBLibrary licence and NTLM limits

--- a/src/Connapse.Core/Models/StorageModels.cs
+++ b/src/Connapse.Core/Models/StorageModels.cs
@@ -1,4 +1,4 @@
-namespace Connapse.Core;
+﻿namespace Connapse.Core;
 
 public enum ConnectorType { ManagedStorage = 0, Filesystem = 1, S3 = 3, AzureBlob = 4, Sftp = 5 }
 
@@ -45,7 +45,19 @@ public record Document(
     string? Summary = null,
     DateTime? SummaryGeneratedAt = null,
     string? SummaryContentHash = null,
-    IngestionState IngestionState = IngestionState.Pending);
+    IngestionState IngestionState = IngestionState.Pending)
+{
+    /// <summary>
+    /// Which owner the row actually has. Needed because <see cref="ContainerId"/> carries
+    /// COALESCE(container_id, source_id) — it is never blank, so a source-owned document is
+    /// indistinguishable from a container-owned one by that field alone, and a caller that
+    /// guessed "container" would look up a container by a source's id and find nothing.
+    /// <para>
+    /// Null only for documents built outside the store, which have not been read from a row.
+    /// </para>
+    /// </summary>
+    public OwnerRef? Owner { get; init; }
+}
 
 public record StoreResult(string DocumentId, int Generation);
 

--- a/src/Connapse.Core/Utilities/SftpHostSetup.cs
+++ b/src/Connapse.Core/Utilities/SftpHostSetup.cs
@@ -1,0 +1,323 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>The operator's own machine, which decides what the setup command looks like.</summary>
+public enum HostPlatform { Windows, MacOS, Linux }
+
+/// <summary>
+/// What the setup command reported back. Every field comes from the host, because the host
+/// is the only place that knows it — which is the reason for the round trip at all.
+/// </summary>
+/// <param name="Username">The account the SSH server will authenticate.</param>
+/// <param name="HomePath">
+/// The home directory as SFTP presents it. On Windows that carries a leading slash before
+/// the drive letter, which is the detail that costs people an hour.
+/// </param>
+/// <param name="Fingerprint">
+/// The server's host key, read on the machine itself. Arriving out of band is what turns
+/// trust-on-first-use into verified-first-use.
+/// </param>
+/// <param name="Drives">
+/// Filesystem roots the account can reach, as SFTP paths — <c>/C:/</c>, <c>/D:/</c> and so
+/// on. Windows only; empty elsewhere, where everything already hangs off <c>/</c>.
+/// <para>
+/// Reported because the home directory is not where people keep things. A second drive is
+/// completely normal, and a flow that can only reach <c>C:</c> would be answering a question
+/// nobody asked.
+/// </para>
+/// </param>
+public record SftpHostSetupResult(
+    string Username,
+    string HomePath,
+    string Fingerprint,
+    IReadOnlyList<string>? Drives = null)
+{
+    public IReadOnlyList<string> Drives { get; init; } = Drives ?? [];
+}
+
+/// <summary>
+/// Builds the one command an operator runs on their own machine, and reads back what it
+/// reports.
+/// <para>
+/// Connapse cannot configure the host — that boundary is the entire reason the container is
+/// worth running. What it can do is everything either side of the boundary: generate the key,
+/// write the command, and consume the result. The operator copies twice and types nothing.
+/// </para>
+/// </summary>
+public static class SftpHostSetup
+{
+    /// <summary>
+    /// Delimits the block the operator pastes back. Deliberately unmistakable, because the
+    /// usual failure is pasting the whole terminal buffer, and that should still work.
+    /// </summary>
+    public const string BeginMarker = "----- BEGIN CONNAPSE SETUP -----";
+
+    public const string EndMarker = "----- END CONNAPSE SETUP -----";
+
+    /// <summary>
+    /// Options prefixed to the <c>authorized_keys</c> entry, so the installed key can do nothing
+    /// but SFTP.
+    /// </summary>
+    /// <remarks>
+    /// Without these the entry is a bare public key, which grants everything the account can do:
+    /// an interactive shell, port forwarding, agent forwarding. Connapse only ever needs to read
+    /// files, and the path confinement it applies is an <i>application</i> rule — it bounds what
+    /// Connapse does with the credential, not what the credential can do. Anyone who obtained the
+    /// stored private key would not be bound by it at all.
+    /// <para>
+    /// <c>restrict</c> (OpenSSH 7.2+) disables port forwarding, agent forwarding, X11 and PTY
+    /// allocation. <c>command</c> replaces whatever the client asks for, so a session requesting
+    /// a shell gets the SFTP server instead. Both are supported by Win32-OpenSSH as well as
+    /// portable OpenSSH.
+    /// </para>
+    /// <para>
+    /// This does not make an administrator account safe to use — the key still authenticates as
+    /// that account, and an SFTP session for an administrator can read everything on the machine.
+    /// It bounds the <i>kind</i> of access, not its reach, which is why the wizard says to prefer
+    /// a non-administrator account.
+    /// </para>
+    /// </remarks>
+    public const string KeyRestrictions = """restrict,command="internal-sftp" """;
+
+    /// <summary>
+    /// The command for <paramref name="platform"/>, with <paramref name="publicKeyLine"/>
+    /// already embedded.
+    /// </summary>
+    /// <remarks>
+    /// Meant to be read before it is run. It enables a network service and installs an
+    /// authorized key, so it is shown in full rather than offered as a download or a pipe
+    /// from a URL — the operator should be able to see exactly what they are agreeing to at
+    /// the moment they agree to it.
+    /// </remarks>
+    public static string GenerateScript(string publicKeyLine, HostPlatform platform)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(publicKeyLine);
+
+        // The key is base64 plus a sanitised comment, so it cannot contain a quote or a
+        // newline — SshKeyPairGenerator guarantees that. Asserted rather than assumed,
+        // because everything below embeds it into a shell string.
+        if (publicKeyLine.Any(c => c is '\n' or '\r' or '\'' or '"'))
+            throw new ArgumentException(
+                "A public key line cannot contain quotes or newlines.", nameof(publicKeyLine));
+
+        // The key is installed restricted, never bare. See KeyRestrictions.
+        string entry = KeyRestrictions + publicKeyLine;
+
+        return platform switch
+        {
+            HostPlatform.Windows => WindowsScript(entry),
+            HostPlatform.MacOS => UnixScript(entry, macOs: true),
+            HostPlatform.Linux => UnixScript(entry, macOs: false),
+            _ => throw new ArgumentOutOfRangeException(nameof(platform)),
+        };
+    }
+
+    private static string WindowsScript(string publicKeyLine) =>
+        $$"""
+        # Connapse — allow this computer to be indexed. Run in PowerShell as Administrator.
+        # Safe to run more than once.
+
+        # 0. Stop if not elevated, rather than half-succeeding.
+        #    Without elevation the steps below fail in ways that leave SSH looking configured
+        #    while it is not, and the symptom is an authentication failure with nothing to
+        #    explain it.
+        if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+                 ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+            Write-Host 'Run this in a PowerShell window opened with "Run as Administrator".' -ForegroundColor Red
+            return
+        }
+
+        # 1. Make sure an SSH server is installed and running.
+        if (-not (Get-Service sshd -ErrorAction SilentlyContinue)) {
+            Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 | Out-Null
+        }
+        Set-Service -Name sshd -StartupType Automatic
+        if ((Get-Service sshd).Status -ne 'Running') { Start-Service sshd }
+
+        if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
+            New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' `
+                -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
+        }
+
+        # 2. Work out which authorized_keys file sshd will actually read.
+        #    For an account in the Administrators group it is NOT the one in your profile —
+        #    sshd_config redirects those to a machine-wide file with a locked-down ACL. This
+        #    is the single most common reason Windows SSH keys silently fail to authenticate.
+        #
+        #    Asked of the group itself, not of this process's token. UAC filters the
+        #    Administrators SID out of an unelevated token, so a token check reports False for
+        #    an account that genuinely is a member — and the key would then be written where
+        #    sshd will never look.
+        $mySid = ([Security.Principal.WindowsIdentity]::GetCurrent()).User.Value
+        try {
+            $isAdmin = $null -ne (Get-LocalGroupMember -Group 'Administrators' -ErrorAction Stop |
+                                  Where-Object { $_.SID.Value -eq $mySid })
+        } catch {
+            # Domain-joined machines can refuse that cmdlet. Elevated, the token is unfiltered
+            # and this is accurate — and step 0 guarantees we are elevated.
+            $isAdmin = ([Security.Principal.WindowsIdentity]::GetCurrent()).Groups.Value -contains 'S-1-5-32-544'
+        }
+
+        if ($isAdmin) {
+            $keyFile = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'
+        } else {
+            $keyFile = Join-Path $env:USERPROFILE '.ssh\authorized_keys'
+        }
+
+        New-Item -ItemType Directory -Force -Path (Split-Path $keyFile) | Out-Null
+        if (-not (Test-Path $keyFile)) { New-Item -ItemType File -Path $keyFile | Out-Null }
+
+        # 3. Add Connapse's key, but only once, and without disturbing any other key present.
+        $key = '{{publicKeyLine}}'
+        if (-not (Select-String -Path $keyFile -SimpleMatch -Pattern $key -Quiet)) {
+            Add-Content -Path $keyFile -Value $key
+        }
+
+        if ($isAdmin) {
+            # sshd refuses to read this file unless only SYSTEM and Administrators can write it.
+            icacls $keyFile /inheritance:r /grant 'SYSTEM:F' 'Administrators:F' | Out-Null
+        }
+
+        # 4. Report back what only this machine knows.
+        #    Wrapped, because the key is already installed by this point and a failure to read
+        #    the fingerprint must not throw away a setup that otherwise worked. An empty
+        #    fingerprint costs the operator verified-first-use, not the connection.
+        $fingerprint = ''
+        try {
+            $hostKey = Get-ChildItem (Join-Path $env:ProgramData 'ssh') -Filter 'ssh_host_*_key.pub' -ErrorAction Stop |
+                       Sort-Object { $_.Name -notlike '*ed25519*' } | Select-Object -First 1
+            $line = & ssh-keygen -lf $hostKey.FullName 2>$null
+            if ($LASTEXITCODE -eq 0 -and $line) { $fingerprint = ($line -split ' ')[1] }
+        } catch { }
+
+        # Every drive the account can reach, because the home folder is not where most people
+        # keep things and a second drive is entirely normal.
+        $drives = (Get-PSDrive -PSProvider FileSystem | ForEach-Object { "/$($_.Name):/" }) -join ','
+
+        Write-Host ''
+        Write-Host '{{BeginMarker}}'
+        Write-Host "user=$env:USERNAME"
+        Write-Host "home=/$($env:USERPROFILE -replace '\\','/')"
+        Write-Host "drives=$drives"
+        Write-Host "fingerprint=$fingerprint"
+        Write-Host '{{EndMarker}}'
+        Write-Host ''
+        Write-Host 'Copy the block above, including both marker lines, back into Connapse.'
+        if (-not $fingerprint) {
+            Write-Host 'The host key fingerprint could not be read, so the first connection will be trusted rather than verified. Everything else is set up.' -ForegroundColor Yellow
+        }
+        """;
+
+    private static string UnixScript(string publicKeyLine, bool macOs)
+    {
+        string enable = macOs
+            ? """
+              # 1. Turn on Remote Login, which is what serves SFTP on macOS.
+              sudo systemsetup -setremotelogin on
+              """
+            : """
+              # 1. Make sure an SSH server is installed and running.
+              #    The unit is 'ssh' on Debian and Ubuntu, 'sshd' most other places.
+              sudo systemctl enable --now sshd 2>/dev/null || sudo systemctl enable --now ssh
+              """;
+
+        // $$ so a single brace is literal — the awk program below needs them, and doubling
+        // every interpolation is the lesser evil against escaping the shell.
+        return $$"""
+        # Connapse — allow this computer to be indexed. Safe to run more than once.
+
+        {{enable}}
+
+        # 2. Add Connapse's key, but only once, and without disturbing any other key present.
+        mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys
+        chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys
+
+        KEY='{{publicKeyLine}}'
+        grep -qxF "$KEY" ~/.ssh/authorized_keys || echo "$KEY" >> ~/.ssh/authorized_keys
+
+        # 3. Report back what only this machine knows.
+        HOSTKEY=$(ls /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null || ls /etc/ssh/ssh_host_rsa_key.pub)
+        FINGERPRINT=$(ssh-keygen -lf "$HOSTKEY" | awk '{print $2}')
+
+        printf '\n{{BeginMarker}}\n'
+        printf 'user=%s\n' "$(whoami)"
+        printf 'home=%s\n' "$HOME"
+        printf 'fingerprint=%s\n' "$FINGERPRINT"
+        printf '{{EndMarker}}\n\n'
+        echo 'Copy the block above, including both marker lines, back into Connapse.'
+        """;
+    }
+
+    /// <summary>
+    /// Reads the block the setup command printed. Returns null when the text does not contain
+    /// a usable one.
+    /// </summary>
+    /// <remarks>
+    /// Tolerant on purpose. Operators paste whole terminal buffers, with prompts, wrapping,
+    /// and the command echoed above the output — so this finds the markers rather than
+    /// expecting the text to begin at them, and ignores anything outside.
+    /// </remarks>
+    public static SftpHostSetupResult? ParseResult(string? pasted)
+    {
+        if (string.IsNullOrWhiteSpace(pasted))
+            return null;
+
+        int start = pasted.IndexOf(BeginMarker, StringComparison.Ordinal);
+        int end = pasted.IndexOf(EndMarker, StringComparison.Ordinal);
+
+        // Without both markers there is nothing to be confident about. Guessing at loose
+        // key=value lines would happily accept a paste from somewhere else entirely.
+        if (start < 0 || end < 0 || end <= start)
+            return null;
+
+        string body = pasted[(start + BeginMarker.Length)..end];
+
+        string? user = null, home = null, fingerprint = null;
+        IReadOnlyList<string> drives = [];
+
+        foreach (string raw in body.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            string line = raw.Trim();
+            int split = line.IndexOf('=');
+            if (split <= 0) continue;
+
+            string name = line[..split].Trim();
+            string value = line[(split + 1)..].Trim();
+            if (value.Length == 0) continue;
+
+            switch (name)
+            {
+                case "user": user = value; break;
+                case "home": home = value; break;
+                case "fingerprint": fingerprint = NormaliseFingerprint(value); break;
+
+                // Optional. Older setup commands did not report it, and a Unix host has
+                // nothing to report — neither is a reason to reject the block.
+                case "drives":
+                    drives = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    break;
+            }
+        }
+
+        // The fingerprint is optional, and that is not a weakening — it is what stops the flow
+        // dead-ending. Reading it needs elevation and can still fail, by which point sshd is
+        // running and the key is installed. Requiring it here meant the block parsed to null,
+        // the UI disabled both test and save, and the operator was left with a configured host,
+        // an authorized Connapse key, and no way to finish or undo.
+        //
+        // Blank already has a defined meaning everywhere else: SshHostKeyPolicy reads it as
+        // trust-on-first-use. So an absent fingerprint costs the stronger verified-first-use and
+        // nothing else, which the panel says plainly rather than silently accepting.
+        return user is null || home is null
+            ? null
+            : new SftpHostSetupResult(user, home, fingerprint ?? string.Empty, drives);
+    }
+
+    /// <summary>
+    /// <c>ssh-keygen -l</c> prints <c>SHA256:…</c>, which is already the stored form. An
+    /// operator pasting a fingerprint by hand may well omit the prefix, so it is added back
+    /// rather than treated as a mismatch later, when the only symptom would be a refused
+    /// connection.
+    /// </summary>
+    private static string NormaliseFingerprint(string value) =>
+        value.StartsWith("SHA256:", StringComparison.Ordinal) ? value : $"SHA256:{value}";
+}

--- a/src/Connapse.Core/Utilities/SftpHostSetup.cs
+++ b/src/Connapse.Core/Utilities/SftpHostSetup.cs
@@ -1,4 +1,4 @@
-namespace Connapse.Core.Utilities;
+﻿namespace Connapse.Core.Utilities;
 
 /// <summary>The operator's own machine, which decides what the setup command looks like.</summary>
 public enum HostPlatform { Windows, MacOS, Linux }
@@ -133,9 +133,17 @@ public static class SftpHostSetup
         Set-Service -Name sshd -StartupType Automatic
         if ((Get-Service sshd).Status -ne 'Running') { Start-Service sshd }
 
-        if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
-            New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' `
-                -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
+        # Reachable from this machine's own networks, and no further. An unscoped rule would
+        # also accept port 22 from whatever else is on a hotel or cafe network, and from the
+        # internet on any host whose router forwards the port — a much larger change than
+        # "let Connapse read my files", made silently while the operator was doing something
+        # else. LocalSubnet still covers the Docker and WSL virtual switches, which is how a
+        # Connapse container reaches its host.
+        if (-not (Get-NetFirewallRule -Name 'Connapse-SFTP-In-TCP' -ErrorAction SilentlyContinue)) {
+            New-NetFirewallRule -Name 'Connapse-SFTP-In-TCP' -DisplayName 'Connapse SFTP (sshd)' `
+                -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 `
+                -Profile Any -RemoteAddress LocalSubnet | Out-Null
+            Write-Host 'Opened inbound TCP 22 to this machine''s local subnets only.' -ForegroundColor Cyan
         }
 
         # 2. Work out which authorized_keys file sshd will actually read.
@@ -177,7 +185,21 @@ public static class SftpHostSetup
             icacls $keyFile /inheritance:r /grant 'SYSTEM:F' 'Administrators:F' | Out-Null
         }
 
-        # 4. Report back what only this machine knows.
+        # 4. Say whether this host still accepts passwords over SSH.
+        #    The restrictions on Connapse's key bind that key and nothing else, so they do not
+        #    make the host key-only. Reported rather than changed: turning off password
+        #    authentication is a decision about every account on the machine, and making it
+        #    silently could lock someone out of a login they were relying on.
+        $sshdConfig = Join-Path $env:ProgramData 'ssh\sshd_config'
+        $passwordAuth = 'unknown'
+        if (Test-Path $sshdConfig) {
+            $setting = Select-String -Path $sshdConfig -Pattern '^\s*PasswordAuthentication\s+(\S+)' |
+                       Select-Object -Last 1
+            # OpenSSH defaults this to yes when the directive is absent or commented out.
+            $passwordAuth = if ($setting) { $setting.Matches[0].Groups[1].Value } else { 'yes' }
+        }
+
+        # 5. Report back what only this machine knows.
         #    Wrapped, because the key is already installed by this point and a failure to read
         #    the fingerprint must not throw away a setup that otherwise worked. An empty
         #    fingerprint costs the operator verified-first-use, not the connection.
@@ -204,6 +226,11 @@ public static class SftpHostSetup
         Write-Host 'Copy the block above, including both marker lines, back into Connapse.'
         if (-not $fingerprint) {
             Write-Host 'The host key fingerprint could not be read, so the first connection will be trusted rather than verified. Everything else is set up.' -ForegroundColor Yellow
+        }
+        if ($passwordAuth -eq 'yes' -or $passwordAuth -eq 'unknown') {
+            Write-Host ''
+            Write-Host 'This machine also accepts SSH logins by password, for every account on it.' -ForegroundColor Yellow
+            Write-Host "To allow keys only, set 'PasswordAuthentication no' in $sshdConfig and run: Restart-Service sshd" -ForegroundColor Yellow
         }
         """;
 
@@ -234,7 +261,14 @@ public static class SftpHostSetup
         KEY='{{publicKeyLine}}'
         grep -qxF "$KEY" ~/.ssh/authorized_keys || echo "$KEY" >> ~/.ssh/authorized_keys
 
-        # 3. Report back what only this machine knows.
+        # 3. Say whether this host still accepts passwords over SSH.
+        #    The restrictions on Connapse's key bind that key and nothing else, so they do not
+        #    make the host key-only. Reported rather than changed: turning off password
+        #    authentication is a decision about every account on the machine.
+        #    OpenSSH defaults this to yes when the directive is absent or commented out.
+        PASSWORD_AUTH=$(awk 'tolower($1)=="passwordauthentication" {v=$2} END {print (v?v:"yes")}'                         /etc/ssh/sshd_config 2>/dev/null || echo unknown)
+
+        # 4. Report back what only this machine knows.
         HOSTKEY=$(ls /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null || ls /etc/ssh/ssh_host_rsa_key.pub)
         FINGERPRINT=$(ssh-keygen -lf "$HOSTKEY" | awk '{print $2}')
 
@@ -244,6 +278,12 @@ public static class SftpHostSetup
         printf 'fingerprint=%s\n' "$FINGERPRINT"
         printf '{{EndMarker}}\n\n'
         echo 'Copy the block above, including both marker lines, back into Connapse.'
+
+        if [ "$PASSWORD_AUTH" != "no" ]; then
+            echo ''
+            echo 'This machine also accepts SSH logins by password, for every account on it.'
+            echo "To allow keys only, set 'PasswordAuthentication no' in /etc/ssh/sshd_config and restart the SSH service."
+        fi
         """;
     }
 

--- a/src/Connapse.Core/Utilities/SftpPathConfinement.cs
+++ b/src/Connapse.Core/Utilities/SftpPathConfinement.cs
@@ -1,4 +1,4 @@
-namespace Connapse.Core.Utilities;
+﻿namespace Connapse.Core.Utilities;
 
 /// <summary>
 /// Resolves a remote path so a caller can decide whether it escapes a root, using the
@@ -16,7 +16,13 @@ public interface ISftpRealPathResolver
     /// <c>SSH_FXP_REALPATH</c>, resolving <c>..</c> segments and symlinks there.
     /// Throws when the server refuses or the session is unusable.
     /// </summary>
-    string GetCanonicalPath(string path);
+    /// <remarks>
+    /// Asynchronous because this is a request to a machine that may never answer it. A server
+    /// can complete authentication and then stall its SFTP subsystem, and a blocking call has
+    /// nothing to interrupt it — so the caller's timeout would cover the handshake and nothing
+    /// after it, which is the part that actually waits.
+    /// </remarks>
+    Task<string> GetCanonicalPathAsync(string path, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -50,13 +56,14 @@ public static class SftpPathConfinement
     /// null when it escapes, when the input is unusable, or when the server will not resolve
     /// it.
     /// </summary>
-    public static string? CombineWithin(ISftpRealPathResolver resolver, string root, string? relative)
+    public static async Task<string?> CombineWithinAsync(
+        ISftpRealPathResolver resolver, string root, string? relative, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(resolver);
         ArgumentException.ThrowIfNullOrWhiteSpace(root);
 
         if (string.IsNullOrWhiteSpace(relative))
-            return ResolveWithin(resolver, root, root);
+            return await ResolveWithinAsync(resolver, root, root, ct);
 
         // An absolute relative path is refused rather than honoured. This mirrors
         // PathConfinement.CombineWithin: treating it as a path under the root would hand back
@@ -66,7 +73,7 @@ public static class SftpPathConfinement
 
         string joined = root.TrimEnd(Separator) + Separator + relative;
 
-        return ResolveWithin(resolver, root, joined);
+        return await ResolveWithinAsync(resolver, root, joined, ct);
     }
 
     /// <summary>
@@ -74,7 +81,8 @@ public static class SftpPathConfinement
     /// <paramref name="root"/>, or null when it escapes. Both sides are canonicalised, so a
     /// root that is itself a symlink cannot make a contained path look like an escape.
     /// </summary>
-    public static string? ResolveWithin(ISftpRealPathResolver resolver, string root, string candidate)
+    public static async Task<string?> ResolveWithinAsync(
+        ISftpRealPathResolver resolver, string root, string candidate, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(resolver);
         ArgumentException.ThrowIfNullOrWhiteSpace(root);
@@ -85,8 +93,8 @@ public static class SftpPathConfinement
 
         try
         {
-            canonicalRoot = resolver.GetCanonicalPath(root);
-            canonicalCandidate = resolver.GetCanonicalPath(candidate);
+            canonicalRoot = await resolver.GetCanonicalPathAsync(root, ct);
+            canonicalCandidate = await resolver.GetCanonicalPathAsync(candidate, ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/Connapse.Core/Utilities/SshKeyPairGenerator.cs
+++ b/src/Connapse.Core/Utilities/SshKeyPairGenerator.cs
@@ -1,0 +1,101 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// A generated SSH key pair. The private half is stored; the public half is what the
+/// operator installs on their own machine.
+/// </summary>
+/// <param name="PrivateKeyPem">
+/// PKCS#1 PEM — <c>-----BEGIN RSA PRIVATE KEY-----</c>. The form SSH.NET reads.
+/// </param>
+/// <param name="PublicKeyLine">
+/// A single <c>authorized_keys</c> line, ready to append.
+/// </param>
+public record SshKeyPair(string PrivateKeyPem, string PublicKeyLine);
+
+/// <summary>
+/// Generates an SSH key pair so setting up an SFTP connection never requires
+/// <c>ssh-keygen</c>.
+/// <para>
+/// Generating server-side is not only the easier path, it is the better one. A pasted key
+/// is usually a key the operator already has and uses elsewhere; a generated one exists for
+/// a single connection, has never been on a clipboard, and is revoked by deleting that
+/// connection. The private half is never rendered — it goes straight into the encrypted
+/// column.
+/// </para>
+/// </summary>
+public static class SshKeyPairGenerator
+{
+    /// <summary>
+    /// RSA rather than Ed25519, which would otherwise be the obvious default: .NET exposes
+    /// no Ed25519 primitive, and SSH.NET's key generation surface does not cover it either.
+    /// 3072 bits is the NIST-equivalent of AES-128 and what <c>ssh-keygen</c> defaults to
+    /// for RSA.
+    /// </summary>
+    public const int KeySizeBits = 3072;
+
+    /// <summary>
+    /// Generates a pair. <paramref name="comment"/> is the trailing label on the public key
+    /// line, which is how an operator later recognises the entry in <c>authorized_keys</c>.
+    /// </summary>
+    public static SshKeyPair Generate(string comment = "connapse")
+    {
+        using var rsa = RSA.Create(KeySizeBits);
+
+        return new SshKeyPair(
+            rsa.ExportRSAPrivateKeyPem(),
+            FormatPublicKey(rsa, comment));
+    }
+
+    /// <summary>
+    /// Encodes an RSA public key the way <c>authorized_keys</c> expects: the algorithm name,
+    /// the exponent, and the modulus, each length-prefixed, then base64.
+    /// </summary>
+    /// <remarks>
+    /// A mistake here fails as "authentication failed" with nothing pointing at the cause,
+    /// which is why the round trip against a real server is the test that matters.
+    /// </remarks>
+    public static string FormatPublicKey(RSA rsa, string comment = "connapse")
+    {
+        RSAParameters p = rsa.ExportParameters(includePrivateParameters: false);
+
+        using var buffer = new MemoryStream();
+        WriteLengthPrefixed(buffer, "ssh-rsa"u8.ToArray());
+        WriteLengthPrefixed(buffer, ToMpint(p.Exponent!));
+        WriteLengthPrefixed(buffer, ToMpint(p.Modulus!));
+
+        string label = Sanitise(comment);
+
+        return $"ssh-rsa {Convert.ToBase64String(buffer.ToArray())} {label}";
+    }
+
+    private static void WriteLengthPrefixed(Stream stream, byte[] data)
+    {
+        Span<byte> length = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(length, data.Length);
+        stream.Write(length);
+        stream.Write(data);
+    }
+
+    /// <summary>
+    /// SSH multiple-precision integers are signed, so a value whose top bit is set needs a
+    /// leading zero byte or it reads as negative.
+    /// </summary>
+    private static byte[] ToMpint(byte[] value) =>
+        value.Length > 0 && value[0] >= 0x80 ? [0, .. value] : value;
+
+    /// <summary>
+    /// The comment is the last field on the line, so anything that could end the line early
+    /// or start a second entry has to go. An operator-supplied connection name reaches here.
+    /// </summary>
+    private static string Sanitise(string comment)
+    {
+        string trimmed = new string(comment
+            .Where(c => !char.IsControl(c) && c != '\n' && c != '\r')
+            .ToArray()).Trim();
+
+        return string.IsNullOrEmpty(trimmed) ? "connapse" : trimmed;
+    }
+}

--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -1,4 +1,4 @@
-﻿using Connapse.Core;
+using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
 using Connapse.Storage.Data;
@@ -32,6 +32,9 @@ public class IngestionPipeline : IKnowledgeIngester
     private readonly IContainerStore _containerStore;
     private readonly IManagedStorageProvider _managedStorage;
     private readonly IDocumentStore _documentStore;
+    private readonly ISourceStore _sourceStore;
+    private readonly IConnectionStore _connectionStore;
+    private readonly IConnectorFactory _connectorFactory;
     private readonly ILogger<IngestionPipeline> _logger;
 
     // Metadata keys for tracking indexing settings
@@ -76,6 +79,9 @@ public class IngestionPipeline : IKnowledgeIngester
         IContainerStore containerStore,
         IManagedStorageProvider managedStorage,
         IDocumentStore documentStore,
+        ISourceStore sourceStore,
+        IConnectionStore connectionStore,
+        IConnectorFactory connectorFactory,
         ILogger<IngestionPipeline> logger)
     {
         _context = context;
@@ -90,6 +96,9 @@ public class IngestionPipeline : IKnowledgeIngester
         _containerStore = containerStore;
         _managedStorage = managedStorage;
         _documentStore = documentStore;
+        _sourceStore = sourceStore;
+        _connectionStore = connectionStore;
+        _connectorFactory = connectorFactory;
         _logger = logger;
     }
 
@@ -489,6 +498,15 @@ public class IngestionPipeline : IKnowledgeIngester
         IngestionOptions options,
         CancellationToken ct = default)
     {
+        // A source-owned document is read through its connection's connector, not through
+        // managed storage — checked first, because everything below this resolves a container
+        // and a source does not have one (#398).
+        //
+        // Only this entry point was left container-shaped by the connector/source split.
+        // IngestAsync already honours OwnerRef.ForSource; the gap was getting the bytes.
+        if (options.Owner is { IsSource: true } sourceOwner)
+            return await IngestSourceDocumentAsync(documentId, sourceOwner.Id, options, ct);
+
         // Resolve the container ID — prefer options.ContainerId, fall back to looking up the doc.
         Guid containerId;
         string virtualPath;
@@ -526,6 +544,52 @@ public class IngestionPipeline : IKnowledgeIngester
 
         await using Stream stream = await connector.ReadFileAsync(jobPath, ct);
         return await IngestAsync(stream, options, ct);
+    }
+
+    /// <summary>
+    /// Reads a source-owned document through its connection's connector and ingests it.
+    /// </summary>
+    /// <remarks>
+    /// The path is used as the sync engine recorded it, without <c>ResolveJobPath</c>. That
+    /// method exists to turn a virtual container path into a real one; a source's listing
+    /// already yields the connector's own absolute form — an OS path for Filesystem, a remote
+    /// path for SFTP — and putting it through resolution again would rebase a path that is
+    /// already rooted.
+    /// </remarks>
+    private async Task<IngestionResult> IngestSourceDocumentAsync(
+        string documentId, Guid sourceId, IngestionOptions options, CancellationToken ct)
+    {
+        string path = options.Path ?? options.FileName
+            ?? throw new InvalidOperationException(
+                $"IngestByIdAsync: options must provide Path or FileName for document {documentId}");
+
+        Source source = await _sourceStore.GetAsync(sourceId, ct)
+            ?? throw new InvalidOperationException(
+                $"IngestByIdAsync: source {sourceId} not found for document {documentId}");
+
+        Connection connection = await _connectionStore.GetAsync(source.ConnectionId, ct)
+            ?? throw new InvalidOperationException(
+                $"IngestByIdAsync: connection {source.ConnectionId} not found for source {sourceId}");
+
+        // Only fetched when there is one to fetch, matching SourceSyncService. A key ring that
+        // cannot decrypt throws, and retrying will not help — so it surfaces as a failed job
+        // rather than being swallowed.
+        string? secret = connection.HasSecret
+            ? await _connectionStore.GetSecretAsync(connection.Id, ct)
+            : null;
+
+        IConnector connector = _connectorFactory.Create(source, connection, secret);
+        try
+        {
+            await using Stream stream = await connector.ReadFileAsync(path, ct);
+            return await IngestAsync(stream, options, ct);
+        }
+        finally
+        {
+            // SftpConnector holds an SSH session and S3Connector a socket pool. One job runs
+            // per file, so skipping this abandons a connection per document.
+            if (connector is IDisposable disposable) disposable.Dispose();
+        }
     }
 
     public async IAsyncEnumerable<IngestionProgress> IngestWithProgressAsync(
@@ -646,3 +710,5 @@ internal static class IngestionPipelineStrategyResolver
         return MarkdownExtensions.Contains(ext) ? "DocumentAware" : fallbackStrategy;
     }
 }
+
+

--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -1,4 +1,4 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
 using Connapse.Storage.Data;
@@ -507,6 +507,24 @@ public class IngestionPipeline : IKnowledgeIngester
         if (options.Owner is { IsSource: true } sourceOwner)
             return await IngestSourceDocumentAsync(documentId, sourceOwner.Id, options, ct);
 
+        // No owner in the options at all: the row is the only thing that knows which it is.
+        // Callers that omit it would otherwise be routed down the container branch and throw
+        // — and a reindex throws only after it has already deleted the document's chunks, so
+        // the cost of guessing wrong here is a document that is gone from search and that no
+        // later sync restores, because its remote signature still matches.
+        if (options.Owner is null)
+        {
+            Document? owned = await _documentStore.GetAsync(documentId, ct);
+            if (owned?.Owner is { IsSource: true } inferredOwner)
+            {
+                // Carried on the options, not just used for routing: IngestAsync writes the
+                // document through options.Owner, and a source-owned row recorded against
+                // container_id would violate ck_documents_single_owner.
+                return await IngestSourceDocumentAsync(
+                    documentId, inferredOwner.Id, options with { Owner = inferredOwner }, ct);
+            }
+        }
+
         // Resolve the container ID — prefer options.ContainerId, fall back to looking up the doc.
         Guid containerId;
         string virtualPath;
@@ -522,10 +540,10 @@ public class IngestionPipeline : IKnowledgeIngester
                 ?? throw new InvalidOperationException(
                     $"IngestByIdAsync: document {documentId} not found and no ContainerId in options");
 
-            // Source-owned documents have an empty ContainerId, so Guid.Parse would throw a
-            // bare FormatException here. Fail with something actionable instead. Re-ingesting
-            // a source document goes through the sync engine, which resolves its connector
-            // from the source's connection rather than from a container.
+            // Document.ContainerId carries COALESCE(container_id, source_id), so it parses
+            // even for a source-owned row — which is why source ownership is settled above,
+            // from doc.Owner, before this point. Reaching here with an unparseable value means
+            // the row has no usable owner at all.
             if (string.IsNullOrEmpty(doc.ContainerId) || !Guid.TryParse(doc.ContainerId, out var docContainerId))
                 throw new InvalidOperationException(
                     $"IngestByIdAsync: document {documentId} is not owned by a container. " +

--- a/src/Connapse.Ingestion/Reindex/ReindexService.cs
+++ b/src/Connapse.Ingestion/Reindex/ReindexService.cs
@@ -463,6 +463,19 @@ public class ReindexService : IReindexService
             _chunkingSettings.CurrentValue.Strategy,
             ignoreCase: true);
 
+        // The owner the row actually has, read from the row. Nullable<Guid>.ToString() yields
+        // "" rather than throwing, so a source-owned document used to be enqueued with a blank
+        // ContainerId and no Owner at all — and the pipeline, seeing neither, routed it down
+        // the container branch and threw. By then the chunks above were already deleted, and
+        // the next sync saw an unchanged remote signature and did not restore them, so a
+        // forced reindex quietly removed source documents from search for good.
+        var owner = doc.SourceId is Guid sourceId
+            ? OwnerRef.ForSource(sourceId)
+            : doc.ContainerId is Guid containerId
+                ? OwnerRef.ForContainer(containerId)
+                : throw new InvalidOperationException(
+                    $"Document {doc.Id} has neither a container nor a source and cannot be reindexed.");
+
         // Create and enqueue ingestion job
         var job = new IngestionJob(
             JobId: Guid.NewGuid().ToString(),
@@ -472,10 +485,13 @@ public class ReindexService : IReindexService
                 DocumentId: doc.Id.ToString(),
                 FileName: doc.FileName,
                 ContentType: doc.ContentType,
-                ContainerId: doc.ContainerId.ToString(),
+                ContainerId: owner.ContainerId?.ToString(),
                 Path: doc.Path,
                 Strategy: strategy,
-                Metadata: doc.Metadata),
+                Metadata: doc.Metadata)
+            {
+                Owner = owner,
+            },
             BatchId: batchId);
 
         await _queue.EnqueueAsync(job, ct);

--- a/src/Connapse.Storage/ConnectionTesters/SftpConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/SftpConnectionTester.cs
@@ -1,4 +1,4 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.Connectors;
 
@@ -42,8 +42,10 @@ public class SftpConnectionTester : IConnectionTester
         if (settings is not SftpConnectionTestSettings s)
             return new ConnectionTestResult { Success = false, Message = "Invalid settings type for the SFTP tester." };
 
+        TimeSpan budget = timeout ?? TimeSpan.FromSeconds(15);
+
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        cts.CancelAfter(timeout ?? TimeSpan.FromSeconds(15));
+        cts.CancelAfter(budget);
 
         // No host key store: a test must never pin. Pinning is the sync's job, and doing it
         // here would record a fingerprint from a form the operator has not saved.
@@ -55,6 +57,13 @@ public class SftpConnectionTester : IConnectionTester
             AllowedRoot = s.AllowedRoot,
             PinnedHostKeyFingerprint = s.PinnedHostKeyFingerprint,
             Credential = new SftpCredential { PrivateKey = s.PrivateKey, Passphrase = s.Passphrase },
+
+            // The same budget the token carries, handed to the session itself. The token
+            // covers the awaits; this covers the waits inside SSH.NET that the token cannot
+            // reach. Without it a server that authenticates and then stalls its SFTP
+            // subsystem holds this scope — and its Blazor circuit — well past the timeout
+            // the operator was promised.
+            OperationTimeout = budget,
         });
 
         try
@@ -82,6 +91,20 @@ public class SftpConnectionTester : IConnectionTester
                 Message = $"Timed out reaching {s.Host}:{s.Port}. Connapse has to be able to open a "
                           + "TCP connection to that address from where it runs — inside a container, "
                           + "the host machine is not 'localhost'."
+            };
+        }
+        catch (Exception ex) when (ex is Renci.SshNet.Common.SshOperationTimeoutException
+                                      or TimeoutException)
+        {
+            // Reached the server, and it stopped answering partway through. Distinct from the
+            // timeout above, which never got a connection at all — the remedies have nothing
+            // in common, so saying "check that the address is reachable" here would send the
+            // operator after a problem they do not have.
+            return new ConnectionTestResult
+            {
+                Success = false,
+                Message = $"{s.Host}:{s.Port} accepted the connection but stopped responding. "
+                          + "The SSH service is running but its SFTP subsystem is not answering."
             };
         }
         catch (Exception ex)

--- a/src/Connapse.Storage/ConnectionTesters/SftpConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/SftpConnectionTester.cs
@@ -1,0 +1,93 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Connectors;
+
+namespace Connapse.Storage.ConnectionTesters;
+
+/// <summary>
+/// What the SFTP connection form hands to <see cref="SftpConnectionTester"/>. The private key
+/// is passed rather than looked up, because the operator may be testing a key they have typed
+/// but not yet saved.
+/// </summary>
+public record SftpConnectionTestSettings
+{
+    public string Host { get; init; } = "";
+    public int Port { get; init; } = 22;
+    public string Username { get; init; } = "";
+    public string AllowedRoot { get; init; } = "";
+    public string PrivateKey { get; init; } = "";
+    public string? Passphrase { get; init; }
+
+    /// <summary>
+    /// The fingerprint already pinned, if any, so a test reports a mismatch the same way a sync
+    /// would rather than quietly succeeding against a different server.
+    /// </summary>
+    public string? PinnedHostKeyFingerprint { get; init; }
+}
+
+/// <summary>
+/// Opens a session, verifies the host key, and confirms the allowed root resolves.
+/// <para>
+/// Deliberately does not walk the tree. A test button that lists a large remote turns a
+/// configuration check into a minutes-long operation, and tells the operator nothing the root
+/// check has not already told them: if the root resolves and stays inside itself, the
+/// credential authenticated and the path exists.
+/// </para>
+/// </summary>
+public class SftpConnectionTester : IConnectionTester
+{
+    public async Task<ConnectionTestResult> TestConnectionAsync(
+        object settings, TimeSpan? timeout = null, CancellationToken ct = default)
+    {
+        if (settings is not SftpConnectionTestSettings s)
+            return new ConnectionTestResult { Success = false, Message = "Invalid settings type for the SFTP tester." };
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(timeout ?? TimeSpan.FromSeconds(15));
+
+        // No host key store: a test must never pin. Pinning is the sync's job, and doing it
+        // here would record a fingerprint from a form the operator has not saved.
+        using var connector = new SftpConnector(new SftpConnectorConfig
+        {
+            Host = s.Host,
+            Port = s.Port,
+            Username = s.Username,
+            AllowedRoot = s.AllowedRoot,
+            PinnedHostKeyFingerprint = s.PinnedHostKeyFingerprint,
+            Credential = new SftpCredential { PrivateKey = s.PrivateKey, Passphrase = s.Passphrase },
+        });
+
+        try
+        {
+            string resolved = await connector.ProbeAsync(cts.Token);
+
+            return new ConnectionTestResult
+            {
+                Success = true,
+                Message = $"Connected to {s.Host}:{s.Port} as {s.Username}. "
+                          + $"The allowed root resolved to {resolved} on the server."
+            };
+        }
+        catch (SftpHostKeyMismatchException ex)
+        {
+            // Surfaced on its own, because it is the one failure retrying cannot fix and the
+            // only one whose remedy is a decision rather than a correction.
+            return new ConnectionTestResult { Success = false, Message = ex.Message };
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            return new ConnectionTestResult
+            {
+                Success = false,
+                Message = $"Timed out reaching {s.Host}:{s.Port}. Connapse has to be able to open a "
+                          + "TCP connection to that address from where it runs — inside a container, "
+                          + "the host machine is not 'localhost'."
+            };
+        }
+        catch (Exception ex)
+        {
+            return new ConnectionTestResult { Success = false, Message = ex.Message };
+        }
+    }
+}
+

--- a/src/Connapse.Storage/Connectors/SftpConnector.cs
+++ b/src/Connapse.Storage/Connectors/SftpConnector.cs
@@ -96,6 +96,23 @@ public sealed class SftpConnector : IConnector, IDisposable
     }
 
     /// <summary>
+    /// Opens the session, verifies the host key, and resolves the allowed root and subpath on
+    /// the server. Returns the resolved path this connector would read from.
+    /// </summary>
+    /// <remarks>
+    /// Exists for the connection test, which needs exactly the three things that go wrong —
+    /// reachability, authentication, and whether the root is really there — and none of the
+    /// walking. An explicit method rather than leaning on a side effect of
+    /// <see cref="ExistsAsync"/>, so a later change to that method cannot quietly turn the test
+    /// button into one that always passes.
+    /// </remarks>
+    public async Task<string> ProbeAsync(CancellationToken ct = default)
+    {
+        var (_, root) = await EnsureConnectedAsync(ct);
+        return root;
+    }
+
+    /// <summary>
     /// Refuses a path whose final component is a symlink.
     /// </summary>
     /// <remarks>

--- a/src/Connapse.Storage/Connectors/SftpConnector.cs
+++ b/src/Connapse.Storage/Connectors/SftpConnector.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using Connapse.Core;
@@ -73,7 +73,7 @@ public sealed class SftpConnector : IConnector, IDisposable
 
         string start = string.IsNullOrWhiteSpace(prefix)
             ? root
-            : ConfineDirectory(client, prefix)
+            : await ConfineDirectoryAsync(client, prefix, ct)
               ?? throw new UnauthorizedAccessException(
                   $"Prefix '{prefix}' resolves outside the connection's allowed root.");
 
@@ -86,7 +86,7 @@ public sealed class SftpConnector : IConnector, IDisposable
     {
         var (client, _) = await EnsureConnectedAsync(ct);
 
-        string confined = ConfineFile(client, path)
+        string confined = await ConfineFileAsync(client, path, ct)
             ?? throw new UnauthorizedAccessException(
                 $"Path '{path}' resolves outside the connection's allowed root.");
 
@@ -173,7 +173,7 @@ public sealed class SftpConnector : IConnector, IDisposable
     {
         var (client, _) = await EnsureConnectedAsync(ct);
 
-        string? confined = ConfineFile(client, path);
+        string? confined = await ConfineFileAsync(client, path, ct);
         if (confined is null) return false;
 
         return await client.ExistsAsync(confined, ct);
@@ -294,8 +294,9 @@ public sealed class SftpConnector : IConnector, IDisposable
 
     // ── Confinement ────────────────────────────────────────────────────────
 
-    private string? ConfineDirectory(SftpClient client, string candidate) =>
-        SftpPathConfinement.ResolveWithin(new SftpRealPathResolver(client), _config.AllowedRoot, candidate);
+    private Task<string?> ConfineDirectoryAsync(SftpClient client, string candidate, CancellationToken ct) =>
+        SftpPathConfinement.ResolveWithinAsync(
+            new SftpRealPathResolver(client), _config.AllowedRoot, candidate, ct);
 
     /// <summary>
     /// Confines a file path by canonicalising its <i>parent</i> and reattaching the name.
@@ -307,7 +308,7 @@ public sealed class SftpConnector : IConnector, IDisposable
     /// a symlinked ancestor — and both of those are in the parent. The leaf is checked for
     /// separators instead, so it cannot smuggle a path component of its own.
     /// </remarks>
-    private string? ConfineFile(SftpClient client, string candidate)
+    private async Task<string?> ConfineFileAsync(SftpClient client, string candidate, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(candidate))
             return null;
@@ -323,7 +324,7 @@ public sealed class SftpConnector : IConnector, IDisposable
         if (name.Length == 0 || name is "." or ".." || name.Contains(SftpPathConfinement.Separator))
             return null;
 
-        string? resolvedParent = ConfineDirectory(client, parent);
+        string? resolvedParent = await ConfineDirectoryAsync(client, parent, ct);
         if (resolvedParent is null)
             return null;
 
@@ -348,7 +349,12 @@ public sealed class SftpConnector : IConnector, IDisposable
             _client = null;
             _resolvedRoot = null;
 
-            var client = new SftpClient(BuildConnectionInfo());
+            var client = new SftpClient(BuildConnectionInfo())
+            {
+                // Without this SSH.NET waits forever on an SFTP request. See the config's
+                // remarks: a cancellation token does not reach inside one.
+                OperationTimeout = _config.OperationTimeout,
+            };
             client.HostKeyReceived += OnHostKeyReceived;
 
             try
@@ -384,12 +390,12 @@ public sealed class SftpConnector : IConnector, IDisposable
                 // authenticated or not.
                 await PinFingerprintIfNewAsync(ct);
 
-                string root = ConfineDirectory(client, _config.AllowedRoot)
+                string root = await ConfineDirectoryAsync(client, _config.AllowedRoot, ct)
                     ?? throw new InvalidOperationException(
                         $"The allowed root '{_config.AllowedRoot}' could not be resolved on {_config.Host}.");
 
-                string scoped = SftpPathConfinement.CombineWithin(
-                                    new SftpRealPathResolver(client), root, _config.SubPath)
+                string scoped = await SftpPathConfinement.CombineWithinAsync(
+                                    new SftpRealPathResolver(client), root, _config.SubPath, ct)
                                 ?? throw new InvalidOperationException(
                                     $"The source's subPath '{_config.SubPath}' resolves outside the "
                                     + $"connection's allowed root '{_config.AllowedRoot}'.");
@@ -429,7 +435,10 @@ public sealed class SftpConnector : IConnector, IDisposable
             _config.Host,
             _config.Port,
             _config.Username,
-            new PrivateKeyAuthenticationMethod(_config.Username, key));
+            new PrivateKeyAuthenticationMethod(_config.Username, key))
+        {
+            Timeout = _config.OperationTimeout,
+        };
     }
 
     /// <summary>
@@ -522,9 +531,9 @@ public class SftpHostKeyMismatchException(string message, Exception inner)
 /// </remarks>
 internal sealed class SftpRealPathResolver(SftpClient client) : ISftpRealPathResolver
 {
-    public string GetCanonicalPath(string path)
+    public async Task<string> GetCanonicalPathAsync(string path, CancellationToken ct = default)
     {
-        client.ChangeDirectory(path);
+        await client.ChangeDirectoryAsync(path, ct);
         return client.WorkingDirectory;
     }
 }

--- a/src/Connapse.Storage/Connectors/SftpConnectorConfig.cs
+++ b/src/Connapse.Storage/Connectors/SftpConnectorConfig.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Connapse.Storage.Connectors;
@@ -96,4 +96,17 @@ public record SftpConnectorConfig
     /// nothing is recorded.
     /// </summary>
     public Guid ConnectionId { get; init; }
+
+    /// <summary>
+    /// How long a single SFTP request may take before the session gives up, and how long the
+    /// initial handshake may take.
+    /// </summary>
+    /// <remarks>
+    /// A backstop, not the primary mechanism — cancellation tokens are. It covers the case a
+    /// token cannot: SSH.NET waits on its own semaphores inside a request, and a server that
+    /// answers the handshake and then stops answering leaves the caller holding an SSH session
+    /// and a socket with nothing to release them. The default is infinite, which is the wrong
+    /// default for a server nobody here controls.
+    /// </remarks>
+    public TimeSpan OperationTimeout { get; init; } = TimeSpan.FromMinutes(2);
 }

--- a/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
+++ b/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
@@ -1,4 +1,4 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.Data;
 using Connapse.Storage.Data.Entities;
@@ -357,6 +357,13 @@ public class PostgresDocumentStore : IDocumentStore
             entity.Summary,
             entity.SummaryGeneratedAt,
             entity.SummaryContentHash,
-            entity.IngestionState);
+            entity.IngestionState)
+        {
+            // Which of the two columns is set, kept alongside the collapsed OwnerId above so a
+            // caller can tell a source-owned row from a container-owned one.
+            Owner = entity.SourceId is Guid sourceId
+                ? OwnerRef.ForSource(sourceId)
+                : OwnerRef.ForContainer(entity.ContainerId!.Value),
+        };
     }
 }

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -184,6 +184,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<OllamaConnectionTester>();
         services.AddScoped<MinioConnectionTester>();
         services.AddScoped<S3ConnectionTester>();
+        services.AddScoped<SftpConnectionTester>();
         services.AddScoped<AzureBlobConnectionTester>();
         services.AddScoped<AwsSsoConnectionTester>();
         services.AddScoped<AzureAdConnectionTester>();

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -261,13 +261,25 @@
                             <div class="form-text">Narrows the source to a subtree. Everything below it is indexed.</div>
                         </div>
                     }
-                    else if (selectedProvider is ConnectionProvider.Filesystem)
+                    @* SFTP shares this branch rather than getting its own. Its scope is the same
+                       shape — a subpath beneath the connection's root, plus patterns — and that
+                       was a deliberate choice when the provider was designed, so that this form,
+                       the preflight, and the scope summary each gained a case rather than a
+                       parallel implementation. *@
+                    else if (selectedProvider is ConnectionProvider.Filesystem or ConnectionProvider.Sftp)
                     {
                         <div class="mb-3">
                             <label class="form-label">Sub-path (optional)</label>
-                            <input class="form-control font-monospace" @bind="form.SubPath" placeholder="team-a" />
+                            <input class="form-control font-monospace" @bind="form.SubPath"
+                                   placeholder="@(selectedProvider is ConnectionProvider.Sftp ? "Documents" : "team-a")" />
                             <div class="form-text">
                                 Resolved beneath the connection's allowed root. Leave empty for the root itself.
+                                @if (selectedProvider is ConnectionProvider.Sftp)
+                                {
+                                    <text>
+                                        Resolved on the remote server, so a symlink cannot lead outside the root.
+                                    </text>
+                                }
                             </div>
                         </div>
 

--- a/src/Connapse.Web/Components/Settings/ConnectionForm.cs
+++ b/src/Connapse.Web/Components/Settings/ConnectionForm.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Connapse.Core;
+using Connapse.Storage.Connectors;
 
 namespace Connapse.Web.Components.Settings;
 
@@ -25,11 +26,50 @@ public sealed record ConnectionForm
     public string? StorageAccountName { get; set; }
     public string? ManagedIdentityClientId { get; set; }
 
-    // Filesystem
+    // Filesystem and SFTP both bound a source with a root, so this is shared.
     public string? AllowedRoot { get; set; }
+
+    // SFTP
+    public string? Host { get; set; }
+    public string? Port { get; set; }
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// The private key, entered once and never read back. <see cref="FromConnection"/> leaves
+    /// this null when editing, and a null value means "leave the stored secret alone" — the
+    /// same rule the store applies, so opening and saving a connection cannot wipe its key.
+    /// </summary>
+    public string? PrivateKey { get; set; }
+
+    /// <summary>Only needed when the private key is itself encrypted.</summary>
+    public string? Passphrase { get; set; }
+
+    /// <summary>
+    /// The pinned host key, shown so it can be checked against <c>ssh-keyscan</c>. Recorded by
+    /// the connector on first successful connect, never typed.
+    /// </summary>
+    public string? HostKeyFingerprint { get; set; }
+
+    /// <summary>
+    /// Set by the "forget" control. Clearing the pin re-arms trust on first use, which is how a
+    /// server that was legitimately rekeyed is accepted again.
+    /// </summary>
+    public bool ForgetHostKey { get; set; }
 
     /// <summary>Newline-separated in the UI; an array in the stored JSON.</summary>
     public string? AllowedLocations { get; set; }
+
+    /// <summary>
+    /// Providers whose credential is a cloud identity Connapse never holds, and which are
+    /// therefore bounded by <see cref="AllowedLocations"/> rather than a root.
+    /// <para>
+    /// Named rather than written as "not Filesystem". The old form used the negative, and
+    /// adding SFTP to the enum would have silently swept it into the cloud branch — offering a
+    /// bucket allowlist for a directory on a server, and no root at all.
+    /// </para>
+    /// </summary>
+    public bool IsCloudProvider =>
+        Provider is ConnectionProvider.S3 or ConnectionProvider.AzureBlob;
 
 
     /// <summary>
@@ -60,6 +100,16 @@ public sealed record ConnectionForm
         form.StorageAccountName = Str(node, "storageAccountName");
         form.ManagedIdentityClientId = Str(node, "managedIdentityClientId");
         form.AllowedRoot = Str(node, "allowedRoot");
+        form.Host = Str(node, "host");
+        form.Username = Str(node, "username");
+        form.HostKeyFingerprint = Str(node, "hostKeyFingerprint");
+
+        if (node["port"] is JsonValue port && port.TryGetValue<int>(out int portNumber))
+            form.Port = portNumber.ToString();
+
+        // PrivateKey and Passphrase are deliberately not populated. The store never returns a
+        // secret to a read model, and leaving them blank is what makes "save without retyping
+        // the key" work.
 
         if (node["allowedLocations"] is JsonArray arr)
         {
@@ -109,11 +159,26 @@ public sealed record ConnectionForm
             case ConnectionProvider.Filesystem:
                 node["allowedRoot"] = AllowedRoot?.Trim() ?? "";
                 break;
+
+            case ConnectionProvider.Sftp:
+                node["host"] = Host?.Trim() ?? "";
+                node["port"] = ParsePort(Port);
+                node["username"] = Username?.Trim() ?? "";
+                node["allowedRoot"] = AllowedRoot?.Trim() ?? "";
+
+                // Carried forward rather than rewritten. The connector owns this value — it
+                // records it on first connect and compares against it thereafter — so an
+                // ordinary save must not disturb it. Dropping it here would silently re-arm
+                // trust on first use on the next sync, which is the one thing pinning exists
+                // to prevent.
+                if (!ForgetHostKey && !Blank(HostKeyFingerprint))
+                    node["hostKeyFingerprint"] = HostKeyFingerprint!.Trim();
+                break;
         }
 
-        // Filesystem confinement is the allowed root plus the subpath check; allowedLocations is
-        // the cloud equivalent and does not apply to it.
-        if (Provider != ConnectionProvider.Filesystem)
+        // A root plus a subpath check is how the on-disk providers are bounded; allowedLocations
+        // is the cloud equivalent and does not apply to them.
+        if (IsCloudProvider)
         {
             var locations = ParseLocations(AllowedLocations);
             if (locations.Count > 0)
@@ -154,8 +219,32 @@ public sealed record ConnectionForm
             : (trimmed[..slash], trimmed[(slash + 1)..]);
     }
 
+    /// <summary>
+    /// The credential to store, or null to leave any existing one untouched.
+    /// </summary>
+    /// <remarks>
+    /// SFTP only, and that is the whole point. #371 removed the secret field from this form
+    /// because Connapse does not accept pasted cloud keys; an SSH key for a server you run is a
+    /// different thing from an AWS access key, but only if the distinction is enforced rather
+    /// than described. Returning null for every other provider is where it is enforced.
+    /// </remarks>
+    public string? ToSecretJson()
+    {
+        if (Provider != ConnectionProvider.Sftp || Blank(PrivateKey))
+            return null;
+
+        return new SftpCredential
+        {
+            PrivateKey = PrivateKey!.Trim(),
+            Passphrase = Blank(Passphrase) ? null : Passphrase
+        }.ToSecretJson();
+    }
+
     /// <summary>Returns the first problem with the form, or null when it is ready to save.</summary>
-    public string? Validate()
+    /// <param name="isNew">
+    /// A new SFTP connection must carry a key; an existing one may be saved without retyping it.
+    /// </param>
+    public string? Validate(bool isNew = true)
     {
         if (Blank(Name)) return "A name is required.";
 
@@ -163,9 +252,27 @@ public sealed record ConnectionForm
         {
             ConnectionProvider.Filesystem when Blank(AllowedRoot) => "Choose an allowed root.",
             ConnectionProvider.AzureBlob when Blank(StorageAccountName) => "A storage account is required.",
+
+            ConnectionProvider.Sftp when Blank(Host) => "A host is required.",
+            ConnectionProvider.Sftp when Blank(Username) => "A username is required.",
+            ConnectionProvider.Sftp when Blank(AllowedRoot) => "An allowed root is required.",
+            ConnectionProvider.Sftp when !Blank(Port) && ParsePort(Port) is < 1 or > 65535 =>
+                "The port must be between 1 and 65535.",
+            ConnectionProvider.Sftp when isNew && Blank(PrivateKey) => "A private key is required.",
+
             _ => null
         };
     }
+
+    /// <summary>
+    /// The configured port, or 22. Anything unparseable becomes 0, which
+    /// <see cref="Validate"/> then refuses — rather than silently falling back to 22 and
+    /// connecting somewhere the operator did not ask for.
+    /// </summary>
+    private static int ParsePort(string? raw) =>
+        string.IsNullOrWhiteSpace(raw) ? 22
+        : int.TryParse(raw.Trim(), out int port) ? port
+        : 0;
 
     private static string? Str(JsonObject node, string name) =>
         node[name] is JsonValue value && value.TryGetValue<string>(out var s) && !string.IsNullOrWhiteSpace(s)
@@ -174,3 +281,4 @@ public sealed record ConnectionForm
 
     private static bool Blank(string? s) => string.IsNullOrWhiteSpace(s);
 }
+

--- a/src/Connapse.Web/Components/Settings/ConnectionForm.cs
+++ b/src/Connapse.Web/Components/Settings/ConnectionForm.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Connapse.Core;
+using Connapse.Core.Utilities;
 using Connapse.Storage.Connectors;
 
 namespace Connapse.Web.Components.Settings;
@@ -71,6 +72,92 @@ public sealed record ConnectionForm
     public bool IsCloudProvider =>
         Provider is ConnectionProvider.S3 or ConnectionProvider.AzureBlob;
 
+
+    /// <summary>
+    /// Builds the connection the "Connect this computer" flow creates, from what the host's
+    /// setup command reported.
+    /// </summary>
+    /// <remarks>
+    /// Here rather than in the Razor component for the same reason the rest of this class is:
+    /// a dropped or mis-joined field produces a connection that points somewhere other than
+    /// intended, and the component has no test harness in this repository.
+    /// </remarks>
+    /// <param name="allowedRoot">
+    /// Any absolute path on the host, not merely somewhere under the home directory. Windows
+    /// OpenSSH applies no chroot, so a second drive is reachable as <c>/D:/…</c> and confining
+    /// the flow to the profile would rule out where most people actually keep things.
+    /// Blank falls back to the reported home directory.
+    /// </param>
+    public static ConnectionForm ForLocalMachine(
+        SftpHostSetupResult result, string host, string? allowedRoot, string privateKeyPem)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentException.ThrowIfNullOrWhiteSpace(privateKeyPem);
+
+        return new ConnectionForm
+        {
+            Name = $"{result.Username}@{host.Trim()}",
+            Provider = ConnectionProvider.Sftp,
+            Host = host.Trim(),
+            Port = "22",
+            Username = result.Username,
+            AllowedRoot = NormaliseRemoteRoot(allowedRoot, result.HomePath),
+            HostKeyFingerprint = result.Fingerprint,
+            PrivateKey = privateKeyPem,
+        };
+    }
+
+    /// <summary>
+    /// Cleans an operator-entered remote path into the form SFTP expects, falling back to
+    /// <paramref name="fallback"/> when nothing was entered.
+    /// </summary>
+    /// <remarks>
+    /// Never uses <see cref="System.IO.Path"/>: that applies the rules of whichever machine
+    /// Connapse runs on, which is a Linux container, to a path describing somebody else's
+    /// Windows box. SFTP paths are always '/'-separated, and Windows OpenSSH presents drives
+    /// as <c>/C:/Users/me</c> — a leading slash before the drive letter.
+    /// <para>
+    /// A Windows path pasted from Explorer is accepted and converted, because that is what an
+    /// operator will have on their clipboard.
+    /// </para>
+    /// </remarks>
+    public static string NormaliseRemoteRoot(string? entered, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(entered))
+            return fallback.TrimEnd('/');
+
+        string path = entered.Trim().Replace('\\', '/');
+
+        // "D:/Projects" pasted from Explorer needs the leading slash SFTP presents.
+        if (path.Length >= 2 && char.IsLetter(path[0]) && path[1] == ':')
+            path = "/" + path;
+
+        if (!path.StartsWith('/'))
+            path = "/" + path;
+
+        // A drive root trims to "/D:" rather than "", which is still the drive and not the
+        // filesystem root — so only trim when something remains beneath it.
+        string trimmed = path.TrimEnd('/');
+
+        return trimmed.Length == 0 ? "/" : trimmed;
+    }
+
+    /// <summary>
+    /// True when a root is broad enough to be worth a second look — a drive root, or the
+    /// filesystem root. Permitted, since an administrator may genuinely mean it, but the UI
+    /// should say what it implies.
+    /// </summary>
+    public static bool IsBroadRemoteRoot(string? root)
+    {
+        if (string.IsNullOrWhiteSpace(root)) return false;
+
+        string trimmed = root.Trim().TrimEnd('/');
+
+        // "/" and "/D:" — nothing beneath the drive or the filesystem root.
+        return trimmed.Length == 0
+            || (trimmed.Length == 3 && trimmed[0] == '/' && char.IsLetter(trimmed[1]) && trimmed[2] == ':');
+    }
 
     /// <summary>
     /// Reads a stored connection into an editable form. A config that cannot be parsed yields an
@@ -281,4 +368,5 @@ public sealed record ConnectionForm
 
     private static bool Blank(string? s) => string.IsNullOrWhiteSpace(s);
 }
+
 

--- a/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
@@ -1,4 +1,4 @@
-@using Connapse.Core
+﻿@using Connapse.Core
 @using Connapse.Core.Interfaces
 @using Connapse.Core.Utilities
 @inject IJSRuntime JS
@@ -88,7 +88,7 @@
                         <span class="bi-clipboard me-1"></span> Copy command
                     </button>
                     <span class="small text-muted ms-2">
-                        Safe to run more than once. It adds one key and changes nothing else.
+                        Safe to run more than once.
                     </span>
 
                     @* The key is installed with restrict and a forced internal-sftp command, so it
@@ -101,6 +101,19 @@
                         It still signs in as the account you run this under, so prefer an ordinary
                         account over an administrator one: an administrator's SFTP session can read
                         anything on the machine, whatever folder you pick below.
+                    </div>
+
+                    @* Naming it, because it is the part that reaches past Connapse. Turning on
+                       an SSH server affects every account on the machine and every way of
+                       signing in to it, not only the key installed above — so an operator who
+                       reads "adds one key" and nothing else has been told the smaller half. *@
+                    <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                        <span class="bi-exclamation-triangle me-1"></span>
+                        It also <strong>turns on this computer's SSH server</strong> and allows
+                        inbound port 22 from your local networks — the Docker network among them,
+                        which is how Connapse reaches you. Other accounts on the machine can then
+                        sign in over SSH too, by password if the host allows it. The command reports
+                        whether it does, and prints the one line that turns that off.
                     </div>
                 </div>
             </div>

--- a/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
@@ -10,6 +10,7 @@
 @inject IOptionsMonitor<SourceSecuritySettings> SourceSecurity
 @inject S3ConnectionTester S3Tester
 @inject AzureBlobConnectionTester AzureTester
+@inject SftpConnectionTester SftpTester
 
 @*
     Connections — the credential and filesystem-root boundary.
@@ -92,7 +93,25 @@
                                     <td class="small text-muted">@DescribeScope(c)</td>
                                     <td>@c.SourceCount</td>
                                     <td class="small">
-                                        @if (c.HasSecret)
+                                        @if (c.Provider == ConnectionProvider.Sftp)
+                                        {
+                                            @* SFTP is the one provider that legitimately stores a
+                                               credential: an SSH key for a server the operator runs,
+                                               not a cloud identity. *@
+                                            @if (c.HasSecret)
+                                            {
+                                                <span class="text-success" title="SSH key, encrypted at rest">
+                                                    <span class="bi-key-fill me-1"></span>SSH key
+                                                </span>
+                                            }
+                                            else
+                                            {
+                                                <span class="text-danger" title="This connection cannot authenticate">
+                                                    <span class="bi-exclamation-triangle me-1"></span>No key
+                                                </span>
+                                            }
+                                        }
+                                        else if (c.HasSecret)
                                         {
                                             @* Only reachable for a connection created before this tab
                                                existed. Shown rather than hidden so an operator can see
@@ -137,6 +156,7 @@
                 <option value="@ConnectionProvider.S3">Amazon S3</option>
                 <option value="@ConnectionProvider.AzureBlob">Azure Blob Storage</option>
                 <option value="@ConnectionProvider.Filesystem">Local filesystem</option>
+                <option value="@ConnectionProvider.Sftp">SFTP</option>
             </select>
             @if (!isNew)
             {
@@ -166,6 +186,101 @@
                 <label class="form-label">Managed identity client ID <span class="text-muted">(optional)</span></label>
                 <input class="form-control" @bind="form.ManagedIdentityClientId" placeholder="00000000-0000-0000-0000-000000000000" />
                 <div class="form-text">Selects a specific identity. Leave blank to use the default — which may have wider access.</div>
+            </div>
+        }
+        else if (form.Provider == ConnectionProvider.Sftp)
+        {
+            <div class="col-md-8">
+                <label class="form-label">Host</label>
+                <input class="form-control" @bind="form.Host" placeholder="files.example.com" />
+                <div class="form-text">
+                    To index files on the machine you are sitting at, run an SSH server there and use
+                    <code>host.docker.internal</code> — see
+                    <a href="https://github.com/Destrayon/Connapse/blob/main/docs/connectors.md" target="_blank" rel="noopener">the connector documentation</a>.
+                </div>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Port</label>
+                <input class="form-control" type="number" @bind="form.Port" placeholder="22" />
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label">Username</label>
+                <input class="form-control" @bind="form.Username" placeholder="connapse" />
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label">Allowed root</label>
+                @* Free text, and unlike the local filesystem provider it is not checked against
+                   Sources:Security:AllowedFilesystemRoots — that setting names directories on
+                   this machine, and this one names a directory on somebody else's. The bound
+                   that does apply is enforced on the server, through SSH_FXP_REALPATH. *@
+                <input class="form-control" @bind="form.AllowedRoot" placeholder="/srv/knowledge" />
+                <div class="form-text">
+                    Every source on this connection is confined beneath this directory, resolved on
+                    the server so a symlink cannot lead out of it. Windows OpenSSH presents drives
+                    with a leading slash, as in <code>/C:/Users/you/Documents</code>.
+                </div>
+            </div>
+
+            <div class="col-12">
+                <label class="form-label">
+                    Private key
+                    @if (!isNew)
+                    {
+                        <span class="text-muted">— leave blank to keep the stored key</span>
+                    }
+                </label>
+                <textarea class="form-control font-monospace" rows="5" @bind="form.PrivateKey"
+                          placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;…"></textarea>
+                <div class="form-text">
+                    Encrypted at rest and never shown again. This is an SSH key for a server you run —
+                    the rule that Connapse stores no cloud credentials is about AWS and Azure
+                    identities, which are not stored and are not asked for.
+                </div>
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label">Key passphrase <span class="text-muted">(optional)</span></label>
+                <input class="form-control" type="password" @bind="form.Passphrase"
+                       placeholder="Only if the key is encrypted" />
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label">Host key</label>
+                @if (string.IsNullOrWhiteSpace(form.HostKeyFingerprint))
+                {
+                    <div class="form-control-plaintext text-muted small">
+                        Not yet recorded — the first successful sync will trust and pin whatever this
+                        server presents.
+                    </div>
+                }
+                else
+                {
+                    <div class="input-group">
+                        <input class="form-control font-monospace" readonly value="@form.HostKeyFingerprint" />
+                        <button class="btn btn-outline-warning" type="button"
+                                @onclick="() => form.ForgetHostKey = !form.ForgetHostKey">
+                            @(form.ForgetHostKey ? "Keep" : "Forget")
+                        </button>
+                    </div>
+                    <div class="form-text">
+                        @if (form.ForgetHostKey)
+                        {
+                            <span class="text-warning">
+                                Will be cleared on save, and the next connection will trust whatever
+                                answers. Only do this if you rekeyed the server yourself.
+                            </span>
+                        }
+                        else
+                        {
+                            <span>
+                                Compare against <code>ssh-keyscan @(string.IsNullOrWhiteSpace(form.Host) ? "host" : form.Host) | ssh-keygen -lf -</code>.
+                                Syncing stops if this stops matching.
+                            </span>
+                        }
+                    </div>
+                }
             </div>
         }
         else
@@ -203,7 +318,7 @@
             </div>
         }
 
-        @if (form.Provider != ConnectionProvider.Filesystem)
+        @if (form.IsCloudProvider)
         {
             <div class="col-12">
                 <label class="form-label">
@@ -224,7 +339,7 @@
 
 
         @* ── Test ──────────────────────────────────────────────────── *@
-        @if (form.Provider != ConnectionProvider.Filesystem)
+        @if (form.IsCloudProvider)
         {
             <div class="col-md-6">
                 <label class="form-label">
@@ -246,7 +361,7 @@
                 <span>@(isNew ? "Create connection" : "Save changes")</span>
             </button>
             <button class="btn btn-secondary me-2" @onclick="CancelEdit">Cancel</button>
-            @if (form.Provider != ConnectionProvider.Filesystem)
+            @if (form.IsCloudProvider || form.Provider == ConnectionProvider.Sftp)
             {
                 <button class="btn btn-info" @onclick="Test" disabled="@testing">
                     @if (testing)
@@ -339,7 +454,7 @@
     {
         statusMessage = null;
 
-        if (form.Validate() is { } problem)
+        if (form.Validate(isNew) is { } problem)
         {
             Fail(problem);
             return;
@@ -350,10 +465,14 @@
         {
             string config = form.ToConfigJson();
 
+            // Null for every provider but SFTP, and null again for an SFTP connection saved
+            // without retyping its key — which the store reads as "leave the stored one alone".
+            string? secret = form.ToSecretJson();
+
             if (isNew)
             {
                 await ConnectionStore.CreateAsync(
-                    new CreateConnectionRequest(form.Name.Trim(), form.Provider, config, Secret: null),
+                    new CreateConnectionRequest(form.Name.Trim(), form.Provider, config, secret),
                     createdByUserId: null);
                 Succeed($"Connection '{form.Name.Trim()}' created.");
             }
@@ -362,7 +481,7 @@
                 // Null result means the row is gone — deleted from another session between this
                 // form opening and saving. Reporting "saved" there would be a lie.
                 var updated = await ConnectionStore.UpdateAsync(editing!.Id,
-                    new UpdateConnectionRequest(form.Name.Trim(), config, Secret: null));
+                    new UpdateConnectionRequest(form.Name.Trim(), config, secret));
 
                 if (updated is null)
                 {
@@ -427,6 +546,39 @@
 
         try
         {
+            if (form.Provider == ConnectionProvider.Sftp)
+            {
+                // Tested against the key in the form, not the stored one, so an operator can
+                // check a key before committing to it. Editing an existing connection without
+                // retyping the key therefore cannot be tested — said plainly rather than
+                // silently testing something else.
+                if (string.IsNullOrWhiteSpace(form.PrivateKey))
+                {
+                    testSuccess = false;
+                    testMessage = "Paste the private key to test. Testing uses the key in this form, "
+                                  + "not the stored one.";
+                    return;
+                }
+
+                var sftpResult = await SftpTester.TestConnectionAsync(new SftpConnectionTestSettings
+                {
+                    Host = form.Host?.Trim() ?? "",
+                    Port = int.TryParse(form.Port, out int p) ? p : 22,
+                    Username = form.Username?.Trim() ?? "",
+                    AllowedRoot = form.AllowedRoot?.Trim() ?? "",
+                    PrivateKey = form.PrivateKey.Trim(),
+                    Passphrase = NullIfBlank(form.Passphrase),
+
+                    // Honoured unless the operator has chosen to forget it, so a test reports a
+                    // changed host key the same way a sync would.
+                    PinnedHostKeyFingerprint = form.ForgetHostKey ? null : NullIfBlank(form.HostKeyFingerprint),
+                }, TimeSpan.FromSeconds(15));
+
+                testSuccess = sftpResult.Success;
+                testMessage = sftpResult.Message;
+                return;
+            }
+
             string? target = NullIfBlank(probeTarget) ?? form.FirstAllowedLocation();
             if (target is null)
             {
@@ -483,6 +635,7 @@
             ConnectionProvider.Filesystem => form.AllowedRoot ?? "—",
             ConnectionProvider.S3 => form.Region ?? "—",
             ConnectionProvider.AzureBlob => form.StorageAccountName ?? "—",
+            ConnectionProvider.Sftp => $"{form.Username}@{form.Host}:{form.AllowedRoot}",
             _ => "—"
         };
     }
@@ -501,3 +654,4 @@
         statusMessage = message;
     }
 }
+

--- a/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
@@ -1,5 +1,7 @@
 @using Connapse.Core
 @using Connapse.Core.Interfaces
+@using Connapse.Core.Utilities
+@inject IJSRuntime JS
 @using Connapse.Storage.ConnectionTesters
 @using Connapse.Storage.Connectors
 @using Microsoft.Extensions.Options
@@ -49,14 +51,210 @@
         </div>
     }
 
+    @* ── Connect this computer ─────────────────────────────────────── *@
+    @if (localSetup)
+    {
+        <div class="col-12">
+            <h5>Connect this computer</h5>
+            <p class="text-muted mb-0">
+                Connapse runs in a container, so it cannot see your files directly and cannot
+                configure your machine for you. It can do everything else: it has made a key,
+                and written the one command you need to run.
+            </p>
+        </div>
+
+        @* Step 1 *@
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <h6 class="card-title">1 · Run this on your computer</h6>
+                    <div class="btn-group btn-group-sm mb-2" role="group">
+                        @foreach (var p in Enum.GetValues<HostPlatform>())
+                        {
+                            <button type="button"
+                                    class="btn @(setupPlatform == p ? "btn-secondary" : "btn-outline-secondary")"
+                                    @onclick="() => SelectPlatform(p)">@PlatformLabel(p)</button>
+                        }
+                    </div>
+                    @if (setupPlatform == HostPlatform.Windows)
+                    {
+                        <div class="small text-muted mb-2">
+                            Open PowerShell with <strong>Run as Administrator</strong>, then paste this in.
+                        </div>
+                    }
+                    <textarea class="form-control font-monospace" rows="12" readonly
+                              style="font-size:.78rem">@setupScript</textarea>
+                    <button class="btn btn-sm btn-outline-secondary mt-2" @onclick="CopyScript">
+                        <span class="bi-clipboard me-1"></span> Copy command
+                    </button>
+                    <span class="small text-muted ms-2">
+                        Safe to run more than once. It adds one key and changes nothing else.
+                    </span>
+
+                    @* The key is installed with restrict and a forced internal-sftp command, so it
+                       cannot open a shell or forward ports. That bounds the kind of access, not its
+                       reach: it still authenticates as this account, so an administrator account
+                       yields a key that can read the whole machine over SFTP. *@
+                    <div class="alert alert-secondary py-2 mt-2 mb-0 small">
+                        <span class="bi-shield-lock me-1"></span>
+                        The key is installed <strong>SFTP-only</strong> — no shell, no port forwarding.
+                        It still signs in as the account you run this under, so prefer an ordinary
+                        account over an administrator one: an administrator's SFTP session can read
+                        anything on the machine, whatever folder you pick below.
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        @* Step 2 *@
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <h6 class="card-title">2 · Paste back what it printed</h6>
+                    <textarea class="form-control font-monospace" rows="5" @bind="pastedResult"
+                              @bind:event="oninput"
+                              placeholder="@SftpHostSetup.BeginMarker&#10;user=…&#10;home=…&#10;fingerprint=…&#10;@SftpHostSetup.EndMarker"></textarea>
+                    <div class="form-text">
+                        The whole terminal output is fine — Connapse finds the block. This carries your
+                        username, your folder path, and the server's key fingerprint, so nothing has to
+                        be typed. The fingerprint arriving this way means the very first connection is
+                        verified rather than trusted.
+                    </div>
+
+                    @if (!string.IsNullOrWhiteSpace(pastedResult))
+                    {
+                        var parsed = SftpHostSetup.ParseResult(pastedResult);
+                        @if (parsed is null)
+                        {
+                            <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                <span class="bi-exclamation-triangle me-1"></span>
+                                No setup block found yet. Copy everything the command printed, including
+                                both <code>-----</code> marker lines.
+                            </div>
+                        }
+                        else
+                        {
+                            <div class="alert alert-success py-2 mt-2 mb-0 small">
+                                <span class="bi-check-circle me-1"></span>
+                                Read <strong>@parsed.Username</strong>, home <code>@parsed.HomePath</code>@(string.IsNullOrWhiteSpace(parsed.Fingerprint) ? "." : ", host key ")
+                                @if (!string.IsNullOrWhiteSpace(parsed.Fingerprint))
+                                {
+                                    <code>@parsed.Fingerprint</code><text>.</text>
+                                }
+                            </div>
+
+                            @if (string.IsNullOrWhiteSpace(parsed.Fingerprint))
+                            {
+                                @* Setup is finishable without it. Requiring one dead-ended the flow
+                                   with the host already configured and the key already installed. *@
+                                <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                    <span class="bi-exclamation-triangle me-1"></span>
+                                    No host key fingerprint came back, so the first connection will be
+                                    <strong>trusted</strong> rather than verified. Everything else is set up
+                                    and this is safe to continue with — re-running the command as
+                                    Administrator would capture it.
+                                </div>
+                            }
+                        }
+                    }
+                </div>
+            </div>
+        </div>
+
+        @* Step 3 *@
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <h6 class="card-title">3 · Choose what to index</h6>
+                    <div class="row g-3">
+                        <div class="col-md-8">
+                            <label class="form-label">Folder</label>
+                            <input class="form-control font-monospace" @bind="localRoot" @bind:event="oninput"
+                                   placeholder="@(LocalHome() ?? "/C:/Users/you")" />
+
+                            @if (LocalResult() is { } r)
+                            {
+                                <div class="mt-2 d-flex flex-wrap gap-1 align-items-center">
+                                    <span class="small text-muted me-1">Jump to:</span>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary py-0"
+                                            @onclick="() => localRoot = r.HomePath">Home</button>
+                                    @foreach (var drive in r.Drives)
+                                    {
+                                        <button type="button" class="btn btn-sm btn-outline-secondary py-0"
+                                                @onclick="() => localRoot = drive">@drive</button>
+                                    }
+                                </div>
+                            }
+
+                            <div class="form-text">
+                                Any folder on that machine, not only inside your profile — a second drive
+                                is <code>/D:/Projects</code>. Paths use forward slashes with a leading one
+                                before the drive letter; a path pasted from Explorer is converted for you.
+                                Sources you add later are confined beneath whatever you choose.
+                            </div>
+
+                            @if (ConnectionForm.IsBroadRemoteRoot(EffectiveRoot()))
+                            {
+                                <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                    <span class="bi-exclamation-triangle me-1"></span>
+                                    That is a whole drive. Every source on this connection could then reach
+                                    anything on it that <strong>@LocalResult()?.Username</strong> can read,
+                                    and Connapse indexes what it reads. Naming a folder costs nothing and
+                                    bounds it.
+                                </div>
+                            }
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Reachable at</label>
+                            <input class="form-control font-monospace" @bind="localHost" />
+                            <div class="form-text">
+                                <code>host.docker.internal</code> works on Docker Desktop. A Linux host needs
+                                <code>--add-host=host.docker.internal:host-gateway</code>.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12">
+            <button class="btn btn-primary me-2" @onclick="SaveLocalSetup" disabled="@(saving || !LocalSetupReady())">
+                @if (saving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                <span>Create connection</span>
+            </button>
+            <button class="btn btn-info me-2" @onclick="TestLocalSetup" disabled="@(testing || !LocalSetupReady())">
+                @if (testing) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                <span>Test first</span>
+            </button>
+            <button class="btn btn-secondary" @onclick="CancelLocalSetup">Cancel</button>
+        </div>
+
+        @if (testMessage is not null)
+        {
+            <div class="col-12">
+                <div class="alert @(testSuccess ? "alert-success" : "alert-danger") py-2 mb-0">
+                    <span class="@(testSuccess ? "bi-check-circle" : "bi-x-circle") me-2"></span>
+                    @testMessage
+                </div>
+            </div>
+        }
+    }
     @* ── List ──────────────────────────────────────────────────────── *@
-    @if (editing is null)
+    else if (editing is null)
     {
         <div class="col-12 d-flex justify-content-between align-items-center">
             <h5 class="mb-0">Connections</h5>
-            <button class="btn btn-primary btn-sm" @onclick="StartCreate">
-                <span class="bi-plus-lg me-1"></span> Add connection
-            </button>
+            <div>
+                @* The local case gets its own entry point rather than being a provider hidden
+                   inside "Add connection". It is the one most people want, and reaching it
+                   through a generic SFTP form means understanding SFTP first. *@
+                <button class="btn btn-outline-primary btn-sm me-2" @onclick="StartLocalSetup">
+                    <span class="bi-laptop me-1"></span> Connect this computer
+                </button>
+                <button class="btn btn-primary btn-sm" @onclick="StartCreate">
+                    <span class="bi-plus-lg me-1"></span> Add connection
+                </button>
+            </div>
         </div>
 
         <div class="col-12">
@@ -420,6 +618,139 @@
         loading = false;
     }
 
+    // ── Connect this computer ──────────────────────────────────────────────
+
+    private bool localSetup;
+    private HostPlatform setupPlatform = HostPlatform.Windows;
+    private SshKeyPair? localKeyPair;
+    private string setupScript = "";
+    private string? pastedResult;
+    private string localRoot = "";
+    private string localHost = "host.docker.internal";
+
+    private static string PlatformLabel(HostPlatform p) => p switch
+    {
+        HostPlatform.Windows => "Windows",
+        HostPlatform.MacOS => "macOS",
+        _ => "Linux",
+    };
+
+    private void StartLocalSetup()
+    {
+        // Generated once per visit, not per keystroke: the script embeds the public key, and
+        // regenerating would invalidate a command the operator may have already run.
+        localKeyPair = SshKeyPairGenerator.Generate($"connapse@{Environment.MachineName}");
+
+        localSetup = true;
+        editing = null;
+        pastedResult = null;
+        localRoot = "";
+        localHost = "host.docker.internal";
+        statusMessage = null;
+        testMessage = null;
+
+        RegenerateScript();
+    }
+
+    private void SelectPlatform(HostPlatform platform)
+    {
+        setupPlatform = platform;
+        RegenerateScript();
+    }
+
+    private void RegenerateScript() =>
+        setupScript = localKeyPair is null
+            ? ""
+            : SftpHostSetup.GenerateScript(localKeyPair.PublicKeyLine, setupPlatform);
+
+    private async Task CopyScript() =>
+        await JS.InvokeVoidAsync("navigator.clipboard.writeText", setupScript);
+
+    private SftpHostSetupResult? LocalResult() => SftpHostSetup.ParseResult(pastedResult);
+
+    private string? LocalHome() => LocalResult()?.HomePath;
+
+    /// <summary>What the connection would actually be bounded to, blank meaning the home folder.</summary>
+    private string? EffectiveRoot() =>
+        LocalResult() is { } r ? ConnectionForm.NormaliseRemoteRoot(localRoot, r.HomePath) : null;
+
+    private bool LocalSetupReady() =>
+        LocalResult() is not null && !string.IsNullOrWhiteSpace(localHost);
+
+    private ConnectionForm BuildLocalForm(SftpHostSetupResult result) =>
+        ConnectionForm.ForLocalMachine(result, localHost, localRoot, localKeyPair!.PrivateKeyPem);
+
+    private async Task TestLocalSetup()
+    {
+        if (LocalResult() is not { } result) return;
+
+        testing = true;
+        testMessage = null;
+        try
+        {
+            var form = BuildLocalForm(result);
+
+            var outcome = await SftpTester.TestConnectionAsync(new SftpConnectionTestSettings
+            {
+                Host = form.Host!,
+                Port = 22,
+                Username = form.Username!,
+                AllowedRoot = form.AllowedRoot!,
+                PrivateKey = form.PrivateKey!,
+                PinnedHostKeyFingerprint = form.HostKeyFingerprint,
+            }, TimeSpan.FromSeconds(15));
+
+            testSuccess = outcome.Success;
+            testMessage = outcome.Message;
+        }
+        catch (Exception ex)
+        {
+            testSuccess = false;
+            testMessage = ex.Message;
+        }
+        finally
+        {
+            testing = false;
+        }
+    }
+
+    private async Task SaveLocalSetup()
+    {
+        if (LocalResult() is not { } result) return;
+
+        saving = true;
+        try
+        {
+            var form = BuildLocalForm(result);
+
+            await ConnectionStore.CreateAsync(
+                new CreateConnectionRequest(
+                    form.Name.Trim(), ConnectionProvider.Sftp, form.ToConfigJson(), form.ToSecretJson()),
+                createdByUserId: null);
+
+            Succeed($"Connected. Add a source on '{form.Name}' to start indexing.");
+            CancelLocalSetup();
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Fail(ex.Message);
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private void CancelLocalSetup()
+    {
+        localSetup = false;
+        localKeyPair = null;
+        setupScript = "";
+        pastedResult = null;
+        testMessage = null;
+    }
+
     private void StartCreate()
     {
         editing = new Connection(Guid.Empty, "", ConnectionProvider.S3, null, null, DateTime.UtcNow, DateTime.UtcNow);
@@ -654,4 +985,5 @@
         statusMessage = message;
     }
 }
+
 

--- a/src/Connapse.Web/Components/Settings/SourceForm.cs
+++ b/src/Connapse.Web/Components/Settings/SourceForm.cs
@@ -60,7 +60,11 @@ public sealed record SourceForm
                 if (!Blank(Prefix)) node["prefix"] = Prefix!.Trim();
                 break;
 
+            // One case for both. The SFTP scope was deliberately given the same shape as the
+            // filesystem one so that this form, the preflight and the scope summary each gained
+            // a provider here rather than a parallel implementation to keep in step.
             case ConnectionProvider.Filesystem:
+            case ConnectionProvider.Sftp:
                 // Always present, and empty means the root itself. ConnectorFactory treats a
                 // blank subPath as "the allowed root", so this is a meaningful value rather
                 // than a missing one.

--- a/src/Connapse.Web/Services/SourceScopePreflight.cs
+++ b/src/Connapse.Web/Services/SourceScopePreflight.cs
@@ -55,6 +55,7 @@ public class SourceScopePreflight(IOptionsMonitor<SourceSecuritySettings> source
             ConnectionProvider.S3 => CheckLocation(credential, scope, "bucketName", "bucket", connection.Name),
             ConnectionProvider.AzureBlob => CheckLocation(credential, scope, "containerName", "blob container", connection.Name),
             ConnectionProvider.Filesystem => CheckRoot(credential, scope, connection.Name),
+            ConnectionProvider.Sftp => CheckSftpScope(credential, scope, connection.Name),
             _ => ScopePreflightResult.Refuse(
                 $"Connection '{connection.Name}' uses a provider this form does not understand.")
         };
@@ -86,6 +87,52 @@ public class SourceScopePreflight(IOptionsMonitor<SourceSecuritySettings> source
             _ => ScopePreflightResult.Refuse(
                 $"'{Join(container, prefix)}' is outside the locations connection '{connectionName}' permits.")
         };
+    }
+
+    /// <summary>
+    /// Checks an SFTP scope as far as it can be checked without a network call.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does <b>not</b> reuse <see cref="CheckRoot"/>. That path calls
+    /// <see cref="PathConfinement"/> and <see cref="SourceSecuritySettings.EvaluateRoot"/>, both
+    /// of which touch the local disk and read the deployment's own allowed-roots setting —
+    /// answers about the machine Connapse runs on, not the one being connected to. Against a
+    /// remote path they would resolve nothing and silently degrade to a lexical prefix check,
+    /// which is the mistake <c>SftpPathConfinement</c> exists to avoid.
+    /// <para>
+    /// So this catches only what is wrong on its face. The real confinement happens on the
+    /// server, through <c>SSH_FXP_REALPATH</c>, at the first connect — the same division of
+    /// labour as everywhere else here: this makes the obvious case legible early, and the
+    /// connector remains the thing that actually decides.
+    /// </para>
+    /// </remarks>
+    private static ScopePreflightResult CheckSftpScope(
+        JsonObject? credential, JsonObject scope, string connectionName)
+    {
+        if (string.IsNullOrWhiteSpace(Str(credential, "allowedRoot")))
+            return ScopePreflightResult.Refuse($"Connection '{connectionName}' has no allowed root configured.");
+
+        string? subPath = Str(scope, "subPath");
+        if (string.IsNullOrWhiteSpace(subPath))
+            return ScopePreflightResult.Allowed;
+
+        string cleaned = subPath.Replace('\\', '/');
+
+        if (cleaned.StartsWith('/'))
+        {
+            return ScopePreflightResult.Refuse(
+                "A sub-path is relative to the connection's allowed root, so it cannot start with '/'.");
+        }
+
+        // Refused on the segment, not on the substring: a file legitimately named "..config"
+        // contains ".." without being a traversal.
+        if (cleaned.Split('/').Any(segment => segment == ".."))
+        {
+            return ScopePreflightResult.Refuse(
+                "A sub-path cannot contain '..' — it must stay inside the connection's allowed root.");
+        }
+
+        return ScopePreflightResult.Allowed;
     }
 
     private ScopePreflightResult CheckRoot(JsonObject? credential, JsonObject scope, string connectionName)

--- a/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
+++ b/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
@@ -239,4 +239,187 @@ public class ConnectionFormTests
         new ConnectionForm { Name = "c", Provider = ConnectionProvider.S3 }
             .Validate().Should().BeNull();
     }
+
+    // ── SFTP ───────────────────────────────────────────────────────────────
+
+    private static ConnectionForm SftpForm() => new()
+    {
+        Name = "files",
+        Provider = ConnectionProvider.Sftp,
+        Host = "files.example.com",
+        Port = "2222",
+        Username = "connapse",
+        AllowedRoot = "/srv/knowledge",
+        PrivateKey = "-----BEGIN OPENSSH PRIVATE KEY-----\nkey\n",
+    };
+
+    [Fact]
+    public void Sftp_ConfigRoundTrips()
+    {
+        string json = SftpForm().ToConfigJson();
+        var back = ConnectionForm.FromConnection(Stored(ConnectionProvider.Sftp, json));
+
+        back.Host.Should().Be("files.example.com");
+        back.Port.Should().Be("2222");
+        back.Username.Should().Be("connapse");
+        back.AllowedRoot.Should().Be("/srv/knowledge");
+    }
+
+    [Fact]
+    public void Sftp_NoPort_DefaultsTo22InTheStoredConfig()
+    {
+        var form = SftpForm() with { Port = null };
+
+        JsonNode.Parse(form.ToConfigJson())!["port"]!.GetValue<int>().Should().Be(22);
+    }
+
+    /// <summary>
+    /// The pin belongs to the connector, which records it on first connect and compares against
+    /// it afterwards. An ordinary save must carry it through — dropping it would silently re-arm
+    /// trust on first use, which is the one thing pinning exists to prevent.
+    /// </summary>
+    [Fact]
+    public void Sftp_SavingAnExistingConnection_PreservesThePinnedHostKey()
+    {
+        var stored = Stored(ConnectionProvider.Sftp,
+            """{"host":"h","port":22,"username":"u","allowedRoot":"/srv","hostKeyFingerprint":"SHA256:pinned"}""");
+
+        var form = ConnectionForm.FromConnection(stored);
+        form.HostKeyFingerprint.Should().Be("SHA256:pinned");
+
+        JsonNode.Parse(form.ToConfigJson())!["hostKeyFingerprint"]!.GetValue<string>()
+            .Should().Be("SHA256:pinned");
+    }
+
+    [Fact]
+    public void Sftp_ForgettingTheHostKey_DropsItFromTheStoredConfig()
+    {
+        var stored = Stored(ConnectionProvider.Sftp,
+            """{"host":"h","port":22,"username":"u","allowedRoot":"/srv","hostKeyFingerprint":"SHA256:pinned"}""");
+
+        var form = ConnectionForm.FromConnection(stored);
+        form.ForgetHostKey = true;
+
+        JsonNode.Parse(form.ToConfigJson())!["hostKeyFingerprint"].Should().BeNull();
+    }
+
+    /// <summary>
+    /// A secret is never read back into the form, so an operator opening and saving a connection
+    /// must not wipe its key. Null means "leave the stored one alone", which is the store's own
+    /// rule.
+    /// </summary>
+    [Fact]
+    public void Sftp_FromConnection_LeavesTheKeyBlankSoSavingDoesNotWipeIt()
+    {
+        var form = ConnectionForm.FromConnection(
+            Stored(ConnectionProvider.Sftp, """{"host":"h","username":"u","allowedRoot":"/srv"}""", hasSecret: true));
+
+        form.PrivateKey.Should().BeNull();
+        form.ToSecretJson().Should().BeNull();
+    }
+
+    [Fact]
+    public void Sftp_SecretCarriesTheKeyAndPassphrase()
+    {
+        var form = SftpForm() with { Passphrase = "hunter2" };
+
+        var secret = JsonNode.Parse(form.ToSecretJson()!)!;
+
+        secret["privateKey"]!.GetValue<string>().Should().Contain("OPENSSH PRIVATE KEY");
+        secret["passphrase"]!.GetValue<string>().Should().Be("hunter2");
+    }
+
+    /// <summary>
+    /// #371 removed the secret field because Connapse does not accept pasted cloud keys. SFTP
+    /// brings it back for one provider only, and this is where that stays true.
+    /// </summary>
+    [Theory]
+    [InlineData(ConnectionProvider.S3)]
+    [InlineData(ConnectionProvider.AzureBlob)]
+    [InlineData(ConnectionProvider.Filesystem)]
+    public void NonSftpProviders_NeverProduceASecret(ConnectionProvider provider)
+    {
+        var form = new ConnectionForm
+        {
+            Name = "c",
+            Provider = provider,
+            StorageAccountName = "a",
+            AllowedRoot = "/data",
+
+            // Set deliberately: even with a key sitting in the form, these providers must not
+            // store one.
+            PrivateKey = "-----BEGIN OPENSSH PRIVATE KEY-----\nkey\n",
+        };
+
+        form.ToSecretJson().Should().BeNull();
+    }
+
+    /// <summary>
+    /// SFTP is bounded by a root, not by a bucket allowlist. Written as a positive check on the
+    /// cloud providers rather than "not Filesystem", which is what would have swept SFTP into
+    /// the wrong branch.
+    /// </summary>
+    [Fact]
+    public void Sftp_DoesNotWriteAllowedLocations()
+    {
+        var form = SftpForm() with { AllowedLocations = "some-bucket" };
+
+        JsonNode.Parse(form.ToConfigJson())!["allowedLocations"].Should().BeNull();
+    }
+
+    [Fact]
+    public void Sftp_IsNotACloudProvider()
+    {
+        SftpForm().IsCloudProvider.Should().BeFalse();
+        new ConnectionForm { Provider = ConnectionProvider.S3 }.IsCloudProvider.Should().BeTrue();
+        new ConnectionForm { Provider = ConnectionProvider.AzureBlob }.IsCloudProvider.Should().BeTrue();
+        new ConnectionForm { Provider = ConnectionProvider.Filesystem }.IsCloudProvider.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(nameof(ConnectionForm.Host))]
+    [InlineData(nameof(ConnectionForm.Username))]
+    [InlineData(nameof(ConnectionForm.AllowedRoot))]
+    public void Sftp_MissingARequiredField_IsRefused(string missing)
+    {
+        var form = SftpForm();
+
+        switch (missing)
+        {
+            case nameof(ConnectionForm.Host): form.Host = null; break;
+            case nameof(ConnectionForm.Username): form.Username = null; break;
+            case nameof(ConnectionForm.AllowedRoot): form.AllowedRoot = null; break;
+        }
+
+        form.Validate().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Sftp_NewConnectionWithoutAKey_IsRefused()
+    {
+        (SftpForm() with { PrivateKey = null }).Validate(isNew: true)
+            .Should().Be("A private key is required.");
+    }
+
+    [Fact]
+    public void Sftp_ExistingConnectionWithoutAKey_IsAllowed()
+    {
+        (SftpForm() with { PrivateKey = null }).Validate(isNew: false)
+            .Should().BeNull("an operator editing a connection should not have to retype the key");
+    }
+
+    /// <summary>
+    /// An unparseable port becomes 0 and is refused, rather than silently falling back to 22 and
+    /// connecting somewhere the operator did not ask for.
+    /// </summary>
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("0")]
+    [InlineData("70000")]
+    [InlineData("-1")]
+    public void Sftp_UnusablePort_IsRefused(string port)
+    {
+        (SftpForm() with { Port = port }).Validate()
+            .Should().Be("The port must be between 1 and 65535.");
+    }
 }

--- a/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
+++ b/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Connapse.Core;
+using Connapse.Core.Utilities;
 using Connapse.Web.Components.Settings;
 using FluentAssertions;
 using Xunit;
@@ -376,6 +377,132 @@ public class ConnectionFormTests
         new ConnectionForm { Provider = ConnectionProvider.Filesystem }.IsCloudProvider.Should().BeFalse();
     }
 
+    // ── Connect this computer ──────────────────────────────────────────────
+
+    private static SftpHostSetupResult Reported(
+        string user = "Diviel",
+        string home = "/C:/Users/Diviel",
+        string fingerprint = "SHA256:hostkey") => new(user, home, fingerprint);
+
+    private const string GeneratedKey = "-----BEGIN RSA PRIVATE KEY-----\ngenerated\n";
+
+    [Fact]
+    public void ForLocalMachine_UsesEveryValueTheHostReported()
+    {
+        var form = ConnectionForm.ForLocalMachine(
+            Reported(), "host.docker.internal", "Documents", GeneratedKey);
+
+        form.Provider.Should().Be(ConnectionProvider.Sftp);
+        form.Username.Should().Be("Diviel");
+        form.Host.Should().Be("host.docker.internal");
+        form.Port.Should().Be("22");
+        form.HostKeyFingerprint.Should().Be("SHA256:hostkey");
+        form.PrivateKey.Should().Be(GeneratedKey);
+        form.Name.Should().Be("Diviel@host.docker.internal");
+    }
+
+    /// <summary>
+    /// The restriction that was there by accident. Windows OpenSSH applies no chroot, so a
+    /// second drive is perfectly reachable — and confining the flow to the profile would rule
+    /// out where most people actually keep things.
+    /// </summary>
+    [Fact]
+    public void ForLocalMachine_RootOnAnotherDrive_IsAllowed()
+    {
+        ConnectionForm.ForLocalMachine(Reported(), "h", "/D:/CodeProjects", GeneratedKey)
+            .AllowedRoot.Should().Be("/D:/CodeProjects");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ForLocalMachine_NoFolderChosen_UsesTheHomeDirectory(string? root)
+    {
+        ConnectionForm.ForLocalMachine(Reported(), "h", root, GeneratedKey)
+            .AllowedRoot.Should().Be("/C:/Users/Diviel");
+    }
+
+    /// <summary>
+    /// An operator will paste what Explorer shows them, because that is what is on the
+    /// clipboard. SFTP takes neither the backslashes nor the bare drive letter.
+    /// </summary>
+    [Theory]
+    [InlineData(@"D:\CodeProjects", "/D:/CodeProjects")]
+    [InlineData("D:/CodeProjects", "/D:/CodeProjects")]
+    [InlineData(@"C:\Users\Diviel\Documents", "/C:/Users/Diviel/Documents")]
+    public void NormaliseRemoteRoot_ConvertsAWindowsPathFromExplorer(string entered, string expected)
+    {
+        ConnectionForm.NormaliseRemoteRoot(entered, "/fallback").Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("/D:/Projects/", "/D:/Projects")]
+    [InlineData("/home/me/docs", "/home/me/docs")]
+    [InlineData("home/me", "/home/me")]
+    [InlineData("/", "/")]
+    public void NormaliseRemoteRoot_ProducesAnAbsoluteUnDoubledPath(string entered, string expected)
+    {
+        ConnectionForm.NormaliseRemoteRoot(entered, "/fallback").Should().Be(expected);
+    }
+
+    /// <summary>
+    /// A drive root trims to "/D:" and must stay that, not collapse to the filesystem root —
+    /// which would silently widen the connection from one drive to the whole machine.
+    /// </summary>
+    [Fact]
+    public void NormaliseRemoteRoot_DriveRoot_StaysTheDrive()
+    {
+        ConnectionForm.NormaliseRemoteRoot("/D:/", "/fallback").Should().Be("/D:");
+    }
+
+    [Theory]
+    [InlineData("/", true)]
+    [InlineData("/D:", true)]
+    [InlineData("/D:/", true)]
+    [InlineData("/C:/Users/Diviel", false)]
+    [InlineData("/D:/CodeProjects", false)]
+    [InlineData("/home/me", false)]
+    [InlineData(null, false)]
+    public void IsBroadRemoteRoot_FlagsWholeDrivesAndTheFilesystemRoot(string? root, bool expected)
+    {
+        ConnectionForm.IsBroadRemoteRoot(root).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The whole flow exists to avoid typing, so what it produces must be savable as-is.
+    /// </summary>
+    [Fact]
+    public void ForLocalMachine_ProducesAConnectionThatValidatesAndStoresItsKey()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        var form = ConnectionForm.ForLocalMachine(
+            Reported(), "host.docker.internal", "Documents", pair.PrivateKeyPem);
+
+        form.Validate(isNew: true).Should().BeNull();
+        form.ToSecretJson().Should().NotBeNull();
+
+        var config = JsonNode.Parse(form.ToConfigJson())!;
+        config["host"]!.GetValue<string>().Should().Be("host.docker.internal");
+        config["port"]!.GetValue<int>().Should().Be(22);
+        config["hostKeyFingerprint"]!.GetValue<string>().Should().Be("SHA256:hostkey");
+    }
+
+    /// <summary>
+    /// Carrying the fingerprint into the stored config is what makes the first connection
+    /// verified rather than trusted — the entire reason the operator pastes anything back.
+    /// </summary>
+    [Fact]
+    public void ForLocalMachine_PinsTheFingerprintBeforeTheFirstConnection()
+    {
+        var form = ConnectionForm.ForLocalMachine(
+            Reported(fingerprint: "SHA256:fromTheHost"), "h", null, GeneratedKey);
+
+        JsonNode.Parse(form.ToConfigJson())!["hostKeyFingerprint"]!.GetValue<string>()
+            .Should().Be("SHA256:fromTheHost");
+    }
+
     [Theory]
     [InlineData(nameof(ConnectionForm.Host))]
     [InlineData(nameof(ConnectionForm.Username))]
@@ -423,3 +550,5 @@ public class ConnectionFormTests
             .Should().Be("The port must be between 1 and 65535.");
     }
 }
+
+

--- a/tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using System.Text.Json;
 using Connapse.Core;
 using Connapse.Web.Components.Settings;
@@ -159,4 +160,66 @@ public class SourceFormTests
         var form = new SourceForm { Name = "n", ConnectionId = Guid.NewGuid(), Container = "b" };
         form.Validate(ConnectionProvider.S3).Should().BeNull();
     }
+    // ── SFTP ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The same scope shape as Filesystem, which was the point of designing it that way: this
+    /// form, the preflight and the summary each gain a provider rather than a parallel
+    /// implementation to keep in step.
+    /// </summary>
+    [Fact]
+    public void ToScopeJson_Sftp_ProducesTheSameShapeAsFilesystem()
+    {
+        var form = new SourceForm
+        {
+            Name = "s",
+            ConnectionId = Guid.NewGuid(),
+            SubPath = "Documents",
+            IncludePatterns = "*.md",
+            ExcludePatterns = "*.tmp",
+        };
+
+        var sftp = JsonNode.Parse(form.ToScopeJson(ConnectionProvider.Sftp))!.AsObject();
+        var filesystem = JsonNode.Parse(form.ToScopeJson(ConnectionProvider.Filesystem))!.AsObject();
+
+        sftp.ToJsonString().Should().Be(filesystem.ToJsonString());
+        sftp["subPath"]!.GetValue<string>().Should().Be("Documents");
+    }
+
+    /// <summary>
+    /// Blank means the connection's root itself, which ConnectorFactory reads as a real value
+    /// rather than a missing one — so the key must be present.
+    /// </summary>
+    [Fact]
+    public void ToScopeJson_SftpWithNoSubPath_StillWritesTheKey()
+    {
+        var form = new SourceForm { Name = "s", ConnectionId = Guid.NewGuid() };
+
+        JsonNode.Parse(form.ToScopeJson(ConnectionProvider.Sftp))!.AsObject()
+            .ContainsKey("subPath").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Before this, picking an SFTP connection threw out of the form. The throw is caught now
+    /// rather than tearing down the circuit, but an operator still could not create the source.
+    /// </summary>
+    [Fact]
+    public void ToScopeJson_Sftp_DoesNotThrow()
+    {
+        var form = new SourceForm { Name = "s", ConnectionId = Guid.NewGuid(), SubPath = "docs" };
+
+        Action act = () => form.ToScopeJson(ConnectionProvider.Sftp);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_Sftp_DoesNotRequireAContainerName()
+    {
+        var form = new SourceForm { Name = "s", ConnectionId = Guid.NewGuid() };
+
+        form.Validate(ConnectionProvider.Sftp).Should().BeNull(
+            "an SFTP source is bounded by a sub-path, not a bucket");
+    }
 }
+

--- a/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
@@ -268,4 +268,77 @@ public class SourceScopePreflightTests
 
         result.IsRefused.Should().BeFalse();
     }
+    // ── SFTP ───────────────────────────────────────────────────────────────
+
+    private const string SftpConn = """{"host":"h","port":22,"username":"u","allowedRoot":"/D:/CodeProjects"}""";
+
+    [Fact]
+    public void Check_SftpOrdinarySubPath_IsAllowed()
+    {
+        var result = Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":"Connapse"}""");
+
+        result.IsRefused.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Check_SftpNoSubPath_IsAllowed()
+    {
+        Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":""}""")
+            .IsRefused.Should().BeFalse("blank means the connection's root itself");
+    }
+
+    /// <summary>
+    /// A sub-path is relative to the connection's root, so an absolute one is nonsense rather
+    /// than a path — and the server would resolve it somewhere else entirely.
+    /// </summary>
+    [Fact]
+    public void Check_SftpAbsoluteSubPath_IsRefused()
+    {
+        Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":"/etc"}""")
+            .IsRefused.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("../secrets")]
+    [InlineData("docs/../../etc")]
+    [InlineData(@"docs\..\..\etc")]
+    public void Check_SftpTraversingSubPath_IsRefused(string subPath)
+    {
+        var scope = $$"""{"subPath":{{System.Text.Json.JsonSerializer.Serialize(subPath)}}}""";
+
+        Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), scope)
+            .IsRefused.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Refused on the segment, not the substring: a folder legitimately named "..config"
+    /// contains ".." without being a traversal, and refusing it would be wrong.
+    /// </summary>
+    [Fact]
+    public void Check_SftpSubPathContainingDotsInAName_IsAllowed()
+    {
+        Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":"..config/notes"}""")
+            .IsRefused.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Check_SftpConnectionWithNoAllowedRoot_IsRefused()
+    {
+        Build().Check(Conn(ConnectionProvider.Sftp, """{"host":"h","username":"u"}"""), """{"subPath":"docs"}""")
+            .IsRefused.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The deployment's local allowed-roots setting governs the machine Connapse runs on. An
+    /// SFTP root names a directory on somebody else's, so it must not be judged against it —
+    /// doing so would refuse every remote path that happens not to exist locally.
+    /// </summary>
+    [Fact]
+    public void Check_SftpRoot_IsNotJudgedAgainstTheLocalAllowedRoots()
+    {
+        var preflight = Build("/srv/only-this-local-path");
+
+        preflight.Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":"Connapse"}""")
+            .IsRefused.Should().BeFalse();
+    }
 }

--- a/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
@@ -1,4 +1,4 @@
-using Connapse.Core.Utilities;
+﻿using Connapse.Core.Utilities;
 using FluentAssertions;
 using Xunit;
 
@@ -436,5 +436,34 @@ public class SftpHostSetupTests
         SftpHostSetup.GenerateScript(Key, HostPlatform.Windows)
             .Should().Contain("could not be read",
                 "a silent empty fingerprint would look like the script half-worked");
+    }
+
+    [Fact]
+    public void GenerateScript_Windows_ScopesTheFirewallRuleToLocalSubnets()
+    {
+        // An unscoped New-NetFirewallRule accepts port 22 from any address on any profile —
+        // the rest of a hotel network, and the internet on any host whose router forwards it.
+        // Nothing about indexing local files needs that, and the operator is not being asked.
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("-RemoteAddress LocalSubnet",
+            "the rule must not accept port 22 from arbitrary networks");
+        script.Should().Contain("New-NetFirewallRule");
+    }
+
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.Linux)]
+    [InlineData(HostPlatform.MacOS)]
+    public void GenerateScript_ReportsWhetherTheHostStillAcceptsPasswords(HostPlatform platform)
+    {
+        // The restrictions on Connapse's key bind that key alone. Turning on sshd exposes every
+        // other account too, and by password if the host allows it — which the operator cannot
+        // know unless the script says so.
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain("PasswordAuthentication",
+            "enabling SSH without naming the host's password policy hides half the change");
+        script.Should().Contain("accepts SSH logins by password");
     }
 }

--- a/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
@@ -1,0 +1,440 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class SftpHostSetupTests
+{
+    private const string Key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0example connapse";
+
+    // ── Script generation ──────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Linux)]
+    public void GenerateScript_EmbedsTheKeyAndBothMarkers(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain(Key);
+        script.Should().Contain(SftpHostSetup.BeginMarker);
+        script.Should().Contain(SftpHostSetup.EndMarker);
+    }
+
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Linux)]
+    public void GenerateScript_ReportsAllThreeFieldsConnapseNeeds(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain("user=");
+        script.Should().Contain("home=");
+        script.Should().Contain("fingerprint=");
+    }
+
+    /// <summary>
+    /// Idempotency is not a nicety here — the operator is told the command is safe to re-run,
+    /// and a duplicated key in <c>authorized_keys</c> is the kind of mess nobody goes looking
+    /// for.
+    /// </summary>
+    [Theory]
+    [InlineData(HostPlatform.Windows, "Select-String")]
+    [InlineData(HostPlatform.MacOS, "grep -qxF")]
+    [InlineData(HostPlatform.Linux, "grep -qxF")]
+    public void GenerateScript_AddsTheKeyOnlyIfAbsent(HostPlatform platform, string guard)
+    {
+        SftpHostSetup.GenerateScript(Key, platform).Should().Contain(guard);
+    }
+
+    /// <summary>
+    /// Somebody else's key in that file is not ours to remove.
+    /// </summary>
+    [Theory]
+    [InlineData(HostPlatform.Windows, "Add-Content")]
+    [InlineData(HostPlatform.MacOS, ">> ~/.ssh/authorized_keys")]
+    [InlineData(HostPlatform.Linux, ">> ~/.ssh/authorized_keys")]
+    public void GenerateScript_AppendsRatherThanOverwrites(HostPlatform platform, string append)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain(append);
+        script.Should().NotContain("Set-Content -Path $keyFile");
+
+        // A truncating redirect, meaning a single '>' not preceded by another. Asserting
+        // NotContain("> ~/.ssh/authorized_keys") does not work: that string is a substring of
+        // the appending ">> ~/.ssh/authorized_keys" and the check can never pass.
+        script.Should().NotMatchRegex(@"[^>]> ~/\.ssh/authorized_keys");
+    }
+
+    /// <summary>
+    /// The Windows failure that costs an hour: for an account in the Administrators group,
+    /// sshd ignores the profile's authorized_keys entirely and reads a machine-wide file whose
+    /// ACL it also insists on. A script that skips this produces authentication failures with
+    /// nothing to explain them.
+    /// </summary>
+    [Fact]
+    public void GenerateScript_Windows_HandlesTheAdministratorsAuthorizedKeysFile()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("administrators_authorized_keys");
+        script.Should().Contain("icacls", "sshd refuses the file unless its ACL is restricted");
+    }
+
+    /// <summary>
+    /// Verified against a real machine: an account that <em>is</em> in Administrators reports
+    /// False from the token check when the process is not elevated, because UAC filters the
+    /// SID out. Deciding on that alone writes the key to the profile's authorized_keys, which
+    /// sshd then ignores — an authentication failure with nothing to explain it.
+    /// </summary>
+    [Fact]
+    public void GenerateScript_Windows_AsksTheGroupRatherThanTheToken()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("Get-LocalGroupMember",
+            "actual membership, not what an unelevated token happens to carry");
+        script.Should().Contain("$_.SID.Value -eq $mySid",
+            "matched by SID, since names vary by domain and casing");
+    }
+
+    /// <summary>
+    /// Refusing early beats half-succeeding. Without elevation the steps leave SSH looking
+    /// configured when it is not.
+    /// </summary>
+    [Fact]
+    public void GenerateScript_Windows_StopsWhenNotElevated()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("WindowsBuiltInRole]::Administrator");
+        script.Should().Contain("Run as Administrator");
+    }
+
+    /// <summary>
+    /// Reading the fingerprint needs elevation and can still fail. By that point the key is
+    /// installed, so a throw would discard a setup that otherwise worked — the operator loses
+    /// verified-first-use, not the connection.
+    /// </summary>
+    [Fact]
+    public void GenerateScript_Windows_SurvivesAnUnreadableHostKey()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("$fingerprint = ''", "it must have a value even when reading fails");
+        script.Should().Contain("try {");
+        script.Should().Contain("} catch { }");
+    }
+
+    [Fact]
+    public void GenerateScript_Windows_InstallsAndEnablesTheServer()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("OpenSSH.Server");
+        script.Should().Contain("StartupType Automatic");
+        script.Should().Contain("LocalPort 22");
+    }
+
+    [Fact]
+    public void GenerateScript_MacOs_UsesRemoteLogin()
+    {
+        SftpHostSetup.GenerateScript(Key, HostPlatform.MacOS)
+            .Should().Contain("systemsetup -setremotelogin on");
+    }
+
+    /// <summary>Debian and Ubuntu name the unit `ssh`; most others name it `sshd`.</summary>
+    [Fact]
+    public void GenerateScript_Linux_HandlesEitherServiceName()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Linux);
+
+        script.Should().Contain("--now sshd");
+        script.Should().Contain("--now ssh");
+    }
+
+    /// <summary>
+    /// The key is interpolated into a shell string, so anything that could close it must be
+    /// refused rather than escaped. SshKeyPairGenerator already guarantees this; the check is
+    /// here because this function would be the one exploited if that guarantee ever lapsed.
+    /// </summary>
+    [Theory]
+    [InlineData("ssh-rsa AAAA test\nrm -rf /")]
+    [InlineData("ssh-rsa AAAA'; Remove-Item -Recurse C:\\ ;'")]
+    [InlineData("ssh-rsa AAAA\"malicious\"")]
+    public void GenerateScript_KeyContainingQuotesOrNewlines_IsRefused(string hostile)
+    {
+        Action act = () => SftpHostSetup.GenerateScript(hostile, HostPlatform.Windows);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void GenerateScript_AGeneratedKeyIsAlwaysAccepted()
+    {
+        var pair = SshKeyPairGenerator.Generate("my machine");
+
+        foreach (var platform in Enum.GetValues<HostPlatform>())
+        {
+            Action act = () => SftpHostSetup.GenerateScript(pair.PublicKeyLine, platform);
+            act.Should().NotThrow();
+        }
+    }
+
+    // ── Parsing the result ─────────────────────────────────────────────────
+
+    private static string Block(
+        string user = "Diviel",
+        string home = "/C:/Users/Diviel",
+        string fingerprint = "SHA256:abc123") =>
+        $"""
+        {SftpHostSetup.BeginMarker}
+        user={user}
+        home={home}
+        fingerprint={fingerprint}
+        {SftpHostSetup.EndMarker}
+        """;
+
+    [Fact]
+    public void ParseResult_ReadsAllThreeFields()
+    {
+        var result = SftpHostSetup.ParseResult(Block());
+
+        result.Should().NotBeNull();
+        result!.Username.Should().Be("Diviel");
+        result.HomePath.Should().Be("/C:/Users/Diviel");
+        result.Fingerprint.Should().Be("SHA256:abc123");
+    }
+
+    /// <summary>
+    /// The realistic paste. Nobody selects exactly the block — they grab the whole terminal,
+    /// prompts and echoed command included.
+    /// </summary>
+    [Fact]
+    public void ParseResult_IgnoresEverythingOutsideTheMarkers()
+    {
+        string messy = $"""
+        PS C:\Users\Diviel> .\setup.ps1
+        Path          : C:\
+        Online        : True
+
+        {Block()}
+
+        Copy the block above, including both marker lines, back into Connapse.
+        PS C:\Users\Diviel>
+        """;
+
+        var result = SftpHostSetup.ParseResult(messy);
+
+        result.Should().NotBeNull();
+        result!.Username.Should().Be("Diviel");
+    }
+
+    /// <summary>
+    /// Terminals wrap, indent, and add carriage returns, and none of that is the operator's
+    /// fault. Field names and values are both trimmed, so padding around the '=' is fine.
+    /// </summary>
+    [Fact]
+    public void ParseResult_ToleratesWindowsLineEndingsAndStrayWhitespace()
+    {
+        string block = Block().Replace("\n", "\r\n").Replace("user=", "  user =  ");
+
+        var result = SftpHostSetup.ParseResult(block);
+
+        result.Should().NotBeNull();
+        result!.Username.Should().Be("Diviel");
+    }
+
+    [Fact]
+    public void ParseResult_ToleratesCarriageReturns()
+    {
+        SftpHostSetup.ParseResult(Block().Replace("\n", "\r\n"))!
+            .Username.Should().Be("Diviel");
+    }
+
+    /// <summary>
+    /// A fingerprint typed by hand often loses the prefix. Adding it back beats failing later,
+    /// where the only symptom is a refused connection with no hint that the stored value was
+    /// merely the wrong shape.
+    /// </summary>
+    [Fact]
+    public void ParseResult_FingerprintWithoutThePrefix_GetsItBack()
+    {
+        SftpHostSetup.ParseResult(Block(fingerprint: "abc123"))!
+            .Fingerprint.Should().Be("SHA256:abc123");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("just some text the operator pasted by mistake")]
+    public void ParseResult_WithoutABlock_IsNull(string? pasted)
+    {
+        SftpHostSetup.ParseResult(pasted).Should().BeNull();
+    }
+
+    /// <summary>
+    /// Loose key=value lines with no markers must not be accepted — that would take a paste
+    /// from somewhere else entirely and configure a connection out of it.
+    /// </summary>
+    [Fact]
+    public void ParseResult_FieldsWithoutMarkers_IsNull()
+    {
+        SftpHostSetup.ParseResult("user=x\nhome=/y\nfingerprint=SHA256:z").Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseResult_MarkersInTheWrongOrder_IsNull()
+    {
+        SftpHostSetup.ParseResult(
+            $"{SftpHostSetup.EndMarker}\nuser=x\nhome=/y\nfingerprint=z\n{SftpHostSetup.BeginMarker}")
+            .Should().BeNull();
+    }
+
+    /// <summary>
+    /// The identifying fields only. The fingerprint used to be required too, which dead-ended the
+    /// flow when it could not be read — see
+    /// <see cref="ParseResult_WithoutAFingerprint_StillParses"/>.
+    /// </summary>
+    [Theory]
+    [InlineData("user")]
+    [InlineData("home")]
+    public void ParseResult_MissingAnyField_IsNull(string omit)
+    {
+        string block = string.Join('\n',
+            Block().Split('\n').Where(l => !l.TrimStart().StartsWith(omit + "=")));
+
+        SftpHostSetup.ParseResult(block).Should().BeNull();
+    }
+
+    /// <summary>
+    /// The whole point of the round trip: these are the values Connapse cannot know, and the
+    /// Windows home path is the one that would otherwise be written wrong by hand.
+    /// </summary>
+    [Fact]
+    public void ParseResult_WindowsHomePath_KeepsItsLeadingSlash()
+    {
+        SftpHostSetup.ParseResult(Block(home: "/C:/Users/Diviel"))!
+            .HomePath.Should().StartWith("/C:/");
+    }
+    // ── The installed key is restricted (Codex review on #405) ─────────────
+
+    /// <summary>
+    /// A bare entry grants everything the account can do — interactive shell, port forwarding,
+    /// agent forwarding. Connapse only reads files, and its path confinement is an application
+    /// rule: it bounds what Connapse does with the key, not what the key can do. Anyone holding
+    /// the stored private half is not bound by it at all.
+    /// </summary>
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Linux)]
+    public void GenerateScript_InstallsTheKeyRestrictedToSftp(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain("restrict,", "restrict disables PTY, port, agent and X11 forwarding");
+        script.Should().Contain("""command="internal-sftp" """.TrimEnd(),
+            "a forced command replaces whatever the client asks for, so a shell request gets SFTP");
+        script.Should().Contain($"restrict,command=\"internal-sftp\" {Key}",
+            "the restrictions must prefix the key on the same authorized_keys line");
+    }
+
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Linux)]
+    public void GenerateScript_NeverInstallsABareKey(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        // The key must never appear without its restrictions immediately before it.
+        foreach (int index in AllIndexesOf(script, Key))
+        {
+            script[..index].Should().EndWith(SftpHostSetup.KeyRestrictions,
+                "an unrestricted copy of the key would defeat the restricted one");
+        }
+    }
+
+    private static IEnumerable<int> AllIndexesOf(string haystack, string needle)
+    {
+        for (int i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + 1, StringComparison.Ordinal))
+        {
+            yield return i;
+        }
+    }
+
+    // ── A missing fingerprint must not dead-end the flow ───────────────────
+
+    /// <summary>
+    /// Reading the fingerprint needs elevation and can still fail, by which point sshd is running
+    /// and the key is installed. Requiring one here left the operator with a configured host, an
+    /// authorized key, and no way to finish or undo.
+    /// </summary>
+    [Fact]
+    public void ParseResult_WithoutAFingerprint_StillParses()
+    {
+        string block = $"""
+        {SftpHostSetup.BeginMarker}
+        user=Diviel
+        home=/C:/Users/Diviel
+        fingerprint=
+        {SftpHostSetup.EndMarker}
+        """;
+
+        var result = SftpHostSetup.ParseResult(block);
+
+        result.Should().NotBeNull();
+        result!.Username.Should().Be("Diviel");
+        result.Fingerprint.Should().BeEmpty("blank means trust on first use, which is defined behaviour");
+    }
+
+    [Fact]
+    public void ParseResult_FingerprintLineAbsentEntirely_StillParses()
+    {
+        string block = $"""
+        {SftpHostSetup.BeginMarker}
+        user=Diviel
+        home=/C:/Users/Diviel
+        {SftpHostSetup.EndMarker}
+        """;
+
+        SftpHostSetup.ParseResult(block)!.Fingerprint.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The identifying fields are still required: without a username or home path there is no
+    /// connection to build, and guessing either would point somewhere wrong.
+    /// </summary>
+    [Theory]
+    [InlineData("user")]
+    [InlineData("home")]
+    public void ParseResult_MissingAnIdentifyingField_IsStillNull(string omit)
+    {
+        string block = string.Join('\n',
+            $"""
+            {SftpHostSetup.BeginMarker}
+            user=Diviel
+            home=/C:/Users/Diviel
+            fingerprint=SHA256:abc
+            {SftpHostSetup.EndMarker}
+            """.Split('\n').Where(l => !l.TrimStart().StartsWith(omit + "=")));
+
+        SftpHostSetup.ParseResult(block).Should().BeNull();
+    }
+
+    [Fact]
+    public void GenerateScript_SaysSoWhenTheFingerprintCouldNotBeRead()
+    {
+        SftpHostSetup.GenerateScript(Key, HostPlatform.Windows)
+            .Should().Contain("could not be read",
+                "a silent empty fingerprint would look like the script half-worked");
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/SftpPathConfinementTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SftpPathConfinementTests.cs
@@ -1,4 +1,4 @@
-using Connapse.Core.Utilities;
+﻿using Connapse.Core.Utilities;
 using FluentAssertions;
 using Xunit;
 
@@ -22,7 +22,10 @@ public class SftpPathConfinementTests
 
         public HashSet<string> Unresolvable { get; } = [];
 
-        public string GetCanonicalPath(string path)
+        public Task<string> GetCanonicalPathAsync(string path, CancellationToken ct = default) =>
+            Task.FromResult(Resolve(path));
+
+        private string Resolve(string path)
         {
             if (Unresolvable.Contains(path))
                 throw new InvalidOperationException($"The server refused to resolve '{path}'.");
@@ -56,48 +59,48 @@ public class SftpPathConfinementTests
     }
 
     [Fact]
-    public void CombineWithin_OrdinarySubPath_Resolves()
+    public async Task CombineWithin_OrdinarySubPath_Resolves()
     {
         var server = new FakeServer();
 
-        SftpPathConfinement.CombineWithin(server, "/srv/knowledge", "docs/reports")
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "docs/reports"))
             .Should().Be("/srv/knowledge/docs/reports");
     }
 
     [Fact]
-    public void CombineWithin_NoSubPath_ResolvesToTheRoot()
+    public async Task CombineWithin_NoSubPath_ResolvesToTheRoot()
     {
         var server = new FakeServer();
 
-        SftpPathConfinement.CombineWithin(server, "/srv/knowledge", null)
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", null))
             .Should().Be("/srv/knowledge");
     }
 
     [Fact]
-    public void CombineWithin_DotDotEscape_IsRefused()
+    public async Task CombineWithin_DotDotEscape_IsRefused()
     {
         var server = new FakeServer();
 
-        SftpPathConfinement.CombineWithin(server, "/srv/knowledge", "../../etc")
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "../../etc"))
             .Should().BeNull();
     }
 
     [Fact]
-    public void CombineWithin_DotDotThatStaysInside_IsAllowed()
+    public async Task CombineWithin_DotDotThatStaysInside_IsAllowed()
     {
         var server = new FakeServer();
 
         // Refusing this would be over-strict: it resolves back inside the root.
-        SftpPathConfinement.CombineWithin(server, "/srv/knowledge", "docs/../reports")
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "docs/../reports"))
             .Should().Be("/srv/knowledge/reports");
     }
 
     [Fact]
-    public void CombineWithin_AbsoluteSubPath_IsRefused()
+    public async Task CombineWithin_AbsoluteSubPath_IsRefused()
     {
         var server = new FakeServer();
 
-        SftpPathConfinement.CombineWithin(server, "/srv/knowledge", "/etc/shadow")
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "/etc/shadow"))
             .Should().BeNull();
     }
 
@@ -106,11 +109,11 @@ public class SftpPathConfinementTests
     /// root, and the escape only appears once the server resolves the link.
     /// </summary>
     [Fact]
-    public void CombineWithin_ServerSideSymlinkPointingOutside_IsRefused()
+    public async Task CombineWithin_ServerSideSymlinkPointingOutside_IsRefused()
     {
         var server = new FakeServer(new() { ["/srv/knowledge/escape"] = "/etc" });
 
-        SftpPathConfinement.CombineWithin(server, "/srv/knowledge", "escape")
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "escape"))
             .Should().BeNull();
     }
 
@@ -119,11 +122,11 @@ public class SftpPathConfinementTests
     /// nothing. Only its parent gives the escape away.
     /// </summary>
     [Fact]
-    public void CombineWithin_SymlinkedAncestorWithOrdinaryLeaf_IsRefused()
+    public async Task CombineWithin_SymlinkedAncestorWithOrdinaryLeaf_IsRefused()
     {
         var server = new FakeServer(new() { ["/srv/knowledge/escape"] = "/etc" });
 
-        SftpPathConfinement.CombineWithin(server, "/srv/knowledge", "escape/shadow")
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "escape/shadow"))
             .Should().BeNull();
     }
 
@@ -133,11 +136,11 @@ public class SftpPathConfinementTests
     /// there.
     /// </summary>
     [Fact]
-    public void CombineWithin_SymlinkPointingBackInsideTheRoot_IsAllowed()
+    public async Task CombineWithin_SymlinkPointingBackInsideTheRoot_IsAllowed()
     {
         var server = new FakeServer(new() { ["/srv/knowledge/shortcut"] = "/srv/knowledge/docs" });
 
-        SftpPathConfinement.CombineWithin(server, "/srv/knowledge", "shortcut/a.md")
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "shortcut/a.md"))
             .Should().Be("/srv/knowledge/docs/a.md");
     }
 
@@ -146,11 +149,11 @@ public class SftpPathConfinementTests
     /// Both sides are canonicalised for exactly this reason.
     /// </summary>
     [Fact]
-    public void CombineWithin_SymlinkedRoot_StillConfinesAgainstTheResolvedRoot()
+    public async Task CombineWithin_SymlinkedRoot_StillConfinesAgainstTheResolvedRoot()
     {
         var server = new FakeServer(new() { ["/srv/knowledge"] = "/mnt/vol1/knowledge" });
 
-        SftpPathConfinement.CombineWithin(server, "/srv/knowledge", "docs")
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "docs"))
             .Should().Be("/mnt/vol1/knowledge/docs");
     }
 
@@ -199,22 +202,77 @@ public class SftpPathConfinementTests
     /// than compared as an unverified string.
     /// </summary>
     [Fact]
-    public void CombineWithin_ServerRefusesToResolve_IsRefused()
+    public async Task CombineWithin_ServerRefusesToResolve_IsRefused()
     {
         var server = new FakeServer();
         server.Unresolvable.Add("/srv/knowledge/docs");
 
-        SftpPathConfinement.CombineWithin(server, "/srv/knowledge", "docs")
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "docs"))
             .Should().BeNull();
     }
 
     [Fact]
-    public void CombineWithin_ServerRefusesToResolveTheRoot_IsRefused()
+    public async Task CombineWithin_ServerRefusesToResolveTheRoot_IsRefused()
     {
         var server = new FakeServer();
         server.Unresolvable.Add("/srv/knowledge");
 
-        SftpPathConfinement.CombineWithin(server, "/srv/knowledge", "docs")
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "docs"))
             .Should().BeNull();
+    }
+
+    /// <summary>
+    /// A server that answered the handshake and then went quiet. Real ones do this: sshd is up
+    /// and authenticating, its SFTP subsystem is wedged or the box is thrashing.
+    /// </summary>
+    private sealed class StallingServer : ISftpRealPathResolver
+    {
+        public async Task<string> GetCanonicalPathAsync(string path, CancellationToken ct = default)
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+            return path;
+        }
+    }
+
+    [Fact]
+    public async Task ResolveWithin_ServerStopsAnswering_ObservesCancellation()
+    {
+        // The reason this seam is asynchronous. Canonicalisation used to go through SSH.NET's
+        // blocking ChangeDirectory, which no token can interrupt — so a connection test's
+        // 15-second budget covered the handshake and then waited indefinitely on the very
+        // request that stalls, holding its Blazor circuit and SSH session open.
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        Func<Task> act = async () => await SftpPathConfinement.ResolveWithinAsync(
+            new StallingServer(), "/srv/knowledge", "/srv/knowledge/docs", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "cancellation must reach the round-trip, not just the awaits around it");
+    }
+
+    [Fact]
+    public void SftpConnectorConfig_OperationTimeout_IsFinite()
+    {
+        // SSH.NET's own default is infinite. A session that inherits that has no way back from
+        // a server that stops answering: nothing releases the SSH session or its socket, and
+        // SourceSyncService builds a connector every cycle.
+        var config = new Connapse.Storage.Connectors.SftpConnectorConfig();
+
+        config.OperationTimeout.Should().BePositive().And.NotBe(Timeout.InfiniteTimeSpan);
+    }
+
+    [Fact]
+    public async Task ResolveWithin_Cancellation_IsNotSwallowedAsAnUnresolvablePath()
+    {
+        // The catch that refuses paths the server will not resolve must not also swallow a
+        // cancelled one: returning null there would report "outside the allowed root" for a
+        // path nobody ever asked about, and the caller would never learn it timed out.
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        Func<Task> act = async () => await SftpPathConfinement.CombineWithinAsync(
+            new StallingServer(), "/srv/knowledge", "docs", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 }

--- a/tests/Connapse.Core.Tests/Utilities/SshKeyPairGeneratorTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SshKeyPairGeneratorTests.cs
@@ -1,0 +1,133 @@
+using System.Security.Cryptography;
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+/// <summary>
+/// These cover shape and safety. The encoding itself is only genuinely proven by
+/// <c>SftpConnectorIntegrationTests.GeneratedKeyPair_AuthenticatesAgainstARealServer</c>,
+/// because a wrong encoding produces a well-formed line that simply fails to authenticate.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SshKeyPairGeneratorTests
+{
+    [Fact]
+    public void Generate_ProducesAPrivateKeyInTheFormSshNetReads()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        pair.PrivateKeyPem.Should().StartWith("-----BEGIN RSA PRIVATE KEY-----");
+        pair.PrivateKeyPem.Should().Contain("-----END RSA PRIVATE KEY-----");
+    }
+
+    [Fact]
+    public void Generate_ProducesASingleAuthorizedKeysLine()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        pair.PublicKeyLine.Should().StartWith("ssh-rsa ");
+        pair.PublicKeyLine.Should().NotContain("\n");
+        pair.PublicKeyLine.Split(' ').Should().HaveCount(3, "algorithm, key, comment");
+    }
+
+    [Fact]
+    public void Generate_UsesTheRequestedKeySize()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        using var rsa = RSA.Create();
+        rsa.ImportFromPem(pair.PrivateKeyPem);
+
+        rsa.KeySize.Should().Be(SshKeyPairGenerator.KeySizeBits);
+    }
+
+    [Fact]
+    public void Generate_PublicHalfMatchesThePrivateHalf()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        using var rsa = RSA.Create();
+        rsa.ImportFromPem(pair.PrivateKeyPem);
+
+        SshKeyPairGenerator.FormatPublicKey(rsa).Should().Be(pair.PublicKeyLine);
+    }
+
+    [Fact]
+    public void Generate_EachCallProducesADifferentKey()
+    {
+        SshKeyPairGenerator.Generate().PublicKeyLine
+            .Should().NotBe(SshKeyPairGenerator.Generate().PublicKeyLine);
+    }
+
+    [Fact]
+    public void Generate_CommentAppearsAsTheLabel()
+    {
+        SshKeyPairGenerator.Generate("my-laptop").PublicKeyLine
+            .Should().EndWith(" my-laptop");
+    }
+
+    /// <summary>
+    /// The comment is the final field on the line, so a newline in it would end the entry
+    /// and let whatever followed be parsed as a second authorized key. Connection names reach
+    /// here, and they are operator-supplied.
+    /// </summary>
+    [Fact]
+    public void Generate_CommentCannotInjectASecondAuthorizedKey()
+    {
+        var pair = SshKeyPairGenerator.Generate("ok\nssh-rsa AAAAB3NzaC1yc2EAAAADAQAB attacker");
+
+        pair.PublicKeyLine.Should().NotContain("\n");
+        pair.PublicKeyLine.Split('\n').Should().HaveCount(1);
+        pair.PublicKeyLine.Should().NotContain("attacker\n");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\n\r")]
+    public void Generate_BlankComment_FallsBackToADefaultLabel(string comment)
+    {
+        SshKeyPairGenerator.Generate(comment).PublicKeyLine
+            .Should().EndWith(" connapse");
+    }
+
+    /// <summary>
+    /// An mpint is signed, so a modulus whose top bit is set needs a leading zero byte. A
+    /// 3072-bit RSA modulus always has its top bit set, so this path runs every time — and if
+    /// it were wrong, every generated key would fail to authenticate.
+    /// </summary>
+    [Fact]
+    public void FormatPublicKey_ModulusIsEncodedAsAPositiveMpint()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+        byte[] blob = Convert.FromBase64String(pair.PublicKeyLine.Split(' ')[1]);
+
+        var reader = new BlobReader(blob);
+
+        System.Text.Encoding.ASCII.GetString(reader.Next()).Should().Be("ssh-rsa");
+        reader.Next().Should().NotBeEmpty("the exponent must be present");
+
+        byte[] modulus = reader.Next();
+        modulus[0].Should().Be(0, "a 3072-bit modulus has its top bit set and needs the sign byte");
+        (modulus.Length - 1).Should().Be(SshKeyPairGenerator.KeySizeBits / 8);
+    }
+
+    /// <summary>Walks the length-prefixed fields of an SSH key blob.</summary>
+    private sealed class BlobReader(byte[] blob)
+    {
+        private int _offset;
+
+        public byte[] Next()
+        {
+            int length = System.Buffers.Binary.BinaryPrimitives.ReadInt32BigEndian(
+                blob.AsSpan(_offset, 4));
+            _offset += 4;
+
+            byte[] value = blob[_offset..(_offset + length)];
+            _offset += length;
+            return value;
+        }
+    }
+}

--- a/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
@@ -44,9 +44,20 @@ public class IngestionPipelineTests
     private readonly IOptionsMonitor<EmbeddingSettings> _embeddingSettings;
     private readonly ILogger<IngestionPipeline> _logger;
 
+    // Fields rather than inline substitutes, so a test can say what the store returns. The
+    // source-routing tests need to: which branch IngestByIdAsync takes is decided by them.
+    private readonly IDocumentStore _documentStore;
+    private readonly ISourceStore _sourceStore;
+    private readonly IConnectionStore _connectionStore;
+    private readonly IConnectorFactory _connectorFactory;
+
     public IngestionPipelineTests()
     {
         _fileSystem = Substitute.For<IKnowledgeFileSystem>();
+        _documentStore = Substitute.For<IDocumentStore>();
+        _sourceStore = Substitute.For<ISourceStore>();
+        _connectionStore = Substitute.For<IConnectionStore>();
+        _connectorFactory = Substitute.For<IConnectorFactory>();
         _embeddingProvider = Substitute.For<IEmbeddingProvider>();
         _vectorStore = Substitute.For<IVectorStore>();
         _logger = NullLogger<IngestionPipeline>.Instance;
@@ -98,10 +109,10 @@ public class IngestionPipelineTests
             new EmbeddingCache(dbContext),
             Substitute.For<IContainerStore>(),
             Substitute.For<IManagedStorageProvider>(),
-            Substitute.For<IDocumentStore>(),
-            Substitute.For<ISourceStore>(),
-            Substitute.For<IConnectionStore>(),
-            Substitute.For<IConnectorFactory>(),
+            _documentStore,
+            _sourceStore,
+            _connectionStore,
+            _connectorFactory,
             _logger);
 
     private static KnowledgeDbContext CreateInMemoryContext()
@@ -268,6 +279,66 @@ public class IngestionPipelineTests
     /// <summary>
     /// Wrapper stream that reports CanSeek = false to test non-seekable stream handling.
     /// </summary>
+    // ── Source routing when the caller supplies no owner (#405 review) ─────────────
+
+    /// <summary>
+    /// Stands up the three stores IngestByIdAsync consults on the source path, and returns
+    /// the connector it should end up reading through.
+    /// </summary>
+    private IConnector ArrangeSourceDocument(string documentId, Guid sourceId, string path)
+    {
+        var connectionId = Guid.NewGuid();
+
+        _documentStore.GetAsync(documentId, Arg.Any<CancellationToken>())
+            .Returns(new Document(
+                documentId, sourceId.ToString(), "test.txt", "text/plain", path,
+                SizeBytes: 12, CreatedAt: DateTime.UtcNow, Metadata: new Dictionary<string, string>())
+            {
+                // What PostgresDocumentStore.MapToModel records: ContainerId carries
+                // COALESCE(container_id, source_id), so only this distinguishes the two.
+                Owner = OwnerRef.ForSource(sourceId),
+            });
+
+        _sourceStore.GetAsync(sourceId, Arg.Any<CancellationToken>())
+            .Returns(new Source(
+                sourceId, "src", null, connectionId, "{}", DateTime.UtcNow, DateTime.UtcNow));
+
+        _connectionStore.GetAsync(connectionId, Arg.Any<CancellationToken>())
+            .Returns(new Connection(
+                connectionId, "conn", ConnectionProvider.Filesystem, "{}", null,
+                DateTime.UtcNow, DateTime.UtcNow));
+
+        var connector = Substitute.For<IConnector>();
+        connector.ReadFileAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<Stream>(new MemoryStream("Test content"u8.ToArray())));
+
+        _connectorFactory.Create(Arg.Any<Source>(), Arg.Any<Connection>(), Arg.Any<string?>())
+            .Returns(connector);
+
+        return connector;
+    }
+
+    [Fact]
+    public async Task IngestByIdAsync_SourceOwnedDocumentWithNoOwnerInOptions_ReadsThroughTheSourceConnector()
+    {
+        // ReindexService enqueued jobs this way before #405: no Owner, and a ContainerId that
+        // is blank because Nullable<Guid>.ToString() returns "". The pipeline then took the
+        // container branch and threw — after the reindex had already deleted the document's
+        // chunks, and with the remote signature still matching so no later sync restored them.
+        using var dbContext = CreateInMemoryContext();
+        var pipeline = CreatePipeline(dbContext);
+
+        string documentId = Guid.NewGuid().ToString();
+        var sourceId = Guid.NewGuid();
+        IConnector connector = ArrangeSourceDocument(documentId, sourceId, "/remote/test.txt");
+
+        await pipeline.IngestByIdAsync(
+            documentId,
+            new IngestionOptions(DocumentId: documentId, FileName: "test.txt", Path: "/remote/test.txt"));
+
+        await connector.Received(1).ReadFileAsync("/remote/test.txt", Arg.Any<CancellationToken>());
+    }
+
     private sealed class NonSeekableStream : Stream
     {
         private readonly Stream _inner;

--- a/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
@@ -99,6 +99,9 @@ public class IngestionPipelineTests
             Substitute.For<IContainerStore>(),
             Substitute.For<IManagedStorageProvider>(),
             Substitute.For<IDocumentStore>(),
+            Substitute.For<ISourceStore>(),
+            Substitute.For<IConnectionStore>(),
+            Substitute.For<IConnectorFactory>(),
             _logger);
 
     private static KnowledgeDbContext CreateInMemoryContext()

--- a/tests/Connapse.Integration.Tests/SftpConnectorIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SftpConnectorIntegrationTests.cs
@@ -1,6 +1,9 @@
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
+using System.Text;
 using Connapse.Storage.Connectors;
+using Renci.SshNet;
 using FluentAssertions;
 using Xunit;
 
@@ -306,6 +309,160 @@ public class SftpConnectorIntegrationTests : IAsyncLifetime
             .WithMessage("*partial listing*");
     }
 
+    // ── Generated key pairs ────────────────────────────────────────────────
+
+    /// <summary>
+    /// The test that makes <see cref="SshKeyPairGenerator"/> trustworthy.
+    /// </summary>
+    /// <remarks>
+    /// A wrong <c>authorized_keys</c> encoding produces a line that looks entirely correct
+    /// and simply fails to authenticate, with nothing anywhere pointing at the cause. Unit
+    /// tests can check the blob's structure but cannot tell you whether a real OpenSSH server
+    /// accepts it. This installs a generated public key the way the setup command will, and
+    /// connects with the matching private half.
+    /// </remarks>
+    [Fact]
+    public async Task GeneratedKeyPair_AuthenticatesAgainstARealServer()
+    {
+        var pair = SshKeyPairGenerator.Generate("connapse-generated");
+        await _server.AuthorizeKeyAsync(pair.PublicKeyLine);
+
+        using var connector = new SftpConnector(new SftpConnectorConfig
+        {
+            Host = _server.Host,
+            Port = _server.Port,
+            Username = SftpServerFixture.Username,
+            AllowedRoot = AllowedRoot,
+            Credential = new SftpCredential { PrivateKey = pair.PrivateKeyPem },
+        });
+
+        (await connector.ListFilesAsync()).Should().NotBeEmpty(
+            "a generated pair must authenticate, or the setup flow hands operators a key that "
+            + "silently does not work");
+    }
+
+    /// <summary>
+    /// The restrictions the setup command installs must not break the thing they protect.
+    /// </summary>
+    /// <remarks>
+    /// <c>restrict</c> plus a forced <c>internal-sftp</c> command is what stops the stored key
+    /// being usable for an interactive shell or port forwarding. It is also exactly the kind of
+    /// hardening that silently locks out the legitimate user — so this installs the key the way
+    /// the generated script does, prefix and all, and proves SFTP still works through it.
+    /// <para>
+    /// This covers the failure that would actually be ours: an option OpenSSH does not accept
+    /// makes the whole entry invalid and nothing authenticates. That it also <i>enforces</i> the
+    /// restriction is OpenSSH's contract, and is not asserted here — a test for it was written
+    /// and removed, because <c>atmoz/sftp</c> gives the account no shell to begin with, so it
+    /// passed identically with the restrictions stripped out and proved nothing.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task RestrictedKeyEntry_StillAuthenticatesAndLists()
+    {
+        var pair = SshKeyPairGenerator.Generate("connapse-restricted");
+        await _server.AuthorizeKeyAsync(SftpHostSetup.KeyRestrictions + pair.PublicKeyLine);
+
+        using var connector = new SftpConnector(new SftpConnectorConfig
+        {
+            Host = _server.Host,
+            Port = _server.Port,
+            Username = SftpServerFixture.Username,
+            AllowedRoot = AllowedRoot,
+            Credential = new SftpCredential { PrivateKey = pair.PrivateKeyPem },
+        });
+
+        (await connector.ListFilesAsync()).Should().NotBeEmpty(
+            "the hardening must not lock out the access it exists to bound");
+    }
+
+    /// <summary>
+    /// The negative half. Without it the test above could pass because the server accepts
+    /// anything — the fixture's own key is already authorized, so a generated key that was
+    /// never really used would look identical.
+    /// </summary>
+    [Fact]
+    public async Task GeneratedKeyPair_NotInstalledOnTheServer_IsRefused()
+    {
+        var pair = SshKeyPairGenerator.Generate("never-installed");
+
+        using var connector = new SftpConnector(new SftpConnectorConfig
+        {
+            Host = _server.Host,
+            Port = _server.Port,
+            Username = SftpServerFixture.Username,
+            AllowedRoot = AllowedRoot,
+            Credential = new SftpCredential { PrivateKey = pair.PrivateKeyPem },
+        });
+
+        Func<Task> act = () => connector.ListFilesAsync();
+
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    // ── Verified first use ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// The check that keeps the setup wizard honest, and the one most likely to break without
+    /// anyone noticing.
+    /// </summary>
+    /// <remarks>
+    /// The generated setup command reads the fingerprint with <c>ssh-keygen -l</c> on the host
+    /// and the operator pastes it into Connapse. If that format ever disagreed with what
+    /// <see cref="SshHostKeyPolicy"/> stores, every wizard-configured connection would refuse
+    /// to connect — or worse, silently fall back to trusting whatever answered. Nothing else
+    /// compares the two sides.
+    /// </remarks>
+    [Fact]
+    public async Task FingerprintReadOnTheHost_MatchesWhatTheConnectorWouldRecord()
+    {
+        string fromTheHost = await _server.ReadHostKeyFingerprintAsync();
+        string fromTheConnector = await ObserveFingerprintAsync();
+
+        fromTheHost.Should().Be(fromTheConnector,
+            "the setup command and the connector must agree on the fingerprint format");
+    }
+
+    /// <summary>
+    /// The point of the round trip: with the fingerprint supplied out of band, the very first
+    /// connection is authenticated rather than trusted.
+    /// </summary>
+    [Fact]
+    public async Task PinSuppliedBeforeTheFirstConnect_IsHonouredOnThatConnect()
+    {
+        string fingerprint = await _server.ReadHostKeyFingerprintAsync();
+        var store = new RecordingHostKeyStore();
+
+        using var connector = Connect(
+            pinned: fingerprint, hostKeyStore: store, connectionId: Guid.NewGuid());
+
+        (await connector.ListFilesAsync()).Should().NotBeEmpty();
+
+        store.Recorded.Should().BeEmpty(
+            "nothing is trusted on first use when the pin was already known");
+    }
+
+    /// <summary>
+    /// The half that makes the above worth anything. A wrong fingerprint must stop the
+    /// <em>first</em> connection — if it only took effect from the second, the wizard would be
+    /// decoration.
+    /// </summary>
+    [Fact]
+    public async Task WrongPinSuppliedBeforeTheFirstConnect_RefusesThatConnect()
+    {
+        var store = new RecordingHostKeyStore();
+
+        using var connector = Connect(
+            pinned: "SHA256:aFingerprintFromSomewhereElse",
+            hostKeyStore: store,
+            connectionId: Guid.NewGuid());
+
+        Func<Task> act = () => connector.ListFilesAsync();
+
+        await act.Should().ThrowAsync<SftpHostKeyMismatchException>();
+        store.Recorded.Should().BeEmpty("a refused server must not have its key recorded");
+    }
+
     // ── Host key pinning ───────────────────────────────────────────────────
 
     /// <summary>Records what was pinned, so a test can assert on it.</summary>
@@ -412,4 +569,7 @@ public class SftpConnectorIntegrationTests : IAsyncLifetime
         return store.Recorded.Single().Fingerprint;
     }
 }
+
+
+
 

--- a/tests/Connapse.Integration.Tests/SftpServerFixture.cs
+++ b/tests/Connapse.Integration.Tests/SftpServerFixture.cs
@@ -106,6 +106,35 @@ public sealed class SftpServerFixture : IAsyncLifetime
         ExecAsync($"chown root '{Home}{sftpPath}' && chmod 700 '{Home}{sftpPath}'");
 
     /// <summary>
+    /// Appends a public key to the account's <c>authorized_keys</c>, the way the generated
+    /// setup command does on a real host. Lets a test prove a Connapse-generated key pair
+    /// actually authenticates.
+    /// </summary>
+    public Task AuthorizeKeyAsync(string publicKeyLine) =>
+        ExecAsync(
+            $"mkdir -p '{Home}/.ssh' && "
+            + $"printf '%s\\n' '{publicKeyLine}' >> '{Home}/.ssh/authorized_keys' && "
+            + $"chown -R {Username} '{Home}/.ssh' && "
+            + $"chmod 700 '{Home}/.ssh' && chmod 600 '{Home}/.ssh/authorized_keys'");
+
+    /// <summary>
+    /// Reads the server's host key fingerprint the way the generated setup command does —
+    /// with <c>ssh-keygen -l</c>, on the machine itself, never over the network.
+    /// </summary>
+    /// <remarks>
+    /// This is the out-of-band channel that makes verified-first-use possible, so a test using
+    /// it is testing the real mechanism rather than a stand-in.
+    /// </remarks>
+    public async Task<string> ReadHostKeyFingerprintAsync()
+    {
+        string output = await ExecAsync(
+            "ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null "
+            + "|| ssh-keygen -lf /etc/ssh/ssh_host_rsa_key.pub");
+
+        return output.Split(' ', StringSplitOptions.RemoveEmptyEntries)[1].Trim();
+    }
+
+    /// <summary>
     /// Replaces the server's host keys and restarts sshd, so the next connection presents a
     /// different key. This is what a rekey looks like to a client, and what an interposition
     /// looks like too — the connector cannot tell them apart, which is the point of pinning.

--- a/tests/Connapse.Integration.Tests/SourceIngestionOwnershipTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceIngestionOwnershipTests.cs
@@ -1,9 +1,12 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Ingestion.Reindex;
 using Connapse.Storage.Data;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Connapse.Integration.Tests;
@@ -200,5 +203,80 @@ public class SourceIngestionOwnershipTests(SharedWebAppFixture fixture)
 
         doc.Metadata!["RemoteLastModified"].Should().Be("2026-08-16T00:00:00.0000000Z");
         doc.Metadata["RemoteSize"].Should().Be("1234");
+    }
+
+    [Fact]
+    public async Task ForcedReindex_OfSourceOwnedDocument_EnqueuesItAsSourceOwned()
+    {
+        // The reindex deletes a document's chunks before enqueueing it. If the job it then
+        // enqueues cannot be routed, the chunks are gone for good: the pipeline throws, and
+        // the next sync sees an unchanged remote signature and does not re-ingest the file.
+        // So what the job carries is the whole safety property here.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        Guid sourceId = await SeedSourceAsync(scope.ServiceProvider);
+
+        var pipeline = scope.ServiceProvider.GetRequiredService<IKnowledgeIngester>();
+        using var content = new MemoryStream("content to be force-reindexed"u8.ToArray());
+        var created = await pipeline.IngestAsync(content, new IngestionOptions(
+            FileName: "reindexed.md", ContentType: "text/markdown", Path: "/reindexed.md")
+        {
+            Owner = OwnerRef.ForSource(sourceId)
+        }, CancellationToken.None);
+
+        var queue = new CapturingIngestionQueue();
+        await using var ctx = await factory.CreateDbContextAsync();
+        var reindex = new ReindexService(
+            ctx,
+            scope.ServiceProvider.GetRequiredService<IKnowledgeFileSystem>(),
+            scope.ServiceProvider.GetRequiredService<IManagedStorageProvider>(),
+            scope.ServiceProvider.GetRequiredService<IContainerStore>(),
+            queue,
+            scope.ServiceProvider.GetRequiredService<IOptionsMonitor<ChunkingSettings>>(),
+            scope.ServiceProvider.GetRequiredService<IOptionsMonitor<EmbeddingSettings>>(),
+            NullLogger<ReindexService>.Instance);
+
+        await reindex.ReindexAsync(
+            new ReindexOptions { Force = true, DocumentIds = [created.DocumentId] },
+            CancellationToken.None);
+
+        IngestionJob job = queue.Jobs.Should().ContainSingle().Subject;
+        job.Options.Owner.Should().Be(OwnerRef.ForSource(sourceId),
+            "the pipeline routes source documents by Owner, and nothing else on the job says so");
+        job.Options.ContainerId.Should().BeNull(
+            "Nullable<Guid>.ToString() yields \"\", which reads as a container id that is merely blank");
+    }
+
+    private sealed class CapturingIngestionQueue : IIngestionQueue
+    {
+        public List<IngestionJob> Jobs { get; } = [];
+
+        public Task EnqueueAsync(IngestionJob job, CancellationToken ct = default)
+        {
+            Jobs.Add(job);
+            return Task.CompletedTask;
+        }
+
+        public Task<IngestionJob?> DequeueAsync(CancellationToken ct = default) =>
+            Task.FromResult<IngestionJob?>(null);
+
+        public Task<IngestionJobStatus?> GetStatusAsync(string jobId) =>
+            Task.FromResult<IngestionJobStatus?>(null);
+
+        public Task<bool> CancelJobForDocumentAsync(string documentId) => Task.FromResult(false);
+
+        public int QueueDepth => Jobs.Count;
+
+        public void UpdateJobStatus(
+            string jobId, IngestionJobState state, IngestionPhase? currentPhase = null,
+            double percentComplete = 0, string? errorMessage = null)
+        { }
+
+        public IReadOnlyDictionary<string, IngestionJobStatus> GetAllStatuses() =>
+            new Dictionary<string, IngestionJobStatus>();
+
+        public void RegisterJobCancellation(string jobId, CancellationTokenSource cts) { }
+
+        public void UnregisterJobCancellation(string jobId) { }
     }
 }


### PR DESCRIPTION
Closes #387. Targets `feature/386-sftp-connector` (#388), which must merge first.

#388 built the SFTP connector. Connections are UI-only by design — there is no REST route for them — so without this form there is no way to create an SFTP connection at all, and the connector is unreachable.

## The secret field returns, for SFTP only

[#371](https://github.com/Destrayon/Connapse/pull/371) removed the secret field from the connection form because Connapse does not accept pasted cloud keys. It comes back for SFTP and nothing else.

That distinction only holds if it is enforced rather than described, so `ToSecretJson()` returns null for every other provider, and there is a test that puts a private key on an S3 form and asserts nothing is stored. The rule was always about **cloud identities** — an AWS access key is a credential AWS already has a better answer for. An SSH key for a machine you run has no such alternative.

## A latent trap in the existing form

The form had three `Provider != ConnectionProvider.Filesystem` checks standing in for "is a cloud provider". Adding SFTP to the enum would have swept it into the cloud branch — offering a bucket allowlist for a directory on a server, and no root field at all.

Replaced with a named `IsCloudProvider`. The negative was already load-bearing in three places and read as correct in all of them.

## Host key

Shown on the connection in the format `ssh-keygen` prints, so it can be checked against `ssh-keyscan`. Carried through an ordinary save rather than rewritten — the connector owns that value, and dropping it would silently re-arm trust on first use, which is the one thing pinning exists to prevent. A **Forget** control clears it deliberately, which is how a legitimate rekey is accepted.

## Test button

Added `SftpConnectionTester`, and `SftpConnector.ProbeAsync` for it to call. It opens a session, verifies the host key, and resolves the root — the three things that go wrong — and deliberately does not walk the tree.

The tester first called `ExistsAsync` for its side effect of connecting. That would have become a test button that always passed the moment that method changed, so the probe is now explicit.

Testing uses the key **in the form**, not the stored one, so an operator can check a key before committing to it. Editing a connection without retyping the key therefore cannot be tested — said plainly rather than silently testing something else.

## Documentation

`docs/connectors.md` gains SFTP confinement, host keys, and **Indexing files on your own machine** — the section that answers the problem this epic started from. It names the three things that each cost an hour: Windows OpenSSH presenting paths as `/C:/Users/...`, `host.docker.internal` being Docker Desktop only, and list-and-diff on every poll meaning you point a source at a folder rather than a drive.

## Smaller things

An unparseable port becomes 0 and is refused, rather than falling back to 22 and connecting somewhere the operator did not ask for.

The credential column shows SFTP connections as "SSH key" rather than the "Legacy secret" warning, which was written when no connector read a stored secret. A connection with no key shows as an error, since it cannot authenticate.

## Verification

`dotnet test --filter "Category=Unit"` — **884 passed, 0 failed**; 41 in `ConnectionFormTests`.

Ran the stack with `docker compose up -d --build`: migrations applied, DI resolved the new `ISshHostKeyStore` and tester, app healthy on :5001 with no startup errors.

## Not included

`SourceForm` and `SourceScopePreflight` gaining an `Sftp` case, which #387 also lists. Those types live in #380, which targets `main` and has not merged, so they do not exist on this branch. Once #380 lands and the epic rebases, the SFTP case is a one-line addition to each — the scope shape is identical to Filesystem by design.

Sources are creatable via `POST /api/sources` in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)