### PR TITLE
fix(ingestion): let source-owned documents be ingested, and retry the ones that failed

### DIFF
--- a/src/Connapse.Core/Models/SourceModels.cs
+++ b/src/Connapse.Core/Models/SourceModels.cs
@@ -20,7 +20,16 @@ public record Source(
     string? Summary = null,
     DateTime? SummaryGeneratedAt = null,
     string? SummaryDocSetHash = null,
-    int DocumentCount = 0);
+    int DocumentCount = 0,
+
+    // Appended rather than inserted: this record is constructed positionally in places, so a
+    // parameter added anywhere else shifts every argument after it.
+    //
+    // Counted separately because DocumentCount includes every row whatever its status, so a
+    // source where nothing could be embedded still reported its files and a green badge. The
+    // sync did succeed — it listed and enqueued correctly — and the failure downstream had no
+    // way back to the page (#400).
+    int FailedDocumentCount = 0);
 
 public record CreateSourceRequest(
     string Name,

--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -1,4 +1,4 @@
-﻿using Connapse.Core;
+using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
 using Connapse.Storage.Data;
@@ -32,6 +32,9 @@ public class IngestionPipeline : IKnowledgeIngester
     private readonly IContainerStore _containerStore;
     private readonly IManagedStorageProvider _managedStorage;
     private readonly IDocumentStore _documentStore;
+    private readonly ISourceStore _sourceStore;
+    private readonly IConnectionStore _connectionStore;
+    private readonly IConnectorFactory _connectorFactory;
     private readonly ILogger<IngestionPipeline> _logger;
 
     // Metadata keys for tracking indexing settings
@@ -76,6 +79,9 @@ public class IngestionPipeline : IKnowledgeIngester
         IContainerStore containerStore,
         IManagedStorageProvider managedStorage,
         IDocumentStore documentStore,
+        ISourceStore sourceStore,
+        IConnectionStore connectionStore,
+        IConnectorFactory connectorFactory,
         ILogger<IngestionPipeline> logger)
     {
         _context = context;
@@ -90,6 +96,9 @@ public class IngestionPipeline : IKnowledgeIngester
         _containerStore = containerStore;
         _managedStorage = managedStorage;
         _documentStore = documentStore;
+        _sourceStore = sourceStore;
+        _connectionStore = connectionStore;
+        _connectorFactory = connectorFactory;
         _logger = logger;
     }
 
@@ -489,6 +498,15 @@ public class IngestionPipeline : IKnowledgeIngester
         IngestionOptions options,
         CancellationToken ct = default)
     {
+        // A source-owned document is read through its connection's connector, not through
+        // managed storage — checked first, because everything below this resolves a container
+        // and a source does not have one (#398).
+        //
+        // Only this entry point was left container-shaped by the connector/source split.
+        // IngestAsync already honours OwnerRef.ForSource; the gap was getting the bytes.
+        if (options.Owner is { IsSource: true } sourceOwner)
+            return await IngestSourceDocumentAsync(documentId, sourceOwner.Id, options, ct);
+
         // Resolve the container ID — prefer options.ContainerId, fall back to looking up the doc.
         Guid containerId;
         string virtualPath;
@@ -526,6 +544,48 @@ public class IngestionPipeline : IKnowledgeIngester
 
         await using Stream stream = await connector.ReadFileAsync(jobPath, ct);
         return await IngestAsync(stream, options, ct);
+    }
+
+    /// <summary>
+    /// Reads a source-owned document through its connection's connector and ingests it.
+    /// </summary>
+    /// <remarks>
+    /// The path is used as the sync engine recorded it, without <c>ResolveJobPath</c>. That
+    /// method exists to turn a virtual container path into a real one; a source's listing
+    /// already yields the connector's own absolute form — an OS path for Filesystem, a remote
+    /// path for SFTP — and putting it through resolution again would rebase a path that is
+    /// already rooted.
+    /// </remarks>
+    private async Task<IngestionResult> IngestSourceDocumentAsync(
+        string documentId, Guid sourceId, IngestionOptions options, CancellationToken ct)
+    {
+        string path = options.Path ?? options.FileName
+            ?? throw new InvalidOperationException(
+                $"IngestByIdAsync: options must provide Path or FileName for document {documentId}");
+
+        Source source = await _sourceStore.GetAsync(sourceId, ct)
+            ?? throw new InvalidOperationException(
+                $"IngestByIdAsync: source {sourceId} not found for document {documentId}");
+
+        Connection connection = await _connectionStore.GetAsync(source.ConnectionId, ct)
+            ?? throw new InvalidOperationException(
+                $"IngestByIdAsync: connection {source.ConnectionId} not found for source {sourceId}");
+
+        // No credential is passed: every provider here authenticates from ambient identity —
+        // S3 through the AWS default chain, Azure through managed identity — or needs nothing
+        // at all. A provider that stores one would have to be handed it here too.
+        IConnector connector = _connectorFactory.Create(source, connection);
+        try
+        {
+            await using Stream stream = await connector.ReadFileAsync(path, ct);
+            return await IngestAsync(stream, options, ct);
+        }
+        finally
+        {
+            // SftpConnector holds an SSH session and S3Connector a socket pool. One job runs
+            // per file, so skipping this abandons a connection per document.
+            if (connector is IDisposable disposable) disposable.Dispose();
+        }
     }
 
     public async IAsyncEnumerable<IngestionProgress> IngestWithProgressAsync(
@@ -646,3 +706,5 @@ internal static class IngestionPipelineStrategyResolver
         return MarkdownExtensions.Contains(ext) ? "DocumentAware" : fallbackStrategy;
     }
 }
