### PR TITLE
feat(web): guided SFTP setup — generate the key, write the command, verify the host key

### DIFF
--- a/docs/research/docker-local-filesystem-access-2026-08-23.md
+++ b/docs/research/docker-local-filesystem-access-2026-08-23.md
@@ -1,0 +1,175 @@
+# How should Connapse in Docker reach files on the operator's own machine?
+
+**Date:** 2026-08-23
+**Status:** Complete
+**Supersedes nothing.** Narrows a question [the earlier report](filesystem-ingestion-2026-08-23.md) answered under an assumption that no longer holds.
+
+## Why this is a second report
+
+The earlier research asked *"which pull protocol should Connapse speak?"* and recommended SFTP for the local case. That framing had already ruled out mounting the host's disk into the container — brainstorming rejected bind mounts as "a security concern and poor UX" before any research began, so every option surveyed was a network protocol by construction.
+
+The new constraint — **everything must be configurable in the UI** — makes that exclusion worth re-testing rather than inheriting. A protocol needs a server and a credential set up per connection, forever. A mount is configured once and then never again. Against a "no terminal" requirement those trade in opposite directions, so the answer can change.
+
+## The hard constraint
+
+**A container's filesystem namespace is fixed when the container is created.** Adding a bind mount to a running container means stopping it, removing it, and creating a new one with the full mount set ([docker/cli#5328](https://github.com/docker/cli/issues/5328), [moby#11105](https://github.com/moby/moby/issues/11105)). This is a property of how containers work, not a Docker limitation awaiting a feature.
+
+**Docker Desktop does not expose host drives automatically.** Verified directly: `docker run --rm alpine ls /` on this machine shows no `/host_mnt` and no host paths. Drive sharing in Docker Desktop settings makes a path *mountable*, not mounted.
+
+So no application running inside a container can grant itself access to a host path it was not given. Every solution is one of four families.
+
+## The four families
+
+### 1. Mount once at deployment, choose paths in the UI
+
+Mount a broad host path read-only when the container is created; afterwards every source is configured in the UI within it.
+
+This is what comparable self-hosted products do, and [Immich's external library flow](https://oneuptime.com/blog/post/2026-03-20-photo-gallery-portainer/view) is the closest match to Connapse's model: uncomment an optional bind mount, then add the path in the admin panel and scan. [Paperless-ngx](https://docs.paperless-ngx.com/setup/) is the same shape — the consumption directory is a compose volume, and everything else is application configuration.
+
+It maps onto Connapse's existing split without inventing anything:
+
+| Layer | Who sets it | Connapse concept |
+|---|---|---|
+| What the container can see at all | Deployment, once | the bind mount |
+| Which roots an admin may name | `Sources:Security:AllowedFilesystemRoots` | connection `allowedRoot` |
+| Which subtree gets indexed | Admin, in the UI, any number of times | source `subPath` |
+
+**Cost:** one line in `docker-compose.yml` and a `docker compose up -d`. No new code, no credential of any kind, no server on the host.
+
+### 2. Speak a network protocol to a server on the host
+
+SFTP, SMB, or WebDAV. Nothing in the container's configuration changes; the host runs a server and Connapse authenticates to it.
+
+Covered in depth by the earlier report. The relevant update is what is **already true on this machine** (all verified directly):
+
+| | Status |
+|---|---|
+| `sshd` service | **Running**, automatic start |
+| `Subsystem sftp` | **Configured** (`sftp-server.exe`) |
+| `PubkeyAuthentication` | **yes** |
+| `authorized_keys` | **Present**, both user and administrators paths |
+| Port 22 from a container | **Open** via `host.docker.internal` |
+| `LanmanServer` (SMB) | **Running**, shares `C$`, `D$`, `ADMIN$` |
+| Port 445 from a container | **Open** |
+
+SFTP is therefore about one step from working here: generate a key pair and add the public half to `authorized_keys`. [#392](https://github.com/Destrayon/Connapse/issues/392) removes the terminal from the first half of that.
+
+**SMB is worse here despite being equally reachable.** The shares that exist are `C$` and `D$`, which are administrative shares — reaching them means storing a Windows *administrator* password. SMBLibrary is also NTLM-only and LGPL-3.0. Trading an SSH key scoped to one account for an administrator password is a clear downgrade.
+
+### 3. Push from the host to Connapse
+
+An agent, a sync tool, or the existing upload UI. The earlier report rejected a purpose-built agent on distribution and signing cost, and that stands.
+
+Worth noting the honest zero-infrastructure member of this family: **Connapse already accepts uploads into managed containers through the UI.** That is fully UI-driven with nothing to install. It is copy-in rather than sync — files do not track changes on disk — but for a fixed corpus it is the shortest path that exists today.
+
+### 4. Do not run Connapse in a container
+
+If Connapse runs natively on the machine holding the files, the Filesystem connector works with real paths. No mount, no server, no credential, no key.
+
+This deserves stating plainly because the entire problem is an artefact of the deployment choice. For a single-user local install it is the simplest answer available, and it is the one configuration where "point it at a folder" needs nothing else at all.
+
+## The tempting answer, and why it is wrong
+
+The obvious way to make mounts UI-configurable is to give Connapse the Docker socket so it can recreate its own container with new mounts.
+
+**Do not do this under any circumstances.** Access to `/var/run/docker.sock` is [root-equivalent on the host](https://www.netdata.cloud/guides/docker/docker-socket-security/): anything that can talk to the daemon can create a container that mounts `/` and execute as root. Mounting the socket read-only does not help, because the restriction is on the filesystem handle and not on the API it exposes.
+
+The mount boundary exists to stop a compromised Connapse reading arbitrary host files. Handing Connapse the ability to move that boundary hands it root on the machine — strictly worse than the exposure it was meant to bound. **This is the principled reason the mount stays a deployment concern: it is the one decision the application must not be able to make about itself.**
+
+## Recommendation
+
+**For the local case, mount once and read-only. For the remote case, SFTP.** They are not competitors; they answer different questions.
+
+The "everything in the UI" requirement is satisfied in the sense that matters: **all recurring work is in the UI.** Adding a source, changing a subpath, adding a second folder inside the mount, excluding a pattern — every one of those is a UI action. What remains outside is a single line set once at install, and it is outside precisely because it is the security boundary.
+
+Concretely, mount the profile rather than a whole drive:
+
+```yaml
+    volumes:
+      - appdata:/app/appdata
+      - C:/Users/Diviel:/mnt/host:ro
+```
+
+`:ro` costs nothing, since Connapse never writes to a source, and removes an entire class of accident. Then set `Sources:Security:AllowedFilesystemRoots` to `/mnt/host` so the allowlist and the mount agree, and every connection is bounded twice.
+
+**SFTP is still worth finishing**, and not as a consolation. It is the only option in the list that works when the files are on a machine Connapse does not share hardware with — a NAS, a work laptop, a hosted deployment — and on this machine it is one paste away from working.
+
+## What Connapse should change
+
+1. **Ship the bind mount commented out in `docker-compose.yml`**, with the target path and `:ro` already written, exactly as Immich does. This turns the one-time step from "know that this is possible and write it correctly" into "uncomment a line". Filed as [#393](https://github.com/Destrayon/Connapse/issues/393).
+2. **Say this in `docs/connectors.md`.** The document currently explains that the Filesystem connector needs a shared disk without telling anyone how to arrange one.
+3. **Finish [#392](https://github.com/Destrayon/Connapse/issues/392)** so the SFTP path needs no terminal either.
+
+## Addendum — optimising for operator setup cost
+
+The first pass asked what *works*. This pass asks what costs the operator least, which turns out to have a different answer, because the browser is a route none of the four families covers.
+
+### The category has not solved this, and says so out loud
+
+[AnythingLLM](https://docs.anythingllm.com/installation-docker/overview) is the closest comparable product, and it ships **two builds**: a desktop app — one-click, single-user, direct filesystem access, no configuration — and a Docker build for teams that adds roles and access control. The split is not accidental. Their Docker users have been asking for exactly this since at least [#1873](https://github.com/Mintplex-Labs/anything-llm/issues/1873) and [#4877](https://github.com/Mintplex-Labs/anything-llm/issues/4877) (watch folders), and the community answer is a [third-party Python sync script](https://github.com/dastra/anythingllm-document-sync).
+
+The instructive one is [#3640](https://github.com/Mintplex-Labs/anything-llm/issues/3640): a user who **already mounted their NAS into the container** and still could not use it, because the UI offered no way to point at an existing directory. Their native sync feature watches individual files and [cannot watch a directory at all](https://docs.anythingllm.com/beta-preview/active-features/live-document-sync).
+
+**Connapse is ahead of this, not behind it.** The connection/source split already expresses "here is a root, index this subtree of it" — the exact thing #3640 wanted and could not find. What is missing is only the mount, and the documentation for it.
+
+### The route none of the four families covers: the browser
+
+The container cannot see the host's disk, but **the operator's browser can**, and it is already talking to Connapse.
+
+**`<input type="file" webkitdirectory>`** lets a user pick a whole folder from a native dialog; the browser then hands over every file beneath it, with the relative path on each as `webkitRelativePath`. It reached [Baseline in 2025](https://caniuse.com/input-file-directory) and works in Chrome, Edge, Firefox, and Safari 11.1+ — everything except iOS Safari. There is no permission API, no flag, and nothing to install.
+
+**Setup cost: none.** Not "one line in a compose file" — actually none. The operator opens Connapse, clicks a button, picks a folder.
+
+Connapse is most of the way there already and does not know it. `wwwroot/js/fileDrop.js` uploads via `fetch()` and `FormData`, which is the right shape — but it reads `e.dataTransfer.files`, so **dropping a folder does not work today**. Directory drops need `webkitGetAsEntry()` and a recursive walk; folder *picking* needs the attribute above. Both are small, and both feed the upload path that already exists.
+
+**What it does not do is stay in sync.** This is an import, into a managed container, and refreshing means importing again. That is a real limitation and it is also the honest shape of the thing: once the bytes are uploaded, Connapse owns them, which is exactly what a container is. It suits "index my documents" and does not suit "mirror a folder that changes".
+
+Practical ceiling: this is a browser upload, so a few thousand files is comfortable and a hundred thousand is not.
+
+### The File System Access API, and why not
+
+[`showDirectoryPicker()`](https://developer.chrome.com/docs/capabilities/web-apis/file-system-access) is the more powerful version — a directory handle that can be stored in IndexedDB and re-used, with [persistent permissions since Chrome 122](https://developer.chrome.com/blog/persistent-permissions-for-the-file-system-access-api) that survive a browser restart. It would allow genuine re-sync with no setup.
+
+**It is the wrong fit anyway, for a reason that has nothing to do with browser support.** Connapse syncs from a background service on a timer. A directory handle only lives in a page — so a source backed by one can only reconcile while somebody has the tab open, and Chrome auto-revokes on tab backgrounding besides. A "source" that silently stops syncing when you close the tab is worse than an import that never claimed to.
+
+It is also Chromium-only (no Firefox, no Safari), where `webkitdirectory` is Baseline. More work, narrower support, and a sync model that does not match the product.
+
+### Revised recommendation
+
+Three answers for three shapes of need, and the cheapest one covers most people:
+
+| Need | Answer | Operator setup |
+|---|---|---|
+| "Get my documents in" | **Folder upload in the browser** | **None** |
+| "Mirror a folder that keeps changing" | Bind mount, read-only | One line, once |
+| "Files are on another machine" | SFTP | SSH server + key |
+| Single machine, no Docker wanted | Native install | None; connector works as-is |
+
+**Build the folder upload.** It is the smallest change of the four, it needs nothing from the user, it works in every desktop browser, and it reuses an upload path that already exists. Filed as [#394](https://github.com/Destrayon/Connapse/issues/394).
+
+The mount stays the answer for continuous sync and should be [shipped commented-out](https://github.com/Destrayon/Connapse/issues/393) so it is an uncomment rather than a thing to know. SFTP stays the answer for another machine. And AnythingLLM's split is worth taking seriously as positioning: **Docker is the deployment for teams and servers; a single user indexing their own laptop has a simpler option, and Connapse should say so rather than making them fight the container.**
+
+## What this does not solve
+
+- **Files on a machine that is off, asleep, or behind NAT.** Unchanged from the earlier report, and still deliberately the operator's problem.
+- **A mount is as broad as you make it.** Mounting `C:/` gives every source in Connapse a potential view of the whole drive, bounded only by `AllowedFilesystemRoots`. The narrower the mount, the less the allowlist has to carry.
+- **Changing which folder is mounted still requires a container recreate.** Choosing a *sub*path does not. Mount broadly enough that the sub-path choice is the one you actually make.
+
+## Verification log
+
+Everything asserted about this machine was checked rather than assumed:
+
+- `docker run --rm alpine ls /` — no host paths, no `/host_mnt`.
+- `nc -z host.docker.internal 22 / 445 / 139` from a container — 22 open, 445 open, 139 closed.
+- `Get-Service sshd, LanmanServer` — both Running, both Automatic.
+- `Get-SmbShare` — `ADMIN$`, `C$`, `D$`, `IPC$`.
+- `sshd_config` — `PubkeyAuthentication yes`, `Subsystem sftp sftp-server.exe`, `PasswordAuthentication yes`, administrators override present.
+- `authorized_keys` present at both the user and administrators locations.
+
+## Sources
+
+- [docker/cli#5328](https://github.com/docker/cli/issues/5328), [moby#11105](https://github.com/moby/moby/issues/11105) — mounts cannot be added to a running container
+- [Docker bind mounts documentation](https://docs.docker.com/engine/storage/bind-mounts.md)
+- [Docker socket security](https://www.netdata.cloud/guides/docker/docker-socket-security/), [The Dangers of Docker.sock](https://raesene.github.io/blog/2016/03/06/The-Dangers-Of-Docker.sock/)
+- [Paperless-ngx setup](https://docs.paperless-ngx.com/setup/), [Immich external libraries via Portainer](https://oneuptime.com/blog/post/2026-03-20-photo-gallery-portainer/view)
+- [Earlier report: filesystem ingestion](filesystem-ingestion-2026-08-23.md) — protocol comparison, SMBLibrary licence and NTLM limits

--- a/src/Connapse.Core/Utilities/SftpHostSetup.cs
+++ b/src/Connapse.Core/Utilities/SftpHostSetup.cs
@@ -16,7 +16,23 @@ public enum HostPlatform { Windows, MacOS, Linux }
 /// The server's host key, read on the machine itself. Arriving out of band is what turns
 /// trust-on-first-use into verified-first-use.
 /// </param>
-public record SftpHostSetupResult(string Username, string HomePath, string Fingerprint);
+/// <param name="Drives">
+/// Filesystem roots the account can reach, as SFTP paths — <c>/C:/</c>, <c>/D:/</c> and so
+/// on. Windows only; empty elsewhere, where everything already hangs off <c>/</c>.
+/// <para>
+/// Reported because the home directory is not where people keep things. A second drive is
+/// completely normal, and a flow that can only reach <c>C:</c> would be answering a question
+/// nobody asked.
+/// </para>
+/// </param>
+public record SftpHostSetupResult(
+    string Username,
+    string HomePath,
+    string Fingerprint,
+    IReadOnlyList<string>? Drives = null)
+{
+    public IReadOnlyList<string> Drives { get; init; } = Drives ?? [];
+}
 
 /// <summary>
 /// Builds the one command an operator runs on their own machine, and reads back what it
@@ -145,10 +161,15 @@ public static class SftpHostSetup
             if ($LASTEXITCODE -eq 0 -and $line) { $fingerprint = ($line -split ' ')[1] }
         } catch { }
 
+        # Every drive the account can reach, because the home folder is not where most people
+        # keep things and a second drive is entirely normal.
+        $drives = (Get-PSDrive -PSProvider FileSystem | ForEach-Object { "/$($_.Name):/" }) -join ','
+
         Write-Host ''
         Write-Host '{{BeginMarker}}'
         Write-Host "user=$env:USERNAME"
         Write-Host "home=/$($env:USERPROFILE -replace '\\','/')"
+        Write-Host "drives=$drives"
         Write-Host "fingerprint=$fingerprint"
         Write-Host '{{EndMarker}}'
         Write-Host ''
@@ -220,6 +241,7 @@ public static class SftpHostSetup
         string body = pasted[(start + BeginMarker.Length)..end];
 
         string? user = null, home = null, fingerprint = null;
+        IReadOnlyList<string> drives = [];
 
         foreach (string raw in body.Split('\n', StringSplitOptions.RemoveEmptyEntries))
         {
@@ -236,12 +258,18 @@ public static class SftpHostSetup
                 case "user": user = value; break;
                 case "home": home = value; break;
                 case "fingerprint": fingerprint = NormaliseFingerprint(value); break;
+
+                // Optional. Older setup commands did not report it, and a Unix host has
+                // nothing to report — neither is a reason to reject the block.
+                case "drives":
+                    drives = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    break;
             }
         }
 
         return user is null || home is null || fingerprint is null
             ? null
-            : new SftpHostSetupResult(user, home, fingerprint);
+            : new SftpHostSetupResult(user, home, fingerprint, drives);
     }
 
     /// <summary>

--- a/src/Connapse.Core/Utilities/SftpHostSetup.cs
+++ b/src/Connapse.Core/Utilities/SftpHostSetup.cs
@@ -54,6 +54,31 @@ public static class SftpHostSetup
     public const string EndMarker = "----- END CONNAPSE SETUP -----";
 
     /// <summary>
+    /// Options prefixed to the <c>authorized_keys</c> entry, so the installed key can do nothing
+    /// but SFTP.
+    /// </summary>
+    /// <remarks>
+    /// Without these the entry is a bare public key, which grants everything the account can do:
+    /// an interactive shell, port forwarding, agent forwarding. Connapse only ever needs to read
+    /// files, and the path confinement it applies is an <i>application</i> rule — it bounds what
+    /// Connapse does with the credential, not what the credential can do. Anyone who obtained the
+    /// stored private key would not be bound by it at all.
+    /// <para>
+    /// <c>restrict</c> (OpenSSH 7.2+) disables port forwarding, agent forwarding, X11 and PTY
+    /// allocation. <c>command</c> replaces whatever the client asks for, so a session requesting
+    /// a shell gets the SFTP server instead. Both are supported by Win32-OpenSSH as well as
+    /// portable OpenSSH.
+    /// </para>
+    /// <para>
+    /// This does not make an administrator account safe to use — the key still authenticates as
+    /// that account, and an SFTP session for an administrator can read everything on the machine.
+    /// It bounds the <i>kind</i> of access, not its reach, which is why the wizard says to prefer
+    /// a non-administrator account.
+    /// </para>
+    /// </remarks>
+    public const string KeyRestrictions = """restrict,command="internal-sftp" """;
+
+    /// <summary>
     /// The command for <paramref name="platform"/>, with <paramref name="publicKeyLine"/>
     /// already embedded.
     /// </summary>
@@ -74,11 +99,14 @@ public static class SftpHostSetup
             throw new ArgumentException(
                 "A public key line cannot contain quotes or newlines.", nameof(publicKeyLine));
 
+        // The key is installed restricted, never bare. See KeyRestrictions.
+        string entry = KeyRestrictions + publicKeyLine;
+
         return platform switch
         {
-            HostPlatform.Windows => WindowsScript(publicKeyLine),
-            HostPlatform.MacOS => UnixScript(publicKeyLine, macOs: true),
-            HostPlatform.Linux => UnixScript(publicKeyLine, macOs: false),
+            HostPlatform.Windows => WindowsScript(entry),
+            HostPlatform.MacOS => UnixScript(entry, macOs: true),
+            HostPlatform.Linux => UnixScript(entry, macOs: false),
             _ => throw new ArgumentOutOfRangeException(nameof(platform)),
         };
     }
@@ -174,6 +202,9 @@ public static class SftpHostSetup
         Write-Host '{{EndMarker}}'
         Write-Host ''
         Write-Host 'Copy the block above, including both marker lines, back into Connapse.'
+        if (-not $fingerprint) {
+            Write-Host 'The host key fingerprint could not be read, so the first connection will be trusted rather than verified. Everything else is set up.' -ForegroundColor Yellow
+        }
         """;
 
     private static string UnixScript(string publicKeyLine, bool macOs)
@@ -267,9 +298,18 @@ public static class SftpHostSetup
             }
         }
 
-        return user is null || home is null || fingerprint is null
+        // The fingerprint is optional, and that is not a weakening — it is what stops the flow
+        // dead-ending. Reading it needs elevation and can still fail, by which point sshd is
+        // running and the key is installed. Requiring it here meant the block parsed to null,
+        // the UI disabled both test and save, and the operator was left with a configured host,
+        // an authorized Connapse key, and no way to finish or undo.
+        //
+        // Blank already has a defined meaning everywhere else: SshHostKeyPolicy reads it as
+        // trust-on-first-use. So an absent fingerprint costs the stronger verified-first-use and
+        // nothing else, which the panel says plainly rather than silently accepting.
+        return user is null || home is null
             ? null
-            : new SftpHostSetupResult(user, home, fingerprint, drives);
+            : new SftpHostSetupResult(user, home, fingerprint ?? string.Empty, drives);
     }
 
     /// <summary>

--- a/src/Connapse.Core/Utilities/SftpHostSetup.cs
+++ b/src/Connapse.Core/Utilities/SftpHostSetup.cs
@@ -1,0 +1,255 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>The operator's own machine, which decides what the setup command looks like.</summary>
+public enum HostPlatform { Windows, MacOS, Linux }
+
+/// <summary>
+/// What the setup command reported back. Every field comes from the host, because the host
+/// is the only place that knows it — which is the reason for the round trip at all.
+/// </summary>
+/// <param name="Username">The account the SSH server will authenticate.</param>
+/// <param name="HomePath">
+/// The home directory as SFTP presents it. On Windows that carries a leading slash before
+/// the drive letter, which is the detail that costs people an hour.
+/// </param>
+/// <param name="Fingerprint">
+/// The server's host key, read on the machine itself. Arriving out of band is what turns
+/// trust-on-first-use into verified-first-use.
+/// </param>
+public record SftpHostSetupResult(string Username, string HomePath, string Fingerprint);
+
+/// <summary>
+/// Builds the one command an operator runs on their own machine, and reads back what it
+/// reports.
+/// <para>
+/// Connapse cannot configure the host — that boundary is the entire reason the container is
+/// worth running. What it can do is everything either side of the boundary: generate the key,
+/// write the command, and consume the result. The operator copies twice and types nothing.
+/// </para>
+/// </summary>
+public static class SftpHostSetup
+{
+    /// <summary>
+    /// Delimits the block the operator pastes back. Deliberately unmistakable, because the
+    /// usual failure is pasting the whole terminal buffer, and that should still work.
+    /// </summary>
+    public const string BeginMarker = "----- BEGIN CONNAPSE SETUP -----";
+
+    public const string EndMarker = "----- END CONNAPSE SETUP -----";
+
+    /// <summary>
+    /// The command for <paramref name="platform"/>, with <paramref name="publicKeyLine"/>
+    /// already embedded.
+    /// </summary>
+    /// <remarks>
+    /// Meant to be read before it is run. It enables a network service and installs an
+    /// authorized key, so it is shown in full rather than offered as a download or a pipe
+    /// from a URL — the operator should be able to see exactly what they are agreeing to at
+    /// the moment they agree to it.
+    /// </remarks>
+    public static string GenerateScript(string publicKeyLine, HostPlatform platform)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(publicKeyLine);
+
+        // The key is base64 plus a sanitised comment, so it cannot contain a quote or a
+        // newline — SshKeyPairGenerator guarantees that. Asserted rather than assumed,
+        // because everything below embeds it into a shell string.
+        if (publicKeyLine.Any(c => c is '\n' or '\r' or '\'' or '"'))
+            throw new ArgumentException(
+                "A public key line cannot contain quotes or newlines.", nameof(publicKeyLine));
+
+        return platform switch
+        {
+            HostPlatform.Windows => WindowsScript(publicKeyLine),
+            HostPlatform.MacOS => UnixScript(publicKeyLine, macOs: true),
+            HostPlatform.Linux => UnixScript(publicKeyLine, macOs: false),
+            _ => throw new ArgumentOutOfRangeException(nameof(platform)),
+        };
+    }
+
+    private static string WindowsScript(string publicKeyLine) =>
+        $$"""
+        # Connapse — allow this computer to be indexed. Run in PowerShell as Administrator.
+        # Safe to run more than once.
+
+        # 0. Stop if not elevated, rather than half-succeeding.
+        #    Without elevation the steps below fail in ways that leave SSH looking configured
+        #    while it is not, and the symptom is an authentication failure with nothing to
+        #    explain it.
+        if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+                 ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+            Write-Host 'Run this in a PowerShell window opened with "Run as Administrator".' -ForegroundColor Red
+            return
+        }
+
+        # 1. Make sure an SSH server is installed and running.
+        if (-not (Get-Service sshd -ErrorAction SilentlyContinue)) {
+            Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 | Out-Null
+        }
+        Set-Service -Name sshd -StartupType Automatic
+        if ((Get-Service sshd).Status -ne 'Running') { Start-Service sshd }
+
+        if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
+            New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' `
+                -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
+        }
+
+        # 2. Work out which authorized_keys file sshd will actually read.
+        #    For an account in the Administrators group it is NOT the one in your profile —
+        #    sshd_config redirects those to a machine-wide file with a locked-down ACL. This
+        #    is the single most common reason Windows SSH keys silently fail to authenticate.
+        #
+        #    Asked of the group itself, not of this process's token. UAC filters the
+        #    Administrators SID out of an unelevated token, so a token check reports False for
+        #    an account that genuinely is a member — and the key would then be written where
+        #    sshd will never look.
+        $mySid = ([Security.Principal.WindowsIdentity]::GetCurrent()).User.Value
+        try {
+            $isAdmin = $null -ne (Get-LocalGroupMember -Group 'Administrators' -ErrorAction Stop |
+                                  Where-Object { $_.SID.Value -eq $mySid })
+        } catch {
+            # Domain-joined machines can refuse that cmdlet. Elevated, the token is unfiltered
+            # and this is accurate — and step 0 guarantees we are elevated.
+            $isAdmin = ([Security.Principal.WindowsIdentity]::GetCurrent()).Groups.Value -contains 'S-1-5-32-544'
+        }
+
+        if ($isAdmin) {
+            $keyFile = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'
+        } else {
+            $keyFile = Join-Path $env:USERPROFILE '.ssh\authorized_keys'
+        }
+
+        New-Item -ItemType Directory -Force -Path (Split-Path $keyFile) | Out-Null
+        if (-not (Test-Path $keyFile)) { New-Item -ItemType File -Path $keyFile | Out-Null }
+
+        # 3. Add Connapse's key, but only once, and without disturbing any other key present.
+        $key = '{{publicKeyLine}}'
+        if (-not (Select-String -Path $keyFile -SimpleMatch -Pattern $key -Quiet)) {
+            Add-Content -Path $keyFile -Value $key
+        }
+
+        if ($isAdmin) {
+            # sshd refuses to read this file unless only SYSTEM and Administrators can write it.
+            icacls $keyFile /inheritance:r /grant 'SYSTEM:F' 'Administrators:F' | Out-Null
+        }
+
+        # 4. Report back what only this machine knows.
+        #    Wrapped, because the key is already installed by this point and a failure to read
+        #    the fingerprint must not throw away a setup that otherwise worked. An empty
+        #    fingerprint costs the operator verified-first-use, not the connection.
+        $fingerprint = ''
+        try {
+            $hostKey = Get-ChildItem (Join-Path $env:ProgramData 'ssh') -Filter 'ssh_host_*_key.pub' -ErrorAction Stop |
+                       Sort-Object { $_.Name -notlike '*ed25519*' } | Select-Object -First 1
+            $line = & ssh-keygen -lf $hostKey.FullName 2>$null
+            if ($LASTEXITCODE -eq 0 -and $line) { $fingerprint = ($line -split ' ')[1] }
+        } catch { }
+
+        Write-Host ''
+        Write-Host '{{BeginMarker}}'
+        Write-Host "user=$env:USERNAME"
+        Write-Host "home=/$($env:USERPROFILE -replace '\\','/')"
+        Write-Host "fingerprint=$fingerprint"
+        Write-Host '{{EndMarker}}'
+        Write-Host ''
+        Write-Host 'Copy the block above, including both marker lines, back into Connapse.'
+        """;
+
+    private static string UnixScript(string publicKeyLine, bool macOs)
+    {
+        string enable = macOs
+            ? """
+              # 1. Turn on Remote Login, which is what serves SFTP on macOS.
+              sudo systemsetup -setremotelogin on
+              """
+            : """
+              # 1. Make sure an SSH server is installed and running.
+              #    The unit is 'ssh' on Debian and Ubuntu, 'sshd' most other places.
+              sudo systemctl enable --now sshd 2>/dev/null || sudo systemctl enable --now ssh
+              """;
+
+        // $$ so a single brace is literal — the awk program below needs them, and doubling
+        // every interpolation is the lesser evil against escaping the shell.
+        return $$"""
+        # Connapse — allow this computer to be indexed. Safe to run more than once.
+
+        {{enable}}
+
+        # 2. Add Connapse's key, but only once, and without disturbing any other key present.
+        mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys
+        chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys
+
+        KEY='{{publicKeyLine}}'
+        grep -qxF "$KEY" ~/.ssh/authorized_keys || echo "$KEY" >> ~/.ssh/authorized_keys
+
+        # 3. Report back what only this machine knows.
+        HOSTKEY=$(ls /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null || ls /etc/ssh/ssh_host_rsa_key.pub)
+        FINGERPRINT=$(ssh-keygen -lf "$HOSTKEY" | awk '{print $2}')
+
+        printf '\n{{BeginMarker}}\n'
+        printf 'user=%s\n' "$(whoami)"
+        printf 'home=%s\n' "$HOME"
+        printf 'fingerprint=%s\n' "$FINGERPRINT"
+        printf '{{EndMarker}}\n\n'
+        echo 'Copy the block above, including both marker lines, back into Connapse.'
+        """;
+    }
+
+    /// <summary>
+    /// Reads the block the setup command printed. Returns null when the text does not contain
+    /// a usable one.
+    /// </summary>
+    /// <remarks>
+    /// Tolerant on purpose. Operators paste whole terminal buffers, with prompts, wrapping,
+    /// and the command echoed above the output — so this finds the markers rather than
+    /// expecting the text to begin at them, and ignores anything outside.
+    /// </remarks>
+    public static SftpHostSetupResult? ParseResult(string? pasted)
+    {
+        if (string.IsNullOrWhiteSpace(pasted))
+            return null;
+
+        int start = pasted.IndexOf(BeginMarker, StringComparison.Ordinal);
+        int end = pasted.IndexOf(EndMarker, StringComparison.Ordinal);
+
+        // Without both markers there is nothing to be confident about. Guessing at loose
+        // key=value lines would happily accept a paste from somewhere else entirely.
+        if (start < 0 || end < 0 || end <= start)
+            return null;
+
+        string body = pasted[(start + BeginMarker.Length)..end];
+
+        string? user = null, home = null, fingerprint = null;
+
+        foreach (string raw in body.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            string line = raw.Trim();
+            int split = line.IndexOf('=');
+            if (split <= 0) continue;
+
+            string name = line[..split].Trim();
+            string value = line[(split + 1)..].Trim();
+            if (value.Length == 0) continue;
+
+            switch (name)
+            {
+                case "user": user = value; break;
+                case "home": home = value; break;
+                case "fingerprint": fingerprint = NormaliseFingerprint(value); break;
+            }
+        }
+
+        return user is null || home is null || fingerprint is null
+            ? null
+            : new SftpHostSetupResult(user, home, fingerprint);
+    }
+
+    /// <summary>
+    /// <c>ssh-keygen -l</c> prints <c>SHA256:…</c>, which is already the stored form. An
+    /// operator pasting a fingerprint by hand may well omit the prefix, so it is added back
+    /// rather than treated as a mismatch later, when the only symptom would be a refused
+    /// connection.
+    /// </summary>
+    private static string NormaliseFingerprint(string value) =>
+        value.StartsWith("SHA256:", StringComparison.Ordinal) ? value : $"SHA256:{value}";
+}

--- a/src/Connapse.Core/Utilities/SshKeyPairGenerator.cs
+++ b/src/Connapse.Core/Utilities/SshKeyPairGenerator.cs
@@ -1,0 +1,101 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// A generated SSH key pair. The private half is stored; the public half is what the
+/// operator installs on their own machine.
+/// </summary>
+/// <param name="PrivateKeyPem">
+/// PKCS#1 PEM — <c>-----BEGIN RSA PRIVATE KEY-----</c>. The form SSH.NET reads.
+/// </param>
+/// <param name="PublicKeyLine">
+/// A single <c>authorized_keys</c> line, ready to append.
+/// </param>
+public record SshKeyPair(string PrivateKeyPem, string PublicKeyLine);
+
+/// <summary>
+/// Generates an SSH key pair so setting up an SFTP connection never requires
+/// <c>ssh-keygen</c>.
+/// <para>
+/// Generating server-side is not only the easier path, it is the better one. A pasted key
+/// is usually a key the operator already has and uses elsewhere; a generated one exists for
+/// a single connection, has never been on a clipboard, and is revoked by deleting that
+/// connection. The private half is never rendered — it goes straight into the encrypted
+/// column.
+/// </para>
+/// </summary>
+public static class SshKeyPairGenerator
+{
+    /// <summary>
+    /// RSA rather than Ed25519, which would otherwise be the obvious default: .NET exposes
+    /// no Ed25519 primitive, and SSH.NET's key generation surface does not cover it either.
+    /// 3072 bits is the NIST-equivalent of AES-128 and what <c>ssh-keygen</c> defaults to
+    /// for RSA.
+    /// </summary>
+    public const int KeySizeBits = 3072;
+
+    /// <summary>
+    /// Generates a pair. <paramref name="comment"/> is the trailing label on the public key
+    /// line, which is how an operator later recognises the entry in <c>authorized_keys</c>.
+    /// </summary>
+    public static SshKeyPair Generate(string comment = "connapse")
+    {
+        using var rsa = RSA.Create(KeySizeBits);
+
+        return new SshKeyPair(
+            rsa.ExportRSAPrivateKeyPem(),
+            FormatPublicKey(rsa, comment));
+    }
+
+    /// <summary>
+    /// Encodes an RSA public key the way <c>authorized_keys</c> expects: the algorithm name,
+    /// the exponent, and the modulus, each length-prefixed, then base64.
+    /// </summary>
+    /// <remarks>
+    /// A mistake here fails as "authentication failed" with nothing pointing at the cause,
+    /// which is why the round trip against a real server is the test that matters.
+    /// </remarks>
+    public static string FormatPublicKey(RSA rsa, string comment = "connapse")
+    {
+        RSAParameters p = rsa.ExportParameters(includePrivateParameters: false);
+
+        using var buffer = new MemoryStream();
+        WriteLengthPrefixed(buffer, "ssh-rsa"u8.ToArray());
+        WriteLengthPrefixed(buffer, ToMpint(p.Exponent!));
+        WriteLengthPrefixed(buffer, ToMpint(p.Modulus!));
+
+        string label = Sanitise(comment);
+
+        return $"ssh-rsa {Convert.ToBase64String(buffer.ToArray())} {label}";
+    }
+
+    private static void WriteLengthPrefixed(Stream stream, byte[] data)
+    {
+        Span<byte> length = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(length, data.Length);
+        stream.Write(length);
+        stream.Write(data);
+    }
+
+    /// <summary>
+    /// SSH multiple-precision integers are signed, so a value whose top bit is set needs a
+    /// leading zero byte or it reads as negative.
+    /// </summary>
+    private static byte[] ToMpint(byte[] value) =>
+        value.Length > 0 && value[0] >= 0x80 ? [0, .. value] : value;
+
+    /// <summary>
+    /// The comment is the last field on the line, so anything that could end the line early
+    /// or start a second entry has to go. An operator-supplied connection name reaches here.
+    /// </summary>
+    private static string Sanitise(string comment)
+    {
+        string trimmed = new string(comment
+            .Where(c => !char.IsControl(c) && c != '\n' && c != '\r')
+            .ToArray()).Trim();
+
+        return string.IsNullOrEmpty(trimmed) ? "connapse" : trimmed;
+    }
+}

--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -1,4 +1,4 @@
-﻿using Connapse.Core;
+using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
 using Connapse.Storage.Data;
@@ -32,6 +32,9 @@ public class IngestionPipeline : IKnowledgeIngester
     private readonly IContainerStore _containerStore;
     private readonly IManagedStorageProvider _managedStorage;
     private readonly IDocumentStore _documentStore;
+    private readonly ISourceStore _sourceStore;
+    private readonly IConnectionStore _connectionStore;
+    private readonly IConnectorFactory _connectorFactory;
     private readonly ILogger<IngestionPipeline> _logger;
 
     // Metadata keys for tracking indexing settings
@@ -76,6 +79,9 @@ public class IngestionPipeline : IKnowledgeIngester
         IContainerStore containerStore,
         IManagedStorageProvider managedStorage,
         IDocumentStore documentStore,
+        ISourceStore sourceStore,
+        IConnectionStore connectionStore,
+        IConnectorFactory connectorFactory,
         ILogger<IngestionPipeline> logger)
     {
         _context = context;
@@ -90,6 +96,9 @@ public class IngestionPipeline : IKnowledgeIngester
         _containerStore = containerStore;
         _managedStorage = managedStorage;
         _documentStore = documentStore;
+        _sourceStore = sourceStore;
+        _connectionStore = connectionStore;
+        _connectorFactory = connectorFactory;
         _logger = logger;
     }
 
@@ -489,6 +498,15 @@ public class IngestionPipeline : IKnowledgeIngester
         IngestionOptions options,
         CancellationToken ct = default)
     {
+        // A source-owned document is read through its connection's connector, not through
+        // managed storage — checked first, because everything below this resolves a container
+        // and a source does not have one (#398).
+        //
+        // Only this entry point was left container-shaped by the connector/source split.
+        // IngestAsync already honours OwnerRef.ForSource; the gap was getting the bytes.
+        if (options.Owner is { IsSource: true } sourceOwner)
+            return await IngestSourceDocumentAsync(documentId, sourceOwner.Id, options, ct);
+
         // Resolve the container ID — prefer options.ContainerId, fall back to looking up the doc.
         Guid containerId;
         string virtualPath;
@@ -526,6 +544,52 @@ public class IngestionPipeline : IKnowledgeIngester
 
         await using Stream stream = await connector.ReadFileAsync(jobPath, ct);
         return await IngestAsync(stream, options, ct);
+    }
+
+    /// <summary>
+    /// Reads a source-owned document through its connection's connector and ingests it.
+    /// </summary>
+    /// <remarks>
+    /// The path is used as the sync engine recorded it, without <c>ResolveJobPath</c>. That
+    /// method exists to turn a virtual container path into a real one; a source's listing
+    /// already yields the connector's own absolute form — an OS path for Filesystem, a remote
+    /// path for SFTP — and putting it through resolution again would rebase a path that is
+    /// already rooted.
+    /// </remarks>
+    private async Task<IngestionResult> IngestSourceDocumentAsync(
+        string documentId, Guid sourceId, IngestionOptions options, CancellationToken ct)
+    {
+        string path = options.Path ?? options.FileName
+            ?? throw new InvalidOperationException(
+                $"IngestByIdAsync: options must provide Path or FileName for document {documentId}");
+
+        Source source = await _sourceStore.GetAsync(sourceId, ct)
+            ?? throw new InvalidOperationException(
+                $"IngestByIdAsync: source {sourceId} not found for document {documentId}");
+
+        Connection connection = await _connectionStore.GetAsync(source.ConnectionId, ct)
+            ?? throw new InvalidOperationException(
+                $"IngestByIdAsync: connection {source.ConnectionId} not found for source {sourceId}");
+
+        // Only fetched when there is one to fetch, matching SourceSyncService. A key ring that
+        // cannot decrypt throws, and retrying will not help — so it surfaces as a failed job
+        // rather than being swallowed.
+        string? secret = connection.HasSecret
+            ? await _connectionStore.GetSecretAsync(connection.Id, ct)
+            : null;
+
+        IConnector connector = _connectorFactory.Create(source, connection, secret);
+        try
+        {
+            await using Stream stream = await connector.ReadFileAsync(path, ct);
+            return await IngestAsync(stream, options, ct);
+        }
+        finally
+        {
+            // SftpConnector holds an SSH session and S3Connector a socket pool. One job runs
+            // per file, so skipping this abandons a connection per document.
+            if (connector is IDisposable disposable) disposable.Dispose();
+        }
     }
 
     public async IAsyncEnumerable<IngestionProgress> IngestWithProgressAsync(
@@ -646,3 +710,5 @@ internal static class IngestionPipelineStrategyResolver
         return MarkdownExtensions.Contains(ext) ? "DocumentAware" : fallbackStrategy;
     }
 }
+
+

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -261,13 +261,25 @@
                             <div class="form-text">Narrows the source to a subtree. Everything below it is indexed.</div>
                         </div>
                     }
-                    else if (selectedProvider is ConnectionProvider.Filesystem)
+                    @* SFTP shares this branch rather than getting its own. Its scope is the same
+                       shape — a subpath beneath the connection's root, plus patterns — and that
+                       was a deliberate choice when the provider was designed, so that this form,
+                       the preflight, and the scope summary each gained a case rather than a
+                       parallel implementation. *@
+                    else if (selectedProvider is ConnectionProvider.Filesystem or ConnectionProvider.Sftp)
                     {
                         <div class="mb-3">
                             <label class="form-label">Sub-path (optional)</label>
-                            <input class="form-control font-monospace" @bind="form.SubPath" placeholder="team-a" />
+                            <input class="form-control font-monospace" @bind="form.SubPath"
+                                   placeholder="@(selectedProvider is ConnectionProvider.Sftp ? "Documents" : "team-a")" />
                             <div class="form-text">
                                 Resolved beneath the connection's allowed root. Leave empty for the root itself.
+                                @if (selectedProvider is ConnectionProvider.Sftp)
+                                {
+                                    <text>
+                                        Resolved on the remote server, so a symlink cannot lead outside the root.
+                                    </text>
+                                }
                             </div>
                         </div>
 

--- a/src/Connapse.Web/Components/Settings/ConnectionForm.cs
+++ b/src/Connapse.Web/Components/Settings/ConnectionForm.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Connapse.Core;
+using Connapse.Core.Utilities;
 using Connapse.Storage.Connectors;
 
 namespace Connapse.Web.Components.Settings;
@@ -71,6 +72,64 @@ public sealed record ConnectionForm
     public bool IsCloudProvider =>
         Provider is ConnectionProvider.S3 or ConnectionProvider.AzureBlob;
 
+
+    /// <summary>
+    /// Builds the connection the "Connect this computer" flow creates, from what the host's
+    /// setup command reported.
+    /// </summary>
+    /// <remarks>
+    /// Here rather than in the Razor component for the same reason the rest of this class is:
+    /// a dropped or mis-joined field produces a connection that points somewhere other than
+    /// intended, and the component has no test harness in this repository.
+    /// </remarks>
+    /// <param name="subPath">
+    /// Folder beneath the reported home directory. Blank means the home directory itself.
+    /// </param>
+    public static ConnectionForm ForLocalMachine(
+        SftpHostSetupResult result, string host, string? subPath, string privateKeyPem)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentException.ThrowIfNullOrWhiteSpace(privateKeyPem);
+
+        return new ConnectionForm
+        {
+            Name = $"{result.Username}@{host.Trim()}",
+            Provider = ConnectionProvider.Sftp,
+            Host = host.Trim(),
+            Port = "22",
+            Username = result.Username,
+
+            // The chosen folder, not the home directory. A source cannot escape its
+            // connection's root, so narrowing here is the difference between exposing one
+            // folder and exposing everything the account can read.
+            AllowedRoot = CombineRemote(result.HomePath, subPath),
+
+            HostKeyFingerprint = result.Fingerprint,
+            PrivateKey = privateKeyPem,
+        };
+    }
+
+    /// <summary>
+    /// Joins a subfolder onto a remote home path.
+    /// </summary>
+    /// <remarks>
+    /// SFTP paths use '/' whatever the server runs — Windows OpenSSH presents
+    /// <c>C:\Users\me</c> as <c>/C:/Users/me</c>, keeping the leading slash and the drive
+    /// letter. So this must not use <see cref="System.IO.Path"/>, which would apply the rules
+    /// of whichever machine Connapse happens to be running on.
+    /// </remarks>
+    public static string CombineRemote(string home, string? subPath)
+    {
+        string root = home.TrimEnd('/');
+
+        if (string.IsNullOrWhiteSpace(subPath))
+            return root;
+
+        string cleaned = subPath.Trim().Replace('\\', '/').Trim('/');
+
+        return cleaned.Length == 0 ? root : $"{root}/{cleaned}";
+    }
 
     /// <summary>
     /// Reads a stored connection into an editable form. A config that cannot be parsed yields an
@@ -281,4 +340,5 @@ public sealed record ConnectionForm
 
     private static bool Blank(string? s) => string.IsNullOrWhiteSpace(s);
 }
+
 

--- a/src/Connapse.Web/Components/Settings/ConnectionForm.cs
+++ b/src/Connapse.Web/Components/Settings/ConnectionForm.cs
@@ -82,11 +82,14 @@ public sealed record ConnectionForm
     /// a dropped or mis-joined field produces a connection that points somewhere other than
     /// intended, and the component has no test harness in this repository.
     /// </remarks>
-    /// <param name="subPath">
-    /// Folder beneath the reported home directory. Blank means the home directory itself.
+    /// <param name="allowedRoot">
+    /// Any absolute path on the host, not merely somewhere under the home directory. Windows
+    /// OpenSSH applies no chroot, so a second drive is reachable as <c>/D:/…</c> and confining
+    /// the flow to the profile would rule out where most people actually keep things.
+    /// Blank falls back to the reported home directory.
     /// </param>
     public static ConnectionForm ForLocalMachine(
-        SftpHostSetupResult result, string host, string? subPath, string privateKeyPem)
+        SftpHostSetupResult result, string host, string? allowedRoot, string privateKeyPem)
     {
         ArgumentNullException.ThrowIfNull(result);
         ArgumentException.ThrowIfNullOrWhiteSpace(host);
@@ -99,36 +102,61 @@ public sealed record ConnectionForm
             Host = host.Trim(),
             Port = "22",
             Username = result.Username,
-
-            // The chosen folder, not the home directory. A source cannot escape its
-            // connection's root, so narrowing here is the difference between exposing one
-            // folder and exposing everything the account can read.
-            AllowedRoot = CombineRemote(result.HomePath, subPath),
-
+            AllowedRoot = NormaliseRemoteRoot(allowedRoot, result.HomePath),
             HostKeyFingerprint = result.Fingerprint,
             PrivateKey = privateKeyPem,
         };
     }
 
     /// <summary>
-    /// Joins a subfolder onto a remote home path.
+    /// Cleans an operator-entered remote path into the form SFTP expects, falling back to
+    /// <paramref name="fallback"/> when nothing was entered.
     /// </summary>
     /// <remarks>
-    /// SFTP paths use '/' whatever the server runs — Windows OpenSSH presents
-    /// <c>C:\Users\me</c> as <c>/C:/Users/me</c>, keeping the leading slash and the drive
-    /// letter. So this must not use <see cref="System.IO.Path"/>, which would apply the rules
-    /// of whichever machine Connapse happens to be running on.
+    /// Never uses <see cref="System.IO.Path"/>: that applies the rules of whichever machine
+    /// Connapse runs on, which is a Linux container, to a path describing somebody else's
+    /// Windows box. SFTP paths are always '/'-separated, and Windows OpenSSH presents drives
+    /// as <c>/C:/Users/me</c> — a leading slash before the drive letter.
+    /// <para>
+    /// A Windows path pasted from Explorer is accepted and converted, because that is what an
+    /// operator will have on their clipboard.
+    /// </para>
     /// </remarks>
-    public static string CombineRemote(string home, string? subPath)
+    public static string NormaliseRemoteRoot(string? entered, string fallback)
     {
-        string root = home.TrimEnd('/');
+        if (string.IsNullOrWhiteSpace(entered))
+            return fallback.TrimEnd('/');
 
-        if (string.IsNullOrWhiteSpace(subPath))
-            return root;
+        string path = entered.Trim().Replace('\\', '/');
 
-        string cleaned = subPath.Trim().Replace('\\', '/').Trim('/');
+        // "D:/Projects" pasted from Explorer needs the leading slash SFTP presents.
+        if (path.Length >= 2 && char.IsLetter(path[0]) && path[1] == ':')
+            path = "/" + path;
 
-        return cleaned.Length == 0 ? root : $"{root}/{cleaned}";
+        if (!path.StartsWith('/'))
+            path = "/" + path;
+
+        // A drive root trims to "/D:" rather than "", which is still the drive and not the
+        // filesystem root — so only trim when something remains beneath it.
+        string trimmed = path.TrimEnd('/');
+
+        return trimmed.Length == 0 ? "/" : trimmed;
+    }
+
+    /// <summary>
+    /// True when a root is broad enough to be worth a second look — a drive root, or the
+    /// filesystem root. Permitted, since an administrator may genuinely mean it, but the UI
+    /// should say what it implies.
+    /// </summary>
+    public static bool IsBroadRemoteRoot(string? root)
+    {
+        if (string.IsNullOrWhiteSpace(root)) return false;
+
+        string trimmed = root.Trim().TrimEnd('/');
+
+        // "/" and "/D:" — nothing beneath the drive or the filesystem root.
+        return trimmed.Length == 0
+            || (trimmed.Length == 3 && trimmed[0] == '/' && char.IsLetter(trimmed[1]) && trimmed[2] == ':');
     }
 
     /// <summary>

--- a/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
@@ -90,6 +90,18 @@
                     <span class="small text-muted ms-2">
                         Safe to run more than once. It adds one key and changes nothing else.
                     </span>
+
+                    @* The key is installed with restrict and a forced internal-sftp command, so it
+                       cannot open a shell or forward ports. That bounds the kind of access, not its
+                       reach: it still authenticates as this account, so an administrator account
+                       yields a key that can read the whole machine over SFTP. *@
+                    <div class="alert alert-secondary py-2 mt-2 mb-0 small">
+                        <span class="bi-shield-lock me-1"></span>
+                        The key is installed <strong>SFTP-only</strong> — no shell, no port forwarding.
+                        It still signs in as the account you run this under, so prefer an ordinary
+                        account over an administrator one: an administrator's SFTP session can read
+                        anything on the machine, whatever folder you pick below.
+                    </div>
                 </div>
             </div>
         </div>
@@ -124,10 +136,25 @@
                         {
                             <div class="alert alert-success py-2 mt-2 mb-0 small">
                                 <span class="bi-check-circle me-1"></span>
-                                Read <strong>@parsed.Username</strong>, home
-                                <code>@parsed.HomePath</code>, host key
-                                <code>@parsed.Fingerprint</code>.
+                                Read <strong>@parsed.Username</strong>, home <code>@parsed.HomePath</code>@(string.IsNullOrWhiteSpace(parsed.Fingerprint) ? "." : ", host key ")
+                                @if (!string.IsNullOrWhiteSpace(parsed.Fingerprint))
+                                {
+                                    <code>@parsed.Fingerprint</code><text>.</text>
+                                }
                             </div>
+
+                            @if (string.IsNullOrWhiteSpace(parsed.Fingerprint))
+                            {
+                                @* Setup is finishable without it. Requiring one dead-ended the flow
+                                   with the host already configured and the key already installed. *@
+                                <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                    <span class="bi-exclamation-triangle me-1"></span>
+                                    No host key fingerprint came back, so the first connection will be
+                                    <strong>trusted</strong> rather than verified. Everything else is set up
+                                    and this is safe to continue with — re-running the command as
+                                    Administrator would capture it.
+                                </div>
+                            }
                         }
                     }
                 </div>

--- a/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
@@ -142,13 +142,40 @@
                     <div class="row g-3">
                         <div class="col-md-8">
                             <label class="form-label">Folder</label>
-                            <div class="input-group">
-                                <span class="input-group-text font-monospace small">@(LocalHome() ?? "…")/</span>
-                                <input class="form-control" @bind="localSubPath" placeholder="Documents" />
-                            </div>
+                            <input class="form-control font-monospace" @bind="localRoot" @bind:event="oninput"
+                                   placeholder="@(LocalHome() ?? "/C:/Users/you")" />
+
+                            @if (LocalResult() is { } r)
+                            {
+                                <div class="mt-2 d-flex flex-wrap gap-1 align-items-center">
+                                    <span class="small text-muted me-1">Jump to:</span>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary py-0"
+                                            @onclick="() => localRoot = r.HomePath">Home</button>
+                                    @foreach (var drive in r.Drives)
+                                    {
+                                        <button type="button" class="btn btn-sm btn-outline-secondary py-0"
+                                                @onclick="() => localRoot = drive">@drive</button>
+                                    }
+                                </div>
+                            }
+
                             <div class="form-text">
-                                Relative to your home folder. Sources you add later are confined beneath it.
+                                Any folder on that machine, not only inside your profile — a second drive
+                                is <code>/D:/Projects</code>. Paths use forward slashes with a leading one
+                                before the drive letter; a path pasted from Explorer is converted for you.
+                                Sources you add later are confined beneath whatever you choose.
                             </div>
+
+                            @if (ConnectionForm.IsBroadRemoteRoot(EffectiveRoot()))
+                            {
+                                <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                    <span class="bi-exclamation-triangle me-1"></span>
+                                    That is a whole drive. Every source on this connection could then reach
+                                    anything on it that <strong>@LocalResult()?.Username</strong> can read,
+                                    and Connapse indexes what it reads. Naming a folder costs nothing and
+                                    bounds it.
+                                </div>
+                            }
                         </div>
                         <div class="col-md-4">
                             <label class="form-label">Reachable at</label>
@@ -571,7 +598,7 @@
     private SshKeyPair? localKeyPair;
     private string setupScript = "";
     private string? pastedResult;
-    private string localSubPath = "";
+    private string localRoot = "";
     private string localHost = "host.docker.internal";
 
     private static string PlatformLabel(HostPlatform p) => p switch
@@ -590,7 +617,7 @@
         localSetup = true;
         editing = null;
         pastedResult = null;
-        localSubPath = "";
+        localRoot = "";
         localHost = "host.docker.internal";
         statusMessage = null;
         testMessage = null;
@@ -616,11 +643,15 @@
 
     private string? LocalHome() => LocalResult()?.HomePath;
 
+    /// <summary>What the connection would actually be bounded to, blank meaning the home folder.</summary>
+    private string? EffectiveRoot() =>
+        LocalResult() is { } r ? ConnectionForm.NormaliseRemoteRoot(localRoot, r.HomePath) : null;
+
     private bool LocalSetupReady() =>
         LocalResult() is not null && !string.IsNullOrWhiteSpace(localHost);
 
     private ConnectionForm BuildLocalForm(SftpHostSetupResult result) =>
-        ConnectionForm.ForLocalMachine(result, localHost, localSubPath, localKeyPair!.PrivateKeyPem);
+        ConnectionForm.ForLocalMachine(result, localHost, localRoot, localKeyPair!.PrivateKeyPem);
 
     private async Task TestLocalSetup()
     {
@@ -927,4 +958,5 @@
         statusMessage = message;
     }
 }
+
 

--- a/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
@@ -1,5 +1,7 @@
 @using Connapse.Core
 @using Connapse.Core.Interfaces
+@using Connapse.Core.Utilities
+@inject IJSRuntime JS
 @using Connapse.Storage.ConnectionTesters
 @using Connapse.Storage.Connectors
 @using Microsoft.Extensions.Options
@@ -49,14 +51,156 @@
         </div>
     }
 
+    @* ── Connect this computer ─────────────────────────────────────── *@
+    @if (localSetup)
+    {
+        <div class="col-12">
+            <h5>Connect this computer</h5>
+            <p class="text-muted mb-0">
+                Connapse runs in a container, so it cannot see your files directly and cannot
+                configure your machine for you. It can do everything else: it has made a key,
+                and written the one command you need to run.
+            </p>
+        </div>
+
+        @* Step 1 *@
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <h6 class="card-title">1 · Run this on your computer</h6>
+                    <div class="btn-group btn-group-sm mb-2" role="group">
+                        @foreach (var p in Enum.GetValues<HostPlatform>())
+                        {
+                            <button type="button"
+                                    class="btn @(setupPlatform == p ? "btn-secondary" : "btn-outline-secondary")"
+                                    @onclick="() => SelectPlatform(p)">@PlatformLabel(p)</button>
+                        }
+                    </div>
+                    @if (setupPlatform == HostPlatform.Windows)
+                    {
+                        <div class="small text-muted mb-2">
+                            Open PowerShell with <strong>Run as Administrator</strong>, then paste this in.
+                        </div>
+                    }
+                    <textarea class="form-control font-monospace" rows="12" readonly
+                              style="font-size:.78rem">@setupScript</textarea>
+                    <button class="btn btn-sm btn-outline-secondary mt-2" @onclick="CopyScript">
+                        <span class="bi-clipboard me-1"></span> Copy command
+                    </button>
+                    <span class="small text-muted ms-2">
+                        Safe to run more than once. It adds one key and changes nothing else.
+                    </span>
+                </div>
+            </div>
+        </div>
+
+        @* Step 2 *@
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <h6 class="card-title">2 · Paste back what it printed</h6>
+                    <textarea class="form-control font-monospace" rows="5" @bind="pastedResult"
+                              @bind:event="oninput"
+                              placeholder="@SftpHostSetup.BeginMarker&#10;user=…&#10;home=…&#10;fingerprint=…&#10;@SftpHostSetup.EndMarker"></textarea>
+                    <div class="form-text">
+                        The whole terminal output is fine — Connapse finds the block. This carries your
+                        username, your folder path, and the server's key fingerprint, so nothing has to
+                        be typed. The fingerprint arriving this way means the very first connection is
+                        verified rather than trusted.
+                    </div>
+
+                    @if (!string.IsNullOrWhiteSpace(pastedResult))
+                    {
+                        var parsed = SftpHostSetup.ParseResult(pastedResult);
+                        @if (parsed is null)
+                        {
+                            <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                <span class="bi-exclamation-triangle me-1"></span>
+                                No setup block found yet. Copy everything the command printed, including
+                                both <code>-----</code> marker lines.
+                            </div>
+                        }
+                        else
+                        {
+                            <div class="alert alert-success py-2 mt-2 mb-0 small">
+                                <span class="bi-check-circle me-1"></span>
+                                Read <strong>@parsed.Username</strong>, home
+                                <code>@parsed.HomePath</code>, host key
+                                <code>@parsed.Fingerprint</code>.
+                            </div>
+                        }
+                    }
+                </div>
+            </div>
+        </div>
+
+        @* Step 3 *@
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <h6 class="card-title">3 · Choose what to index</h6>
+                    <div class="row g-3">
+                        <div class="col-md-8">
+                            <label class="form-label">Folder</label>
+                            <div class="input-group">
+                                <span class="input-group-text font-monospace small">@(LocalHome() ?? "…")/</span>
+                                <input class="form-control" @bind="localSubPath" placeholder="Documents" />
+                            </div>
+                            <div class="form-text">
+                                Relative to your home folder. Sources you add later are confined beneath it.
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Reachable at</label>
+                            <input class="form-control font-monospace" @bind="localHost" />
+                            <div class="form-text">
+                                <code>host.docker.internal</code> works on Docker Desktop. A Linux host needs
+                                <code>--add-host=host.docker.internal:host-gateway</code>.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12">
+            <button class="btn btn-primary me-2" @onclick="SaveLocalSetup" disabled="@(saving || !LocalSetupReady())">
+                @if (saving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                <span>Create connection</span>
+            </button>
+            <button class="btn btn-info me-2" @onclick="TestLocalSetup" disabled="@(testing || !LocalSetupReady())">
+                @if (testing) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                <span>Test first</span>
+            </button>
+            <button class="btn btn-secondary" @onclick="CancelLocalSetup">Cancel</button>
+        </div>
+
+        @if (testMessage is not null)
+        {
+            <div class="col-12">
+                <div class="alert @(testSuccess ? "alert-success" : "alert-danger") py-2 mb-0">
+                    <span class="@(testSuccess ? "bi-check-circle" : "bi-x-circle") me-2"></span>
+                    @testMessage
+                </div>
+            </div>
+        }
+    }
     @* ── List ──────────────────────────────────────────────────────── *@
-    @if (editing is null)
+    else if (editing is null)
     {
         <div class="col-12 d-flex justify-content-between align-items-center">
             <h5 class="mb-0">Connections</h5>
-            <button class="btn btn-primary btn-sm" @onclick="StartCreate">
-                <span class="bi-plus-lg me-1"></span> Add connection
-            </button>
+            <div>
+                @* The local case gets its own entry point rather than being a provider hidden
+                   inside "Add connection". It is the one most people want, and reaching it
+                   through a generic SFTP form means understanding SFTP first. *@
+                <button class="btn btn-outline-primary btn-sm me-2" @onclick="StartLocalSetup">
+                    <span class="bi-laptop me-1"></span> Connect this computer
+                </button>
+                <button class="btn btn-primary btn-sm" @onclick="StartCreate">
+                    <span class="bi-plus-lg me-1"></span> Add connection
+                </button>
+            </div>
         </div>
 
         <div class="col-12">
@@ -418,6 +562,135 @@
         loading = true;
         connections = (await ConnectionStore.ListAsync(take: int.MaxValue)).ToList();
         loading = false;
+    }
+
+    // ── Connect this computer ──────────────────────────────────────────────
+
+    private bool localSetup;
+    private HostPlatform setupPlatform = HostPlatform.Windows;
+    private SshKeyPair? localKeyPair;
+    private string setupScript = "";
+    private string? pastedResult;
+    private string localSubPath = "";
+    private string localHost = "host.docker.internal";
+
+    private static string PlatformLabel(HostPlatform p) => p switch
+    {
+        HostPlatform.Windows => "Windows",
+        HostPlatform.MacOS => "macOS",
+        _ => "Linux",
+    };
+
+    private void StartLocalSetup()
+    {
+        // Generated once per visit, not per keystroke: the script embeds the public key, and
+        // regenerating would invalidate a command the operator may have already run.
+        localKeyPair = SshKeyPairGenerator.Generate($"connapse@{Environment.MachineName}");
+
+        localSetup = true;
+        editing = null;
+        pastedResult = null;
+        localSubPath = "";
+        localHost = "host.docker.internal";
+        statusMessage = null;
+        testMessage = null;
+
+        RegenerateScript();
+    }
+
+    private void SelectPlatform(HostPlatform platform)
+    {
+        setupPlatform = platform;
+        RegenerateScript();
+    }
+
+    private void RegenerateScript() =>
+        setupScript = localKeyPair is null
+            ? ""
+            : SftpHostSetup.GenerateScript(localKeyPair.PublicKeyLine, setupPlatform);
+
+    private async Task CopyScript() =>
+        await JS.InvokeVoidAsync("navigator.clipboard.writeText", setupScript);
+
+    private SftpHostSetupResult? LocalResult() => SftpHostSetup.ParseResult(pastedResult);
+
+    private string? LocalHome() => LocalResult()?.HomePath;
+
+    private bool LocalSetupReady() =>
+        LocalResult() is not null && !string.IsNullOrWhiteSpace(localHost);
+
+    private ConnectionForm BuildLocalForm(SftpHostSetupResult result) =>
+        ConnectionForm.ForLocalMachine(result, localHost, localSubPath, localKeyPair!.PrivateKeyPem);
+
+    private async Task TestLocalSetup()
+    {
+        if (LocalResult() is not { } result) return;
+
+        testing = true;
+        testMessage = null;
+        try
+        {
+            var form = BuildLocalForm(result);
+
+            var outcome = await SftpTester.TestConnectionAsync(new SftpConnectionTestSettings
+            {
+                Host = form.Host!,
+                Port = 22,
+                Username = form.Username!,
+                AllowedRoot = form.AllowedRoot!,
+                PrivateKey = form.PrivateKey!,
+                PinnedHostKeyFingerprint = form.HostKeyFingerprint,
+            }, TimeSpan.FromSeconds(15));
+
+            testSuccess = outcome.Success;
+            testMessage = outcome.Message;
+        }
+        catch (Exception ex)
+        {
+            testSuccess = false;
+            testMessage = ex.Message;
+        }
+        finally
+        {
+            testing = false;
+        }
+    }
+
+    private async Task SaveLocalSetup()
+    {
+        if (LocalResult() is not { } result) return;
+
+        saving = true;
+        try
+        {
+            var form = BuildLocalForm(result);
+
+            await ConnectionStore.CreateAsync(
+                new CreateConnectionRequest(
+                    form.Name.Trim(), ConnectionProvider.Sftp, form.ToConfigJson(), form.ToSecretJson()),
+                createdByUserId: null);
+
+            Succeed($"Connected. Add a source on '{form.Name}' to start indexing.");
+            CancelLocalSetup();
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Fail(ex.Message);
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private void CancelLocalSetup()
+    {
+        localSetup = false;
+        localKeyPair = null;
+        setupScript = "";
+        pastedResult = null;
+        testMessage = null;
     }
 
     private void StartCreate()

--- a/src/Connapse.Web/Components/Settings/SourceForm.cs
+++ b/src/Connapse.Web/Components/Settings/SourceForm.cs
@@ -60,7 +60,11 @@ public sealed record SourceForm
                 if (!Blank(Prefix)) node["prefix"] = Prefix!.Trim();
                 break;
 
+            // One case for both. The SFTP scope was deliberately given the same shape as the
+            // filesystem one so that this form, the preflight and the scope summary each gained
+            // a provider here rather than a parallel implementation to keep in step.
             case ConnectionProvider.Filesystem:
+            case ConnectionProvider.Sftp:
                 // Always present, and empty means the root itself. ConnectorFactory treats a
                 // blank subPath as "the allowed root", so this is a meaningful value rather
                 // than a missing one.

--- a/src/Connapse.Web/Services/SourceScopePreflight.cs
+++ b/src/Connapse.Web/Services/SourceScopePreflight.cs
@@ -55,6 +55,7 @@ public class SourceScopePreflight(IOptionsMonitor<SourceSecuritySettings> source
             ConnectionProvider.S3 => CheckLocation(credential, scope, "bucketName", "bucket", connection.Name),
             ConnectionProvider.AzureBlob => CheckLocation(credential, scope, "containerName", "blob container", connection.Name),
             ConnectionProvider.Filesystem => CheckRoot(credential, scope, connection.Name),
+            ConnectionProvider.Sftp => CheckSftpScope(credential, scope, connection.Name),
             _ => ScopePreflightResult.Refuse(
                 $"Connection '{connection.Name}' uses a provider this form does not understand.")
         };
@@ -86,6 +87,52 @@ public class SourceScopePreflight(IOptionsMonitor<SourceSecuritySettings> source
             _ => ScopePreflightResult.Refuse(
                 $"'{Join(container, prefix)}' is outside the locations connection '{connectionName}' permits.")
         };
+    }
+
+    /// <summary>
+    /// Checks an SFTP scope as far as it can be checked without a network call.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does <b>not</b> reuse <see cref="CheckRoot"/>. That path calls
+    /// <see cref="PathConfinement"/> and <see cref="SourceSecuritySettings.EvaluateRoot"/>, both
+    /// of which touch the local disk and read the deployment's own allowed-roots setting —
+    /// answers about the machine Connapse runs on, not the one being connected to. Against a
+    /// remote path they would resolve nothing and silently degrade to a lexical prefix check,
+    /// which is the mistake <c>SftpPathConfinement</c> exists to avoid.
+    /// <para>
+    /// So this catches only what is wrong on its face. The real confinement happens on the
+    /// server, through <c>SSH_FXP_REALPATH</c>, at the first connect — the same division of
+    /// labour as everywhere else here: this makes the obvious case legible early, and the
+    /// connector remains the thing that actually decides.
+    /// </para>
+    /// </remarks>
+    private static ScopePreflightResult CheckSftpScope(
+        JsonObject? credential, JsonObject scope, string connectionName)
+    {
+        if (string.IsNullOrWhiteSpace(Str(credential, "allowedRoot")))
+            return ScopePreflightResult.Refuse($"Connection '{connectionName}' has no allowed root configured.");
+
+        string? subPath = Str(scope, "subPath");
+        if (string.IsNullOrWhiteSpace(subPath))
+            return ScopePreflightResult.Allowed;
+
+        string cleaned = subPath.Replace('\\', '/');
+
+        if (cleaned.StartsWith('/'))
+        {
+            return ScopePreflightResult.Refuse(
+                "A sub-path is relative to the connection's allowed root, so it cannot start with '/'.");
+        }
+
+        // Refused on the segment, not on the substring: a file legitimately named "..config"
+        // contains ".." without being a traversal.
+        if (cleaned.Split('/').Any(segment => segment == ".."))
+        {
+            return ScopePreflightResult.Refuse(
+                "A sub-path cannot contain '..' — it must stay inside the connection's allowed root.");
+        }
+
+        return ScopePreflightResult.Allowed;
     }
 
     private ScopePreflightResult CheckRoot(JsonObject? credential, JsonObject scope, string connectionName)

--- a/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
+++ b/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Connapse.Core;
+using Connapse.Core.Utilities;
 using Connapse.Web.Components.Settings;
 using FluentAssertions;
 using Xunit;
@@ -376,6 +377,123 @@ public class ConnectionFormTests
         new ConnectionForm { Provider = ConnectionProvider.Filesystem }.IsCloudProvider.Should().BeFalse();
     }
 
+    // ── Connect this computer ──────────────────────────────────────────────
+
+    private static SftpHostSetupResult Reported(
+        string user = "Diviel",
+        string home = "/C:/Users/Diviel",
+        string fingerprint = "SHA256:hostkey") => new(user, home, fingerprint);
+
+    private const string GeneratedKey = "-----BEGIN RSA PRIVATE KEY-----\ngenerated\n";
+
+    [Fact]
+    public void ForLocalMachine_UsesEveryValueTheHostReported()
+    {
+        var form = ConnectionForm.ForLocalMachine(
+            Reported(), "host.docker.internal", "Documents", GeneratedKey);
+
+        form.Provider.Should().Be(ConnectionProvider.Sftp);
+        form.Username.Should().Be("Diviel");
+        form.Host.Should().Be("host.docker.internal");
+        form.Port.Should().Be("22");
+        form.HostKeyFingerprint.Should().Be("SHA256:hostkey");
+        form.PrivateKey.Should().Be(GeneratedKey);
+        form.Name.Should().Be("Diviel@host.docker.internal");
+    }
+
+    /// <summary>
+    /// The Windows shape, and the reason the home path is reported rather than typed. A leading
+    /// slash before the drive letter is what OpenSSH presents, and getting it wrong is an
+    /// afternoon.
+    /// </summary>
+    [Fact]
+    public void ForLocalMachine_WindowsHomePath_IsJoinedWithForwardSlashes()
+    {
+        ConnectionForm.ForLocalMachine(Reported(), "h", "Documents", GeneratedKey)
+            .AllowedRoot.Should().Be("/C:/Users/Diviel/Documents");
+    }
+
+    /// <summary>
+    /// The root is the chosen folder, not the home directory. A source cannot escape its
+    /// connection's root, so this is the difference between exposing one folder and exposing
+    /// everything the account can read.
+    /// </summary>
+    [Fact]
+    public void ForLocalMachine_NarrowsTheRootToTheChosenFolder()
+    {
+        var form = ConnectionForm.ForLocalMachine(Reported(), "h", "Documents/work", GeneratedKey);
+
+        form.AllowedRoot.Should().Be("/C:/Users/Diviel/Documents/work");
+        form.AllowedRoot.Should().NotBe("/C:/Users/Diviel");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("/")]
+    public void ForLocalMachine_NoFolderChosen_UsesTheHomeDirectory(string? subPath)
+    {
+        ConnectionForm.ForLocalMachine(Reported(), "h", subPath, GeneratedKey)
+            .AllowedRoot.Should().Be("/C:/Users/Diviel");
+    }
+
+    /// <summary>
+    /// An operator on Windows will type a Windows path, because that is what they see in
+    /// Explorer. SFTP does not take one.
+    /// </summary>
+    [Fact]
+    public void ForLocalMachine_BackslashesInTheChosenFolder_AreConverted()
+    {
+        ConnectionForm.ForLocalMachine(Reported(), "h", @"Documents\work", GeneratedKey)
+            .AllowedRoot.Should().Be("/C:/Users/Diviel/Documents/work");
+    }
+
+    [Theory]
+    [InlineData("/home/diviel", "docs", "/home/diviel/docs")]
+    [InlineData("/home/diviel/", "docs", "/home/diviel/docs")]
+    [InlineData("/home/diviel", "/docs/", "/home/diviel/docs")]
+    [InlineData("/C:/Users/me", null, "/C:/Users/me")]
+    public void CombineRemote_JoinsWithoutDoublingOrDroppingSeparators(
+        string home, string? subPath, string expected)
+    {
+        ConnectionForm.CombineRemote(home, subPath).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The whole flow exists to avoid typing, so what it produces must be savable as-is.
+    /// </summary>
+    [Fact]
+    public void ForLocalMachine_ProducesAConnectionThatValidatesAndStoresItsKey()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        var form = ConnectionForm.ForLocalMachine(
+            Reported(), "host.docker.internal", "Documents", pair.PrivateKeyPem);
+
+        form.Validate(isNew: true).Should().BeNull();
+        form.ToSecretJson().Should().NotBeNull();
+
+        var config = JsonNode.Parse(form.ToConfigJson())!;
+        config["host"]!.GetValue<string>().Should().Be("host.docker.internal");
+        config["port"]!.GetValue<int>().Should().Be(22);
+        config["hostKeyFingerprint"]!.GetValue<string>().Should().Be("SHA256:hostkey");
+    }
+
+    /// <summary>
+    /// Carrying the fingerprint into the stored config is what makes the first connection
+    /// verified rather than trusted — the entire reason the operator pastes anything back.
+    /// </summary>
+    [Fact]
+    public void ForLocalMachine_PinsTheFingerprintBeforeTheFirstConnection()
+    {
+        var form = ConnectionForm.ForLocalMachine(
+            Reported(fingerprint: "SHA256:fromTheHost"), "h", null, GeneratedKey);
+
+        JsonNode.Parse(form.ToConfigJson())!["hostKeyFingerprint"]!.GetValue<string>()
+            .Should().Be("SHA256:fromTheHost");
+    }
+
     [Theory]
     [InlineData(nameof(ConnectionForm.Host))]
     [InlineData(nameof(ConnectionForm.Username))]
@@ -423,3 +541,4 @@ public class ConnectionFormTests
             .Should().Be("The port must be between 1 and 65535.");
     }
 }
+

--- a/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
+++ b/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
@@ -402,62 +402,71 @@ public class ConnectionFormTests
     }
 
     /// <summary>
-    /// The Windows shape, and the reason the home path is reported rather than typed. A leading
-    /// slash before the drive letter is what OpenSSH presents, and getting it wrong is an
-    /// afternoon.
+    /// The restriction that was there by accident. Windows OpenSSH applies no chroot, so a
+    /// second drive is perfectly reachable — and confining the flow to the profile would rule
+    /// out where most people actually keep things.
     /// </summary>
     [Fact]
-    public void ForLocalMachine_WindowsHomePath_IsJoinedWithForwardSlashes()
+    public void ForLocalMachine_RootOnAnotherDrive_IsAllowed()
     {
-        ConnectionForm.ForLocalMachine(Reported(), "h", "Documents", GeneratedKey)
-            .AllowedRoot.Should().Be("/C:/Users/Diviel/Documents");
-    }
-
-    /// <summary>
-    /// The root is the chosen folder, not the home directory. A source cannot escape its
-    /// connection's root, so this is the difference between exposing one folder and exposing
-    /// everything the account can read.
-    /// </summary>
-    [Fact]
-    public void ForLocalMachine_NarrowsTheRootToTheChosenFolder()
-    {
-        var form = ConnectionForm.ForLocalMachine(Reported(), "h", "Documents/work", GeneratedKey);
-
-        form.AllowedRoot.Should().Be("/C:/Users/Diviel/Documents/work");
-        form.AllowedRoot.Should().NotBe("/C:/Users/Diviel");
+        ConnectionForm.ForLocalMachine(Reported(), "h", "/D:/CodeProjects", GeneratedKey)
+            .AllowedRoot.Should().Be("/D:/CodeProjects");
     }
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    [InlineData("/")]
-    public void ForLocalMachine_NoFolderChosen_UsesTheHomeDirectory(string? subPath)
+    public void ForLocalMachine_NoFolderChosen_UsesTheHomeDirectory(string? root)
     {
-        ConnectionForm.ForLocalMachine(Reported(), "h", subPath, GeneratedKey)
+        ConnectionForm.ForLocalMachine(Reported(), "h", root, GeneratedKey)
             .AllowedRoot.Should().Be("/C:/Users/Diviel");
     }
 
     /// <summary>
-    /// An operator on Windows will type a Windows path, because that is what they see in
-    /// Explorer. SFTP does not take one.
+    /// An operator will paste what Explorer shows them, because that is what is on the
+    /// clipboard. SFTP takes neither the backslashes nor the bare drive letter.
     /// </summary>
-    [Fact]
-    public void ForLocalMachine_BackslashesInTheChosenFolder_AreConverted()
+    [Theory]
+    [InlineData(@"D:\CodeProjects", "/D:/CodeProjects")]
+    [InlineData("D:/CodeProjects", "/D:/CodeProjects")]
+    [InlineData(@"C:\Users\Diviel\Documents", "/C:/Users/Diviel/Documents")]
+    public void NormaliseRemoteRoot_ConvertsAWindowsPathFromExplorer(string entered, string expected)
     {
-        ConnectionForm.ForLocalMachine(Reported(), "h", @"Documents\work", GeneratedKey)
-            .AllowedRoot.Should().Be("/C:/Users/Diviel/Documents/work");
+        ConnectionForm.NormaliseRemoteRoot(entered, "/fallback").Should().Be(expected);
     }
 
     [Theory]
-    [InlineData("/home/diviel", "docs", "/home/diviel/docs")]
-    [InlineData("/home/diviel/", "docs", "/home/diviel/docs")]
-    [InlineData("/home/diviel", "/docs/", "/home/diviel/docs")]
-    [InlineData("/C:/Users/me", null, "/C:/Users/me")]
-    public void CombineRemote_JoinsWithoutDoublingOrDroppingSeparators(
-        string home, string? subPath, string expected)
+    [InlineData("/D:/Projects/", "/D:/Projects")]
+    [InlineData("/home/me/docs", "/home/me/docs")]
+    [InlineData("home/me", "/home/me")]
+    [InlineData("/", "/")]
+    public void NormaliseRemoteRoot_ProducesAnAbsoluteUnDoubledPath(string entered, string expected)
     {
-        ConnectionForm.CombineRemote(home, subPath).Should().Be(expected);
+        ConnectionForm.NormaliseRemoteRoot(entered, "/fallback").Should().Be(expected);
+    }
+
+    /// <summary>
+    /// A drive root trims to "/D:" and must stay that, not collapse to the filesystem root —
+    /// which would silently widen the connection from one drive to the whole machine.
+    /// </summary>
+    [Fact]
+    public void NormaliseRemoteRoot_DriveRoot_StaysTheDrive()
+    {
+        ConnectionForm.NormaliseRemoteRoot("/D:/", "/fallback").Should().Be("/D:");
+    }
+
+    [Theory]
+    [InlineData("/", true)]
+    [InlineData("/D:", true)]
+    [InlineData("/D:/", true)]
+    [InlineData("/C:/Users/Diviel", false)]
+    [InlineData("/D:/CodeProjects", false)]
+    [InlineData("/home/me", false)]
+    [InlineData(null, false)]
+    public void IsBroadRemoteRoot_FlagsWholeDrivesAndTheFilesystemRoot(string? root, bool expected)
+    {
+        ConnectionForm.IsBroadRemoteRoot(root).Should().Be(expected);
     }
 
     /// <summary>
@@ -541,4 +550,5 @@ public class ConnectionFormTests
             .Should().Be("The port must be between 1 and 65535.");
     }
 }
+
 

--- a/tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using System.Text.Json;
 using Connapse.Core;
 using Connapse.Web.Components.Settings;
@@ -159,4 +160,66 @@ public class SourceFormTests
         var form = new SourceForm { Name = "n", ConnectionId = Guid.NewGuid(), Container = "b" };
         form.Validate(ConnectionProvider.S3).Should().BeNull();
     }
+    // ── SFTP ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The same scope shape as Filesystem, which was the point of designing it that way: this
+    /// form, the preflight and the summary each gain a provider rather than a parallel
+    /// implementation to keep in step.
+    /// </summary>
+    [Fact]
+    public void ToScopeJson_Sftp_ProducesTheSameShapeAsFilesystem()
+    {
+        var form = new SourceForm
+        {
+            Name = "s",
+            ConnectionId = Guid.NewGuid(),
+            SubPath = "Documents",
+            IncludePatterns = "*.md",
+            ExcludePatterns = "*.tmp",
+        };
+
+        var sftp = JsonNode.Parse(form.ToScopeJson(ConnectionProvider.Sftp))!.AsObject();
+        var filesystem = JsonNode.Parse(form.ToScopeJson(ConnectionProvider.Filesystem))!.AsObject();
+
+        sftp.ToJsonString().Should().Be(filesystem.ToJsonString());
+        sftp["subPath"]!.GetValue<string>().Should().Be("Documents");
+    }
+
+    /// <summary>
+    /// Blank means the connection's root itself, which ConnectorFactory reads as a real value
+    /// rather than a missing one — so the key must be present.
+    /// </summary>
+    [Fact]
+    public void ToScopeJson_SftpWithNoSubPath_StillWritesTheKey()
+    {
+        var form = new SourceForm { Name = "s", ConnectionId = Guid.NewGuid() };
+
+        JsonNode.Parse(form.ToScopeJson(ConnectionProvider.Sftp))!.AsObject()
+            .ContainsKey("subPath").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Before this, picking an SFTP connection threw out of the form. The throw is caught now
+    /// rather than tearing down the circuit, but an operator still could not create the source.
+    /// </summary>
+    [Fact]
+    public void ToScopeJson_Sftp_DoesNotThrow()
+    {
+        var form = new SourceForm { Name = "s", ConnectionId = Guid.NewGuid(), SubPath = "docs" };
+
+        Action act = () => form.ToScopeJson(ConnectionProvider.Sftp);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_Sftp_DoesNotRequireAContainerName()
+    {
+        var form = new SourceForm { Name = "s", ConnectionId = Guid.NewGuid() };
+
+        form.Validate(ConnectionProvider.Sftp).Should().BeNull(
+            "an SFTP source is bounded by a sub-path, not a bucket");
+    }
 }
+

--- a/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
@@ -268,4 +268,77 @@ public class SourceScopePreflightTests
 
         result.IsRefused.Should().BeFalse();
     }
+    // ── SFTP ───────────────────────────────────────────────────────────────
+
+    private const string SftpConn = """{"host":"h","port":22,"username":"u","allowedRoot":"/D:/CodeProjects"}""";
+
+    [Fact]
+    public void Check_SftpOrdinarySubPath_IsAllowed()
+    {
+        var result = Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":"Connapse"}""");
+
+        result.IsRefused.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Check_SftpNoSubPath_IsAllowed()
+    {
+        Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":""}""")
+            .IsRefused.Should().BeFalse("blank means the connection's root itself");
+    }
+
+    /// <summary>
+    /// A sub-path is relative to the connection's root, so an absolute one is nonsense rather
+    /// than a path — and the server would resolve it somewhere else entirely.
+    /// </summary>
+    [Fact]
+    public void Check_SftpAbsoluteSubPath_IsRefused()
+    {
+        Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":"/etc"}""")
+            .IsRefused.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("../secrets")]
+    [InlineData("docs/../../etc")]
+    [InlineData(@"docs\..\..\etc")]
+    public void Check_SftpTraversingSubPath_IsRefused(string subPath)
+    {
+        var scope = $$"""{"subPath":{{System.Text.Json.JsonSerializer.Serialize(subPath)}}}""";
+
+        Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), scope)
+            .IsRefused.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Refused on the segment, not the substring: a folder legitimately named "..config"
+    /// contains ".." without being a traversal, and refusing it would be wrong.
+    /// </summary>
+    [Fact]
+    public void Check_SftpSubPathContainingDotsInAName_IsAllowed()
+    {
+        Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":"..config/notes"}""")
+            .IsRefused.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Check_SftpConnectionWithNoAllowedRoot_IsRefused()
+    {
+        Build().Check(Conn(ConnectionProvider.Sftp, """{"host":"h","username":"u"}"""), """{"subPath":"docs"}""")
+            .IsRefused.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The deployment's local allowed-roots setting governs the machine Connapse runs on. An
+    /// SFTP root names a directory on somebody else's, so it must not be judged against it —
+    /// doing so would refuse every remote path that happens not to exist locally.
+    /// </summary>
+    [Fact]
+    public void Check_SftpRoot_IsNotJudgedAgainstTheLocalAllowedRoots()
+    {
+        var preflight = Build("/srv/only-this-local-path");
+
+        preflight.Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":"Connapse"}""")
+            .IsRefused.Should().BeFalse();
+    }
 }

--- a/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
@@ -297,10 +297,14 @@ public class SftpHostSetupTests
             .Should().BeNull();
     }
 
+    /// <summary>
+    /// The identifying fields only. The fingerprint used to be required too, which dead-ended the
+    /// flow when it could not be read — see
+    /// <see cref="ParseResult_WithoutAFingerprint_StillParses"/>.
+    /// </summary>
     [Theory]
     [InlineData("user")]
     [InlineData("home")]
-    [InlineData("fingerprint")]
     public void ParseResult_MissingAnyField_IsNull(string omit)
     {
         string block = string.Join('\n',
@@ -318,5 +322,119 @@ public class SftpHostSetupTests
     {
         SftpHostSetup.ParseResult(Block(home: "/C:/Users/Diviel"))!
             .HomePath.Should().StartWith("/C:/");
+    }
+    // ── The installed key is restricted (Codex review on #405) ─────────────
+
+    /// <summary>
+    /// A bare entry grants everything the account can do — interactive shell, port forwarding,
+    /// agent forwarding. Connapse only reads files, and its path confinement is an application
+    /// rule: it bounds what Connapse does with the key, not what the key can do. Anyone holding
+    /// the stored private half is not bound by it at all.
+    /// </summary>
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Linux)]
+    public void GenerateScript_InstallsTheKeyRestrictedToSftp(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain("restrict,", "restrict disables PTY, port, agent and X11 forwarding");
+        script.Should().Contain("""command="internal-sftp" """.TrimEnd(),
+            "a forced command replaces whatever the client asks for, so a shell request gets SFTP");
+        script.Should().Contain($"restrict,command=\"internal-sftp\" {Key}",
+            "the restrictions must prefix the key on the same authorized_keys line");
+    }
+
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Linux)]
+    public void GenerateScript_NeverInstallsABareKey(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        // The key must never appear without its restrictions immediately before it.
+        foreach (int index in AllIndexesOf(script, Key))
+        {
+            script[..index].Should().EndWith(SftpHostSetup.KeyRestrictions,
+                "an unrestricted copy of the key would defeat the restricted one");
+        }
+    }
+
+    private static IEnumerable<int> AllIndexesOf(string haystack, string needle)
+    {
+        for (int i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + 1, StringComparison.Ordinal))
+        {
+            yield return i;
+        }
+    }
+
+    // ── A missing fingerprint must not dead-end the flow ───────────────────
+
+    /// <summary>
+    /// Reading the fingerprint needs elevation and can still fail, by which point sshd is running
+    /// and the key is installed. Requiring one here left the operator with a configured host, an
+    /// authorized key, and no way to finish or undo.
+    /// </summary>
+    [Fact]
+    public void ParseResult_WithoutAFingerprint_StillParses()
+    {
+        string block = $"""
+        {SftpHostSetup.BeginMarker}
+        user=Diviel
+        home=/C:/Users/Diviel
+        fingerprint=
+        {SftpHostSetup.EndMarker}
+        """;
+
+        var result = SftpHostSetup.ParseResult(block);
+
+        result.Should().NotBeNull();
+        result!.Username.Should().Be("Diviel");
+        result.Fingerprint.Should().BeEmpty("blank means trust on first use, which is defined behaviour");
+    }
+
+    [Fact]
+    public void ParseResult_FingerprintLineAbsentEntirely_StillParses()
+    {
+        string block = $"""
+        {SftpHostSetup.BeginMarker}
+        user=Diviel
+        home=/C:/Users/Diviel
+        {SftpHostSetup.EndMarker}
+        """;
+
+        SftpHostSetup.ParseResult(block)!.Fingerprint.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The identifying fields are still required: without a username or home path there is no
+    /// connection to build, and guessing either would point somewhere wrong.
+    /// </summary>
+    [Theory]
+    [InlineData("user")]
+    [InlineData("home")]
+    public void ParseResult_MissingAnIdentifyingField_IsStillNull(string omit)
+    {
+        string block = string.Join('\n',
+            $"""
+            {SftpHostSetup.BeginMarker}
+            user=Diviel
+            home=/C:/Users/Diviel
+            fingerprint=SHA256:abc
+            {SftpHostSetup.EndMarker}
+            """.Split('\n').Where(l => !l.TrimStart().StartsWith(omit + "=")));
+
+        SftpHostSetup.ParseResult(block).Should().BeNull();
+    }
+
+    [Fact]
+    public void GenerateScript_SaysSoWhenTheFingerprintCouldNotBeRead()
+    {
+        SftpHostSetup.GenerateScript(Key, HostPlatform.Windows)
+            .Should().Contain("could not be read",
+                "a silent empty fingerprint would look like the script half-worked");
     }
 }

--- a/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
@@ -1,0 +1,322 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class SftpHostSetupTests
+{
+    private const string Key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0example connapse";
+
+    // ── Script generation ──────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Linux)]
+    public void GenerateScript_EmbedsTheKeyAndBothMarkers(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain(Key);
+        script.Should().Contain(SftpHostSetup.BeginMarker);
+        script.Should().Contain(SftpHostSetup.EndMarker);
+    }
+
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Linux)]
+    public void GenerateScript_ReportsAllThreeFieldsConnapseNeeds(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain("user=");
+        script.Should().Contain("home=");
+        script.Should().Contain("fingerprint=");
+    }
+
+    /// <summary>
+    /// Idempotency is not a nicety here — the operator is told the command is safe to re-run,
+    /// and a duplicated key in <c>authorized_keys</c> is the kind of mess nobody goes looking
+    /// for.
+    /// </summary>
+    [Theory]
+    [InlineData(HostPlatform.Windows, "Select-String")]
+    [InlineData(HostPlatform.MacOS, "grep -qxF")]
+    [InlineData(HostPlatform.Linux, "grep -qxF")]
+    public void GenerateScript_AddsTheKeyOnlyIfAbsent(HostPlatform platform, string guard)
+    {
+        SftpHostSetup.GenerateScript(Key, platform).Should().Contain(guard);
+    }
+
+    /// <summary>
+    /// Somebody else's key in that file is not ours to remove.
+    /// </summary>
+    [Theory]
+    [InlineData(HostPlatform.Windows, "Add-Content")]
+    [InlineData(HostPlatform.MacOS, ">> ~/.ssh/authorized_keys")]
+    [InlineData(HostPlatform.Linux, ">> ~/.ssh/authorized_keys")]
+    public void GenerateScript_AppendsRatherThanOverwrites(HostPlatform platform, string append)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain(append);
+        script.Should().NotContain("Set-Content -Path $keyFile");
+
+        // A truncating redirect, meaning a single '>' not preceded by another. Asserting
+        // NotContain("> ~/.ssh/authorized_keys") does not work: that string is a substring of
+        // the appending ">> ~/.ssh/authorized_keys" and the check can never pass.
+        script.Should().NotMatchRegex(@"[^>]> ~/\.ssh/authorized_keys");
+    }
+
+    /// <summary>
+    /// The Windows failure that costs an hour: for an account in the Administrators group,
+    /// sshd ignores the profile's authorized_keys entirely and reads a machine-wide file whose
+    /// ACL it also insists on. A script that skips this produces authentication failures with
+    /// nothing to explain them.
+    /// </summary>
+    [Fact]
+    public void GenerateScript_Windows_HandlesTheAdministratorsAuthorizedKeysFile()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("administrators_authorized_keys");
+        script.Should().Contain("icacls", "sshd refuses the file unless its ACL is restricted");
+    }
+
+    /// <summary>
+    /// Verified against a real machine: an account that <em>is</em> in Administrators reports
+    /// False from the token check when the process is not elevated, because UAC filters the
+    /// SID out. Deciding on that alone writes the key to the profile's authorized_keys, which
+    /// sshd then ignores — an authentication failure with nothing to explain it.
+    /// </summary>
+    [Fact]
+    public void GenerateScript_Windows_AsksTheGroupRatherThanTheToken()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("Get-LocalGroupMember",
+            "actual membership, not what an unelevated token happens to carry");
+        script.Should().Contain("$_.SID.Value -eq $mySid",
+            "matched by SID, since names vary by domain and casing");
+    }
+
+    /// <summary>
+    /// Refusing early beats half-succeeding. Without elevation the steps leave SSH looking
+    /// configured when it is not.
+    /// </summary>
+    [Fact]
+    public void GenerateScript_Windows_StopsWhenNotElevated()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("WindowsBuiltInRole]::Administrator");
+        script.Should().Contain("Run as Administrator");
+    }
+
+    /// <summary>
+    /// Reading the fingerprint needs elevation and can still fail. By that point the key is
+    /// installed, so a throw would discard a setup that otherwise worked — the operator loses
+    /// verified-first-use, not the connection.
+    /// </summary>
+    [Fact]
+    public void GenerateScript_Windows_SurvivesAnUnreadableHostKey()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("$fingerprint = ''", "it must have a value even when reading fails");
+        script.Should().Contain("try {");
+        script.Should().Contain("} catch { }");
+    }
+
+    [Fact]
+    public void GenerateScript_Windows_InstallsAndEnablesTheServer()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("OpenSSH.Server");
+        script.Should().Contain("StartupType Automatic");
+        script.Should().Contain("LocalPort 22");
+    }
+
+    [Fact]
+    public void GenerateScript_MacOs_UsesRemoteLogin()
+    {
+        SftpHostSetup.GenerateScript(Key, HostPlatform.MacOS)
+            .Should().Contain("systemsetup -setremotelogin on");
+    }
+
+    /// <summary>Debian and Ubuntu name the unit `ssh`; most others name it `sshd`.</summary>
+    [Fact]
+    public void GenerateScript_Linux_HandlesEitherServiceName()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Linux);
+
+        script.Should().Contain("--now sshd");
+        script.Should().Contain("--now ssh");
+    }
+
+    /// <summary>
+    /// The key is interpolated into a shell string, so anything that could close it must be
+    /// refused rather than escaped. SshKeyPairGenerator already guarantees this; the check is
+    /// here because this function would be the one exploited if that guarantee ever lapsed.
+    /// </summary>
+    [Theory]
+    [InlineData("ssh-rsa AAAA test\nrm -rf /")]
+    [InlineData("ssh-rsa AAAA'; Remove-Item -Recurse C:\\ ;'")]
+    [InlineData("ssh-rsa AAAA\"malicious\"")]
+    public void GenerateScript_KeyContainingQuotesOrNewlines_IsRefused(string hostile)
+    {
+        Action act = () => SftpHostSetup.GenerateScript(hostile, HostPlatform.Windows);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void GenerateScript_AGeneratedKeyIsAlwaysAccepted()
+    {
+        var pair = SshKeyPairGenerator.Generate("my machine");
+
+        foreach (var platform in Enum.GetValues<HostPlatform>())
+        {
+            Action act = () => SftpHostSetup.GenerateScript(pair.PublicKeyLine, platform);
+            act.Should().NotThrow();
+        }
+    }
+
+    // ── Parsing the result ─────────────────────────────────────────────────
+
+    private static string Block(
+        string user = "Diviel",
+        string home = "/C:/Users/Diviel",
+        string fingerprint = "SHA256:abc123") =>
+        $"""
+        {SftpHostSetup.BeginMarker}
+        user={user}
+        home={home}
+        fingerprint={fingerprint}
+        {SftpHostSetup.EndMarker}
+        """;
+
+    [Fact]
+    public void ParseResult_ReadsAllThreeFields()
+    {
+        var result = SftpHostSetup.ParseResult(Block());
+
+        result.Should().NotBeNull();
+        result!.Username.Should().Be("Diviel");
+        result.HomePath.Should().Be("/C:/Users/Diviel");
+        result.Fingerprint.Should().Be("SHA256:abc123");
+    }
+
+    /// <summary>
+    /// The realistic paste. Nobody selects exactly the block — they grab the whole terminal,
+    /// prompts and echoed command included.
+    /// </summary>
+    [Fact]
+    public void ParseResult_IgnoresEverythingOutsideTheMarkers()
+    {
+        string messy = $"""
+        PS C:\Users\Diviel> .\setup.ps1
+        Path          : C:\
+        Online        : True
+
+        {Block()}
+
+        Copy the block above, including both marker lines, back into Connapse.
+        PS C:\Users\Diviel>
+        """;
+
+        var result = SftpHostSetup.ParseResult(messy);
+
+        result.Should().NotBeNull();
+        result!.Username.Should().Be("Diviel");
+    }
+
+    /// <summary>
+    /// Terminals wrap, indent, and add carriage returns, and none of that is the operator's
+    /// fault. Field names and values are both trimmed, so padding around the '=' is fine.
+    /// </summary>
+    [Fact]
+    public void ParseResult_ToleratesWindowsLineEndingsAndStrayWhitespace()
+    {
+        string block = Block().Replace("\n", "\r\n").Replace("user=", "  user =  ");
+
+        var result = SftpHostSetup.ParseResult(block);
+
+        result.Should().NotBeNull();
+        result!.Username.Should().Be("Diviel");
+    }
+
+    [Fact]
+    public void ParseResult_ToleratesCarriageReturns()
+    {
+        SftpHostSetup.ParseResult(Block().Replace("\n", "\r\n"))!
+            .Username.Should().Be("Diviel");
+    }
+
+    /// <summary>
+    /// A fingerprint typed by hand often loses the prefix. Adding it back beats failing later,
+    /// where the only symptom is a refused connection with no hint that the stored value was
+    /// merely the wrong shape.
+    /// </summary>
+    [Fact]
+    public void ParseResult_FingerprintWithoutThePrefix_GetsItBack()
+    {
+        SftpHostSetup.ParseResult(Block(fingerprint: "abc123"))!
+            .Fingerprint.Should().Be("SHA256:abc123");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("just some text the operator pasted by mistake")]
+    public void ParseResult_WithoutABlock_IsNull(string? pasted)
+    {
+        SftpHostSetup.ParseResult(pasted).Should().BeNull();
+    }
+
+    /// <summary>
+    /// Loose key=value lines with no markers must not be accepted — that would take a paste
+    /// from somewhere else entirely and configure a connection out of it.
+    /// </summary>
+    [Fact]
+    public void ParseResult_FieldsWithoutMarkers_IsNull()
+    {
+        SftpHostSetup.ParseResult("user=x\nhome=/y\nfingerprint=SHA256:z").Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseResult_MarkersInTheWrongOrder_IsNull()
+    {
+        SftpHostSetup.ParseResult(
+            $"{SftpHostSetup.EndMarker}\nuser=x\nhome=/y\nfingerprint=z\n{SftpHostSetup.BeginMarker}")
+            .Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("user")]
+    [InlineData("home")]
+    [InlineData("fingerprint")]
+    public void ParseResult_MissingAnyField_IsNull(string omit)
+    {
+        string block = string.Join('\n',
+            Block().Split('\n').Where(l => !l.TrimStart().StartsWith(omit + "=")));
+
+        SftpHostSetup.ParseResult(block).Should().BeNull();
+    }
+
+    /// <summary>
+    /// The whole point of the round trip: these are the values Connapse cannot know, and the
+    /// Windows home path is the one that would otherwise be written wrong by hand.
+    /// </summary>
+    [Fact]
+    public void ParseResult_WindowsHomePath_KeepsItsLeadingSlash()
+    {
+        SftpHostSetup.ParseResult(Block(home: "/C:/Users/Diviel"))!
+            .HomePath.Should().StartWith("/C:/");
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/SshKeyPairGeneratorTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SshKeyPairGeneratorTests.cs
@@ -1,0 +1,133 @@
+using System.Security.Cryptography;
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+/// <summary>
+/// These cover shape and safety. The encoding itself is only genuinely proven by
+/// <c>SftpConnectorIntegrationTests.GeneratedKeyPair_AuthenticatesAgainstARealServer</c>,
+/// because a wrong encoding produces a well-formed line that simply fails to authenticate.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SshKeyPairGeneratorTests
+{
+    [Fact]
+    public void Generate_ProducesAPrivateKeyInTheFormSshNetReads()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        pair.PrivateKeyPem.Should().StartWith("-----BEGIN RSA PRIVATE KEY-----");
+        pair.PrivateKeyPem.Should().Contain("-----END RSA PRIVATE KEY-----");
+    }
+
+    [Fact]
+    public void Generate_ProducesASingleAuthorizedKeysLine()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        pair.PublicKeyLine.Should().StartWith("ssh-rsa ");
+        pair.PublicKeyLine.Should().NotContain("\n");
+        pair.PublicKeyLine.Split(' ').Should().HaveCount(3, "algorithm, key, comment");
+    }
+
+    [Fact]
+    public void Generate_UsesTheRequestedKeySize()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        using var rsa = RSA.Create();
+        rsa.ImportFromPem(pair.PrivateKeyPem);
+
+        rsa.KeySize.Should().Be(SshKeyPairGenerator.KeySizeBits);
+    }
+
+    [Fact]
+    public void Generate_PublicHalfMatchesThePrivateHalf()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        using var rsa = RSA.Create();
+        rsa.ImportFromPem(pair.PrivateKeyPem);
+
+        SshKeyPairGenerator.FormatPublicKey(rsa).Should().Be(pair.PublicKeyLine);
+    }
+
+    [Fact]
+    public void Generate_EachCallProducesADifferentKey()
+    {
+        SshKeyPairGenerator.Generate().PublicKeyLine
+            .Should().NotBe(SshKeyPairGenerator.Generate().PublicKeyLine);
+    }
+
+    [Fact]
+    public void Generate_CommentAppearsAsTheLabel()
+    {
+        SshKeyPairGenerator.Generate("my-laptop").PublicKeyLine
+            .Should().EndWith(" my-laptop");
+    }
+
+    /// <summary>
+    /// The comment is the final field on the line, so a newline in it would end the entry
+    /// and let whatever followed be parsed as a second authorized key. Connection names reach
+    /// here, and they are operator-supplied.
+    /// </summary>
+    [Fact]
+    public void Generate_CommentCannotInjectASecondAuthorizedKey()
+    {
+        var pair = SshKeyPairGenerator.Generate("ok\nssh-rsa AAAAB3NzaC1yc2EAAAADAQAB attacker");
+
+        pair.PublicKeyLine.Should().NotContain("\n");
+        pair.PublicKeyLine.Split('\n').Should().HaveCount(1);
+        pair.PublicKeyLine.Should().NotContain("attacker\n");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\n\r")]
+    public void Generate_BlankComment_FallsBackToADefaultLabel(string comment)
+    {
+        SshKeyPairGenerator.Generate(comment).PublicKeyLine
+            .Should().EndWith(" connapse");
+    }
+
+    /// <summary>
+    /// An mpint is signed, so a modulus whose top bit is set needs a leading zero byte. A
+    /// 3072-bit RSA modulus always has its top bit set, so this path runs every time — and if
+    /// it were wrong, every generated key would fail to authenticate.
+    /// </summary>
+    [Fact]
+    public void FormatPublicKey_ModulusIsEncodedAsAPositiveMpint()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+        byte[] blob = Convert.FromBase64String(pair.PublicKeyLine.Split(' ')[1]);
+
+        var reader = new BlobReader(blob);
+
+        System.Text.Encoding.ASCII.GetString(reader.Next()).Should().Be("ssh-rsa");
+        reader.Next().Should().NotBeEmpty("the exponent must be present");
+
+        byte[] modulus = reader.Next();
+        modulus[0].Should().Be(0, "a 3072-bit modulus has its top bit set and needs the sign byte");
+        (modulus.Length - 1).Should().Be(SshKeyPairGenerator.KeySizeBits / 8);
+    }
+
+    /// <summary>Walks the length-prefixed fields of an SSH key blob.</summary>
+    private sealed class BlobReader(byte[] blob)
+    {
+        private int _offset;
+
+        public byte[] Next()
+        {
+            int length = System.Buffers.Binary.BinaryPrimitives.ReadInt32BigEndian(
+                blob.AsSpan(_offset, 4));
+            _offset += 4;
+
+            byte[] value = blob[_offset..(_offset + length)];
+            _offset += length;
+            return value;
+        }
+    }
+}

