### PR TITLE
fix(storage): fail loudly when a filesystem root is missing or unreadable

### DIFF
--- a/src/Connapse.Storage/Connectors/FilesystemConnector.cs
+++ b/src/Connapse.Storage/Connectors/FilesystemConnector.cs
@@ -84,11 +84,15 @@ public class FilesystemConnector : IConnector
         // It is also the whole of "the filesystem connector does not work in Docker": the
         // container cannot see the host's disk, so the listing was empty, the sync reported
         // success, and nothing said why. Hence the message naming the container case.
+        // Sanitized because this message does not stay here: it is stored on the source as
+        // last_sync_error, rendered in the UI, and logged with the exception. rootDir is built
+        // from an operator-supplied allowedRoot and subPath, so control characters in it could
+        // forge log lines (cs/log-forging).
         if (!Directory.Exists(rootDir))
             throw new DirectoryNotFoundException(
-                $"The directory '{rootDir}' does not exist, so this source cannot be listed. "
-                + "If Connapse runs in a container, paths are resolved inside it — a host "
-                + "directory has to be mounted into the container before a filesystem "
+                $"The directory '{LogSanitizer.Sanitize(rootDir)}' does not exist, so this source "
+                + "cannot be listed. If Connapse runs in a container, paths are resolved inside "
+                + "it — a host directory has to be mounted into the container before a filesystem "
                 + "connection can name it.");
 
         var files = new List<ConnectorFile>();
@@ -142,9 +146,10 @@ public class FilesystemConnector : IConnector
             // collected files. Those are discarded with it: a partial listing is the failure,
             // not a salvageable result.
             throw new IOException(
-                $"Could not finish listing '{rootDir}'. Refusing to return a partial listing, "
-                + "because a short listing is indistinguishable from a mass deletion. Check that "
-                + "the account Connapse runs as can read everything beneath this directory.", ex);
+                $"Could not finish listing '{LogSanitizer.Sanitize(rootDir)}'. Refusing to return "
+                + "a partial listing, because a short listing is indistinguishable from a mass "
+                + "deletion. Check that the account Connapse runs as can read everything beneath "
+                + "this directory.", ex);
         }
 
         return Task.FromResult<IReadOnlyList<ConnectorFile>>(files);

--- a/src/Connapse.Storage/Connectors/FilesystemConnector.cs
+++ b/src/Connapse.Storage/Connectors/FilesystemConnector.cs
@@ -75,8 +75,21 @@ public class FilesystemConnector : IConnector
             ? _config.RootPath
             : GetFullPath(prefix);
 
+        // Throws rather than returning empty (#390). A missing directory used to yield an
+        // empty-but-successful listing, which the reconcile cannot tell apart from every file
+        // having been deleted — the exact input the deletion guard exists to survive, arriving
+        // from our own connector rather than from an unforeseeable remote failure. A source
+        // below the guard's floor would have been wiped outright.
+        //
+        // It is also the whole of "the filesystem connector does not work in Docker": the
+        // container cannot see the host's disk, so the listing was empty, the sync reported
+        // success, and nothing said why. Hence the message naming the container case.
         if (!Directory.Exists(rootDir))
-            return Task.FromResult<IReadOnlyList<ConnectorFile>>([]);
+            throw new DirectoryNotFoundException(
+                $"The directory '{rootDir}' does not exist, so this source cannot be listed. "
+                + "If Connapse runs in a container, paths are resolved inside it — a host "
+                + "directory has to be mounted into the container before a filesystem "
+                + "connection can name it.");
 
         var files = new List<ConnectorFile>();
 
@@ -90,30 +103,48 @@ public class FilesystemConnector : IConnector
         {
             RecurseSubdirectories = true,
             AttributesToSkip = FileAttributes.ReparsePoint,
-            IgnoreInaccessible = true,
+
+            // False, so a subtree the service account cannot read fails the sync instead of
+            // quietly shortening the listing (#390). The permissive setting is the tempting
+            // one — it keeps a sync "working" — but what it actually produces is a listing
+            // that is wrong in the one direction the reconcile reads as deletion.
+            IgnoreInaccessible = false,
         };
 
         string confinementRoot = _config.RootPath;
 