+
+

--- a/src/Connapse.Storage/Sources/PostgresSourceStore.cs
+++ b/src/Connapse.Storage/Sources/PostgresSourceStore.cs
@@ -67,10 +67,15 @@ public class PostgresSourceStore(
         var result = await context.Sources
             .AsNoTracking()
             .Where(s => s.Id == id)
-            .Select(s => new { Source = s, DocumentCount = s.Documents.Count })
+            .Select(s => new
+            {
+                Source = s,
+                DocumentCount = s.Documents.Count,
+                FailedDocumentCount = s.Documents.Count(d => d.Status == "Failed"),
+            })
             .FirstOrDefaultAsync(ct);
 
-        return result is null ? null : MapToModel(result.Source, result.DocumentCount);
+        return result is null ? null : MapToModel(result.Source, result.DocumentCount, result.FailedDocumentCount);
     }
 
     public async Task<Source?> GetByNameAsync(string name, CancellationToken ct = default)
@@ -82,10 +87,15 @@ public class PostgresSourceStore(
         var result = await context.Sources
             .AsNoTracking()
             .Where(s => s.Name == normalized)
-            .Select(s => new { Source = s, DocumentCount = s.Documents.Count })
+            .Select(s => new
+            {
+                Source = s,
+                DocumentCount = s.Documents.Count,
+                FailedDocumentCount = s.Documents.Count(d => d.Status == "Failed"),
+            })
             .FirstOrDefaultAsync(ct);
 
-        return result is null ? null : MapToModel(result.Source, result.DocumentCount);
+        return result is null ? null : MapToModel(result.Source, result.DocumentCount, result.FailedDocumentCount);
     }
 
     public async Task<IReadOnlyList<Source>> ListAsync(int skip = 0, int take = 50, CancellationToken ct = default)
@@ -97,10 +107,15 @@ public class PostgresSourceStore(
             .OrderBy(s => s.Name)
             .Skip(skip)
             .Take(take)
-            .Select(s => new { Source = s, DocumentCount = s.Documents.Count })
+            .Select(s => new
+            {
+                Source = s,
+                DocumentCount = s.Documents.Count,
+                FailedDocumentCount = s.Documents.Count(d => d.Status == "Failed"),
+            })
             .ToListAsync(ct);
 
-        return results.Select(r => MapToModel(r.Source, r.DocumentCount)).ToList();
+        return results.Select(r => MapToModel(r.Source, r.DocumentCount, r.FailedDocumentCount)).ToList();
     }
 
     public async Task<IReadOnlyList<Source>> ListByConnectionAsync(Guid connectionId, CancellationToken ct = default)