--- a/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
@@ -99,6 +99,9 @@ public class IngestionPipelineTests
             Substitute.For<IContainerStore>(),
             Substitute.For<IManagedStorageProvider>(),
             Substitute.For<IDocumentStore>(),
+            Substitute.For<ISourceStore>(),
+            Substitute.For<IConnectionStore>(),
+            Substitute.For<IConnectorFactory>(),
             _logger);
 
     private static KnowledgeDbContext CreateInMemoryContext()

--- a/tests/Connapse.Integration.Tests/SftpConnectorIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SftpConnectorIntegrationTests.cs
@@ -1,5 +1,6 @@
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
 using Connapse.Storage.Connectors;
 using FluentAssertions;
 using Xunit;
@@ -306,6 +307,62 @@ public class SftpConnectorIntegrationTests : IAsyncLifetime
             .WithMessage("*partial listing*");
     }
 
+    // ── Generated key pairs ────────────────────────────────────────────────
+
+    /// <summary>
+    /// The test that makes <see cref="SshKeyPairGenerator"/> trustworthy.
+    /// </summary>
+    /// <remarks>
+    /// A wrong <c>authorized_keys</c> encoding produces a line that looks entirely correct
+    /// and simply fails to authenticate, with nothing anywhere pointing at the cause. Unit
+    /// tests can check the blob's structure but cannot tell you whether a real OpenSSH server
+    /// accepts it. This installs a generated public key the way the setup command will, and
+    /// connects with the matching private half.
+    /// </remarks>
+    [Fact]
+    public async Task GeneratedKeyPair_AuthenticatesAgainstARealServer()
+    {
+        var pair = SshKeyPairGenerator.Generate("connapse-generated");
+        await _server.AuthorizeKeyAsync(pair.PublicKeyLine);
+
+        using var connector = new SftpConnector(new SftpConnectorConfig
+        {
+            Host = _server.Host,
+            Port = _server.Port,
+            Username = SftpServerFixture.Username,
+            AllowedRoot = AllowedRoot,
+            Credential = new SftpCredential { PrivateKey = pair.PrivateKeyPem },
+        });
+
+        (await connector.ListFilesAsync()).Should().NotBeEmpty(
+            "a generated pair must authenticate, or the setup flow hands operators a key that "
+            + "silently does not work");
+    }
+
+    /// <summary>
+    /// The negative half. Without it the test above could pass because the server accepts
+    /// anything — the fixture's own key is already authorized, so a generated key that was
+    /// never really used would look identical.
+    /// </summary>
+    [Fact]
+    public async Task GeneratedKeyPair_NotInstalledOnTheServer_IsRefused()
+    {
+        var pair = SshKeyPairGenerator.Generate("never-installed");
+
+        using var connector = new SftpConnector(new SftpConnectorConfig
+        {
+            Host = _server.Host,
+            Port = _server.Port,
+            Username = SftpServerFixture.Username,
+            AllowedRoot = AllowedRoot,
+            Credential = new SftpCredential { PrivateKey = pair.PrivateKeyPem },
+        });
+
+        Func<Task> act = () => connector.ListFilesAsync();
+
+        await act.Should().ThrowAsync<Exception>();
+    }
+
     // ── Host key pinning ───────────────────────────────────────────────────
 
     /// <summary>Records what was pinned, so a test can assert on it.</summary>