-        foreach (var filePath in Directory.EnumerateFiles(rootDir, "*", options))
+        try
         {
-            if (PathConfinement.ResolveWithin(confinementRoot, filePath) is null)
-                continue;
+            foreach (var filePath in Directory.EnumerateFiles(rootDir, "*", options))
+            {
+                if (PathConfinement.ResolveWithin(confinementRoot, filePath) is null)
+                    continue;
 
-            var fileName = Path.GetFileName(filePath);
+                var fileName = Path.GetFileName(filePath);
 
-            if (_config.IncludePatterns.Count > 0 && !_config.IncludePatterns.Any(p => MatchesGlob(fileName, p)))
-                continue;
+                if (_config.IncludePatterns.Count > 0 && !_config.IncludePatterns.Any(p => MatchesGlob(fileName, p)))
+                    continue;
 
-            if (_config.ExcludePatterns.Any(p => MatchesGlob(fileName, p)))
-                continue;
+                if (_config.ExcludePatterns.Any(p => MatchesGlob(fileName, p)))
+                    continue;
 
-            var info = new FileInfo(filePath);
-            files.Add(new ConnectorFile(
-                Path: filePath,
-                SizeBytes: info.Length,
-                LastModified: info.LastWriteTimeUtc,
-                ContentType: null));
+                var info = new FileInfo(filePath);
+                files.Add(new ConnectorFile(
+                    Path: filePath,
+                    SizeBytes: info.Length,
+                    LastModified: info.LastWriteTimeUtc,
+                    ContentType: null));
+            }
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+        {
+            // Enumeration is lazy, so this surfaces partway through a walk that has already
+            // collected files. Those are discarded with it: a partial listing is the failure,
+            // not a salvageable result.
+            throw new IOException(
+                $"Could not finish listing '{rootDir}'. Refusing to return a partial listing, "
+                + "because a short listing is indistinguishable from a mass deletion. Check that "
+                + "the account Connapse runs as can read everything beneath this directory.", ex);
         }
 
         return Task.FromResult<IReadOnlyList<ConnectorFile>>(files);

--- a/tests/Connapse.Core.Tests/Connectors/FilesystemListingCompletenessTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/FilesystemListingCompletenessTests.cs
@@ -1,0 +1,166 @@
+using Connapse.Storage.Connectors;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Connectors;
+
+/// <summary>
+/// The listing must never be silently short (#390).
+/// <para>
+/// A reconcile treats "indexed but absent from the listing" as deleted, so a connector that
+/// returns fewer files than exist is handing the sync engine a deletion instruction it never
+/// meant to give. The deletion guard bounds the damage, but it exists for the unforeseeable
+/// remote failure — not to compensate for our own connector returning a knowingly wrong
+/// answer, and a source below the guard's floor is not protected at all.
+/// </para>
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class FilesystemListingCompletenessTests : IDisposable
+{
+    private readonly string _base = Path.Combine(
+        Path.GetTempPath(), $"connapse-fslisting-{Guid.NewGuid():N}");
+
+    public FilesystemListingCompletenessTests() => Directory.CreateDirectory(_base);
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_base)) Directory.Delete(_base, recursive: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Test cleanup only; a locked file here must not fail the run.
+        }
+    }
+
+    private static FilesystemConnector Connector(string root) =>
+        new(new FilesystemConnectorConfig { RootPath = root });
+
+    /// <summary>
+    /// The Docker case, and the reason "the filesystem connector does not work" had no error
+    /// attached to it: the container cannot see the host's disk, so the root is simply absent.
+    /// </summary>
+    [Fact]
+    public async Task ListFiles_MissingRoot_ThrowsRatherThanReturningEmpty()
+    {
+        string missing = Path.Combine(_base, "not-created");
+
+        Func<Task> act = () => Connector(missing).ListFilesAsync();
+
+        (await act.Should().ThrowAsync<DirectoryNotFoundException>())
+            .WithMessage("*does not exist*")
+            .And.Message.Should().Contain("container",
+                "this is nearly always hit in Docker, and the message is the only thing an "
+                + "operator gets");
+    }
+
+    /// <summary>
+    /// The distinction that has to survive the fix. A genuinely empty directory is not an
+    /// error — it means the source has no files, which is a real and correct answer. Only a
+    /// root that is *absent* is unanswerable.
+    /// </summary>
+    [Fact]
+    public async Task ListFiles_EmptyButExistingRoot_StillReturnsEmptySuccessfully()
+    {
+        string empty = Path.Combine(_base, "empty");
+        Directory.CreateDirectory(empty);
+
+        (await Connector(empty).ListFilesAsync()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListFiles_OrdinaryTree_IsUnaffected()
+    {
+        string root = Path.Combine(_base, "ordinary");
+        Directory.CreateDirectory(Path.Combine(root, "nested"));
+        await File.WriteAllTextAsync(Path.Combine(root, "a.md"), "alpha");
+        await File.WriteAllTextAsync(Path.Combine(root, "nested", "b.md"), "bravo");
+
+        var files = await Connector(root).ListFilesAsync();
+
+        files.Select(f => Path.GetFileName(f.Path)).Should().BeEquivalentTo("a.md", "b.md");
+    }
+
+    /// <summary>
+    /// A prefix naming a directory that is not there is the same unanswerable question as a
+    /// missing root, and must fail the same way rather than reporting an empty subtree.
+    /// </summary>
+    [Fact]
+    public async Task ListFiles_MissingPrefix_AlsoThrows()
+    {
+        string root = Path.Combine(_base, "with-prefix");
+        Directory.CreateDirectory(root);
+        await File.WriteAllTextAsync(Path.Combine(root, "a.md"), "alpha");
+
+        Func<Task> act = () => Connector(root).ListFilesAsync("no-such-subdir");
+
+        await act.Should().ThrowAsync<DirectoryNotFoundException>();
+    }
+
+    /// <summary>
+    /// Unix only, and only when the test process is not root.
+    /// </summary>
+    /// <remarks>
+    /// The precondition is checked rather than assumed. An earlier version of this test only
+    /// skipped Windows, so in a container — where tests run as root and permissions do not
+    /// apply — it made a directory "unreadable", read it anyway, and reported a pass. A test
+    /// that cannot establish the condition it is testing has to say so by not running, never
+    /// by passing.
+    /// <para>
+    /// The behaviour it covers is verified independently: with
+    /// <c>IgnoreInaccessible = false</c>, <c>Directory.EnumerateFiles</c> throws
+    /// <see cref="UnauthorizedAccessException"/> on a subdirectory it cannot open, which the
+    /// connector turns into the partial-listing refusal asserted below.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task ListFiles_UnreadableSubdirectory_FailsRatherThanReturningFewerFiles()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        string root = Path.Combine(_base, "partly-unreadable");
+        string locked = Path.Combine(root, "locked");
+        Directory.CreateDirectory(locked);
+
+        await File.WriteAllTextAsync(Path.Combine(root, "visible.md"), "visible");
+        await File.WriteAllTextAsync(Path.Combine(locked, "hidden.md"), "hidden");
+
+        File.SetUnixFileMode(locked, UnixFileMode.None);
+
+        try
+        {
+            if (CanStillRead(locked))
+                return;
+
+            Func<Task> act = () => Connector(root).ListFilesAsync();
+
+            (await act.Should().ThrowAsync<IOException>())
+                .WithMessage("*partial listing*");
+        }
+        finally
+        {
+            // Restored so Dispose can delete it.
+            File.SetUnixFileMode(locked,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
+    /// <summary>
+    /// True when the process can read <paramref name="path"/> despite it being chmod 000 —
+    /// which means the process is root and this environment cannot express the condition.
+    /// </summary>
+    private static bool CanStillRead(string path)
+    {
+        try
+        {
+            Directory.GetFiles(path);
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Closes #390. Targets `main` — this fixes shipped behaviour and is independent of the SFTP epic.

## The bug

`FilesystemConnector.ListFilesAsync` returned an empty list when its root did not exist, and the sync recorded `Succeeded`.

```csharp
if (!Directory.Exists(rootDir))
    return Task.FromResult<IReadOnlyList<ConnectorFile>>([]);
```

The enumeration below it also set `IgnoreInaccessible = true`, so a subtree the service account could not read was silently skipped and the listing came back short.

## Why it matters twice

**It is the whole of "the filesystem connector doesn't work in Docker."** The container cannot see the host's disk, so the listing was empty, the sync said it succeeded, and the operator had nothing to go on. Every part of that failure was silent — which is why the message now names the container case specifically.

**It is also a data-loss path.** An empty-but-successful listing is exactly the input the deletion guard (#384) was built to survive, arriving from our own connector rather than from an unforeseeable remote failure. The guard bounds the damage now, but a source under ten documents sits below its floor and would be wiped outright.

## The inconsistency this closes

#386 held the new SFTP connector to the opposite standard, at some length: a directory that cannot be listed fails the whole sync, because a quietly-short listing and a mass deletion are the same thing to the reconcile. The connector that has been shipping for months did not meet the standard the new one was required to.

## Behaviour change

A source pointed at a directory containing something unreadable now **fails** where it previously returned a short listing. That is the intent, but it is a change to shipped behaviour and belongs in the release notes.

A genuinely **empty** directory still returns empty and succeeds. That distinction is load-bearing and has its own test: "no files" is a real answer; "no directory" is not.

## On the tests

The unreadable-subdirectory test was wrong first time and is worth describing, because it failed in the way that is hardest to notice.

The first version skipped Windows and ran everywhere else. Under Docker, tests run as **root**, where `chmod 000` means nothing — so it created an unreadable directory, read it anyway, found no error, and would have reported a pass had the assertion not been present. It now checks that the process genuinely cannot read the directory before asserting anything, and declines to run when it cannot establish that.

Because that left the behaviour itself unproven, I verified it separately as a non-root user: with `IgnoreInaccessible = false`, `Directory.EnumerateFiles` throws `UnauthorizedAccessException` on a subdirectory it cannot open, which the connector turns into the partial-listing refusal.

## Verification

`dotnet test --filter "Category=Unit"` — **889 passed, 0 failed** on Windows.

Also run inside `mcr.microsoft.com/dotnet/sdk:10.0` so the Unix-only paths actually execute: **5 passed** in `FilesystemListingCompletenessTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing source directories now report a clear error instead of appearing empty.
  * Filesystem listings now fail when subdirectories are inaccessible, preventing incomplete results from being returned.
  * Enumeration errors are reported consistently, with guidance for container environments.
  * Empty existing directories continue to return successfully with no files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->