@@ -111,10 +126,15 @@ public class PostgresSourceStore(
             .AsNoTracking()
             .Where(s => s.ConnectionId == connectionId)
             .OrderBy(s => s.Name)
-            .Select(s => new { Source = s, DocumentCount = s.Documents.Count })
+            .Select(s => new
+            {
+                Source = s,
+                DocumentCount = s.Documents.Count,
+                FailedDocumentCount = s.Documents.Count(d => d.Status == "Failed"),
+            })
             .ToListAsync(ct);
 
-        return results.Select(r => MapToModel(r.Source, r.DocumentCount)).ToList();
+        return results.Select(r => MapToModel(r.Source, r.DocumentCount, r.FailedDocumentCount)).ToList();
     }
 
     public async Task<Source?> UpdateAsync(Guid id, UpdateSourceRequest request, CancellationToken ct = default)
@@ -264,7 +284,8 @@ public class PostgresSourceStore(
         await context.SaveChangesAsync(ct);
     }
 
-    private static Source MapToModel(SourceEntity entity, int documentCount) => new(
+    private static Source MapToModel(
+        SourceEntity entity, int documentCount, int failedDocumentCount = 0) => new(
         Id: entity.Id,
         Name: entity.Name,
         Description: entity.Description,
@@ -284,5 +305,7 @@ public class PostgresSourceStore(
         Summary: entity.Summary,
         SummaryGeneratedAt: entity.SummaryGeneratedAt,
         SummaryDocSetHash: entity.SummaryDocSetHash,
-        DocumentCount: documentCount);
+        DocumentCount: documentCount,
+        FailedDocumentCount: failedDocumentCount);
 }
+

--- a/src/Connapse.Storage/Sources/PostgresSourceStore.cs
+++ b/src/Connapse.Storage/Sources/PostgresSourceStore.cs
@@ -57,7 +57,9 @@ public class PostgresSourceStore(
 
         logger.LogInformation("Created source {SourceId} ({Name})", entity.Id, Sanitize(entity.Name));
 
-        return MapToModel(entity, 0);
+        // A source that was created a line ago owns no documents, so both counts are genuinely
+        // zero rather than merely unknown.
+        return MapToModel(entity, documentCount: 0, failedDocumentCount: 0);
     }
 
     public async Task<Source?> GetAsync(Guid id, CancellationToken ct = default)
@@ -165,7 +167,10 @@ public class PostgresSourceStore(
         await context.SaveChangesAsync(ct);
 
         int documentCount = await context.Documents.CountAsync(d => d.SourceId == id, ct);
-        return MapToModel(entity, documentCount);
+        int failedDocumentCount = await context.Documents
+            .CountAsync(d => d.SourceId == id && d.Status == "Failed", ct);
+
+        return MapToModel(entity, documentCount, failedDocumentCount);
     }
 
     public async Task<bool> DeleteAsync(Guid id, CancellationToken ct = default)
@@ -285,7 +290,7 @@ public class PostgresSourceStore(
     }
 
     private static Source MapToModel(
-        SourceEntity entity, int documentCount, int failedDocumentCount = 0) => new(
+        SourceEntity entity, int documentCount, int failedDocumentCount) => new(
         Id: entity.Id,
         Name: entity.Name,
         Description: entity.Description,
@@ -308,4 +313,5 @@ public class PostgresSourceStore(
         DocumentCount: documentCount,
         FailedDocumentCount: failedDocumentCount);
 }
+
 

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -119,7 +119,19 @@
                                than content. Shown because an operator needs to know what a source
                                points at; it is never a listing of what is inside. *@
                             <td class="small text-muted font-monospace">@DescribeScope(source)</td>
-                            <td>@source.DocumentCount</td>
+                            <td>
+                                @source.DocumentCount
+                                @if (source.FailedDocumentCount > 0)
+                                {
+                                    @* The count alone reported work that produced nothing as though it
+                                       had succeeded: the sync did list and enqueue correctly, and the
+                                       failure downstream had no way back to this page. *@
+                                    <span class="badge text-bg-danger ms-1"
+                                          title="These files were found and queued, but could not be indexed. They are retried on the next sync.">
+                                        @source.FailedDocumentCount failed
+                                    </span>
+                                }
+                            </td>
                             <td class="small text-muted">@FormatLastSync(source)</td>
                             <td>@StatusBadge(source)</td>
                             @if (isAdmin)