@@ -412,4 +469,5 @@ public class SftpConnectorIntegrationTests : IAsyncLifetime
         return store.Recorded.Single().Fingerprint;
     }
 }
+
 

--- a/tests/Connapse.Integration.Tests/SftpConnectorIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SftpConnectorIntegrationTests.cs
@@ -1,7 +1,9 @@
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
+using System.Text;
 using Connapse.Storage.Connectors;
+using Renci.SshNet;
 using FluentAssertions;
 using Xunit;
 
@@ -340,6 +342,41 @@ public class SftpConnectorIntegrationTests : IAsyncLifetime
     }
 
     /// <summary>
+    /// The restrictions the setup command installs must not break the thing they protect.
+    /// </summary>
+    /// <remarks>
+    /// <c>restrict</c> plus a forced <c>internal-sftp</c> command is what stops the stored key
+    /// being usable for an interactive shell or port forwarding. It is also exactly the kind of
+    /// hardening that silently locks out the legitimate user — so this installs the key the way
+    /// the generated script does, prefix and all, and proves SFTP still works through it.
+    /// <para>
+    /// This covers the failure that would actually be ours: an option OpenSSH does not accept
+    /// makes the whole entry invalid and nothing authenticates. That it also <i>enforces</i> the
+    /// restriction is OpenSSH's contract, and is not asserted here — a test for it was written
+    /// and removed, because <c>atmoz/sftp</c> gives the account no shell to begin with, so it
+    /// passed identically with the restrictions stripped out and proved nothing.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task RestrictedKeyEntry_StillAuthenticatesAndLists()
+    {
+        var pair = SshKeyPairGenerator.Generate("connapse-restricted");
+        await _server.AuthorizeKeyAsync(SftpHostSetup.KeyRestrictions + pair.PublicKeyLine);
+
+        using var connector = new SftpConnector(new SftpConnectorConfig
+        {
+            Host = _server.Host,
+            Port = _server.Port,
+            Username = SftpServerFixture.Username,
+            AllowedRoot = AllowedRoot,
+            Credential = new SftpCredential { PrivateKey = pair.PrivateKeyPem },
+        });
+
+        (await connector.ListFilesAsync()).Should().NotBeEmpty(
+            "the hardening must not lock out the access it exists to bound");
+    }
+
+    /// <summary>
     /// The negative half. Without it the test above could pass because the server accepts
     /// anything — the fixture's own key is already authorized, so a generated key that was
     /// never really used would look identical.
@@ -532,5 +569,7 @@ public class SftpConnectorIntegrationTests : IAsyncLifetime
         return store.Recorded.Single().Fingerprint;
     }
 }
+
+
 
 

--- a/tests/Connapse.Integration.Tests/SftpConnectorIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SftpConnectorIntegrationTests.cs
@@ -363,6 +363,69 @@ public class SftpConnectorIntegrationTests : IAsyncLifetime
         await act.Should().ThrowAsync<Exception>();
     }
 
+    // ── Verified first use ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// The check that keeps the setup wizard honest, and the one most likely to break without
+    /// anyone noticing.
+    /// </summary>
+    /// <remarks>
+    /// The generated setup command reads the fingerprint with <c>ssh-keygen -l</c> on the host
+    /// and the operator pastes it into Connapse. If that format ever disagreed with what
+    /// <see cref="SshHostKeyPolicy"/> stores, every wizard-configured connection would refuse
+    /// to connect — or worse, silently fall back to trusting whatever answered. Nothing else
+    /// compares the two sides.
+    /// </remarks>
+    [Fact]
+    public async Task FingerprintReadOnTheHost_MatchesWhatTheConnectorWouldRecord()
+    {
+        string fromTheHost = await _server.ReadHostKeyFingerprintAsync();
+        string fromTheConnector = await ObserveFingerprintAsync();
+
+        fromTheHost.Should().Be(fromTheConnector,
+            "the setup command and the connector must agree on the fingerprint format");
+    }
+
+    /// <summary>
+    /// The point of the round trip: with the fingerprint supplied out of band, the very first
+    /// connection is authenticated rather than trusted.
+    /// </summary>
+    [Fact]
+    public async Task PinSuppliedBeforeTheFirstConnect_IsHonouredOnThatConnect()
+    {
+        string fingerprint = await _server.ReadHostKeyFingerprintAsync();
+        var store = new RecordingHostKeyStore();
+
+        using var connector = Connect(
+            pinned: fingerprint, hostKeyStore: store, connectionId: Guid.NewGuid());
+
+        (await connector.ListFilesAsync()).Should().NotBeEmpty();
+
+        store.Recorded.Should().BeEmpty(
+            "nothing is trusted on first use when the pin was already known");
+    }
+
+    /// <summary>
+    /// The half that makes the above worth anything. A wrong fingerprint must stop the
+    /// <em>first</em> connection — if it only took effect from the second, the wizard would be
+    /// decoration.
+    /// </summary>
+    [Fact]
+    public async Task WrongPinSuppliedBeforeTheFirstConnect_RefusesThatConnect()
+    {
+        var store = new RecordingHostKeyStore();
+
+        using var connector = Connect(
+            pinned: "SHA256:aFingerprintFromSomewhereElse",
+            hostKeyStore: store,
+            connectionId: Guid.NewGuid());
+
+        Func<Task> act = () => connector.ListFilesAsync();
+
+        await act.Should().ThrowAsync<SftpHostKeyMismatchException>();
+        store.Recorded.Should().BeEmpty("a refused server must not have its key recorded");
+    }
+
     // ── Host key pinning ───────────────────────────────────────────────────
 
     /// <summary>Records what was pinned, so a test can assert on it.</summary>