--- a/src/Connapse.Web/Services/SourceSyncService.cs
+++ b/src/Connapse.Web/Services/SourceSyncService.cs
@@ -338,6 +338,20 @@ public class SourceSyncService(
         if (existing.Status is "Pending" or "Queued" or "Processing")
             return false;
 
+        // A failed document is retried, regardless of the signature (#400). The signature is
+        // written as ingestion metadata before the failure, so it matches — which meant the
+        // comparison below skipped the document and it stayed Failed with zero chunks for ever,
+        // or until the remote file happened to change.
+        //
+        // That made any transient downstream fault permanent: an embedding service that was
+        // briefly unreachable poisoned every document caught in the window, and no amount of
+        // re-syncing recovered them.
+        //
+        // The cost is a genuinely unparseable file being re-fetched every cycle. Bounded, and
+        // much the lesser evil: it fails before embedding, which is the part that costs money.
+        if (existing.Status is "Failed")
+            return true;
+
         var metadata = existing.Metadata;
         string? lastModified = metadata?.GetValueOrDefault(RemoteLastModifiedKey);
         string? size = metadata?.GetValueOrDefault(RemoteSizeKey);

--- a/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
@@ -99,6 +99,9 @@ public class IngestionPipelineTests
             Substitute.For<IContainerStore>(),
             Substitute.For<IManagedStorageProvider>(),
             Substitute.For<IDocumentStore>(),
+            Substitute.For<ISourceStore>(),
+            Substitute.For<IConnectionStore>(),
+            Substitute.For<IConnectorFactory>(),
             _logger);
 
     private static KnowledgeDbContext CreateInMemoryContext()

--- a/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Text.Json;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
@@ -519,5 +519,97 @@ public class SourceSyncIntegrationTests(SharedWebAppFixture fixture)
 
         result.Upserted.Should().Be(0);
         connector.ListCalls.Should().Be(0, "a disabled source must not touch the remote at all");