--- a/tests/Connapse.Integration.Tests/SftpServerFixture.cs
+++ b/tests/Connapse.Integration.Tests/SftpServerFixture.cs
@@ -118,6 +118,23 @@ public sealed class SftpServerFixture : IAsyncLifetime
             + $"chmod 700 '{Home}/.ssh' && chmod 600 '{Home}/.ssh/authorized_keys'");
 
     /// <summary>
+    /// Reads the server's host key fingerprint the way the generated setup command does —
+    /// with <c>ssh-keygen -l</c>, on the machine itself, never over the network.
+    /// </summary>
+    /// <remarks>
+    /// This is the out-of-band channel that makes verified-first-use possible, so a test using
+    /// it is testing the real mechanism rather than a stand-in.
+    /// </remarks>
+    public async Task<string> ReadHostKeyFingerprintAsync()
+    {
+        string output = await ExecAsync(
+            "ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null "
+            + "|| ssh-keygen -lf /etc/ssh/ssh_host_rsa_key.pub");
+
+        return output.Split(' ', StringSplitOptions.RemoveEmptyEntries)[1].Trim();
+    }
+
+    /// <summary>
     /// Replaces the server's host keys and restarts sshd, so the next connection presents a
     /// different key. This is what a rekey looks like to a client, and what an interposition
     /// looks like too — the connector cannot tell them apart, which is the point of pinning.

--- a/tests/Connapse.Integration.Tests/SftpServerFixture.cs
+++ b/tests/Connapse.Integration.Tests/SftpServerFixture.cs
@@ -106,6 +106,18 @@ public sealed class SftpServerFixture : IAsyncLifetime
         ExecAsync($"chown root '{Home}{sftpPath}' && chmod 700 '{Home}{sftpPath}'");
 
     /// <summary>
+    /// Appends a public key to the account's <c>authorized_keys</c>, the way the generated
+    /// setup command does on a real host. Lets a test prove a Connapse-generated key pair
+    /// actually authenticates.
+    /// </summary>
+    public Task AuthorizeKeyAsync(string publicKeyLine) =>
+        ExecAsync(
+            $"mkdir -p '{Home}/.ssh' && "
+            + $"printf '%s\\n' '{publicKeyLine}' >> '{Home}/.ssh/authorized_keys' && "
+            + $"chown -R {Username} '{Home}/.ssh' && "
+            + $"chmod 700 '{Home}/.ssh' && chmod 600 '{Home}/.ssh/authorized_keys'");
+
+    /// <summary>
     /// Replaces the server's host keys and restarts sshd, so the next connection presents a
     /// different key. This is what a rekey looks like to a client, and what an interposition
     /// looks like too — the connector cannot tell them apart, which is the point of pinning.