+    }
+    // ── Retrying a failed document (#400) ──────────────────────────────────
+
+    /// <summary>
+    /// Seeds one document with a given status and a remote signature matching what the connector
+    /// will report, so change detection sees an unchanged file and the status is the only thing
+    /// that can decide whether it is re-enqueued.
+    /// </summary>
+    /// <remarks>
+    /// Inserted via raw SQL because <c>IDocumentStore.StoreAsync</c> always populates
+    /// <c>container_id</c> and so cannot express a source-owned row.
+    /// </remarks>
+    private static async Task SeedDocumentWithSignatureAsync(
+        IServiceProvider sp, Guid sourceId, string path, string status, DateTime lastModified, long size)
+    {
+        var dbFactory = sp.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var context = await dbFactory.CreateDbContextAsync();
+
+        await context.Database.ExecuteSqlRawAsync(
+            "INSERT INTO documents (id, container_id, source_id, file_name, path, content_hash, size_bytes, status, metadata, created_at) "
+            + "VALUES ({0}, NULL, {1}, {2}, {3}, '', {4}, {5}, {6}::jsonb, now())",
+            Guid.NewGuid(), sourceId, Path.GetFileName(path), path, size, status,
+            $$"""{"RemoteLastModified":"{{lastModified:O}}","RemoteSize":"{{size}}"}""");
+    }
+
+    /// <summary>
+    /// The regression. A failed document keeps the signature written before it failed, so change
+    /// detection saw an unchanged file and skipped it — leaving it Failed with zero chunks for
+    /// ever, or until the remote happened to change. Any transient downstream fault was
+    /// therefore permanent.
+    /// </summary>
+    [Fact]
+    public async Task Sync_DocumentLeftFailed_IsRetriedEvenThoughTheRemoteIsUnchanged()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+        var modified = new DateTime(2026, 8, 23, 7, 4, 54, DateTimeKind.Utc);
+
+        await SeedDocumentWithSignatureAsync(
+            scope.ServiceProvider, source.Id, "/a.md", "Failed", modified, size: 100);
+
+        var connector = new FakeListConnector(new ConnectorFile("/a.md", 100, modified, null));
+        var result = await BuildService(scope.ServiceProvider, connector)
+            .SyncSourceAsync(source, connection, CancellationToken.None);
+
+        result.Upserted.Should().Be(1, "a failed document must be retried, not skipped as unchanged");
+    }
+
+    /// <summary>
+    /// The other half, and why this cannot simply ignore status: an already-indexed document with
+    /// a matching signature must still be skipped, or a five-minute poll re-embeds the whole
+    /// source on every cycle.
+    /// </summary>
+    [Fact]
+    public async Task Sync_DocumentAlreadyIndexed_IsStillSkippedWhenUnchanged()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+        var modified = new DateTime(2026, 8, 23, 7, 4, 54, DateTimeKind.Utc);
+
+        await SeedDocumentWithSignatureAsync(
+            scope.ServiceProvider, source.Id, "/a.md", "Ready", modified, size: 100);
+
+        var connector = new FakeListConnector(new ConnectorFile("/a.md", 100, modified, null));
+        var result = await BuildService(scope.ServiceProvider, connector)
+            .SyncSourceAsync(source, connection, CancellationToken.None);
+
+        result.Upserted.Should().Be(0, "change detection is what keeps a poll from re-embedding everything");
+    }
+
+    /// <summary>
+    /// And the in-flight guard survives: a document mid-ingestion must not be enqueued twice
+    /// against the same id.
+    /// </summary>
+    [Theory]
+    [InlineData("Pending")]
+    [InlineData("Queued")]
+    [InlineData("Processing")]
+    public async Task Sync_DocumentInFlight_IsStillSkipped(string status)
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+        var modified = new DateTime(2026, 8, 23, 7, 4, 54, DateTimeKind.Utc);
+
+        await SeedDocumentWithSignatureAsync(
+            scope.ServiceProvider, source.Id, "/a.md", status, modified, size: 100);
+
+        var connector = new FakeListConnector(new ConnectorFile("/a.md", 100, modified, null));
+        var result = await BuildService(scope.ServiceProvider, connector)
+            .SyncSourceAsync(source, connection, CancellationToken.None);
+
+        result.Upserted.Should().Be(0, "enqueueing again would race the in-flight job");
     }
 }

--- a/tests/Connapse.Integration.Tests/SourceSyncS3IntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceSyncS3IntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.S3.Model;
+using Amazon.S3.Model;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.Data;
@@ -164,4 +164,46 @@ public class SourceSyncS3IntegrationTests(SharedWebAppFixture fixture) : IAsyncL
 
         second.Upserted.Should().Be(0, "an object untouched in S3 must not be re-embedded every cycle");
     }
+
+    /// <summary>
+    /// The seam nothing crossed. Sync tests assert what is <em>enqueued</em>; pipeline tests
+    /// start from <c>IngestAsync</c>. Between them sat <c>IngestByIdAsync</c>, which resolved
+    /// ownership only through a container — so every job a source enqueued failed, for every
+    /// provider, and the Sources page showed files queued with the document count stuck at zero
+    /// (#398).
+    /// </summary>
+    [Fact]
+    public async Task IngestByIdAsync_SourceOwnedDocument_ReadsItThroughTheSourcesConnector()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var (source, _) = await CreateSourceAsync(scope.ServiceProvider);
+
+        await SeedObjectAsync("notes.md", "content that must reach the index");
+
+        var pipeline = scope.ServiceProvider.GetRequiredService<IKnowledgeIngester>();
+        var documentId = Guid.NewGuid();
+
+        var result = await pipeline.IngestByIdAsync(
+            documentId.ToString(),
+            new IngestionOptions(
+                DocumentId: documentId.ToString(),
+                FileName: "notes.md",
+                ContentType: "text/markdown",
+                Path: "notes.md")
+            {
+                // No ContainerId, because a source does not have one. That is the whole case.
+                Owner = OwnerRef.ForSource(source.Id),
+            });
+
+        result.ChunkCount.Should().BeGreaterThan(0, "the file must actually have been read and indexed");
+
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        var document = await db.Documents.FirstOrDefaultAsync(d => d.Id == documentId);
+        document.Should().NotBeNull();
+        document!.SourceId.Should().Be(source.Id);
+        document.ContainerId.Should().BeNull("ownership is exclusive — a source document has no container");
+    }
 }