### PR DESCRIPTION
Closes #395 and #392. Targets `feature/387-sftp-connection-form` (#389), which targets #388. Merge innermost first.

Part 2c of the SFTP epic. #388 built the connector, #389 made a connection creatable — this makes creating one require no terminal knowledge, and closes the gap you land in immediately afterwards when the source form offers no scope fields.

## Connect this computer

Its own entry point on the Connections tab, not a provider buried inside **Add connection**. The local case is the one most people want, and reaching it through a generic SFTP form means understanding SFTP first.

The flow is **two copy-pastes and no typing**:

1. Copy a generated command, run it on your machine.
2. Paste back the block it prints.
3. Pick a folder, test, create.

Username, home path, available drives and host key fingerprint all come from that pasted block, because the host is the only thing that knows them. Connapse cannot reach across to configure the machine — that boundary is why the container is worth running — so it does everything on both sides of it and writes the one command in the middle.

## The bonus: verified first use, not trust on first use

Because the fingerprint arrives **out of band**, read on the machine itself, the *first* connection is authenticated rather than trusted. That closes the standing weakness of TOFU at no extra cost to the operator, since they are already copying something back.

Leaving it blank still falls back to trust-on-first-use, so this makes the stronger path the easy one rather than making setup fail without it.

`FingerprintReadOnTheHost_MatchesWhatTheConnectorWouldRecord` is the test that keeps this honest: the setup command reads the fingerprint with `ssh-keygen -l`, the connector derives it from the key blob SSH.NET returns, and nothing else compares those two independent implementations. If they ever disagreed, every wizard-configured connection would refuse to connect — or worse, silently fall back to trusting whatever answered.

## Key generation (#392)

Connapse generates the pair; the private half goes straight into the encrypted column and is never rendered. That is not only easier than `ssh-keygen`, it is better: a pasted key is usually one the operator already has and uses elsewhere, while a generated one exists for a single connection, has never been on a clipboard, and is revoked by deleting the connection.

RSA 3072 rather than Ed25519, which would otherwise be the obvious choice — .NET exposes no Ed25519 primitive and SSH.NET's key generation does not cover it.

Unit tests check shape and safety, including that a newline in the comment cannot end the `authorized_keys` line and smuggle a second key, since connection names reach that field. They cannot tell you whether a real server accepts the encoding, so `GeneratedKeyPair_AuthenticatesAgainstARealServer` installs a generated public key into the `atmoz/sftp` container the way the setup command will, and connects with the private half — paired with a negative, because the fixture's own key is already authorized and the positive would otherwise prove nothing.

## The Windows trap this exists to avoid

For an account in the Administrators group, sshd ignores `~/.ssh/authorized_keys` entirely and reads `%ProgramData%\ssh\administrators_authorized_keys`, whose ACL it also insists on. Getting that wrong produces an authentication failure with nothing to explain it, and it is the most common way Windows SSH key setup fails.

The generated script branches on it — and asks the **group**, not the process token. Verified against a real machine: an account that *is* a member reports `False` from a token check when the process is not elevated, because UAC filters the SID out. Deciding on that alone would have written the key where sshd never looks, which is the exact trap the branch exists to prevent.

Also found by running it: reading the fingerprint threw `Permission denied` and killed the script *after* the key was installed. Now guarded — an empty fingerprint costs verified-first-use, not the connection.

## Any folder, not just under home

The first version confined the choice to a subpath of the home directory. That was accidental: Windows OpenSSH applies no chroot, so `/D:/CodeProjects` is a perfectly valid SFTP path, and the restriction ruled out where most people actually keep things.

The folder is now a full path. The setup command reports the account's drives so the UI can offer them as shortcuts, and a path pasted from Explorer — backslashes, bare drive letter — is converted. `NormaliseRemoteRoot` deliberately never uses `System.IO.Path`, which would apply the rules of the Linux container Connapse runs in to a path describing somebody else's Windows machine.

A drive root normalises to `/D:` rather than collapsing to `/`, which would silently widen a connection from one drive to the whole machine. Whole drives are still permitted — an administrator may mean it — but flagged, because a source can reach anything beneath its connection's root and Connapse indexes what it reads.

## Source scope fields for SFTP

Without this you can create the connection and then not create a source: `SourceForm.ToScopeJson` threw for the provider and the form rendered no fields.

Unblocked rather than new work — `SourceForm` and `SourceScopePreflight` live in #380, which only reached `main` recently.

Filesystem and SFTP share one case, which is why the scope was given the same shape when the provider was designed. The **preflight** does not share `CheckRoot` and must not: that path calls `PathConfinement` and `EvaluateRoot`, both of which touch the local disk and read the deployment's own allowed-roots setting — answers about the wrong machine. Against a remote path they resolve nothing and degrade to a lexical prefix check. The SFTP branch catches only what is wrong on its face, and the server decides the rest.

Traversal is refused per path *segment*, so a folder named `..config` is not mistaken for an escape.

## Two bugs this uncovered are not here

Testing this end to end surfaced #398 (source-owned documents could never be ingested, for **any** provider) and #400 (failed documents never retried, and hidden by the count). Neither is SFTP-specific and #398 affects S3 and Azure on `main` today, so both are in #403 against `main` rather than waiting behind an SFTP feature review.

## Verification

`dotnet build --no-incremental` — **0 warnings, 0 errors**.
`dotnet test --filter "Category=Unit"` — **1,052 passed, 0 failed**.
SFTP integration suite against a real OpenSSH container — **23 passed**, including the generated-key round trip and the fingerprint-format agreement.

Also run end to end against a real machine: connection created through the wizard, source scoped to `/D:/CodeProjects`, files listed over SFTP, ingested, and searchable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