+


### PR DESCRIPTION
Closes #398 and #400. Two bugs in source ingestion, both affecting **every provider on `main` today** — S3, Azure and Filesystem alike. Found while testing SFTP, but nothing here is SFTP-specific, which is why they are on their own PR rather than riding an epic branch.Together they mean: **a source has never been able to index a new file, and any file that failed could never be retried.**## Source-owned documents could never be ingested (#398)`IngestByIdAsync` — the entry point Hangfire calls — resolved ownership only through a container:- `options.ContainerId`, which source sync never sets, or- an existing document's `ContainerId`, which a newly discovered file does not have and a source-owned document never has by design.It then built a **managed storage** connector, which cannot reach a source's bytes at all. Every job a source enqueued failed:```IngestByIdAsync: document {id} not found and no ContainerId in options````IngestAsync` was already correct — it honours `OwnerRef.ForSource`, writes `SourceId`, and refuses an ownership change. Only fetching the bytes was missing. It now resolves the source's connection and builds the connector through `IConnectorFactory`, disposing it afterwards since `S3Connector` holds a socket pool.The path is used as the sync engine recorded it, without `ResolveJobPath`: that turns a virtual container path into a real one, and a source's listing already yields the connector's own absolute form.## Failed documents were never retried, and never shown (#400)`HasRemoteChanged` skips `Pending`, `Queued` and `Processing` — sensible, those are in flight — but not `Failed`. The remote signature is written as ingestion metadata *before* the failure, so it matched, the document was skipped as unchanged, and it stayed `Failed` with zero chunks permanently, or until the remote file changed.**Any transient downstream fault was therefore permanent.** Observed directly: six files failed because an embedding service was briefly unreachable, and every later sync skipped all six.The cost of retrying is a genuinely unparseable file being re-fetched each cycle. Bounded, and much the lesser evil — it fails *before* embedding, which is the part that costs money. Backoff can be layered on if the noise proves worse than the loss.`DocumentCount` also counted every row whatever its status, so the Sources page showed six documents and a green **Synced** badge for a source where nothing was searchable. The sync had genuinely succeeded — it listed and enqueued correctly — and the failure downstream had no route back to the page. `FailedDocumentCount` is now counted separately and badged.## Why no test caught eitherThe sync tests substitute `IIngestionQueue` and assert what is **enqueued**. The pipeline tests start at `IngestAsync`. #398 lived exactly in the seam between them, and both sides looked fully covered.The new test for it crosses that seam: it calls `IngestByIdAsync` with source ownership against a real LocalStack bucket and asserts a document row is written with `SourceId` set and `ContainerId` null.## On verificationBoth regressions were checked by disabling the fix and watching them fail, not by watching them pass.That mattered for #398: my first attempt at that check silently did not apply — a string replacement that matched nothing — and the test "passed against unmodified code". Doing it properly reproduced the exact error from the logs.The #400 test is paired with two that must keep passing, because "ignore status" would have been the wrong fix:- an indexed document with a matching signature is still skipped, or a five-minute poll re-embeds the entire source every cycle;- an in-flight document is still skipped, so the guard against racing a running job is not lost while fixing this.## Verification`dotnet build --no-incremental` — **0 warnings, 0 errors**.`dotnet test --filter "Category=Unit"` — **891 passed, 0 failed**.Sync and S3 integration suites — **23 passed, 0 failed**.🤖 Generated with [Claude Code](https://claude.com/claude-code)<!-- This is an auto-generated comment: release notes by coderabbit.ai -->## Summary by CodeRabbit* **New Features**  * Source listings now show the number of failed documents and provide retry details.  * Source-owned documents are ingested through their configured source connection.* **Bug Fixes**  * Failed documents are automatically retried, even when their remote content has not changed.  * Documents currently being processed continue to be protected from duplicate retries.* **Tests**  * Added coverage for failed-document retry behavior and ingestion scenarios.<!-- end of auto-generated comment: release notes by coderabbit.ai -->