### PR TITLE
feat: SFTP source ingestion, with source-sync and reindex fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ Thumbs.db
 docs/plans/
 docs/v0.2.0-plan.md
 docs/v0.3.0-plan.md
+
+# Subagent-driven-development scratch (ledger, briefs, review packages)
+.superpowers/

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -219,7 +219,7 @@ A sync reconciles by absence: anything indexed but missing from the remote listi
 
 So a reconcile that would delete more than **both 10 documents and 10% of what the source has indexed** applies its additions and **withholds the deletions**, recording how many. The Sources page shows the count to administrators with an "Apply deletions" button.
 
-Two details worth knowing:
+Three details worth knowing:
 
 - **Additions still apply.** A source that trips the guard keeps ingesting, because a safety check that stops a source working is an outage.
 - **Approving re-runs the sync**, it does not replay the earlier list. If the remote recovered in the meantime, nothing is deleted.

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -168,6 +168,22 @@ Deleting a source removes its indexed documents. The external data is untouched.
 
 Containers have their own `POST /api/containers/{id}/sync`, which reconciles managed storage against the document table. It exists because objects can land in the bucket out of band; it does not talk to any external system.
 
+### Deletions are guarded
+
+A sync reconciles by absence: anything indexed but missing from the remote listing is treated as deleted. That inference is only as good as the listing — and a listing can come back empty *and successful*, from a narrowed bucket policy returning `200 OK` with no keys, or a directory that is temporarily unmounted.
+
+So a reconcile that would delete more than **both 10 documents and 10% of what the source has indexed** applies its additions and **withholds the deletions**, recording how many. The Sources page shows the count to administrators with an "Apply deletions" button.
+
+Two details worth knowing:
+
+- **Additions still apply.** A source that trips the guard keeps ingesting, because a safety check that stops a source working is an outage.
+- **Approving re-runs the sync**, it does not replay the earlier list. If the remote recovered in the meantime, nothing is deleted.
+- **Approving is a ceiling, not a licence.** It authorises up to the number you were shown. If the remote degraded further between reading the count and approving it, the larger set is withheld again and needs fresh approval — so a worsening outage cannot have the whole index applied on the strength of a smaller approval.
+
+The threshold is fixed and not configurable. Small sources are never blocked — losing five of five files applies immediately, since re-ingesting them is cheap.
+
+The guard bounds a single reconcile, not the source's history. A listing that persistently returns just under the threshold — say 9% missing every cycle — never trips it, and the index erodes a little on every sync.
+
 ---
 
 ## Why the split

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -47,6 +47,7 @@ There is no secret field on a connection form, because Connapse does not accept 
 - **S3** authenticates through the AWS default credential chain — an instance profile, an IRSA role, or an SSO session. `roleArn` optionally names a role to assume on top of that.
 - **Azure Blob** authenticates through `DefaultAzureCredential` — a managed identity, a workload identity, or a developer sign-in. `managedIdentityClientId` optionally selects a specific user-assigned identity.
 - **Filesystem** has no credential at all; it runs as whatever account the server runs as.
+- **SFTP** is the one exception, and it is a narrow one: an SSH private key, encrypted at rest with the same DataProtection machinery everything else uses. The rule this does not break is about **cloud identities** — an AWS access key or an Azure secret is a credential a cloud provider already offers a better answer for, and Connapse refuses to be the worse one. An SSH key for a machine you run has no such alternative.
 
 The consequence worth internalising: **rotating credentials is an operation you perform in AWS or Azure, and Connapse needs no involvement.** There is nothing stored here to rotate.
 
@@ -79,6 +80,20 @@ The consequence worth internalising: **rotating credentials is an operation you 
   "allowedRoot": "/srv/knowledge"
 }
 ```
+
+**SFTP**
+
+```json
+{
+  "host": "files.example.com",
+  "port": 22,
+  "username": "connapse",
+  "allowedRoot": "/srv/knowledge",
+  "hostKeyFingerprint": "SHA256:…"
+}
+```
+
+`hostKeyFingerprint` is not typed. Connapse records it on the first successful connection and refuses every later one that does not match — see [Host keys](#host-keys).
 
 ### The two allowlists
 
@@ -115,6 +130,35 @@ Two limits an operator has to handle outside Connapse, because no path check can
 
 Run the server under a low-privilege account, and keep configuration and the DataProtection key ring outside every configured root.
 
+### SFTP confinement
+
+An SFTP source's `subPath` is confined the same way, with one difference that matters: **resolution happens on the server.**
+
+`allowedRoot` names a directory on a machine that is not the one running Connapse, so resolving it locally would answer a question about the wrong filesystem — and answer it permissively, because a remote path almost never exists locally and a link check that finds nothing reports no link. That degrades confinement to a string-prefix comparison, which is exactly the bug [#365](https://github.com/Destrayon/Connapse/issues/365) fixed for local paths.
+
+So SFTP paths are canonicalised through the protocol's own `SSH_FXP_REALPATH`, and `..` segments and symlinks collapse where they actually mean something before the comparison.
+
+Two related rules:
+
+- **Symlinks are stepped over during the walk, never followed.** A link inside the root whose target is outside it would otherwise pull that target into the index.
+- **A directory that cannot be read fails the whole sync**, rather than contributing nothing to the listing. This matters more than it looks: to the reconcile, a listing that quietly omits a subtree is indistinguishable from every file in it having been deleted. The [deletion guard](#deletions-are-guarded) bounds that damage, but it should not have to.
+
+`allowedRoot` for SFTP is **not** checked against `Sources:Security:AllowedFilesystemRoots`. That setting names directories on the server's own disk; an SFTP root names one on somebody else's.
+
+### Host keys
+
+SSH's protection against somebody else answering on your server's address is the host key, and it only helps if a changed key is noticed.
+
+Connapse **trusts the first key it sees and pins it.** Every later connection compares against the stored fingerprint and refuses on mismatch, naming both keys. The fingerprint is shown on the connection in the format `ssh-keygen` prints, so it can be checked against the server directly:
+
+```bash
+ssh-keyscan files.example.com | ssh-keygen -lf -
+```
+
+Trust-on-first-use does not authenticate the *first* connection — that is its standing trade-off, and the reason the fingerprint is displayed rather than hidden. What it does catch is the realistic case: an address that has been working for months starts answering with a different key.
+
+**If you rekey the server yourself**, syncing stops with a mismatch error. Clear the recorded fingerprint on the connection — the "Forget" control beside it — and the next connection pins the new key.
+
 ---
 
 ## Sources
@@ -137,6 +181,7 @@ Scope keys by provider:
 | S3 | `bucketName`, `prefix` |
 | Azure Blob | `containerName`, `prefix` |
 | Filesystem | `subPath`, `includePatterns`, `excludePatterns` |
+| SFTP | `subPath`, `includePatterns`, `excludePatterns` |
 
 ### API
 
@@ -185,6 +230,25 @@ The threshold is fixed and not configurable. Small sources are never blocked —
 The guard bounds a single reconcile, not the source's history. A listing that persistently returns just under the threshold — say 9% missing every cycle — never trips it, and the index erodes a little on every sync.
 
 ---
+
+## Indexing files on your own machine
+
+The Filesystem connector needs the server process to see a path on its own disk. In Docker the container's filesystem is not yours, and on a hosted deployment there is no shared disk at all — so "point Connapse at my Documents folder" has no answer through that connector.
+
+SFTP is the answer. Run an SSH server on the machine holding the files and let Connapse connect to it.
+
+1. **Enable an SSH server.** OpenSSH Server is an optional feature on Windows, Remote Login on macOS, `sshd` on Linux.
+2. **Add a public key** to that account's `authorized_keys`, and give Connapse the matching private key.
+3. **Create an SFTP connection** under Settings → Connections, pointing at the machine with an `allowedRoot` of the folder you want reachable.
+4. **Create a source** on that connection naming a `subPath` within it.
+
+Three things worth knowing before you spend an hour on them:
+
+- **Windows OpenSSH presents paths with a leading slash before the drive letter** — `/C:/Users/you/Documents`, not `C:\Users\you\Documents`. Write `allowedRoot` that way.
+- **`host.docker.internal` is Docker Desktop only.** From a container on Docker Desktop, that name reaches the host. On a Linux host, add `--add-host=host.docker.internal:host-gateway`. On a remote deployment it does not apply at all — the server needs a real address it can reach, and making the machine reachable is your problem, not Connapse's.
+- **It is list-and-diff on every poll.** SFTP has no change notification, so each cycle walks the tree. Point a source at a folder, not a whole drive; at a hundred thousand files a scan is minutes.
+
+The Filesystem connector is unchanged and remains the better choice when the server genuinely does share a disk with the data — it is cheaper and it supports live watching.
 
 ## Why the split
 

--- a/docs/research/docker-local-filesystem-access-2026-08-23.md
+++ b/docs/research/docker-local-filesystem-access-2026-08-23.md
@@ -6,7 +6,7 @@
 
 ## Why this is a second report
 
-The earlier research asked *"which pull protocol should Connapse speak?"* and recommended SFTP for the local case. That framing had already ruled out mounting the host's disk into the container — brainstorming rejected bind mounts as "a security concern and poor UX" before any research began, so every option surveyed was a network protocol by construction.
+The earlier research asked *"which pull protocol should Connapse speak?"* and recommended SFTP for the local case. Where the two disagree, that one still governs the phasing — S3 first, SFTP second, the Filesystem connector kept for single-host installs. This report only revisits how a container reaches the host's disk, and does not reorder anything. That framing had already ruled out mounting the host's disk into the container — brainstorming rejected bind mounts as "a security concern and poor UX" before any research began, so every option surveyed was a network protocol by construction.
 
 The new constraint — **everything must be configurable in the UI** — makes that exclusion worth re-testing rather than inheriting. A protocol needs a server and a credential set up per connection, forever. A mount is configured once and then never again. Against a "no terminal" requirement those trade in opposite directions, so the answer can change.
 
@@ -87,8 +87,10 @@ Concretely, mount the profile rather than a whole drive:
 ```yaml
     volumes:
       - appdata:/app/appdata
-      - C:/Users/Diviel:/mnt/host:ro
+      - ${CONNAPSE_HOST_ROOT}:/mnt/host:ro
 ```
+
+`CONNAPSE_HOST_ROOT` is whatever the operator wants exposed — `C:/Users/alice`, `/home/alice`, `D:/archive`. It is deliberately not a default: the right answer is specific to the machine, and a default here would either be wrong or expose more than the operator meant.
 
 `:ro` costs nothing, since Connapse never writes to a source, and removes an entire class of accident. Then set `Sources:Security:AllowedFilesystemRoots` to `/mnt/host` so the allowlist and the mount agree, and every connection is bounded twice.
 

--- a/docs/research/docker-local-filesystem-access-2026-08-23.md
+++ b/docs/research/docker-local-filesystem-access-2026-08-23.md
@@ -1,0 +1,175 @@
+# How should Connapse in Docker reach files on the operator's own machine?
+
+**Date:** 2026-08-23
+**Status:** Complete
+**Supersedes nothing.** Narrows a question [the earlier report](filesystem-ingestion-2026-08-23.md) answered under an assumption that no longer holds.
+
+## Why this is a second report
+
+The earlier research asked *"which pull protocol should Connapse speak?"* and recommended SFTP for the local case. That framing had already ruled out mounting the host's disk into the container — brainstorming rejected bind mounts as "a security concern and poor UX" before any research began, so every option surveyed was a network protocol by construction.
+
+The new constraint — **everything must be configurable in the UI** — makes that exclusion worth re-testing rather than inheriting. A protocol needs a server and a credential set up per connection, forever. A mount is configured once and then never again. Against a "no terminal" requirement those trade in opposite directions, so the answer can change.
+
+## The hard constraint
+
+**A container's filesystem namespace is fixed when the container is created.** Adding a bind mount to a running container means stopping it, removing it, and creating a new one with the full mount set ([docker/cli#5328](https://github.com/docker/cli/issues/5328), [moby#11105](https://github.com/moby/moby/issues/11105)). This is a property of how containers work, not a Docker limitation awaiting a feature.
+
+**Docker Desktop does not expose host drives automatically.** Verified directly: `docker run --rm alpine ls /` on this machine shows no `/host_mnt` and no host paths. Drive sharing in Docker Desktop settings makes a path *mountable*, not mounted.
+
+So no application running inside a container can grant itself access to a host path it was not given. Every solution is one of four families.
+
+## The four families
+
+### 1. Mount once at deployment, choose paths in the UI
+
+Mount a broad host path read-only when the container is created; afterwards every source is configured in the UI within it.
+
+This is what comparable self-hosted products do, and [Immich's external library flow](https://oneuptime.com/blog/post/2026-03-20-photo-gallery-portainer/view) is the closest match to Connapse's model: uncomment an optional bind mount, then add the path in the admin panel and scan. [Paperless-ngx](https://docs.paperless-ngx.com/setup/) is the same shape — the consumption directory is a compose volume, and everything else is application configuration.
+
+It maps onto Connapse's existing split without inventing anything:
+
+| Layer | Who sets it | Connapse concept |
+|---|---|---|
+| What the container can see at all | Deployment, once | the bind mount |
+| Which roots an admin may name | `Sources:Security:AllowedFilesystemRoots` | connection `allowedRoot` |
+| Which subtree gets indexed | Admin, in the UI, any number of times | source `subPath` |
+
+**Cost:** one line in `docker-compose.yml` and a `docker compose up -d`. No new code, no credential of any kind, no server on the host.
+
+### 2. Speak a network protocol to a server on the host
+
+SFTP, SMB, or WebDAV. Nothing in the container's configuration changes; the host runs a server and Connapse authenticates to it.
+
+Covered in depth by the earlier report. The relevant update is what is **already true on this machine** (all verified directly):
+
+| | Status |
+|---|---|
+| `sshd` service | **Running**, automatic start |
+| `Subsystem sftp` | **Configured** (`sftp-server.exe`) |
+| `PubkeyAuthentication` | **yes** |
+| `authorized_keys` | **Present**, both user and administrators paths |
+| Port 22 from a container | **Open** via `host.docker.internal` |
+| `LanmanServer` (SMB) | **Running**, shares `C$`, `D$`, `ADMIN$` |
+| Port 445 from a container | **Open** |
+
+SFTP is therefore about one step from working here: generate a key pair and add the public half to `authorized_keys`. [#392](https://github.com/Destrayon/Connapse/issues/392) removes the terminal from the first half of that.
+
+**SMB is worse here despite being equally reachable.** The shares that exist are `C$` and `D$`, which are administrative shares — reaching them means storing a Windows *administrator* password. SMBLibrary is also NTLM-only and LGPL-3.0. Trading an SSH key scoped to one account for an administrator password is a clear downgrade.
+
+### 3. Push from the host to Connapse
+
+An agent, a sync tool, or the existing upload UI. The earlier report rejected a purpose-built agent on distribution and signing cost, and that stands.
+
+Worth noting the honest zero-infrastructure member of this family: **Connapse already accepts uploads into managed containers through the UI.** That is fully UI-driven with nothing to install. It is copy-in rather than sync — files do not track changes on disk — but for a fixed corpus it is the shortest path that exists today.
+
+### 4. Do not run Connapse in a container
+
+If Connapse runs natively on the machine holding the files, the Filesystem connector works with real paths. No mount, no server, no credential, no key.
+
+This deserves stating plainly because the entire problem is an artefact of the deployment choice. For a single-user local install it is the simplest answer available, and it is the one configuration where "point it at a folder" needs nothing else at all.
+
+## The tempting answer, and why it is wrong
+
+The obvious way to make mounts UI-configurable is to give Connapse the Docker socket so it can recreate its own container with new mounts.
+
+**Do not do this under any circumstances.** Access to `/var/run/docker.sock` is [root-equivalent on the host](https://www.netdata.cloud/guides/docker/docker-socket-security/): anything that can talk to the daemon can create a container that mounts `/` and execute as root. Mounting the socket read-only does not help, because the restriction is on the filesystem handle and not on the API it exposes.
+
+The mount boundary exists to stop a compromised Connapse reading arbitrary host files. Handing Connapse the ability to move that boundary hands it root on the machine — strictly worse than the exposure it was meant to bound. **This is the principled reason the mount stays a deployment concern: it is the one decision the application must not be able to make about itself.**
+
+## Recommendation
+
+**For the local case, mount once and read-only. For the remote case, SFTP.** They are not competitors; they answer different questions.
+
+The "everything in the UI" requirement is satisfied in the sense that matters: **all recurring work is in the UI.** Adding a source, changing a subpath, adding a second folder inside the mount, excluding a pattern — every one of those is a UI action. What remains outside is a single line set once at install, and it is outside precisely because it is the security boundary.
+
+Concretely, mount the profile rather than a whole drive:
+
+```yaml
+    volumes:
+      - appdata:/app/appdata
+      - C:/Users/Diviel:/mnt/host:ro
+```
+
+`:ro` costs nothing, since Connapse never writes to a source, and removes an entire class of accident. Then set `Sources:Security:AllowedFilesystemRoots` to `/mnt/host` so the allowlist and the mount agree, and every connection is bounded twice.
+
+**SFTP is still worth finishing**, and not as a consolation. It is the only option in the list that works when the files are on a machine Connapse does not share hardware with — a NAS, a work laptop, a hosted deployment — and on this machine it is one paste away from working.
+
+## What Connapse should change
+
+1. **Ship the bind mount commented out in `docker-compose.yml`**, with the target path and `:ro` already written, exactly as Immich does. This turns the one-time step from "know that this is possible and write it correctly" into "uncomment a line". Filed as [#393](https://github.com/Destrayon/Connapse/issues/393).
+2. **Say this in `docs/connectors.md`.** The document currently explains that the Filesystem connector needs a shared disk without telling anyone how to arrange one.
+3. **Finish [#392](https://github.com/Destrayon/Connapse/issues/392)** so the SFTP path needs no terminal either.
+
+## Addendum — optimising for operator setup cost
+
+The first pass asked what *works*. This pass asks what costs the operator least, which turns out to have a different answer, because the browser is a route none of the four families covers.
+
+### The category has not solved this, and says so out loud
+
+[AnythingLLM](https://docs.anythingllm.com/installation-docker/overview) is the closest comparable product, and it ships **two builds**: a desktop app — one-click, single-user, direct filesystem access, no configuration — and a Docker build for teams that adds roles and access control. The split is not accidental. Their Docker users have been asking for exactly this since at least [#1873](https://github.com/Mintplex-Labs/anything-llm/issues/1873) and [#4877](https://github.com/Mintplex-Labs/anything-llm/issues/4877) (watch folders), and the community answer is a [third-party Python sync script](https://github.com/dastra/anythingllm-document-sync).
+
+The instructive one is [#3640](https://github.com/Mintplex-Labs/anything-llm/issues/3640): a user who **already mounted their NAS into the container** and still could not use it, because the UI offered no way to point at an existing directory. Their native sync feature watches individual files and [cannot watch a directory at all](https://docs.anythingllm.com/beta-preview/active-features/live-document-sync).
+
+**Connapse is ahead of this, not behind it.** The connection/source split already expresses "here is a root, index this subtree of it" — the exact thing #3640 wanted and could not find. What is missing is only the mount, and the documentation for it.
+
+### The route none of the four families covers: the browser
+
+The container cannot see the host's disk, but **the operator's browser can**, and it is already talking to Connapse.
+
+**`<input type="file" webkitdirectory>`** lets a user pick a whole folder from a native dialog; the browser then hands over every file beneath it, with the relative path on each as `webkitRelativePath`. It reached [Baseline in 2025](https://caniuse.com/input-file-directory) and works in Chrome, Edge, Firefox, and Safari 11.1+ — everything except iOS Safari. There is no permission API, no flag, and nothing to install.
+
+**Setup cost: none.** Not "one line in a compose file" — actually none. The operator opens Connapse, clicks a button, picks a folder.
+
+Connapse is most of the way there already and does not know it. `wwwroot/js/fileDrop.js` uploads via `fetch()` and `FormData`, which is the right shape — but it reads `e.dataTransfer.files`, so **dropping a folder does not work today**. Directory drops need `webkitGetAsEntry()` and a recursive walk; folder *picking* needs the attribute above. Both are small, and both feed the upload path that already exists.
+
+**What it does not do is stay in sync.** This is an import, into a managed container, and refreshing means importing again. That is a real limitation and it is also the honest shape of the thing: once the bytes are uploaded, Connapse owns them, which is exactly what a container is. It suits "index my documents" and does not suit "mirror a folder that changes".
+
+Practical ceiling: this is a browser upload, so a few thousand files is comfortable and a hundred thousand is not.
+
+### The File System Access API, and why not
+
+[`showDirectoryPicker()`](https://developer.chrome.com/docs/capabilities/web-apis/file-system-access) is the more powerful version — a directory handle that can be stored in IndexedDB and re-used, with [persistent permissions since Chrome 122](https://developer.chrome.com/blog/persistent-permissions-for-the-file-system-access-api) that survive a browser restart. It would allow genuine re-sync with no setup.
+
+**It is the wrong fit anyway, for a reason that has nothing to do with browser support.** Connapse syncs from a background service on a timer. A directory handle only lives in a page — so a source backed by one can only reconcile while somebody has the tab open, and Chrome auto-revokes on tab backgrounding besides. A "source" that silently stops syncing when you close the tab is worse than an import that never claimed to.
+
+It is also Chromium-only (no Firefox, no Safari), where `webkitdirectory` is Baseline. More work, narrower support, and a sync model that does not match the product.
+
+### Revised recommendation
+
+Three answers for three shapes of need, and the cheapest one covers most people:
+
+| Need | Answer | Operator setup |
+|---|---|---|
+| "Get my documents in" | **Folder upload in the browser** | **None** |
+| "Mirror a folder that keeps changing" | Bind mount, read-only | One line, once |
+| "Files are on another machine" | SFTP | SSH server + key |
+| Single machine, no Docker wanted | Native install | None; connector works as-is |
+
+**Build the folder upload.** It is the smallest change of the four, it needs nothing from the user, it works in every desktop browser, and it reuses an upload path that already exists. Filed as [#394](https://github.com/Destrayon/Connapse/issues/394).
+
+The mount stays the answer for continuous sync and should be [shipped commented-out](https://github.com/Destrayon/Connapse/issues/393) so it is an uncomment rather than a thing to know. SFTP stays the answer for another machine. And AnythingLLM's split is worth taking seriously as positioning: **Docker is the deployment for teams and servers; a single user indexing their own laptop has a simpler option, and Connapse should say so rather than making them fight the container.**
+
+## What this does not solve
+
+- **Files on a machine that is off, asleep, or behind NAT.** Unchanged from the earlier report, and still deliberately the operator's problem.
+- **A mount is as broad as you make it.** Mounting `C:/` gives every source in Connapse a potential view of the whole drive, bounded only by `AllowedFilesystemRoots`. The narrower the mount, the less the allowlist has to carry.
+- **Changing which folder is mounted still requires a container recreate.** Choosing a *sub*path does not. Mount broadly enough that the sub-path choice is the one you actually make.
+
+## Verification log
+
+Everything asserted about this machine was checked rather than assumed:
+
+- `docker run --rm alpine ls /` — no host paths, no `/host_mnt`.
+- `nc -z host.docker.internal 22 / 445 / 139` from a container — 22 open, 445 open, 139 closed.
+- `Get-Service sshd, LanmanServer` — both Running, both Automatic.
+- `Get-SmbShare` — `ADMIN$`, `C$`, `D$`, `IPC$`.
+- `sshd_config` — `PubkeyAuthentication yes`, `Subsystem sftp sftp-server.exe`, `PasswordAuthentication yes`, administrators override present.
+- `authorized_keys` present at both the user and administrators locations.
+
+## Sources
+
+- [docker/cli#5328](https://github.com/docker/cli/issues/5328), [moby#11105](https://github.com/moby/moby/issues/11105) — mounts cannot be added to a running container
+- [Docker bind mounts documentation](https://docs.docker.com/engine/storage/bind-mounts.md)
+- [Docker socket security](https://www.netdata.cloud/guides/docker/docker-socket-security/), [The Dangers of Docker.sock](https://raesene.github.io/blog/2016/03/06/The-Dangers-Of-Docker.sock/)
+- [Paperless-ngx setup](https://docs.paperless-ngx.com/setup/), [Immich external libraries via Portainer](https://oneuptime.com/blog/post/2026-03-20-photo-gallery-portainer/view)
+- [Earlier report: filesystem ingestion](filesystem-ingestion-2026-08-23.md) — protocol comparison, SMBLibrary licence and NTLM limits

--- a/docs/research/filesystem-ingestion-2026-08-23.md
+++ b/docs/research/filesystem-ingestion-2026-08-23.md
@@ -1,0 +1,193 @@
+# How should Connapse ingest files from local and remote filesystems?
+
+**Date:** 2026-08-23
+**Status:** Reviewed (adversarial pass applied — see *Corrections after review*)
+**Built on:** no prior corpus material — the Connapse MCP server was not connected to this session, so no corpus pre-check ran.
+
+## Executive summary
+
+**Connapse should stop trying to read filesystems directly and instead read S3-compatible object storage — but this is real work, not a free win.** The current Filesystem connector requires the server process to see a path on its own disk, which is false in Docker and false again on any hosted deployment. S3-compatible endpoints are the only transport surveyed with all four properties Connapse needs at once: authentication with no stored long-lived secret, a complete paginated listing that is an *authoritative* snapshot (so absence genuinely means deleted), pure outbound HTTPS from a container, and scale (a 1,000-key page cap puts 100k objects at ~100 requests).
+
+**The recommendation rests on those correctness properties, not on implementation cost.** An earlier draft of this report claimed Connapse "already has the connector" and the change "costs almost no new code." That was false, and verifying it is what produced this version: `S3ConnectorConfig` exposes only `BucketName`, `Region`, `Prefix` and `RoleArn` — **no endpoint field** — and `S3Connector.CreateS3Client` constructs `new AmazonS3Client(region)` without ever setting `ServiceURL` or `ForcePathStyle`. **Connapse's S3 connector can only talk to real AWS S3 today.** The LocalStack integration test passes only because `LocalStackFixture` sets a *process-wide* `AWS_ENDPOINT_URL_S3` environment variable, which cannot vary per connection and would redirect every S3 connection in the process. Phase 1 is therefore a genuine feature: per-connection endpoint and path-style support, plus web-identity STS.
+
+**What this does not solve, stated plainly: none of the recommended transports reaches a laptop.** S3, SFTP and Graph all require the server to reach the source. A machine behind NAT with only outbound connectivity — which is the original complaint about Docker isolation, generalised — needs a tunnel, a publicly reachable endpoint, or an agent. Running MinIO in front of a folder does not change the direction of the connection. See *What this recommendation does not solve*.
+
+**The most consequential finding is not about transport.** The maintainer proposed letting editors create sources inside admin-created connections. That must not ship until the allowlists are deny-by-default. Connapse *indexes content and makes it searchable*, so an editor choosing a scope inside somebody else's credential converts "the admin holds a broad credential" into "an editor can grep everything that credential can reach." Snowflake — the closest analogue — makes its allowlist a **required** parameter for exactly this reason.
+
+## Research brief
+
+**Question:** What mechanism(s) should Connapse use to ingest files from filesystems the server cannot directly access — local, networked, and remote — given that an admin owns the trust boundary and no long-lived secrets may be stored?
+
+**Sub-questions:**
+1. Server-reachable pull protocols — SFTP/SSH, SMB/CIFS, WebDAV, NFS, S3-compatible.
+2. Push-based agents for machines the server can never reach.
+3. Existing tools — rclone, Syncthing, cloud drive APIs, purpose-built ingestion tools, .NET abstraction libraries.
+4. Trust and delegation — does the connection/source split hold if editors may create sources? Plus safe delete semantics as a cross-cutting concern.
+
+**Out of scope:** S3 and Azure Blob as already-shipped *cloud* connectors; any design requiring stored cloud credentials; Connapse as an OIDC provider; making sources browsable; ingestion pipeline internals. The browser File System Access API was dropped during elicitation because it produces a copy Connapse owns — a container, not a mirror — and therefore answers a different question. It is out of scope rather than rejected on merit.
+
+**Success criteria:** one recommended primary mechanism with a phased path, its security model spelled out, and an explicit rejected-options list with reasons.
+
+## Findings by sub-question
+
+### Sub-question 1 — Server-reachable pull protocols
+
+**Claim: of SFTP, SMB, WebDAV, NFS and S3-compatible, S3-compatible has the best property set for a read-only mirror; NFS is disqualified outright for containerised deployment.**
+
+**S3-compatible endpoints** (MinIO, Ceph, Garage, Backblaze B2, Wasabi) via first-party `AWSSDK.S3`. Change detection is unusually cheap because `ListObjectsV2` returns key, ETag, size and LastModified *in the listing itself* — no per-file stat call. Delete detection is the strongest of the five: a paginated listing that ran to `IsTruncated: false` is an authoritative snapshot, so absence genuinely means deleted. Contrast SFTP or SMB, where a half-failed directory walk is indistinguishable from a mass deletion. **Two caveats the raw comparison hides:** a bucket policy that narrows `ListBucket`, credentials expiring mid-pagination, or versioned buckets with delete markers can all produce a *shorter* listing rather than an error — so "complete listing" must mean "pagination confirmed complete *and* no error at any page," and even then the delete-safety layer below is required. And ETag is not an MD5 for multipart or SSE-KMS objects.
+
+On authentication, MinIO supports `AssumeRoleWithWebIdentity`, exchanging an OIDC JWT for credentials expiring in roughly an hour (primary: MinIO STS docs). **This has an unstated prerequisite worth surfacing: it requires an OIDC issuer, and Connapse is deliberately not one.** The JWT must come from the operator's own identity provider — Keycloak, Entra ID, Auth0 — configured against MinIO. That is an operator prerequisite, not something Connapse supplies. Where no IdP exists, this degrades to a stored access key, which the constraints forbid; the honest fallback is a short-lived key injected as a container secret.
+
+**SFTP** is the viable second. Authentication is the cleanest of any protocol here: an SSH private key mounted as a Docker or Kubernetes secret file, loaded by SSH.NET from a stream, never touching the database. It is fully user-space over outbound TCP/22 — no mounts, no capabilities. The weaknesses are real but tolerable: the protocol has *no* change notification whatsoever, so `SSH_FXP_READDIR` plus mtime/size comparison is the only option, and round-trip cost dominates at scale — 100k files means tens of thousands of round-trips, minutes per scan. Acceptable nightly, painful at a 15-minute poll. Elasticsearch's FSCrawler ssh provider does exactly this and exposes `remove_deleted` (default true), warning that with `index_folders: false` it cannot detect removed folders at all (primary: FSCrawler docs).
+
+**The SSH.NET advisory in Connapse's dependency tree resolves benignly.** `GHSA-q939-rpr3-3284` is CVE-2026-48798, CVSS 7.1 High: a path traversal in `ScpClient.Download()`'s recursive mode where a malicious server returns filenames containing `../`. It affects ≤ 2025.1.0 and is patched in 2026.0.0. It is in the **SCP** client, not SFTP, so an SFTP-only connector never touches the vulnerable code path. (Verified independently against this repository: SSH.NET arrives only transitively via Testcontainers, in the integration test project, and no Connapse code calls SCP.)
+
+**SMB/CIFS** is possible but compromised on the constraint that matters most. SMBLibrary 1.5.7.1 is user-mode — a genuine win, since no kernel mount means no `CAP_SYS_ADMIN` — but it supports **NTLM only**; Kerberos/SPNEGO remains an open issue, not shipped. That forces storing a username and password, directly violating the no-long-lived-secret rule unless scoped to a dedicated read-only service account. It is also LGPL-3.0-or-later, warranting a licence review. SMB2 CHANGE_NOTIFY exists in the protocol and Nextcloud uses it, but Nextcloud's documentation states it "only works reliably on Windows SMB servers due to limitations of linux based SMB servers," and they still fall back to a cron `files:scan`.
+
+**WebDAV wins one dimension outright and is the strongest candidate this report does *not* place in the phased plan.** RFC 6578 `sync-collection` is the only protocol surveyed with a real change feed: the server returns a `DAV:sync-token`, and subsequent REPORTs return only added, changed, and *deleted* member URLs — deletions become explicit events rather than inferred absence, which solves the hardest problem properly. Authentication is good too: bearer tokens or mTLS over HTTPS. **It is excluded on library support, not on protocol merit:** the available .NET clients (`WebDav.Client`, `WebDAVClient`) implement none of `sync-collection`, so the REPORT and token handling would be hand-rolled, and server support is optional so the fallback path (plain PROPFIND, which RFC 6578 §1 says "doesn't scale well") must be built anyway. That is two implementations for one transport. It is a defensible candidate for a later phase and should be reconsidered if a maintained .NET `sync-collection` client appears, or if Nextcloud/ownCloud become a common deployment target.
+
+**NFS should be dropped.** Creating a mount in a non-initial user namespace is disallowed for NFS, requiring `CAP_SYS_ADMIN` or `--privileged` plus host kernel modules (primary: moby#16429, podman#20717). No mature user-space NFS client exists for .NET. It fails the library, authentication, and Docker dimensions simultaneously.
+
+### Sub-question 2 — Push-based agents
+
+**Claim: the architecture is well-understood and convergent, but the distribution cost makes it a second product rather than a feature. This leaves the unreachable-machine case genuinely unsolved — see *What this recommendation does not solve*.**
+
+**Every production agent converges on the same three parts**: a local durable state store, a scanner, and an outbound-only shipper with acknowledged delivery. Filebeat keeps a *registry file* of per-file read offset plus a unique file identifier — explicitly because "the filename and path are not enough to identify a file" — flushes continuously, and resumes from the registry on restart, giving at-least-once and never exactly-once (primary: Elastic docs).
+
+**Dropbox's sync-engine rewrite is the strongest cautionary tale, and its lesson is about the data model, not the transport.** The old engine's failure was that files "lacked a stable identifier that would be preserved across moves," so a move was represented as delete-plus-add; a transient hiccup where "a delete goes through but its corresponding add does not" makes the file vanish everywhere (primary: dropbox.tech). **Stable file IDs rather than paths are the load-bearing decision** for any mirror — and this applies to Connapse's *pull-based* sources just as much as to an agent, which makes it the most transferable finding in this section.
+
+**Enrollment is a solved problem that needs no identity provider.** Elastic Fleet's pattern transfers directly: an admin mints an enrollment token bound to a policy, the agent presents it once, and the server returns a *distinct per-agent* communication API key. Revoking the enrollment token stops new enrollments but already-enrolled agents keep working — so revocation and unenrollment are separate operations, a distinction Tailscale's auth-key docs make just as explicitly. The stolen-laptop answer is therefore: short-lived enrollment token → long-lived per-agent credential → server-side per-agent kill switch. **RFC 8628 device authorization grant is a poor fit** and should be skipped: it explicitly treats devices as public clients that "cannot securely store credentials," and contains no guidance on device credential revocation at all.
+
+**Nobody trusts the filesystem watcher.** All three platform APIs are documented-unreliable: Windows `FileSystemWatcher.InternalBufferSize` defaults to 8 KB and caps at 64 KB, and on overflow "loses track of changes in the directory"; macOS FSEvents coalesces *hierarchically* and can demand a full recursive rescan via `kFSEventStreamEventFlagMustScanSubDirs`; Linux inotify defaults to 8192 watches and fails outright with no fallback when exceeded. Syncthing's resolution is the one to copy — a full rescan hourly *even when the watcher is running*, every minute when it is not. **Treat the watcher as a latency optimisation over an authoritative periodic scan, never as the source of truth.** This finding also applies to the *existing* Filesystem connector, which is watcher-based.
+
+**Distribution cost is the disqualifier.** Native AOT supports the three platforms but each target requires a native toolchain *on that OS*, so a three-platform CI matrix is mandatory; the build image also sets the glibc floor. Signing is a recurring tax: since June 2023 the CA/Browser Forum requires OV code-signing keys on FIPS 140 Level 2 hardware. macOS requires a Developer ID certificate, hardened runtime, notarization and stapling. Auto-update is its own subsystem — Elastic's minimum viable shape is a separate watcher process supervising the new version for ten minutes with automatic rollback. *(One frequently-cited additional cost — that the EV certificate SmartScreen bypass was removed in 2024, leaving no way to avoid cold-start warnings per release — rests on a search summary rather than a Microsoft primary document and should be verified before it informs a decision. The rejection stands on the toolchain and notarization costs without it.)* Note the existing `connapse-cli` distribution route (`dotnet tool install -g`) does not help, since it requires the .NET SDK on the target — fine for developers, wrong for a daemon on a file server.
+
+### Sub-question 3 — Existing tools
+
+**Claim: rclone is MIT rather than MPL, which materially improves its viability; Microsoft Graph is the only cloud-drive API that satisfies the no-stored-credentials rule.**
+
+**rclone's licence was mis-assumed in the brief.** Its `COPYING` is the **MIT License**, not MPL (primary: rclone repo). Bundling the binary or linking `librclone` therefore carries only attribution obligations. Any earlier reasoning that rejected rclone on licence grounds should be revisited.
+
+**`rclone serve s3` is the cheapest breadth play, with a significant caveat.** Pointing Connapse's S3 connector at an rclone S3 endpoint would reach 70+ backends for no new *connector* code — though note it still requires the per-connection endpoint support that Phase 1 adds, since that capability does not exist today. It supports S3v4 auth via `--auth-key` and TLS via `--cert`/`--key`. But the documentation marks it **Experimental**, it is unversioned, and **only mtime is persisted** — other metadata is memory-only. Betting read-only ingestion on an experimental server is the tradeoff to weigh. Credentials need not be stored: rclone accepts configuration entirely via environment variables or inline connection strings, `--config ""` keeps config in memory only, and the azureblob backend supports `env_auth`/`use_msi` for managed identity. rclone has **no change feed** — `sync` is a full listing diff every run.
+
+**Microsoft Graph is the strongest single finding in this sub-question.** `driveItem: delta` returns deleted items with an explicit `deleted` facet and hands back an `@odata.deltaLink` for incremental polling; the documentation states delta is the *only* way to guarantee a complete local representation. Because `Files.Read.All` is an **application** permission, a managed identity's service principal can hold it — client credentials, no secret, no refresh token, **no stored cloud credential**. This is the only cloud-drive candidate satisfying the hard constraint cleanly, and it matches the maintainer's existing Azure managed-identity posture. Caveat: Graph permissions are additive, so granting `Files.Read.All` alongside a narrower `Sites.Selected` defeats the narrower scope.
+
+**Google Drive** has solid delete detection (`changes.list` with `includeRemoved=true`) but a worse credential story — keyless only when running on GCP with an attached service account, otherwise a JSON key file. **Dropbox is not viable under the constraints**: long-lived tokens are deprecated, offline access requires storing a refresh token, and there is no app-only or service-account path.
+
+**Syncthing is the right auth model attached to the wrong problem shape.** Device IDs are certificate fingerprints, so no central identity provider is needed — genuinely aligned with "Connapse is not an OIDC provider" — and `receiveonly` folders exist and behave correctly. But it requires a peer on every source machine, which is an agent by another name, and it is a bidirectional sync engine coerced into read-only ingestion. MPL-2.0, actively maintained. *(Worth noting against the agent rejection: adopting Syncthing is the cheapest way to get agent-shaped reach without building or signing a binary, since the user installs a third-party tool that is already signed and maintained. It remains unrecommended, but it is the strongest fallback if the unreachable-machine case becomes a priority.)*
+
+**The industry answer for the push case is unglamorous: a watched drop folder.** Paperless-ngx consumes from a directory and *moves files out* into its own structure — a drop model, not a mirror, so there is no source-side delete to detect. For the mirror case, FSCrawler's periodic full crawl (`update_rate` default 15m, `remove_deleted` default true) validates list-and-diff as the norm.
+
+**No .NET abstraction library closes the gap.** FluentStorage (MIT, actively maintained) covers S3, Azure Blob/Files/Data Lake, GCP, FTP and SFTP behind one interface — roughly 8–10 backends against rclone's 70+, and no cloud-drive support at all, which is precisely where Connapse's gap is. **No .NET library provides change-feed abstraction; delete detection remains something Connapse must write.**
+
+### Sub-question 4 — Trust, delegation, and safe deletion
+
+**Claim: deny-by-default allowlists are a prerequisite for editor-created sources, not an improvement to schedule afterwards.**
+
+**Snowflake is a near-exact analogue and it made the allowlist mandatory.** `CREATE INTEGRATION` is an account-level privilege held only by ACCOUNTADMIN by default; creating a stage inside one needs only `CREATE STAGE` plus `USAGE` on the integration — a delegable, lower-privileged grant, exactly the shape proposed for Connapse. Crucially `STORAGE_ALLOWED_LOCATIONS` is a **required** parameter — not optional, not empty-means-all — and Snowflake enforces that a stage's URL falls inside it. `STORAGE_BLOCKED_LOCATIONS` exists specifically for the wildcard case (primary: Snowflake docs).
+
+**AWS has a formal name for the risk: `iam:PassRole`, and the confused-deputy problem.** PassRole exists solely to stop a low-privileged principal attaching a high-privileged credential to a resource it controls; AWS guidance is to restrict it to explicit role ARNs and never wildcards. Mapping onto Connapse: **the connection is the passed role, `allowedLocations` is the ARN restriction, and a permissive-when-empty allowlist is `iam:PassRole` on `Resource: "*"`.**
+
+**The dominant attack is exfiltration-into-search, and it is worse than plain read access.** Connapse indexes content and makes it searchable. An editor pointing a source at `/etc`, at a payroll prefix, or at the connection's own credential store converts "the admin holds a broad credential" into "an editor can grep everything that credential can reach." The credential itself never leaks — the *data* does, and search is a lower-friction exfiltration channel than file listing. Three further attacks: an **existence oracle**, since S3 returns 403 versus 404 depending on whether the caller holds `s3:ListBucket`, letting differential error text enumerate buckets the admin's credential can see; **resource exhaustion** via egress charges, embedding spend and index bloat; and **blast-radius laundering**, where an audit trail recording only "connection X read bucket Y" loses which editor chose the scope.
+
+**Counter-evidence from systems that declined to solve this** reinforces the point. Kubernetes documents that anyone who can create a Pod in a namespace can read any Secret in it, and prescribes namespace separation rather than in-boundary delegation. Airflow simply declares DAG authors trusted. HCP Terraform states outright that it cannot prevent a malicious module from exfiltrating sensitive variables. Grafana takes the opposite approach — provisioned datasources are `editable: false`. CVE-2023-40610 shows the escalation shape concretely in Superset.
+
+**Verdict on delegation:** warn-when-empty is tolerable *while sources remain admin-only*, because the admin already holds the credential and no privilege boundary is crossed. The moment an editor can pick the scope, an empty allowlist is unrestricted PassRole. The minimum gate before shipping editor-created sources: allowlist required and non-empty, validated at write time against a canonicalized path, plus a scope preview and per-creator audit.
+
+**On safe deletion, five named safeguards from production systems:**
+
+| Safeguard | System | Specifics |
+|---|---|---|
+| Absolute/percentage delete cap | rclone `--max-delete` | Fatal error, stops the operation. Explicitly framed as protection against "a wrong or inaccessible sync source." |
+| Whole-run abort | Google Cloud Directory Sync | Limits of 0–100% or absolute; on breach **GCDS syncs nothing at all** — deletes and non-deletes alike. |
+| On-by-default threshold | Microsoft Entra Connect Sync | "Prevent accidental deletes" on by default at **500 deletes per export cycle**; on trip the export stops *before deleting any object* and mails an admin. |
+| Health marker before trusting a listing | Syncthing `.stfolder` | A marker directory must be present; if missing the folder is treated as *unhealthy* rather than empty. Cheapest defence against the catastrophic case. |
+| Atomic swap instead of in-place reconcile | Algolia `replaceAllObjects` | Build into a temp index then `moveIndex`; on error the live index is untouched. Cost: record count temporarily doubles. |
+
+**Filebeat's own documentation warns about this exact failure mode**: `clean_removed` "can cause complete file re-reading if shared drives temporarily disconnect," and Elastic advises disabling it in unstable network environments — absence of a file is explicitly treated as untrustworthy evidence.
+
+**Delta APIs shrink the problem but do not remove it.** Microsoft Graph marks deletions with `@removed`, so an empty page means "no changes," never "everything is gone." But delta tokens have **no published TTL** and can be invalidated at any time; the service then returns **HTTP 410 Gone** with `resyncRequired`, forcing full re-enumeration — described in the docs as a normal recovery scenario, not an edge case. The dangerous list-and-diff path therefore still exists; it is merely rarer, and fires on a trigger nobody sees coming.
+
+## Recommendation
+
+**Phase 1 — Per-connection S3 endpoints, with delete safety built in from the start.** Add `ServiceUrl` and `ForcePathStyle` to `S3ConnectorConfig` and thread them through `ConnectorFactory` and the connection form; add `AssumeRoleWithWebIdentity` alongside the existing `AssumeRole`. Replace the LocalStack fixture's process-wide `AWS_ENDPOINT_URL_S3` with per-connection configuration, which is also what makes the test honest. Ship the delete-safety layer in the same phase rather than after it, because this phase already deletes: require pagination confirmed complete with no page error before any reconcile; apply a percentage-or-absolute threshold that **aborts the whole run** GCDS-style rather than partially applying; route deletes to tombstones hidden from search immediately and purged after N days; stamp each successful crawl with a generation counter so "not seen in generation N" is distinguishable from "generation N never completed."
+
+Then document MinIO (or any S3-compatible server) as the supported way to expose a filesystem, and **mark the local-disk Filesystem connector as single-host-only** rather than deleting it — deleting it would strip a working feature from existing single-host users for no gain, and it remains the correct choice when Connapse runs on the same host as the data.
+
+**Phase 2 — SFTP**, with the key mounted as a secret, for genuine remote-disk cases where standing up object storage is not reasonable. Take the SSH.NET 2026.0.0 bump regardless of whether this ships.
+
+**Phase 3 — Microsoft Graph** for OneDrive and SharePoint, using application permissions via managed identity.
+
+**Deferred pending deny-by-default allowlists:** editor-created sources.
+
+**Rejected:** NFS (needs `CAP_SYS_ADMIN`, no .NET client); Dropbox (requires a stored refresh token); a push agent (distribution and signing cost is a second product). **Excluded but defensible, revisit on trigger:** WebDAV (best change feed of any protocol; excluded only on .NET library support); Syncthing (right auth model, wrong shape, but the cheapest route to agent-like reach without shipping a binary); rclone (MIT, viable, gated on accepting an Experimental server on the ingestion path); SMB (gated on LGPL acceptance and a stored NTLM password).
+
+## What this recommendation does not solve
+
+**No transport recommended here reaches a machine the server cannot connect to.** S3, SFTP and Graph are all server-initiated pulls. A laptop or workstation behind NAT, with only outbound connectivity, remains unreachable — and since the question originated in Docker isolation, it is worth being explicit that **running MinIO in front of a folder does not change the direction of the connection.** It solves the *container cannot see the host disk* problem on a single machine; it does not solve *the server is somewhere else entirely*.
+
+For that case the honest options are, in ascending cost: a **tunnel or reverse proxy** exposing an endpoint the server can reach (Tailscale, Cloudflare Tunnel, an SSH reverse tunnel), which moves the problem to network configuration the operator already understands; **Syncthing in `receiveonly` mode** on the server paired with a send-only peer on the machine, which gets agent-shaped reach using a third-party binary the user installs and Connapse never signs; or **building the agent**, whose cost this report argues against but does not argue is unjustifiable if that case becomes the priority.
+
+A fourth non-answer worth naming: **bulk upload**. If the data does not need to stay in sync, uploading a folder into a container is already supported and is not a worse answer merely because it is unglamorous.
+
+## Corrections after review
+
+An adversarial review of the first draft found a load-bearing factual error, since verified directly against this repository and corrected above:
+
+- **The claim that S3-compatible endpoints "already work" was false.** `S3ConnectorConfig` has no endpoint field; `S3Connector.CreateS3Client` never sets `ServiceURL` or `ForcePathStyle`; `AssumeRoleWithWebIdentity` is not implemented (only `AssumeRoleAsync`, which needs base credentials); and the LocalStack test passes only via a process-wide environment variable that cannot vary per connection. The recommendation survived, but its justification changed from *cheapest* to *most correct*, and Phase 1 grew from documentation into a feature.
+- **The original tiebreaker was self-serving.** The first draft resolved a disagreement between two investigations by preferring the option "requiring no new connector code" — a criterion that favours the writer, and which rested on the error above. The tiebreak is now made on correctness properties.
+- **The unreachable-machine case was silently unanswered.** Sub-question 2 asked about machines the server can never reach; the draft rejected the agent and then never acknowledged that every remaining option requires reachability. *What this recommendation does not solve* was added.
+- **Delete safety was mis-phased**, scheduled after a phase that already deletes. It is now inside Phase 1.
+- **WebDAV vanished** — praised as solving the hardest problem, then absent from both the plan and the rejected list. It is now explicitly excluded on library support, with a revisit trigger.
+
+## Conflicts and uncertainties
+
+**Two investigations disagreed on the first move, and the disagreement is real rather than one of emphasis.** The protocol investigation concluded "ship S3-compatible first"; the tools investigation concluded "adopt Microsoft Graph directly, use rclone for breadth." Both are defensible. This report resolves it toward S3 because it serves filesystem-shaped data — which is what the question asked about — while Graph serves cloud-drive-shaped data, a different population. That is a judgement call, and the first draft's stated reason for it (implementation cost) turned out to be factually wrong, which is worth weighing when deciding how much confidence to place in the resolution.
+
+**`rclone serve s3` is simultaneously the cheapest breadth option and the least stable.** Reusing one connector for 70+ backends is genuinely attractive; the server is documented as Experimental, unversioned, and persists only mtime. Unresolved.
+
+**S3's "authoritative listing" property is weaker than a one-line comparison suggests.** Narrowed `ListBucket` permissions, mid-pagination credential expiry, and versioned-bucket delete markers can each shorten a listing without raising an error. This is why the delete-safety layer is inside Phase 1 rather than after it.
+
+**`AssumeRoleWithWebIdentity` requires an OIDC issuer that Connapse deliberately is not.** The keyless-auth claim therefore depends on the operator already running an IdP. Where none exists, this degrades to a short-lived key injected as a secret — still better than a stored long-lived key, but not the clean story the summary implies.
+
+**Two source-quality caveats.** No published formal postmortem of a *search index* wiped by an empty-listing reconcile was found; the evidence comes from file-sync and directory-sync systems, so the transfer is sound by analogy but not directly attested. And the Nextcloud/ownCloud incidents are bug reports rather than formal RCAs.
+
+## Gaps — what we did not find
+
+- **SMBLibrary CHANGE_NOTIFY client support could not be confirmed.** The protocol has it; whether this library exposes it is unverified.
+- **SMB behaviour at 100k files** — no source found.
+- **SSH.NET ssh-agent support** — absence inferred from the library surface, not documented.
+- **rclone `mount` Docker/FUSE requirements** were not verified against primary docs.
+- **The 2024 removal of the EV SmartScreen bypass** rests on a search summary, not a Microsoft primary document.
+- **Delta token TTL for Microsoft Graph is genuinely unpublished**, so resync frequency cannot be planned for — only handled.
+- **No formal postmortem of an index-wipe** as noted above.
+- **LlamaIndex reader licensing and semantics** were not verified.
+- **Cost and latency of tunnelling options** (Tailscale, Cloudflare Tunnel) for the unreachable-machine case were not investigated; that recommendation is directional rather than evidenced.
+
+## Source quality assessment
+
+The synthesis rests predominantly on **primary sources**: protocol specifications and RFCs (RFC 6578, RFC 8628), vendor documentation (AWS IAM, MinIO STS, Microsoft Graph, Snowflake, Elastic, Apple FSEvents, Microsoft Learn), licence files read directly from source repositories, the GitHub Advisory Database, and project issue trackers. The strongest claims — Snowflake's mandatory allowlist, Graph's `@removed` facet and 410 resync behaviour, the platform watcher limits, the Native AOT toolchain constraints — are all primary.
+
+**The claims about Connapse's own code are the highest-confidence in the report**, having been verified by reading the source directly rather than inferred: `S3ConnectorConfig.cs`, `S3Connector.CreateS3Client`, and `LocalStackFixture.InitializeAsync`.
+
+**Secondary sources** carry the confused-deputy framing and some engineering-blog analysis. **The weakest links are listed in Gaps**; none is load-bearing except the SmartScreen claim, and the agent rejection stands without it.
+
+## Sources
+
+**Primary — specifications and standards**
+RFC 6578 (WebDAV sync-collection) · RFC 8628 (OAuth Device Authorization Grant) · draft-ietf-secsh-filexfer · CA/Browser Forum code-signing baseline requirements
+
+**Primary — vendor and project documentation**
+AWS S3 API and IAM PassRole documentation · MinIO STS `AssumeRoleWithWebIdentity` · Microsoft Graph `driveItem: delta` and delta-query overview · Microsoft Entra Connect Sync deletion threshold · Microsoft Learn `FileSystemWatcher.InternalBufferSize` and Native AOT deployment · Apple FSEvents Programming Guide · Snowflake `CREATE STORAGE INTEGRATION` · Elastic Filebeat, Fleet enrollment tokens, elastic-agent upgrades · Datadog Agent architecture · Syncthing FAQ and folder types · rclone (`COPYING`, `sync`, `serve s3`, `rc`, `azureblob`, librclone README) · restic `design.rst` · Paperless-ngx configuration · FSCrawler local-fs documentation · Google Drive `manage-changes` · Dropbox OAuth guide · Grafana provisioning · Kubernetes Secrets concepts · Airflow security model · HCP Terraform security model · Tailscale auth keys · Apple notarization · Algolia `replaceAllObjects` · Google Cloud Directory Sync deletion limits
+
+**Primary — advisories and trackers**
+GHSA-q939-rpr3-3284 / CVE-2026-48798 · CVE-2023-40610 (Superset) · moby#16429 · podman#20717 · nextcloud/desktop#9280, #7831, #8831 · owncloud/client#6322, #2687, #10253 · rclone#959 · SMBLibrary#137 · SSH.NET#100
+
+**Primary — this repository (read directly)**
+`src/Connapse.Storage/Connectors/S3ConnectorConfig.cs` · `src/Connapse.Storage/Connectors/S3Connector.cs` · `tests/Connapse.Integration.Tests/LocalStackFixture.cs`
+
+**Primary — repositories and licences**
+rclone `COPYING` (MIT) · Syncthing `LICENSE` (MPL-2.0) · SMBLibrary (LGPL-3.0-or-later) · FluentStorage (MIT) · Unstructured (Apache-2.0)
+
+**Secondary — engineering analysis**
+Dropbox "Rewriting the heart of our sync engine" · sra.io "An Overview of Deputies in AWS" · Atlassian April 2022 post-incident review · DigiCert 2023 key-storage change notice · kdgregory on S3 403/404 differential responses

--- a/docs/superpowers/plans/2026-08-23-delete-guard.md
+++ b/docs/superpowers/plans/2026-08-23-delete-guard.md
@@ -1,0 +1,758 @@
+﻿# Delete Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a source's index being wiped when its remote listing comes back empty-but-successful, while letting an admin approve a genuine bulk deletion in one action.
+
+**Architecture:** A pure predicate decides whether a computed deletion set is too large to trust. When it trips, `SourceSyncService` applies the upserts, skips the deletions, and records how many were withheld on the source. The Sources page surfaces that count with an admin-only button that re-runs the sync with the guard lifted — recomputing the vanished set rather than replaying a stored one, so a recovered mount deletes nothing.
+
+**Tech Stack:** .NET 10, EF Core + PostgreSQL, Blazor Server, xUnit + FluentAssertions + NSubstitute, Testcontainers.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-sftp-ingestion-and-delete-guard-design.md`
+
+## Global Constraints
+
+- .NET 10, file-scoped namespaces, nullable enabled, implicit usings.
+- Records for DTOs; primary constructors for DI; async all the way (never `.Result`/`.Wait()`).
+- Never use `var` for primitive types.
+- Parameterized SQL only — never string interpolation.
+- Wrap user-controlled values in `LogSanitizer.Sanitize(...)` from `Connapse.Core.Utilities` before logging.
+- Always use `IDbContextFactory<KnowledgeDbContext>` and short-lived contexts: `await using var ctx = await factory.CreateDbContextAsync(ct)`.
+- Tag every test `[Trait("Category", "Unit")]` or `[Trait("Category", "Integration")]`.
+- Test naming: `MethodName_Scenario_ExpectedResult`.
+- Commit style: `<type>: <summary>` — `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `perf:`, `chore:`.
+- Branch: `feature/<issue>-desc`. File the GitHub issue **before** creating the branch.
+- **The threshold is fixed and not configurable.** Do not add settings, options, or per-source config for it.
+- **`SyncStatus` must not gain a member.** Withheld is a count, not a status.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/Connapse.Core/Utilities/DeletionGuard.cs` — the predicate. Core has zero dependencies, and this is pure logic with no I/O.
+- `src/Connapse.Storage/Migrations/<timestamp>_AddSourceWithheldDeletions.cs` — generated.
+- `tests/Connapse.Core.Tests/Sources/DeletionGuardTests.cs`
+- `tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs`
+
+**Modify:**
+- `src/Connapse.Core/Models/SourceModels.cs` — add `WithheldDeletions` to `Source`.
+- `src/Connapse.Storage/Data/Entities/SourceEntity.cs` — add `WithheldDeletions`.
+- `src/Connapse.Storage/Data/KnowledgeDbContext.cs` — map the column (block starts line 494).
+- `src/Connapse.Storage/Sources/PostgresSourceStore.cs` — map it in `MapToModel`; add `UpdateWithheldDeletionsAsync`.
+- `src/Connapse.Core/Interfaces/ISourceStore.cs` — declare `UpdateWithheldDeletionsAsync`.
+- `src/Connapse.Core/Models/SyncModels.cs` — add `WithheldDeletions` to `SourceSyncResult`.
+- `src/Connapse.Web/Services/SourceSyncService.cs` — apply the guard in `SyncViaListAndDiffAsync`; thread an override flag.
+- `src/Connapse.Web/Endpoints/SourceResponse.cs` — expose the count.
+- `src/Connapse.Web/Endpoints/SourcesEndpoints.cs` — accept the override on the sync route.
+- `src/Connapse.Web/Components/Pages/Sources.razor` — surface the count and the button.
+
+---
+
+### Task 1: The deletion guard predicate
+
+**Files:**
+- Create: `src/Connapse.Core/Utilities/DeletionGuard.cs`
+- Test: `tests/Connapse.Core.Tests/Sources/DeletionGuardTests.cs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `public static class DeletionGuard` with `public static bool ShouldWithhold(int vanished, int indexed)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Connapse.Core.Tests/Sources/DeletionGuardTests.cs`:
+
+```csharp
+using Connapse.Core.Utilities;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Sources;
+
+/// <summary>
+/// The boundary this guard draws is the whole of its behaviour, so it is pinned by example
+/// rather than described. Both terms of the rule are load-bearing: a percentage alone fires
+/// constantly on small sources, an absolute alone is meaningless on large ones.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DeletionGuardTests
+{
+    [Theory]
+    // Small sources clean themselves up: re-ingesting five files is cheap, and blocking
+    // them would make the guard fire on ordinary tidying.
+    [InlineData(5, 5, false)]
+    [InlineData(10, 10, false)]
+    // Losing everything from a source big enough to notice is suspicious.
+    [InlineData(15, 15, true)]
+    // Proportionality on large sources: 5% is plausible churn, 50% is not.
+    [InlineData(5_000, 100_000, false)]
+    [InlineData(50_000, 100_000, true)]
+    // Exactly at each bound, so an off-by-one in either term is caught.
+    [InlineData(10, 100, false)]
+    [InlineData(11, 100, true)]
+    // Nothing to delete is never withheld, including on an empty index.
+    [InlineData(0, 0, false)]
+    [InlineData(0, 100, false)]
+    public void ShouldWithhold_AtTheBoundaries_MatchesTheRule(int vanished, int indexed, bool expected)
+    {
+        DeletionGuard.ShouldWithhold(vanished, indexed).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ShouldWithhold_MoreVanishedThanIndexed_DoesNotThrow()
+    {
+        // Not reachable through SyncViaListAndDiffAsync, which derives vanished from the
+        // indexed set — but a predicate that throws on nonsense input would turn a caller
+        // bug into a failed sync rather than a logged oddity.
+        var act = () => DeletionGuard.ShouldWithhold(200, 100);
+
+        act.Should().NotThrow();
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/Connapse.Core.Tests --filter "FullyQualifiedName~DeletionGuardTests"`
+Expected: FAIL — `DeletionGuard` does not exist (compile error `CS0103`).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/Connapse.Core/Utilities/DeletionGuard.cs`:
+
+```csharp
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Decides whether a computed deletion set is too large to trust.
+/// <para>
+/// A reconcile infers deletions from absence: anything indexed but missing from the remote
+/// listing is assumed deleted. That inference is only as good as the listing, and a listing
+/// can come back empty <em>and successful</em> — a narrowed bucket policy returning 200 OK
+/// with zero keys, or a filesystem directory that is temporarily unmounted. Without this
+/// check, one such listing deletes every document the source owns.
+/// </para>
+/// <para>
+/// The rule deliberately does not try to decide whether a deletion is <em>correct</em>. For a
+/// mirror, a wrong deletion is recoverable — the next sync re-ingests it — so what needs
+/// preventing is the catastrophic case, not every false positive.
+/// </para>
+/// </summary>
+public static class DeletionGuard
+{
+    /// <summary>Deletion sets at or below this size are always applied.</summary>
+    /// <remarks>
+    /// A floor rather than a pure percentage: on a five-document source, deleting three is
+    /// 60% and would trip a percentage rule on completely ordinary tidying.
+    /// </remarks>
+    public const int AlwaysAllowedCount = 10;
+
+    /// <summary>Proportion of a source's index above which a deletion set is withheld.</summary>
+    /// <remarks>
+    /// A ceiling rather than a pure count: ten documents out of a hundred thousand is noise,
+    /// and an absolute-only rule would block routine churn on any large source.
+    /// </remarks>
+    public const int WithheldPercent = 10;
+
+    /// <summary>
+    /// True when the deletion set should be withheld pending an administrator's approval.
+    /// Requires <em>both</em> bounds to be exceeded, so neither degenerate case fires.
+    /// </summary>
+    public static bool ShouldWithhold(int vanished, int indexed) =>
+        vanished > AlwaysAllowedCount && vanished > indexed / (100 / WithheldPercent);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/Connapse.Core.Tests --filter "FullyQualifiedName~DeletionGuardTests"`
+Expected: PASS — 10 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Utilities/DeletionGuard.cs tests/Connapse.Core.Tests/Sources/DeletionGuardTests.cs
+git commit -m "feat(core): add the deletion guard predicate"
+```
+
+---
+
+### Task 2: Persist the withheld count
+
+**Files:**
+- Modify: `src/Connapse.Storage/Data/Entities/SourceEntity.cs`
+- Modify: `src/Connapse.Storage/Data/KnowledgeDbContext.cs` (SourceEntity block, from line 494)
+- Modify: `src/Connapse.Core/Models/SourceModels.cs`
+- Modify: `src/Connapse.Storage/Sources/PostgresSourceStore.cs`
+- Modify: `src/Connapse.Core/Interfaces/ISourceStore.cs`
+- Create: migration (generated)
+- Test: `tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `Source.WithheldDeletions` (`int?`); `ISourceStore.UpdateWithheldDeletionsAsync(Guid id, int? withheld, CancellationToken ct = default)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs`:
+
+```csharp
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
+{
+    private static string ShortName(string prefix) => $"{prefix}-{Guid.NewGuid():N}"[..20];
+
+    private async Task<Source> SeedSourceAsync()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+
+        var connection = await connections.CreateAsync(
+            new CreateConnectionRequest(ShortName("conn"), ConnectionProvider.S3, """{"region":"us-east-1"}"""),
+            createdByUserId: null);
+
+        return await sources.CreateAsync(
+            new CreateSourceRequest(ShortName("src"), connection.Id, """{"bucketName":"b"}"""));
+    }
+
+    [Fact]
+    public async Task UpdateWithheldDeletionsAsync_RoundTripsTheCount()
+    {
+        var source = await SeedSourceAsync();
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+
+        (await sources.GetAsync(source.Id))!.WithheldDeletions
+            .Should().BeNull("a source with nothing pending must not claim a count of zero");
+
+        await sources.UpdateWithheldDeletionsAsync(source.Id, 42);
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().Be(42);
+
+        // Clearing must return to null, not zero: the UI distinguishes "nothing pending"
+        // from "a decision was made", and zero would leave the button showing forever.
+        await sources.UpdateWithheldDeletionsAsync(source.Id, null);
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Integration.Tests --filter "FullyQualifiedName~UpdateWithheldDeletionsAsync_RoundTripsTheCount"`
+Expected: FAIL — compile error, `Source` has no `WithheldDeletions` and `ISourceStore` has no `UpdateWithheldDeletionsAsync`.
+
+- [ ] **Step 3: Add the field to the entity**
+
+In `src/Connapse.Storage/Data/Entities/SourceEntity.cs`, after the `SyncIntervalSeconds` line in the `// Sync state` block:
+
+```csharp
+    /// <summary>
+    /// How many deletions the last reconcile declined to apply, or null when none are pending.
+    /// Null rather than zero: the Sources page distinguishes "nothing pending" from "an
+    /// administrator decided", and zero would leave the approval button showing forever.
+    /// </summary>
+    public int? WithheldDeletions { get; set; }
+```
+
+- [ ] **Step 4: Map the column**
+
+In `src/Connapse.Storage/Data/KnowledgeDbContext.cs`, inside the `Entity<SourceEntity>` block, after the `SyncIntervalSeconds` property mapping:
+
+```csharp
+            entity.Property(e => e.WithheldDeletions)
+                .HasColumnName("withheld_deletions");
+```
+
+- [ ] **Step 5: Add the field to the domain record**
+
+In `src/Connapse.Core/Models/SourceModels.cs`, add a parameter to `Source` **at the end of the parameter list**, after `int DocumentCount = 0`:
+
+```csharp
+    int DocumentCount = 0,
+    int? WithheldDeletions = null);
+```
+
+Appending rather than inserting: every positional construction of `Source` in the codebase and tests would otherwise shift.
+
+- [ ] **Step 6: Map it in the store and add the update method**
+
+In `src/Connapse.Storage/Sources/PostgresSourceStore.cs`, in `MapToModel`, after `DocumentCount: documentCount`:
+
+```csharp
+        DocumentCount: documentCount,
+        WithheldDeletions: entity.WithheldDeletions);
+```
+
+Then add the method to the same class:
+
+```csharp
+    public async Task UpdateWithheldDeletionsAsync(Guid id, int? withheld, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var entity = await context.Sources.FirstOrDefaultAsync(s => s.Id == id, ct);
+        if (entity is null) return;
+
+        entity.WithheldDeletions = withheld;
+        entity.UpdatedAt = DateTime.UtcNow;
+        await context.SaveChangesAsync(ct);
+    }
+```
+
+- [ ] **Step 7: Declare it on the interface**
+
+In `src/Connapse.Core/Interfaces/ISourceStore.cs`, next to the other sync-state methods:
+
+```csharp
+    /// <summary>
+    /// Records how many deletions the last reconcile declined to apply, or null to clear.
+    /// Separate from <see cref="UpdateSyncStateAsync"/> because a sync that withholds
+    /// deletions still succeeded — the count is orthogonal to the status, not a variant of it.
+    /// </summary>
+    Task UpdateWithheldDeletionsAsync(Guid id, int? withheld, CancellationToken ct = default);
+```
+
+- [ ] **Step 8: Generate the migration**
+
+```bash
+dotnet ef migrations add AddSourceWithheldDeletions --project src/Connapse.Storage --startup-project src/Connapse.Web
+```
+
+Open the generated `.cs` and confirm it contains exactly one `AddColumn<int>` for `withheld_deletions` on `sources`, nullable, with no default. If it contains anything else, the model has drifted — stop and investigate rather than editing the migration.
+
+Then check `KnowledgeDbContextModelSnapshot.cs`: if `ProductVersion` changed, revert that one line. It reflects the scaffolding tool's runtime rather than the project's EF Core version, and flip-flops between contributors.
+
+- [ ] **Step 9: Run the test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Integration.Tests --filter "FullyQualifiedName~UpdateWithheldDeletionsAsync_RoundTripsTheCount"`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/Connapse.Core/Models/SourceModels.cs src/Connapse.Core/Interfaces/ISourceStore.cs src/Connapse.Storage/Data/Entities/SourceEntity.cs src/Connapse.Storage/Data/KnowledgeDbContext.cs src/Connapse.Storage/Sources/PostgresSourceStore.cs src/Connapse.Storage/Migrations/ tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+git commit -m "feat(storage): persist a source's withheld deletion count"
+```
+
+---
+
+### Task 3: Apply the guard during sync
+
+**Files:**
+- Modify: `src/Connapse.Core/Models/SyncModels.cs`
+- Modify: `src/Connapse.Web/Services/SourceSyncService.cs` (`SyncViaListAndDiffAsync`, from line 206)
+- Test: `tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: `DeletionGuard.ShouldWithhold(int, int)` (Task 1); `ISourceStore.UpdateWithheldDeletionsAsync` (Task 2).
+- Produces: `SourceSyncResult.WithheldDeletions` (`int`); `SourceSyncService.SyncSourceAsync(Source, Connection, CancellationToken, bool applyWithheldDeletions = false)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs`. This is the regression test for the bug — it must fail against current `main`.
+
+```csharp
+    /// <summary>
+    /// A connector whose listing is empty, without erroring — the shape a narrowed bucket
+    /// policy or an unmounted directory actually takes. Before the guard this deleted every
+    /// document the source owned.
+    /// </summary>
+    private sealed class EmptyListingConnector : IConnector
+    {
+        public ConnectorType Type => ConnectorType.S3;
+        public bool SupportsLiveWatch => false;
+        public string ResolveJobPath(string relativePath) => "/" + relativePath.TrimStart('/');
+        public Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<ConnectorFile>>([]);
+        public Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
+            => Task.FromResult<Stream>(new MemoryStream());
+        public Task<bool> ExistsAsync(string path, CancellationToken ct = default) => Task.FromResult(false);
+        public IAsyncEnumerable<ConnectorFileEvent> WatchAsync(CancellationToken ct = default)
+            => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task Sync_ListingCollapsesToEmpty_WithholdsDeletionsAndKeepsDocuments()
+    {
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        var result = await SyncWithConnectorAsync(source, new EmptyListingConnector());
+
+        result.Deleted.Should().Be(0, "an empty listing is not evidence that 40 files were deleted");
+        result.WithheldDeletions.Should().Be(40);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().HaveCount(40);
+
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().Be(40);
+    }
+
+    [Fact]
+    public async Task Sync_WithOverride_AppliesTheWithheldDeletions()
+    {
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        await SyncWithConnectorAsync(source, new EmptyListingConnector());
+        var result = await SyncWithConnectorAsync(source, new EmptyListingConnector(), applyWithheldDeletions: true);
+
+        result.Deleted.Should().Be(40);
+        result.WithheldDeletions.Should().Be(0);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().BeEmpty();
+
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        (await sources.GetAsync(source.Id))!.WithheldDeletions
+            .Should().BeNull("the pending decision is resolved, so the button must stop showing");
+    }
+
+    [Fact]
+    public async Task Sync_SmallDeletionSet_AppliesWithoutWithholding()
+    {
+        // Five of five is below the floor: small sources must stay able to tidy themselves.
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 5);
+
+        var result = await SyncWithConnectorAsync(source, new EmptyListingConnector());
+
+        result.Deleted.Should().Be(5);
+        result.WithheldDeletions.Should().Be(0);
+    }
+```
+
+You will also need two helpers in this class. `SeedDocumentsAsync(Guid sourceId, int count)` inserts `count` source-owned documents — follow the raw-SQL insert pattern in `tests/Connapse.Integration.Tests/OwnerBridgeSchemaTests.cs`, setting `source_id` and leaving `container_id` NULL. `SyncWithConnectorAsync(Source, IConnector, bool applyWithheldDeletions = false)` builds a `SourceSyncService` with a fixed-connector factory — copy `FixedConnectorFactory` from `tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs`, which already exists for exactly this purpose.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/Connapse.Integration.Tests --filter "FullyQualifiedName~DeleteGuardIntegrationTests"`
+Expected: FAIL — `SourceSyncResult` has no `WithheldDeletions`, and `SyncSourceAsync` has no `applyWithheldDeletions` parameter.
+
+- [ ] **Step 3: Add the field to the result record**
+
+In `src/Connapse.Core/Models/SyncModels.cs`:
+
+```csharp
+public record SourceSyncResult(
+    int Upserted,
+    int Deleted,
+    bool UsedDeltaPath,
+    bool RequiredResync,
+    string? Error,
+    bool AlreadyRunning = false,
+    int WithheldDeletions = 0);
+```
+
+- [ ] **Step 4: Apply the guard in the reconcile**
+
+In `src/Connapse.Web/Services/SourceSyncService.cs`, replace the body of `SyncViaListAndDiffAsync` between computing `vanished` and returning:
+
+```csharp
+        var remotePaths = remote.Select(f => f.Path).ToHashSet(StringComparer.Ordinal);
+        var vanished = indexedPaths.Where(p => !remotePaths.Contains(p)).ToList();
+
+        // Upserts apply regardless. A source that trips the guard must keep ingesting new
+        // content, or the safety mechanism becomes the outage it exists to prevent.
+        int upserted = await EnqueueAllAsync(source, remote, context, sp, ct);
+
+        bool withhold = !applyWithheldDeletions
+            && DeletionGuard.ShouldWithhold(vanished.Count, indexedPaths.Count);
+
+        int deleted = 0;
+        if (withhold)
+        {
+            logger.LogWarning(
+                "Source {SourceId} reconcile would delete {Vanished} of {Indexed} document(s); "
+                + "withholding pending administrator approval",
+                source.Id, vanished.Count, indexedPaths.Count);
+        }
+        else
+        {
+            deleted = await DeleteByPathsAsync(source, vanished, context, sp, ct);
+        }
+
+        await sourceStore.UpdateWithheldDeletionsAsync(
+            source.Id, withhold ? vanished.Count : null, ct);
+
+        await sourceStore.UpdateSyncStateAsync(
+            source.Id, source.SyncCursor, SyncStatus.Succeeded, error: null, DateTime.UtcNow, ct);
+
+        return new SourceSyncResult(
+            upserted, deleted, UsedDeltaPath: false, RequiredResync: false, Error: null,
+            WithheldDeletions: withhold ? vanished.Count : 0);
+```
+
+Add `using Connapse.Core.Utilities;` if it is not already present.
+
+- [ ] **Step 5: Thread the override parameter**
+
+Add `bool applyWithheldDeletions = false` as the last parameter of `SyncViaListAndDiffAsync` and of the public `SyncSourceAsync`, passing it through. Do **not** add it to the delta path — the guard does not apply there.
+
+Add this comment above the public method's new parameter:
+
+```csharp
+    /// <param name="applyWithheldDeletions">
+    /// Lifts the deletion guard for this one cycle. The vanished set is recomputed rather
+    /// than replayed from what was withheld earlier, so a source whose remote has recovered
+    /// in the meantime deletes nothing.
+    /// </param>
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `dotnet test tests/Connapse.Integration.Tests --filter "FullyQualifiedName~DeleteGuardIntegrationTests"`
+Expected: PASS — 4 passed.
+
+- [ ] **Step 7: Run the whole suite**
+
+Run: `dotnet test`
+Expected: all pass. `SourceSyncIntegrationTests` exercises the same method and must not regress.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Connapse.Core/Models/SyncModels.cs src/Connapse.Web/Services/SourceSyncService.cs tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+git commit -m "fix(web): withhold implausibly large deletion sets during source sync"
+```
+
+---
+
+### Task 4: Expose the count and the override over REST
+
+**Files:**
+- Modify: `src/Connapse.Web/Endpoints/SourceResponse.cs`
+- Modify: `src/Connapse.Web/Endpoints/SourcesEndpoints.cs` (sync route, from line 190)
+- Test: `tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: `Source.WithheldDeletions` (Task 2); the `applyWithheldDeletions` parameter (Task 3).
+- Produces: `SourceResponse.WithheldDeletions`; `POST /api/sources/{id}/sync?applyWithheldDeletions=true`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `DeleteGuardIntegrationTests.cs`:
+
+```csharp
+    [Fact]
+    public async Task GetSource_AfterWithholding_ReportsTheCount()
+    {
+        var source = await SeedSourceAsync();
+
+        using (var scope = fixture.Factory.Services.CreateScope())
+        {
+            var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+            await sources.UpdateWithheldDeletionsAsync(source.Id, 40);
+        }
+
+        var response = await fixture.AdminClient.GetAsync($"/api/sources/{source.Id}");
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = System.Text.Json.JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("withheldDeletions").GetInt32().Should().Be(40);
+    }
+
+    [Fact]
+    public async Task GetSource_WithNothingWithheld_ReportsNull()
+    {
+        // Null rather than 0, because the page keys the approval button off "is there a
+        // pending decision" — a zero would leave it showing forever.
+        var source = await SeedSourceAsync();
+
+        var response = await fixture.AdminClient.GetAsync($"/api/sources/{source.Id}");
+        var body = await response.Content.ReadAsStringAsync();
+
+        using var doc = System.Text.Json.JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("withheldDeletions").ValueKind
+            .Should().Be(System.Text.Json.JsonValueKind.Null);
+    }
+```
+
+**Note on what these tests do not cover.** `SharedWebAppFixture` exposes only `AdminClient`, so there is no way here to assert that a viewer sees `withheldDeletions` or that a non-admin is refused the override. Both properties hold by construction — the field is mapped unconditionally in `SourceResponse.From` rather than behind `includeDiagnostics`, and the sync route already carries `.RequireAuthorization("RequireAdmin")` — but neither is pinned by a test. Adding a viewer client to the shared fixture is worth doing and is deliberately **not** part of this plan; do not expand scope to chase it.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/Connapse.Integration.Tests --filter "FullyQualifiedName~GetSource_AfterWithholding_ReportsTheCount"`
+Expected: FAIL — `withheldDeletions` is not in the response body.
+
+- [ ] **Step 3: Add the field to the DTO**
+
+In `src/Connapse.Web/Endpoints/SourceResponse.cs`, add a parameter before `string Kind = "source"`:
+
+```csharp
+    /// <summary>
+    /// How many deletions the last reconcile declined to apply, or null when none are pending.
+    /// Unlike <see cref="LastSyncError"/> this is not administrator-only: it is a count, and
+    /// names nothing about the remote's contents or structure.
+    /// </summary>
+    int? WithheldDeletions,
+```
+
+And in `From`, before `LastSyncError`:
+
+```csharp
+        WithheldDeletions: source.WithheldDeletions,
+```
+
+- [ ] **Step 4: Accept the override on the sync route**
+
+In `src/Connapse.Web/Endpoints/SourcesEndpoints.cs`, add to the sync route's parameters:
+
+```csharp
+            [FromQuery] bool applyWithheldDeletions,
+```
+
+Pass it to `SyncSourceAsync`, and make the audit entry distinguish the two cases:
+
+```csharp
+            await auditLogger.LogAsync(
+                applyWithheldDeletions ? "source.deletions_applied" : "source.synced",
+                "source", source.Id.ToString(),
+                new { source.Name, result.Upserted, result.Deleted, result.WithheldDeletions }, ct);
+```
+
+A separate action name so "an administrator approved 40 deletions" is findable in the audit log rather than indistinguishable from an ordinary sync.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet test tests/Connapse.Integration.Tests --filter "FullyQualifiedName~DeleteGuardIntegrationTests"`
+Expected: PASS — 6 passed (four from Task 3, two here).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Connapse.Web/Endpoints/SourceResponse.cs src/Connapse.Web/Endpoints/SourcesEndpoints.cs tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+git commit -m "feat(api): expose withheld deletions and an admin override on source sync"
+```
+
+---
+
+### Task 5: Surface it on the Sources page
+
+**Files:**
+- Modify: `src/Connapse.Web/Components/Pages/Sources.razor`
+
+**Interfaces:**
+- Consumes: `Source.WithheldDeletions` (Task 2); `SyncSourceAsync(..., applyWithheldDeletions)` (Task 3).
+- Produces: nothing consumed by later tasks.
+
+There is no Blazor test harness in this repository, so this task has no automated test. Keep the logic in the page trivial — a conditional row and a call — and rely on Tasks 1–4 for correctness.
+
+- [ ] **Step 1: Add the pending-deletions row**
+
+In `src/Connapse.Web/Components/Pages/Sources.razor`, after the existing `LastSyncStatus == SyncStatus.Failed` row inside the `@foreach`, add:
+
+```razor
+                        @if (source.WithheldDeletions is { } withheld && isAdmin)
+                        {
+                            <tr class="@(source.Enabled ? "" : "opacity-50")">
+                                @* Administrators only, matching the sync-error row: the count
+                                   is harmless, but the action it offers is destructive. *@
+                                <td colspan="7" class="pt-0 border-top-0">
+                                    <div class="alert alert-warning py-2 mb-0 small d-flex align-items-center justify-content-between">
+                                        <span>
+                                            <span class="bi-exclamation-triangle me-1"></span>
+                                            The last sync would have deleted <strong>@withheld</strong> document(s) —
+                                            more than expected, so they were kept. If the source really did lose them, apply the deletions.
+                                        </span>
+                                        <button class="btn btn-sm btn-outline-danger ms-3 text-nowrap"
+                                                @onclick="() => SyncNow(source, applyWithheldDeletions: true)"
+                                                disabled="@(syncing == source.Id)">
+                                            Apply deletions
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+```
+
+- [ ] **Step 2: Thread the flag through the existing handler**
+
+Change `SyncNow`'s signature to `private async Task SyncNow(Source source, bool applyWithheldDeletions = false)`, pass the flag to `SyncService.SyncSourceAsync`, and change the success message so the two cases are distinguishable:
+
+```csharp
+                await AuditLogger.LogAsync(
+                    applyWithheldDeletions ? "source.deletions_applied" : "source.synced",
+                    "source", source.Id.ToString(),
+                    new { source.Name, result.Upserted, result.Deleted });
+
+                Succeed(result.WithheldDeletions > 0
+                    ? $"'{source.Name}' synced — {result.Upserted} queued, {result.WithheldDeletions} deletion(s) withheld."
+                    : $"'{source.Name}' synced — {result.Upserted} queued, {result.Deleted} removed.");
+```
+
+- [ ] **Step 3: Verify it builds**
+
+Run: `dotnet build src/Connapse.Web`
+Expected: Build succeeded, 0 warnings.
+
+- [ ] **Step 4: Manual check**
+
+Start the stack (`docker compose up -d`), create a source, let it index, then make its listing empty — the simplest way is an S3 source pointed at a bucket you then empty. Confirm the warning row appears with the count, that "Apply deletions" removes the documents, and that the row disappears afterwards.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Web/Components/Pages/Sources.razor
+git commit -m "feat(web): surface withheld deletions on the Sources page"
+```
+
+---
+
+### Task 6: Document the guard
+
+**Files:**
+- Modify: `docs/connectors.md`
+
+- [ ] **Step 1: Add the section**
+
+In `docs/connectors.md`, in the **Sync** section after the bullet list:
+
+```markdown
+### Deletions are guarded
+
+A sync reconciles by absence: anything indexed but missing from the remote listing is treated as deleted. That inference is only as good as the listing — and a listing can come back empty *and successful*, from a narrowed bucket policy returning `200 OK` with no keys, or a directory that is temporarily unmounted.
+
+So a reconcile that would delete more than **both 10 documents and 10% of what the source has indexed** applies its additions and **withholds the deletions**, recording how many. The Sources page shows the count to administrators with an "Apply deletions" button.
+
+Two details worth knowing:
+
+- **Additions still apply.** A source that trips the guard keeps ingesting, because a safety check that stops a source working is an outage.
+- **Approving re-runs the sync**, it does not replay the earlier list. If the remote recovered in the meantime, nothing is deleted.
+
+The threshold is fixed and not configurable. Small sources are never blocked — losing five of five files applies immediately, since re-ingesting them is cheap.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/connectors.md
+git commit -m "docs: describe the source deletion guard"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every Part 1 requirement maps to a task: the rule and both bounds (Task 1); `Source.WithheldDeletions` plus its migration (Task 2); list-and-diff-only application, upserts-still-apply, and count-not-status (Task 3); the DTO field and the audited override (Task 4); the admin button (Task 5); the docs (Task 6). The spec's four Part 1 tests all appear — boundaries in Task 1, the empty-listing regression and the override and upserts-still-apply in Task 3.
+
+**Deliberately deferred to Part 2:** everything under SFTP.
+
+**Type consistency.** `WithheldDeletions` is the name on `Source`, `SourceEntity`, `SourceSyncResult` and `SourceResponse`; `withheld_deletions` is the column; `applyWithheldDeletions` is the parameter and query-string name throughout; `DeletionGuard.ShouldWithhold(int, int)` is called only in Task 3 with the signature Task 1 defines.
+
+**One risk called out for the executor.** Task 2 Step 5 appends `WithheldDeletions` to the *end* of the `Source` record's parameter list. `Source` is constructed positionally in several tests; appending keeps those compiling. Do not insert it next to the other sync-state fields, however tidy that looks.

--- a/docs/superpowers/specs/2026-08-23-sftp-ingestion-and-delete-guard-design.md
+++ b/docs/superpowers/specs/2026-08-23-sftp-ingestion-and-delete-guard-design.md
@@ -1,0 +1,171 @@
+# Design: delete guard and SFTP ingestion
+
+**Date:** 2026-08-23
+**Status:** Approved for planning
+**Research:** `docs/research/filesystem-ingestion-2026-08-23.md`
+
+## Problem
+
+Two problems, one of which is live today.
+
+**The delete guard.** `SourceSyncService.SyncViaListAndDiffAsync` computes the set of indexed paths absent from a remote listing and deletes every one of them, with no check that the listing was trustworthy:
+
+```csharp
+var remotePaths = remote.Select(f => f.Path).ToHashSet(StringComparer.Ordinal);
+var vanished = indexedPaths.Where(p => !remotePaths.Contains(p)).ToList();
+int deleted = await DeleteByPathsAsync(source, vanished, context, sp, ct);
+```
+
+If a listing returns empty but successful, every document for that source is deleted. S3 propagates exceptions mid-pagination, which helps, but a narrowed bucket policy returning `200 OK` with zero keys does not throw — and neither does a filesystem directory that is temporarily unmounted or empty. This affects the S3, Azure and Filesystem sources that already ship.
+
+**Filesystem ingestion is unreachable in the deployments people actually use.** The Filesystem connector requires the server process to see a path on its own disk. In Docker the container filesystem is not the user's; on a hosted deployment there is no shared disk. Bind-mounting host paths is both a security concern and poor UX.
+
+## Decisions taken during brainstorming
+
+| Decision | Choice | Reason |
+|---|---|---|
+| Unreachable machines | Out of scope — operator's problem, documented not coded | Deliberate: Connapse should not hand-hold network reachability |
+| Transport | SFTP | Most common shape of "files on a server somewhere" |
+| SSH key storage | Encrypted in the database via DataProtection | The mechanism already exists; the no-stored-**cloud**-credentials rule is about cloud IAM, not an SSH key for your own box |
+| Host key | Trust on first use, pinned thereafter | Catches the realistic attack — interposition later — without demanding a fingerprint before you can start |
+| Delete safety | Threshold abort only. No tombstones, no generation counter | For a mirror, a wrong deletion is recoverable by re-sync; what needs preventing is the catastrophic case, and a false positive costs re-embedding rather than data |
+| Threshold | Fixed: withhold when vanished exceeds **both** 10 documents and 10% of the source's index | A percentage alone fires constantly on small sources; an absolute alone is meaningless on large ones |
+| Override | Per-source admin button, one shot. Not configurable | Deliberate YAGNI: a config ceiling gets loosened for one event and never tightened again |
+
+## Scope
+
+**In:** the delete guard on the list-and-diff path; an SFTP connection provider and connector; SFTP-specific path confinement; the connection form gaining a credential field for SFTP only; documentation for reaching a local machine over SFTP.
+
+**Out:** tombstones; a generation counter; a configurable threshold; any push/agent mechanism; per-connection S3 endpoints (deferred — see *Deferred work*); credential-source determinism (issue #383, sequenced after this).
+
+**Two issues and at least two PRs, in order.** Part 1 is independently valuable and independently reviewable, and must merge before Part 2 begins — SFTP is list-and-diff, so it is exactly the transport where an unguarded reconcile does the most damage. Part 2 will likely split further under the repo's 300-line convention: the connector and confinement in one PR, the UI and connection-form changes in another.
+
+## Part 1 — The delete guard
+
+Ships first and alone. It fixes shipped behaviour, and SFTP would otherwise be the first transport built on an unsafe foundation.
+
+### The rule
+
+```csharp
+internal static bool ShouldWithholdDeletions(int vanished, int indexed) =>
+    vanished > 10 && vanished > indexed / 10;
+```
+
+Both terms are load-bearing. A 5-document source losing all 5 is not blocked — small sources are cheap to re-ingest and should be allowed to clean themselves up. A 100,000-document source losing 5,000 is not blocked either; losing 50,000 is.
+
+### Where it applies
+
+**The list-and-diff path only.** Delta deletions are *reported* by the provider rather than inferred from absence, so the failure mode the guard exists for does not occur there. More practically, withholding on the delta path would require not advancing the cursor — otherwise those deletions are lost permanently, since a provider will not report the same delta twice — which livelocks the source into reprocessing the same batch every cycle.
+
+The delta path also has no production implementer today, and its 410-resync fallback lands in list-and-diff, which *is* guarded. The risk is covered without the complication.
+
+### State
+
+`SyncStatus` is **unchanged** at `Never/Running/Succeeded/Failed`. A sync that upserted 50 documents and declined to delete 400 genuinely succeeded; an enum cannot express both, and overloading the status is how "withheld" gets treated as failure and stops the source syncing entirely — the outage the guard exists to prevent.
+
+Instead:
+- `Source.WithheldDeletions` — `int?`, null when nothing is pending. **Requires a migration** adding `sources.withheld_deletions` (nullable integer).
+- `SourceSyncResult.WithheldDeletions` — `int`.
+- `SourceResponse.WithheldDeletions` — visible to any viewer. It is a count, not a path, so unlike `LastSyncError` it leaks nothing about the remote and does not need the admin-only treatment.
+
+**Only the count is stored, never the paths.** The override re-runs the sync and recomputes the vanished set rather than replaying a stored list: if the mount returned in the meantime, the recomputed set is empty and nothing is deleted, where a stored list would delete files that are present again.
+
+**Corrected after adversarial review — recomputing is not *strictly* safer, and the count is a ceiling.** An earlier draft of this spec claimed recomputing was safer than replaying, full stop. It is safer when the remote **recovered** and more dangerous when it **degraded further**: an administrator shown 40 could have 1,000 applied if the listing worsened between reading the number and pressing the button. So the stored count binds the approval — a recomputed set larger than what was approved is withheld again, and the flag is inert when nothing was withheld, so it cannot lift a guard that never tripped.
+
+Bound by count rather than by path identity, deliberately. The administrator never sees which paths — the page shows a number and a source is never browsable — so the consent being given is "delete what is missing, about this many". Hashing the path set would invalidate approval on ordinary churn and would mean storing path-derived data this design keeps out of the database.
+
+### Behaviour when the guard trips
+
+Upserts **still apply**. Only deletions are held. A source that trips the guard must keep ingesting new content, or the safety mechanism becomes an outage.
+
+This is a deliberate departure from Google Cloud Directory Sync, which aborts the entire run. Connapse is a mirror for search rather than a directory sync where a partial apply corrupts state, so applying additions while withholding deletions leaves the index strictly more correct than skipping both.
+
+### Override
+
+A flag on the existing admin-only `POST /api/sources/{id}/sync`, and a button on the Sources page shown only when `WithheldDeletions` is non-null and the viewer is an admin. Audited under its own action name so "an admin approved 400 deletions" is distinguishable from an ordinary sync.
+
+### Testing
+
+- Unit tests on `ShouldWithholdDeletions` at boundaries: 10/100, 11/100, 5,000/100,000, 50,000/100,000, 5/5, 0/0.
+- **The regression test that matters:** an integration test seeding a source with documents, making its listing return empty, and asserting the documents are still present and `WithheldDeletions` reports the count. This must fail against current `main`.
+- An integration test that the override applies the deletions.
+- An integration test that upserts still apply on a cycle where deletions are withheld.
+
+## Part 2 — SFTP
+
+### Shape
+
+`ConnectionProvider.Sftp = 5`.
+
+**Connection `ConfigJson`:** `host`, `port` (default 22), `username`, `allowedRoot`, `hostKeyFingerprint` (populated on first connect).
+**Connection `Secret`:** the private key, encrypted by the existing DataProtection machinery.
+**Source `ScopeJson`:** `subPath`, `includePatterns`, `excludePatterns` — **identical to the Filesystem provider**, so `SourceForm`, `SourceScopePreflight` and `SourceScopeSummary` gain a provider case rather than a new branch of logic.
+
+### The passphrase
+
+An encrypted private key needs a passphrase, which is a second secret, and there is one `Secret` field. Store both as a small JSON object inside the existing encrypted blob: one protected value, one decrypt, no schema change.
+
+### Host key verification
+
+**SSH.NET raises `HostKeyReceived` with `CanTrust` defaulting to true** — not handling it is the insecure default, and a mistake here is silent. This must be handled explicitly.
+
+First successful connect records the fingerprint on the connection. Every later connect compares and refuses on mismatch, surfacing as a sync failure naming both the expected and presented fingerprints. The recorded fingerprint is shown on the connection so it can be checked against `ssh-keyscan`. Clearing it re-arms trust-on-first-use, which is how a legitimate server rekey is handled.
+
+### Path confinement — a new implementation, not a reuse
+
+**`PathConfinement` cannot be reused.** It calls `Directory.Exists`, `File.Exists` and `FileSystemInfo.ResolveLinkTarget` — local filesystem I/O. Against a remote path those either return false or resolve something on the *server running Connapse*, silently degrading confinement to a lexical prefix check. That is precisely the bug #365 fixed for local paths, and it would be reintroduced remotely.
+
+SFTP confinement uses the protocol's own `SSH_FXP_REALPATH` via `SftpClient.GetCanonicalPath`, so symlinks resolve **server-side** before the prefix comparison. Same shape as `PathConfinement`, different mechanism, its own tests.
+
+### Listing completeness
+
+The connector must distinguish "I walked everything" from "I walked what I could." A directory it cannot read must **fail the listing**, not silently return fewer files — a quietly-short listing is indistinguishable from a mass deletion to the reconcile, and the delete guard only bounds the damage rather than preventing it. No swallowing per-directory errors during the walk.
+
+### Deliberately not built
+
+- **No tree-walking connection test.** The test button opens a session, verifies the host key, and stats the root. Nothing more.
+- **`SupportsLiveWatch = false`.** SFTP has no change notification. List-and-diff on the normal poll, and at 100k files that is minutes per scan. Documented as a known limit.
+
+### The credential field returns, for SFTP only
+
+[#371](https://github.com/Destrayon/Connapse/pull/371) removed the secret field from the connection form deliberately. It comes back **only when the selected provider is SFTP**. S3 and Azure must continue to have no secret field at all, or the epic's no-stored-cloud-credentials position is quietly reopened. The form is provider-driven the same way the source scope fields are.
+
+### Testing
+
+A Testcontainers SFTP server (`atmoz/sftp`) gives end-to-end coverage the way LocalStack does for S3:
+
+- list and read against a real server;
+- confinement refusal on a `subPath` containing `../`;
+- confinement refusal on a **server-side symlink** pointing outside the root — the case a lexical check would pass;
+- host-key pinning: accept on first connect, refuse after the server's key changes;
+- a source whose remote directory becomes unreadable keeps its documents (ties Parts 1 and 2 together).
+
+## Using SFTP to index a local machine
+
+This is the supported answer to "Connapse in Docker cannot see my files," and it is documentation rather than code.
+
+Enable an SSH server on the host — OpenSSH Server is an optional Windows feature, Remote Login on macOS, sshd on Linux — add a public key to `authorized_keys`, and point an SFTP connection at it. From a Docker Desktop container the host is `host.docker.internal:22`.
+
+Three things the documentation must state, because each costs an hour otherwise:
+
+1. **Windows OpenSSH SFTP presents paths as `/C:/Users/...`** — a leading slash before the drive letter. This affects how `allowedRoot` is written.
+2. **`host.docker.internal` is Docker Desktop only.** A Linux host needs `--add-host=host.docker.internal:host-gateway`; a remote deployment needs the machine's real address, which returns to the reachability question that is the operator's to answer.
+3. **It is list-and-diff on every poll.** Point it at a folder, not a whole drive.
+
+The existing local Filesystem connector is unchanged and remains correct for same-host deployments.
+
+## Deferred work
+
+- **Per-connection S3 endpoints** (MinIO, Ceph, Garage). The S3 connector currently has no endpoint field and can only reach real AWS; the LocalStack test passes only via a process-wide `AWS_ENDPOINT_URL_S3`. Best delete-detection properties of any transport, and worth doing — just not chosen first.
+- **Credential-source determinism** — issue #383.
+- **Editor-created sources** — blocked on deny-by-default allowlists. With an empty allowlist, an editor choosing a scope inside an admin's credential is `iam:PassRole` on `Resource: "*"`, and because Connapse indexes content the result is a query interface over whatever that credential can reach.
+- **Tombstones and a generation counter** — add only if re-ingestion cost proves painful. The generation counter can be added on top of the threshold without redoing it.
+- **WebDAV** — the only surveyed protocol with a real change feed (RFC 6578 `sync-collection`). Excluded on .NET library support, not on merit. Revisit if a maintained client appears.
+
+## Success criteria
+
+1. A source whose remote listing collapses to empty keeps its documents, reports the withheld count, and continues to ingest new content.
+2. An admin can approve the withheld deletions from the Sources page in one action.
+3. An admin can add an SFTP connection and a source inside it entirely from the UI, and index files from a machine the server can reach — including their own, over `host.docker.internal`.
+4. A `subPath` that escapes its `allowedRoot`, whether lexically or through a server-side symlink, is refused.
+5. A changed host key stops the sync rather than being accepted silently.

--- a/docs/superpowers/specs/2026-08-23-sftp-ingestion-and-delete-guard-design.md
+++ b/docs/superpowers/specs/2026-08-23-sftp-ingestion-and-delete-guard-design.md
@@ -115,7 +115,11 @@ First successful connect records the fingerprint on the connection. Every later 
 
 **`PathConfinement` cannot be reused.** It calls `Directory.Exists`, `File.Exists` and `FileSystemInfo.ResolveLinkTarget` — local filesystem I/O. Against a remote path those either return false or resolve something on the *server running Connapse*, silently degrading confinement to a lexical prefix check. That is precisely the bug #365 fixed for local paths, and it would be reintroduced remotely.
 
-SFTP confinement uses the protocol's own `SSH_FXP_REALPATH` via `SftpClient.GetCanonicalPath`, so symlinks resolve **server-side** before the prefix comparison. Same shape as `PathConfinement`, different mechanism, its own tests.
+SFTP confinement uses the protocol's own `SSH_FXP_REALPATH`, so symlinks resolve **server-side** before the prefix comparison. Same shape as `PathConfinement`, different mechanism, its own tests.
+
+**Corrected during implementation — `SftpClient.GetCanonicalPath` does not exist.** This spec named it; SSH.NET keeps `GetCanonicalPath` internal to `ISftpSession` and exposes no public entry point for it. The route that works is `ChangeDirectory`, which issues the realpath request and leaves the resolved answer in `WorkingDirectory`.
+
+That has one consequence worth recording, because it shapes the code: `ChangeDirectory` only accepts directories, so a **file** path cannot be canonicalised directly. Files are confined through their parent instead, with the leaf separately rejected if it carries a separator or is a traversal segment. This is not a weakening — every way out of the root runs through a directory, either a `..` segment or a symlinked ancestor, and both live in the parent — but it is not what the spec described.
 
 ### Listing completeness
 

--- a/src/Connapse.Background/Jobs/IngestionJobs.cs
+++ b/src/Connapse.Background/Jobs/IngestionJobs.cs
@@ -102,7 +102,12 @@ public sealed class IngestionJobs : IIngestionJobs
             // IElectStateFilter — deferred to a follow-up.
             _logger.LogWarning(ex,
                 "IngestAsync threw {DocumentId}", LogSanitizer.Sanitize(documentId));
-            await _docStore.UpdateIngestionStateAsync(documentId, IngestionState.Failed, CancellationToken.None);
+
+            // Status as well as state. The pipeline writes "Failed" itself once it has the row
+            // in hand, but a job that died before that — a source whose SFTP server refused the
+            // connection, say — never reaches it, and the "Pending" a reindex left behind reads
+            // to the sync engine as a job still on its way. It would skip the document forever.
+            await _docStore.MarkIngestionFailedAsync(documentId, ex.Message, CancellationToken.None);
             await _stateBroadcaster.BroadcastIngestionStateChangedAsync(
                 documentId, IngestionState.Failed, CancellationToken.None);
             throw;

--- a/src/Connapse.Core/Interfaces/IConnectorFactory.cs
+++ b/src/Connapse.Core/Interfaces/IConnectorFactory.cs
@@ -11,5 +11,16 @@ public interface IConnectorFactory
     /// connection does not own the source.
     /// </para>
     /// </summary>
-    IConnector Create(Source source, Connection connection);
+    /// <param name="secret">
+    /// The connection's decrypted secret, for the providers that have one. Passed in rather
+    /// than read from <paramref name="connection"/> because <see cref="Connection"/> is the
+    /// read model returned from the connections API, and keeping credentials off it is the
+    /// reason <see cref="IConnectionStore.GetSecretAsync"/> exists as a separate call.
+    /// <para>
+    /// Null for S3, Azure Blob and Filesystem, which authenticate from ambient identity or
+    /// need nothing at all. A provider that requires one and is handed null fails at connect
+    /// time, which is the loud failure it should be.
+    /// </para>
+    /// </param>
+    IConnector Create(Source source, Connection connection, string? secret = null);
 }

--- a/src/Connapse.Core/Interfaces/IDocumentStore.cs
+++ b/src/Connapse.Core/Interfaces/IDocumentStore.cs
@@ -1,4 +1,4 @@
-namespace Connapse.Core.Interfaces;
+﻿namespace Connapse.Core.Interfaces;
 
 public interface IDocumentStore
 {
@@ -25,6 +25,22 @@ public interface IDocumentStore
     /// as they transition through Pending → Indexed → SummaryIndexed → (Failed).
     /// </summary>
     Task UpdateIngestionStateAsync(string documentId, IngestionState state, CancellationToken ct = default);
+
+    /// <summary>
+    /// Records that a document's ingestion failed, in both the enrichment state and the job
+    /// lifecycle status.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="UpdateIngestionStateAsync"/> because that one also carries
+    /// summarization outcomes, and a summary that failed does not make an indexed document a
+    /// failed one. This is only for the ingestion job itself.
+    /// <para>
+    /// Both columns matter: the sync engine reads <c>Status</c>, and treats "Pending" as a job
+    /// that is still coming. A job that died before the pipeline loaded the row leaves that
+    /// status behind, and the document is then skipped on every future cycle.
+    /// </para>
+    /// </remarks>
+    Task MarkIngestionFailedAsync(string documentId, string? errorMessage, CancellationToken ct = default);
 
     /// <summary>
     /// Returns container IDs whose docs have summaries newer than the container's own summary

--- a/src/Connapse.Core/Interfaces/ISourceStore.cs
+++ b/src/Connapse.Core/Interfaces/ISourceStore.cs
@@ -36,6 +36,13 @@ public interface ISourceStore
     /// </summary>
     Task<bool> TryAdvanceSyncStateAsync(Guid id, string? expectedCursor, string? newCursor, SyncStatus status, string? error, DateTime? syncedAt, CancellationToken ct = default);
 
+    /// <summary>
+    /// Records how many deletions the last reconcile declined to apply, or null to clear.
+    /// Separate from <see cref="UpdateSyncStateAsync"/> because a sync that withholds
+    /// deletions still succeeded — the count is orthogonal to the status, not a variant of it.
+    /// </summary>
+    Task UpdateWithheldDeletionsAsync(Guid id, int? withheld, CancellationToken ct = default);
+
     Task<ContainerSettingsOverrides?> GetSettingsOverridesAsync(Guid id, CancellationToken ct = default);
     Task SaveSettingsOverridesAsync(Guid id, ContainerSettingsOverrides overrides, CancellationToken ct = default);
     Task UpdateSummaryAsync(Guid id, string? summary, DateTime? generatedAt, string? docSetHash, CancellationToken ct = default);

--- a/src/Connapse.Core/Interfaces/ISshHostKeyStore.cs
+++ b/src/Connapse.Core/Interfaces/ISshHostKeyStore.cs
@@ -1,0 +1,29 @@
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Records the host key fingerprint a connection is pinned to.
+/// <para>
+/// A seam, rather than handing <see cref="IConnectionStore"/> to the connector. A connector
+/// is built fresh on every sync cycle and is otherwise a read-only view of somebody else's
+/// system; giving it the ability to rewrite arbitrary connection fields to support one
+/// write is a much wider grant than the write needs.
+/// </para>
+/// </summary>
+public interface ISshHostKeyStore
+{
+    /// <summary>
+    /// Pins <paramref name="fingerprint"/> to the connection, first use only.
+    /// </summary>
+    /// <remarks>
+    /// Called after the session is fully established — <b>after</b> authentication, not from
+    /// the host-key callback. A key presented by a server we then failed to authenticate to
+    /// is not a key worth pinning, and pinning it would make a hostile server's key the one
+    /// every later connection is compared against.
+    /// <para>
+    /// Implementations must not overwrite a fingerprint that is already recorded. The
+    /// mismatch path refuses the connection rather than reaching here, so an arriving write
+    /// against an existing value means two cycles raced, and the recorded value wins.
+    /// </para>
+    /// </remarks>
+    Task RecordFingerprintAsync(Guid connectionId, string fingerprint, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Models/ConnectionModels.cs
+++ b/src/Connapse.Core/Models/ConnectionModels.cs
@@ -6,7 +6,7 @@ namespace Connapse.Core;
 /// ManagedStorage is deliberately absent: it is Connapse's own backend, not an
 /// external system requiring credentials.
 /// </summary>
-public enum ConnectionProvider { Filesystem = 1, S3 = 3, AzureBlob = 4 }
+public enum ConnectionProvider { Filesystem = 1, S3 = 3, AzureBlob = 4, Sftp = 5 }
 
 public record Connection(
     Guid Id,

--- a/src/Connapse.Core/Models/SourceModels.cs
+++ b/src/Connapse.Core/Models/SourceModels.cs
@@ -20,7 +20,8 @@ public record Source(
     string? Summary = null,
     DateTime? SummaryGeneratedAt = null,
     string? SummaryDocSetHash = null,
-    int DocumentCount = 0);
+    int DocumentCount = 0,
+    int? WithheldDeletions = null);
 
 public record CreateSourceRequest(
     string Name,

--- a/src/Connapse.Core/Models/StorageModels.cs
+++ b/src/Connapse.Core/Models/StorageModels.cs
@@ -1,6 +1,6 @@
-namespace Connapse.Core;
+﻿namespace Connapse.Core;
 
-public enum ConnectorType { ManagedStorage = 0, Filesystem = 1, S3 = 3, AzureBlob = 4 }
+public enum ConnectorType { ManagedStorage = 0, Filesystem = 1, S3 = 3, AzureBlob = 4, Sftp = 5 }
 
 public record ContainerSettingsOverrides
 {
@@ -45,7 +45,19 @@ public record Document(
     string? Summary = null,
     DateTime? SummaryGeneratedAt = null,
     string? SummaryContentHash = null,
-    IngestionState IngestionState = IngestionState.Pending);
+    IngestionState IngestionState = IngestionState.Pending)
+{
+    /// <summary>
+    /// Which owner the row actually has. Needed because <see cref="ContainerId"/> carries
+    /// COALESCE(container_id, source_id) — it is never blank, so a source-owned document is
+    /// indistinguishable from a container-owned one by that field alone, and a caller that
+    /// guessed "container" would look up a container by a source's id and find nothing.
+    /// <para>
+    /// Null only for documents built outside the store, which have not been read from a row.
+    /// </para>
+    /// </summary>
+    public OwnerRef? Owner { get; init; }
+}
 
 public record StoreResult(string DocumentId, int Generation);
 

--- a/src/Connapse.Core/Models/SyncModels.cs
+++ b/src/Connapse.Core/Models/SyncModels.cs
@@ -33,7 +33,8 @@ public record SourceSyncResult(
     bool UsedDeltaPath,
     bool RequiredResync,
     string? Error,
-    bool AlreadyRunning = false);
+    bool AlreadyRunning = false,
+    int WithheldDeletions = 0);
 
 /// <summary>
 /// Thrown when a reindex would move a document between ownership domains — source to

--- a/src/Connapse.Core/Utilities/DeletionGuard.cs
+++ b/src/Connapse.Core/Utilities/DeletionGuard.cs
@@ -1,0 +1,40 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Decides whether a computed deletion set is too large to trust.
+/// <para>
+/// A reconcile infers deletions from absence: anything indexed but missing from the remote
+/// listing is assumed deleted. That inference is only as good as the listing, and a listing
+/// can come back empty <em>and successful</em> — a narrowed bucket policy returning 200 OK
+/// with zero keys, or a filesystem directory that is temporarily unmounted. Without this
+/// check, one such listing deletes every document the source owns.
+/// </para>
+/// <para>
+/// The rule deliberately does not try to decide whether a deletion is <em>correct</em>. For a
+/// mirror, a wrong deletion is recoverable — the next sync re-ingests it — so what needs
+/// preventing is the catastrophic case, not every false positive.
+/// </para>
+/// </summary>
+public static class DeletionGuard
+{
+    /// <summary>Deletion sets at or below this size are always applied.</summary>
+    /// <remarks>
+    /// A floor rather than a pure percentage: on a five-document source, deleting three is
+    /// 60% and would trip a percentage rule on completely ordinary tidying.
+    /// </remarks>
+    public const int AlwaysAllowedCount = 10;
+
+    /// <summary>Proportion of a source's index above which a deletion set is withheld.</summary>
+    /// <remarks>
+    /// A ceiling rather than a pure count: ten documents out of a hundred thousand is noise,
+    /// and an absolute-only rule would block routine churn on any large source.
+    /// </remarks>
+    public const int WithheldPercent = 10;
+
+    /// <summary>
+    /// True when the deletion set should be withheld pending an administrator's approval.
+    /// Requires <em>both</em> bounds to be exceeded, so neither degenerate case fires.
+    /// </summary>
+    public static bool ShouldWithhold(int vanished, int indexed) =>
+        vanished > AlwaysAllowedCount && vanished > indexed / (100 / WithheldPercent);
+}

--- a/src/Connapse.Core/Utilities/SftpHostSetup.cs
+++ b/src/Connapse.Core/Utilities/SftpHostSetup.cs
@@ -1,0 +1,363 @@
+﻿namespace Connapse.Core.Utilities;
+
+/// <summary>The operator's own machine, which decides what the setup command looks like.</summary>
+public enum HostPlatform { Windows, MacOS, Linux }
+
+/// <summary>
+/// What the setup command reported back. Every field comes from the host, because the host
+/// is the only place that knows it — which is the reason for the round trip at all.
+/// </summary>
+/// <param name="Username">The account the SSH server will authenticate.</param>
+/// <param name="HomePath">
+/// The home directory as SFTP presents it. On Windows that carries a leading slash before
+/// the drive letter, which is the detail that costs people an hour.
+/// </param>
+/// <param name="Fingerprint">
+/// The server's host key, read on the machine itself. Arriving out of band is what turns
+/// trust-on-first-use into verified-first-use.
+/// </param>
+/// <param name="Drives">
+/// Filesystem roots the account can reach, as SFTP paths — <c>/C:/</c>, <c>/D:/</c> and so
+/// on. Windows only; empty elsewhere, where everything already hangs off <c>/</c>.
+/// <para>
+/// Reported because the home directory is not where people keep things. A second drive is
+/// completely normal, and a flow that can only reach <c>C:</c> would be answering a question
+/// nobody asked.
+/// </para>
+/// </param>
+public record SftpHostSetupResult(
+    string Username,
+    string HomePath,
+    string Fingerprint,
+    IReadOnlyList<string>? Drives = null)
+{
+    public IReadOnlyList<string> Drives { get; init; } = Drives ?? [];
+}
+
+/// <summary>
+/// Builds the one command an operator runs on their own machine, and reads back what it
+/// reports.
+/// <para>
+/// Connapse cannot configure the host — that boundary is the entire reason the container is
+/// worth running. What it can do is everything either side of the boundary: generate the key,
+/// write the command, and consume the result. The operator copies twice and types nothing.
+/// </para>
+/// </summary>
+public static class SftpHostSetup
+{
+    /// <summary>
+    /// Delimits the block the operator pastes back. Deliberately unmistakable, because the
+    /// usual failure is pasting the whole terminal buffer, and that should still work.
+    /// </summary>
+    public const string BeginMarker = "----- BEGIN CONNAPSE SETUP -----";
+
+    public const string EndMarker = "----- END CONNAPSE SETUP -----";
+
+    /// <summary>
+    /// Options prefixed to the <c>authorized_keys</c> entry, so the installed key can do nothing
+    /// but SFTP.
+    /// </summary>
+    /// <remarks>
+    /// Without these the entry is a bare public key, which grants everything the account can do:
+    /// an interactive shell, port forwarding, agent forwarding. Connapse only ever needs to read
+    /// files, and the path confinement it applies is an <i>application</i> rule — it bounds what
+    /// Connapse does with the credential, not what the credential can do. Anyone who obtained the
+    /// stored private key would not be bound by it at all.
+    /// <para>
+    /// <c>restrict</c> (OpenSSH 7.2+) disables port forwarding, agent forwarding, X11 and PTY
+    /// allocation. <c>command</c> replaces whatever the client asks for, so a session requesting
+    /// a shell gets the SFTP server instead. Both are supported by Win32-OpenSSH as well as
+    /// portable OpenSSH.
+    /// </para>
+    /// <para>
+    /// This does not make an administrator account safe to use — the key still authenticates as
+    /// that account, and an SFTP session for an administrator can read everything on the machine.
+    /// It bounds the <i>kind</i> of access, not its reach, which is why the wizard says to prefer
+    /// a non-administrator account.
+    /// </para>
+    /// </remarks>
+    public const string KeyRestrictions = """restrict,command="internal-sftp" """;
+
+    /// <summary>
+    /// The command for <paramref name="platform"/>, with <paramref name="publicKeyLine"/>
+    /// already embedded.
+    /// </summary>
+    /// <remarks>
+    /// Meant to be read before it is run. It enables a network service and installs an
+    /// authorized key, so it is shown in full rather than offered as a download or a pipe
+    /// from a URL — the operator should be able to see exactly what they are agreeing to at
+    /// the moment they agree to it.
+    /// </remarks>
+    public static string GenerateScript(string publicKeyLine, HostPlatform platform)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(publicKeyLine);
+
+        // The key is base64 plus a sanitised comment, so it cannot contain a quote or a
+        // newline — SshKeyPairGenerator guarantees that. Asserted rather than assumed,
+        // because everything below embeds it into a shell string.
+        if (publicKeyLine.Any(c => c is '\n' or '\r' or '\'' or '"'))
+            throw new ArgumentException(
+                "A public key line cannot contain quotes or newlines.", nameof(publicKeyLine));
+
+        // The key is installed restricted, never bare. See KeyRestrictions.
+        string entry = KeyRestrictions + publicKeyLine;
+
+        return platform switch
+        {
+            HostPlatform.Windows => WindowsScript(entry),
+            HostPlatform.MacOS => UnixScript(entry, macOs: true),
+            HostPlatform.Linux => UnixScript(entry, macOs: false),
+            _ => throw new ArgumentOutOfRangeException(nameof(platform)),
+        };
+    }
+
+    private static string WindowsScript(string publicKeyLine) =>
+        $$"""
+        # Connapse — allow this computer to be indexed. Run in PowerShell as Administrator.
+        # Safe to run more than once.
+
+        # 0. Stop if not elevated, rather than half-succeeding.
+        #    Without elevation the steps below fail in ways that leave SSH looking configured
+        #    while it is not, and the symptom is an authentication failure with nothing to
+        #    explain it.
+        if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+                 ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+            Write-Host 'Run this in a PowerShell window opened with "Run as Administrator".' -ForegroundColor Red
+            return
+        }
+
+        # 1. Make sure an SSH server is installed and running.
+        if (-not (Get-Service sshd -ErrorAction SilentlyContinue)) {
+            Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 | Out-Null
+        }
+        Set-Service -Name sshd -StartupType Automatic
+        if ((Get-Service sshd).Status -ne 'Running') { Start-Service sshd }
+
+        # Reachable from this machine's own networks, and no further. An unscoped rule would
+        # also accept port 22 from whatever else is on a hotel or cafe network, and from the
+        # internet on any host whose router forwards the port — a much larger change than
+        # "let Connapse read my files", made silently while the operator was doing something
+        # else. LocalSubnet still covers the Docker and WSL virtual switches, which is how a
+        # Connapse container reaches its host.
+        if (-not (Get-NetFirewallRule -Name 'Connapse-SFTP-In-TCP' -ErrorAction SilentlyContinue)) {
+            New-NetFirewallRule -Name 'Connapse-SFTP-In-TCP' -DisplayName 'Connapse SFTP (sshd)' `
+                -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 `
+                -Profile Any -RemoteAddress LocalSubnet | Out-Null
+            Write-Host 'Opened inbound TCP 22 to this machine''s local subnets only.' -ForegroundColor Cyan
+        }
+
+        # 2. Work out which authorized_keys file sshd will actually read.
+        #    For an account in the Administrators group it is NOT the one in your profile —
+        #    sshd_config redirects those to a machine-wide file with a locked-down ACL. This
+        #    is the single most common reason Windows SSH keys silently fail to authenticate.
+        #
+        #    Asked of the group itself, not of this process's token. UAC filters the
+        #    Administrators SID out of an unelevated token, so a token check reports False for
+        #    an account that genuinely is a member — and the key would then be written where
+        #    sshd will never look.
+        $mySid = ([Security.Principal.WindowsIdentity]::GetCurrent()).User.Value
+        try {
+            $isAdmin = $null -ne (Get-LocalGroupMember -Group 'Administrators' -ErrorAction Stop |
+                                  Where-Object { $_.SID.Value -eq $mySid })
+        } catch {
+            # Domain-joined machines can refuse that cmdlet. Elevated, the token is unfiltered
+            # and this is accurate — and step 0 guarantees we are elevated.
+            $isAdmin = ([Security.Principal.WindowsIdentity]::GetCurrent()).Groups.Value -contains 'S-1-5-32-544'
+        }
+
+        if ($isAdmin) {
+            $keyFile = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'
+        } else {
+            $keyFile = Join-Path $env:USERPROFILE '.ssh\authorized_keys'
+        }
+
+        New-Item -ItemType Directory -Force -Path (Split-Path $keyFile) | Out-Null
+        if (-not (Test-Path $keyFile)) { New-Item -ItemType File -Path $keyFile | Out-Null }
+
+        # 3. Add Connapse's key, but only once, and without disturbing any other key present.
+        $key = '{{publicKeyLine}}'
+        if (-not (Select-String -Path $keyFile -SimpleMatch -Pattern $key -Quiet)) {
+            Add-Content -Path $keyFile -Value $key
+        }
+
+        if ($isAdmin) {
+            # sshd refuses to read this file unless only SYSTEM and Administrators can write it.
+            icacls $keyFile /inheritance:r /grant 'SYSTEM:F' 'Administrators:F' | Out-Null
+        }
+
+        # 4. Say whether this host still accepts passwords over SSH.
+        #    The restrictions on Connapse's key bind that key and nothing else, so they do not
+        #    make the host key-only. Reported rather than changed: turning off password
+        #    authentication is a decision about every account on the machine, and making it
+        #    silently could lock someone out of a login they were relying on.
+        $sshdConfig = Join-Path $env:ProgramData 'ssh\sshd_config'
+        $passwordAuth = 'unknown'
+        if (Test-Path $sshdConfig) {
+            $setting = Select-String -Path $sshdConfig -Pattern '^\s*PasswordAuthentication\s+(\S+)' |
+                       Select-Object -Last 1
+            # OpenSSH defaults this to yes when the directive is absent or commented out.
+            $passwordAuth = if ($setting) { $setting.Matches[0].Groups[1].Value } else { 'yes' }
+        }
+
+        # 5. Report back what only this machine knows.
+        #    Wrapped, because the key is already installed by this point and a failure to read
+        #    the fingerprint must not throw away a setup that otherwise worked. An empty
+        #    fingerprint costs the operator verified-first-use, not the connection.
+        $fingerprint = ''
+        try {
+            $hostKey = Get-ChildItem (Join-Path $env:ProgramData 'ssh') -Filter 'ssh_host_*_key.pub' -ErrorAction Stop |
+                       Sort-Object { $_.Name -notlike '*ed25519*' } | Select-Object -First 1
+            $line = & ssh-keygen -lf $hostKey.FullName 2>$null
+            if ($LASTEXITCODE -eq 0 -and $line) { $fingerprint = ($line -split ' ')[1] }
+        } catch { }
+
+        # Every drive the account can reach, because the home folder is not where most people
+        # keep things and a second drive is entirely normal.
+        $drives = (Get-PSDrive -PSProvider FileSystem | ForEach-Object { "/$($_.Name):/" }) -join ','
+
+        Write-Host ''
+        Write-Host '{{BeginMarker}}'
+        Write-Host "user=$env:USERNAME"
+        Write-Host "home=/$($env:USERPROFILE -replace '\\','/')"
+        Write-Host "drives=$drives"
+        Write-Host "fingerprint=$fingerprint"
+        Write-Host '{{EndMarker}}'
+        Write-Host ''
+        Write-Host 'Copy the block above, including both marker lines, back into Connapse.'
+        if (-not $fingerprint) {
+            Write-Host 'The host key fingerprint could not be read, so the first connection will be trusted rather than verified. Everything else is set up.' -ForegroundColor Yellow
+        }
+        if ($passwordAuth -eq 'yes' -or $passwordAuth -eq 'unknown') {
+            Write-Host ''
+            Write-Host 'This machine also accepts SSH logins by password, for every account on it.' -ForegroundColor Yellow
+            Write-Host "To allow keys only, set 'PasswordAuthentication no' in $sshdConfig and run: Restart-Service sshd" -ForegroundColor Yellow
+        }
+        """;
+
+    private static string UnixScript(string publicKeyLine, bool macOs)
+    {
+        string enable = macOs
+            ? """
+              # 1. Turn on Remote Login, which is what serves SFTP on macOS.
+              sudo systemsetup -setremotelogin on
+              """
+            : """
+              # 1. Make sure an SSH server is installed and running.
+              #    The unit is 'ssh' on Debian and Ubuntu, 'sshd' most other places.
+              sudo systemctl enable --now sshd 2>/dev/null || sudo systemctl enable --now ssh
+              """;
+
+        // $$ so a single brace is literal — the awk program below needs them, and doubling
+        // every interpolation is the lesser evil against escaping the shell.
+        return $$"""
+        # Connapse — allow this computer to be indexed. Safe to run more than once.
+
+        {{enable}}
+
+        # 2. Add Connapse's key, but only once, and without disturbing any other key present.
+        mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys
+        chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys
+
+        KEY='{{publicKeyLine}}'
+        grep -qxF "$KEY" ~/.ssh/authorized_keys || echo "$KEY" >> ~/.ssh/authorized_keys
+
+        # 3. Say whether this host still accepts passwords over SSH.
+        #    The restrictions on Connapse's key bind that key and nothing else, so they do not
+        #    make the host key-only. Reported rather than changed: turning off password
+        #    authentication is a decision about every account on the machine.
+        #    OpenSSH defaults this to yes when the directive is absent or commented out.
+        PASSWORD_AUTH=$(awk 'tolower($1)=="passwordauthentication" {v=$2} END {print (v?v:"yes")}'                         /etc/ssh/sshd_config 2>/dev/null || echo unknown)
+
+        # 4. Report back what only this machine knows.
+        HOSTKEY=$(ls /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null || ls /etc/ssh/ssh_host_rsa_key.pub)
+        FINGERPRINT=$(ssh-keygen -lf "$HOSTKEY" | awk '{print $2}')
+
+        printf '\n{{BeginMarker}}\n'
+        printf 'user=%s\n' "$(whoami)"
+        printf 'home=%s\n' "$HOME"
+        printf 'fingerprint=%s\n' "$FINGERPRINT"
+        printf '{{EndMarker}}\n\n'
+        echo 'Copy the block above, including both marker lines, back into Connapse.'
+
+        if [ "$PASSWORD_AUTH" != "no" ]; then
+            echo ''
+            echo 'This machine also accepts SSH logins by password, for every account on it.'
+            echo "To allow keys only, set 'PasswordAuthentication no' in /etc/ssh/sshd_config and restart the SSH service."
+        fi
+        """;
+    }
+
+    /// <summary>
+    /// Reads the block the setup command printed. Returns null when the text does not contain
+    /// a usable one.
+    /// </summary>
+    /// <remarks>
+    /// Tolerant on purpose. Operators paste whole terminal buffers, with prompts, wrapping,
+    /// and the command echoed above the output — so this finds the markers rather than
+    /// expecting the text to begin at them, and ignores anything outside.
+    /// </remarks>
+    public static SftpHostSetupResult? ParseResult(string? pasted)
+    {
+        if (string.IsNullOrWhiteSpace(pasted))
+            return null;
+
+        int start = pasted.IndexOf(BeginMarker, StringComparison.Ordinal);
+        int end = pasted.IndexOf(EndMarker, StringComparison.Ordinal);
+
+        // Without both markers there is nothing to be confident about. Guessing at loose
+        // key=value lines would happily accept a paste from somewhere else entirely.
+        if (start < 0 || end < 0 || end <= start)
+            return null;
+
+        string body = pasted[(start + BeginMarker.Length)..end];
+
+        string? user = null, home = null, fingerprint = null;
+        IReadOnlyList<string> drives = [];
+
+        foreach (string raw in body.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            string line = raw.Trim();
+            int split = line.IndexOf('=');
+            if (split <= 0) continue;
+
+            string name = line[..split].Trim();
+            string value = line[(split + 1)..].Trim();
+            if (value.Length == 0) continue;
+
+            switch (name)
+            {
+                case "user": user = value; break;
+                case "home": home = value; break;
+                case "fingerprint": fingerprint = NormaliseFingerprint(value); break;
+
+                // Optional. Older setup commands did not report it, and a Unix host has
+                // nothing to report — neither is a reason to reject the block.
+                case "drives":
+                    drives = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    break;
+            }
+        }
+
+        // The fingerprint is optional, and that is not a weakening — it is what stops the flow
+        // dead-ending. Reading it needs elevation and can still fail, by which point sshd is
+        // running and the key is installed. Requiring it here meant the block parsed to null,
+        // the UI disabled both test and save, and the operator was left with a configured host,
+        // an authorized Connapse key, and no way to finish or undo.
+        //
+        // Blank already has a defined meaning everywhere else: SshHostKeyPolicy reads it as
+        // trust-on-first-use. So an absent fingerprint costs the stronger verified-first-use and
+        // nothing else, which the panel says plainly rather than silently accepting.
+        return user is null || home is null
+            ? null
+            : new SftpHostSetupResult(user, home, fingerprint ?? string.Empty, drives);
+    }
+
+    /// <summary>
+    /// <c>ssh-keygen -l</c> prints <c>SHA256:…</c>, which is already the stored form. An
+    /// operator pasting a fingerprint by hand may well omit the prefix, so it is added back
+    /// rather than treated as a mismatch later, when the only symptom would be a refused
+    /// connection.
+    /// </summary>
+    private static string NormaliseFingerprint(string value) =>
+        value.StartsWith("SHA256:", StringComparison.Ordinal) ? value : $"SHA256:{value}";
+}

--- a/src/Connapse.Core/Utilities/SftpPathConfinement.cs
+++ b/src/Connapse.Core/Utilities/SftpPathConfinement.cs
@@ -1,0 +1,140 @@
+﻿namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Resolves a remote path so a caller can decide whether it escapes a root, using the
+/// server's own canonicalisation.
+/// </summary>
+/// <remarks>
+/// Deliberately an interface in Core rather than SSH.NET's own type: Core has no external
+/// dependencies, and the seam is what lets the confinement rules be tested without standing
+/// up a server.
+/// </remarks>
+public interface ISftpRealPathResolver
+{
+    /// <summary>
+    /// Canonicalises <paramref name="path"/> on the remote server via
+    /// <c>SSH_FXP_REALPATH</c>, resolving <c>..</c> segments and symlinks there.
+    /// Throws when the server refuses or the session is unusable.
+    /// </summary>
+    /// <remarks>
+    /// Asynchronous because this is a request to a machine that may never answer it. A server
+    /// can complete authentication and then stall its SFTP subsystem, and a blocking call has
+    /// nothing to interrupt it — so the caller's timeout would cover the handshake and nothing
+    /// after it, which is the part that actually waits.
+    /// </remarks>
+    Task<string> GetCanonicalPathAsync(string path, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Confines a remote path beneath an SFTP connection's allowed root.
+/// <para>
+/// A separate implementation from <see cref="PathConfinement"/>, and it has to be.
+/// <see cref="PathConfinement"/> calls <c>Directory.Exists</c>, <c>File.Exists</c> and
+/// <c>FileSystemInfo.ResolveLinkTarget</c> — local filesystem I/O. Handed a remote path
+/// those either return false or resolve something on the machine running Connapse, which
+/// silently degrades confinement to a lexical prefix check. That is precisely the bug #365
+/// fixed for local paths, and reusing the local helper here would reintroduce it remotely.
+/// </para>
+/// <para>
+/// So resolution happens on the server, through <c>SSH_FXP_REALPATH</c>: <c>..</c> segments
+/// and symlinks collapse where they actually mean something, and only the resolved result is
+/// compared.
+/// </para>
+/// </summary>
+public static class SftpPathConfinement
+{
+    /// <summary>
+    /// SFTP paths are POSIX-shaped regardless of the server's operating system. Windows
+    /// OpenSSH presents drives as <c>/C:/Users/...</c> — a leading slash before the drive
+    /// letter — rather than switching to backslashes.
+    /// </summary>
+    public const char Separator = '/';
+
+    /// <summary>
+    /// Combines <paramref name="relative"/> beneath <paramref name="root"/>, canonicalises
+    /// both on the server, and returns the resolved path when it stays inside the root — or
+    /// null when it escapes, when the input is unusable, or when the server will not resolve
+    /// it.
+    /// </summary>
+    public static async Task<string?> CombineWithinAsync(
+        ISftpRealPathResolver resolver, string root, string? relative, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(resolver);
+        ArgumentException.ThrowIfNullOrWhiteSpace(root);
+
+        if (string.IsNullOrWhiteSpace(relative))
+            return await ResolveWithinAsync(resolver, root, root, ct);
+
+        // An absolute relative path is refused rather than honoured. This mirrors
+        // PathConfinement.CombineWithin: treating it as a path under the root would hand back
+        // somewhere else on the server entirely.
+        if (relative.StartsWith(Separator))
+            return null;
+
+        string joined = root.TrimEnd(Separator) + Separator + relative;
+
+        return await ResolveWithinAsync(resolver, root, joined, ct);
+    }
+
+    /// <summary>
+    /// Returns the server-resolved <paramref name="candidate"/> when it lies inside
+    /// <paramref name="root"/>, or null when it escapes. Both sides are canonicalised, so a
+    /// root that is itself a symlink cannot make a contained path look like an escape.
+    /// </summary>
+    public static async Task<string?> ResolveWithinAsync(
+        ISftpRealPathResolver resolver, string root, string candidate, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(resolver);
+        ArgumentException.ThrowIfNullOrWhiteSpace(root);
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        string canonicalRoot;
+        string canonicalCandidate;
+
+        try
+        {
+            canonicalRoot = await resolver.GetCanonicalPathAsync(root, ct);
+            canonicalCandidate = await resolver.GetCanonicalPathAsync(candidate, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A path the server will not resolve is a path we cannot vouch for. Refusing is
+            // the only safe direction: returning the unresolved string would let the
+            // comparison below pass on something nobody verified.
+            return null;
+        }
+
+        if (string.IsNullOrEmpty(canonicalRoot) || string.IsNullOrEmpty(canonicalCandidate))
+            return null;
+
+        return IsWithin(canonicalRoot, canonicalCandidate) ? canonicalCandidate : null;
+    }
+
+    /// <summary>
+    /// True when <paramref name="canonicalCandidate"/> is <paramref name="canonicalRoot"/>
+    /// itself or sits beneath it. Both arguments must already be server-canonicalised.
+    /// </summary>
+    /// <remarks>
+    /// Compared ordinally, including against a Windows OpenSSH server where the underlying
+    /// filesystem is case-insensitive. The failure modes are not symmetric: comparing too
+    /// strictly refuses a legitimate path, which is visible and fixable, while comparing too
+    /// loosely admits a path that escapes the root, which is silent. There is no reliable way
+    /// to learn a remote server's case rules over SFTP, so this takes the visible failure.
+    /// </remarks>
+    public static bool IsWithin(string canonicalRoot, string canonicalCandidate)
+    {
+        string trimmedRoot = canonicalRoot.TrimEnd(Separator);
+
+        // A trailing separator on the prefix test, so a sibling sharing a name prefix cannot
+        // pass: "/data-other" starts with "/data" as a string but is not inside it. This is
+        // the nginx `alias` off-by-slash bug, and the most common way this check is written
+        // wrong.
+        string rootWithSep = trimmedRoot + Separator;
+
+        // A root that canonicalises to "/" trims to empty, which would make rootWithSep "/"
+        // and match everything — correct, since everything genuinely is beneath the server
+        // root, but only reached when an administrator configured "/" as the allowed root.
+        return canonicalCandidate.Equals(trimmedRoot, StringComparison.Ordinal)
+            || canonicalCandidate.StartsWith(rootWithSep, StringComparison.Ordinal);
+    }
+}

--- a/src/Connapse.Core/Utilities/SshHostKeyPolicy.cs
+++ b/src/Connapse.Core/Utilities/SshHostKeyPolicy.cs
@@ -1,0 +1,87 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// What to do with the host key a server just presented.
+/// </summary>
+public enum SshHostKeyDecision
+{
+    /// <summary>Nothing is pinned yet. Trust it and record it — trust on first use.</summary>
+    TrustOnFirstUse,
+
+    /// <summary>The presented key matches what is pinned.</summary>
+    Matches,
+
+    /// <summary>The presented key differs from what is pinned. Refuse the connection.</summary>
+    Mismatch
+}
+
+/// <summary>
+/// Decides whether to trust an SSH server's host key, and formats fingerprints for storage
+/// and display.
+/// <para>
+/// Pulled out of the connector as a pure function because getting it wrong is silent.
+/// SSH.NET raises <c>HostKeyReceived</c> with <c>CanTrust</c> already set to <b>true</b>, so
+/// a connector that simply does not subscribe accepts every key any server offers — the
+/// insecure behaviour is the one you get by writing no code at all, and it looks identical
+/// to the secure one from the outside.
+/// </para>
+/// <para>
+/// The threat this addresses is interposition <i>after</i> a connection has been working:
+/// somebody who can answer on the server's address later cannot silently take over a source
+/// that has already synced. It does not authenticate the very first connection, which is the
+/// standing trade-off of trust-on-first-use and the reason the recorded fingerprint is shown
+/// on the connection for an administrator to check against <c>ssh-keyscan</c>.
+/// </para>
+/// </summary>
+public static class SshHostKeyPolicy
+{
+    /// <summary>
+    /// Compares a presented fingerprint against what is pinned for the connection.
+    /// </summary>
+    /// <param name="pinned">
+    /// The recorded fingerprint, or null/blank when none has been recorded yet. Clearing it
+    /// re-arms trust on first use, which is how a legitimate server rekey is handled.
+    /// </param>
+    public static SshHostKeyDecision Evaluate(string? pinned, string presented)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(presented);
+
+        if (string.IsNullOrWhiteSpace(pinned))
+            return SshHostKeyDecision.TrustOnFirstUse;
+
+        // Ordinal, and deliberately not a case-insensitive or whitespace-tolerant compare.
+        // Both sides are produced by FormatFingerprint, so any difference at all is a
+        // difference that should be surfaced rather than normalised away.
+        return string.Equals(pinned.Trim(), presented.Trim(), StringComparison.Ordinal)
+            ? SshHostKeyDecision.Matches
+            : SshHostKeyDecision.Mismatch;
+    }
+
+    /// <summary>
+    /// Formats a host key's SHA-256 hash the way OpenSSH does — <c>SHA256:</c> followed by
+    /// unpadded base64 — so a recorded fingerprint can be compared by eye against
+    /// <c>ssh-keyscan -t rsa host | ssh-keygen -lf -</c>.
+    /// </summary>
+    /// <param name="sha256Hash">The raw 32-byte SHA-256 of the host key blob.</param>
+    public static string FormatFingerprint(ReadOnlySpan<byte> sha256Hash)
+    {
+        if (sha256Hash.IsEmpty)
+            throw new ArgumentException("A host key hash cannot be empty.", nameof(sha256Hash));
+
+        // OpenSSH prints the base64 without padding. Keeping the '=' would make a recorded
+        // fingerprint fail a copy-paste comparison against ssh-keygen output for no reason.
+        return "SHA256:" + Convert.ToBase64String(sha256Hash).TrimEnd('=');
+    }
+
+    /// <summary>
+    /// The message shown when a pinned key stops matching. Names both fingerprints, because
+    /// the operator's next step is deciding whether this was a rekey they performed or
+    /// somebody answering on the server's address.
+    /// </summary>
+    public static string DescribeMismatch(string host, string pinned, string presented) =>
+        $"The SSH host key for '{host}' does not match the one recorded for this connection. "
+        + $"Expected {pinned}, but the server presented {presented}. "
+        + "If the server was legitimately rekeyed, clear the recorded fingerprint on the "
+        + "connection to trust the new key; otherwise the address is being answered by "
+        + "something else.";
+}

--- a/src/Connapse.Core/Utilities/SshKeyPairGenerator.cs
+++ b/src/Connapse.Core/Utilities/SshKeyPairGenerator.cs
@@ -1,0 +1,101 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// A generated SSH key pair. The private half is stored; the public half is what the
+/// operator installs on their own machine.
+/// </summary>
+/// <param name="PrivateKeyPem">
+/// PKCS#1 PEM — <c>-----BEGIN RSA PRIVATE KEY-----</c>. The form SSH.NET reads.
+/// </param>
+/// <param name="PublicKeyLine">
+/// A single <c>authorized_keys</c> line, ready to append.
+/// </param>
+public record SshKeyPair(string PrivateKeyPem, string PublicKeyLine);
+
+/// <summary>
+/// Generates an SSH key pair so setting up an SFTP connection never requires
+/// <c>ssh-keygen</c>.
+/// <para>
+/// Generating server-side is not only the easier path, it is the better one. A pasted key
+/// is usually a key the operator already has and uses elsewhere; a generated one exists for
+/// a single connection, has never been on a clipboard, and is revoked by deleting that
+/// connection. The private half is never rendered — it goes straight into the encrypted
+/// column.
+/// </para>
+/// </summary>
+public static class SshKeyPairGenerator
+{
+    /// <summary>
+    /// RSA rather than Ed25519, which would otherwise be the obvious default: .NET exposes
+    /// no Ed25519 primitive, and SSH.NET's key generation surface does not cover it either.
+    /// 3072 bits is the NIST-equivalent of AES-128 and what <c>ssh-keygen</c> defaults to
+    /// for RSA.
+    /// </summary>
+    public const int KeySizeBits = 3072;
+
+    /// <summary>
+    /// Generates a pair. <paramref name="comment"/> is the trailing label on the public key
+    /// line, which is how an operator later recognises the entry in <c>authorized_keys</c>.
+    /// </summary>
+    public static SshKeyPair Generate(string comment = "connapse")
+    {
+        using var rsa = RSA.Create(KeySizeBits);
+
+        return new SshKeyPair(
+            rsa.ExportRSAPrivateKeyPem(),
+            FormatPublicKey(rsa, comment));
+    }
+
+    /// <summary>
+    /// Encodes an RSA public key the way <c>authorized_keys</c> expects: the algorithm name,
+    /// the exponent, and the modulus, each length-prefixed, then base64.
+    /// </summary>
+    /// <remarks>
+    /// A mistake here fails as "authentication failed" with nothing pointing at the cause,
+    /// which is why the round trip against a real server is the test that matters.
+    /// </remarks>
+    public static string FormatPublicKey(RSA rsa, string comment = "connapse")
+    {
+        RSAParameters p = rsa.ExportParameters(includePrivateParameters: false);
+
+        using var buffer = new MemoryStream();
+        WriteLengthPrefixed(buffer, "ssh-rsa"u8.ToArray());
+        WriteLengthPrefixed(buffer, ToMpint(p.Exponent!));
+        WriteLengthPrefixed(buffer, ToMpint(p.Modulus!));
+
+        string label = Sanitise(comment);
+
+        return $"ssh-rsa {Convert.ToBase64String(buffer.ToArray())} {label}";
+    }
+
+    private static void WriteLengthPrefixed(Stream stream, byte[] data)
+    {
+        Span<byte> length = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(length, data.Length);
+        stream.Write(length);
+        stream.Write(data);
+    }
+
+    /// <summary>
+    /// SSH multiple-precision integers are signed, so a value whose top bit is set needs a
+    /// leading zero byte or it reads as negative.
+    /// </summary>
+    private static byte[] ToMpint(byte[] value) =>
+        value.Length > 0 && value[0] >= 0x80 ? [0, .. value] : value;
+
+    /// <summary>
+    /// The comment is the last field on the line, so anything that could end the line early
+    /// or start a second entry has to go. An operator-supplied connection name reaches here.
+    /// </summary>
+    private static string Sanitise(string comment)
+    {
+        string trimmed = new string(comment
+            .Where(c => !char.IsControl(c) && c != '\n' && c != '\r')
+            .ToArray()).Trim();
+
+        return string.IsNullOrEmpty(trimmed) ? "connapse" : trimmed;
+    }
+}

--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -32,6 +32,9 @@ public class IngestionPipeline : IKnowledgeIngester
     private readonly IContainerStore _containerStore;
     private readonly IManagedStorageProvider _managedStorage;
     private readonly IDocumentStore _documentStore;
+    private readonly ISourceStore _sourceStore;
+    private readonly IConnectionStore _connectionStore;
+    private readonly IConnectorFactory _connectorFactory;
     private readonly ILogger<IngestionPipeline> _logger;
 
     // Metadata keys for tracking indexing settings
@@ -76,6 +79,9 @@ public class IngestionPipeline : IKnowledgeIngester
         IContainerStore containerStore,
         IManagedStorageProvider managedStorage,
         IDocumentStore documentStore,
+        ISourceStore sourceStore,
+        IConnectionStore connectionStore,
+        IConnectorFactory connectorFactory,
         ILogger<IngestionPipeline> logger)
     {
         _context = context;
@@ -90,6 +96,9 @@ public class IngestionPipeline : IKnowledgeIngester
         _containerStore = containerStore;
         _managedStorage = managedStorage;
         _documentStore = documentStore;
+        _sourceStore = sourceStore;
+        _connectionStore = connectionStore;
+        _connectorFactory = connectorFactory;
         _logger = logger;
     }
 
@@ -489,6 +498,33 @@ public class IngestionPipeline : IKnowledgeIngester
         IngestionOptions options,
         CancellationToken ct = default)
     {
+        // A source-owned document is read through its connection's connector, not through
+        // managed storage — checked first, because everything below this resolves a container
+        // and a source does not have one (#398).
+        //
+        // Only this entry point was left container-shaped by the connector/source split.
+        // IngestAsync already honours OwnerRef.ForSource; the gap was getting the bytes.
+        if (options.Owner is { IsSource: true } sourceOwner)
+            return await IngestSourceDocumentAsync(documentId, sourceOwner.Id, options, ct);
+
+        // No owner in the options at all: the row is the only thing that knows which it is.
+        // Callers that omit it would otherwise be routed down the container branch and throw
+        // — and a reindex throws only after it has already deleted the document's chunks, so
+        // the cost of guessing wrong here is a document that is gone from search and that no
+        // later sync restores, because its remote signature still matches.
+        if (options.Owner is null)
+        {
+            Document? owned = await _documentStore.GetAsync(documentId, ct);
+            if (owned?.Owner is { IsSource: true } inferredOwner)
+            {
+                // Carried on the options, not just used for routing: IngestAsync writes the
+                // document through options.Owner, and a source-owned row recorded against
+                // container_id would violate ck_documents_single_owner.
+                return await IngestSourceDocumentAsync(
+                    documentId, inferredOwner.Id, options with { Owner = inferredOwner }, ct);
+            }
+        }
+
         // Resolve the container ID — prefer options.ContainerId, fall back to looking up the doc.
         Guid containerId;
         string virtualPath;
@@ -504,10 +540,10 @@ public class IngestionPipeline : IKnowledgeIngester
                 ?? throw new InvalidOperationException(
                     $"IngestByIdAsync: document {documentId} not found and no ContainerId in options");
 
-            // Source-owned documents have an empty ContainerId, so Guid.Parse would throw a
-            // bare FormatException here. Fail with something actionable instead. Re-ingesting
-            // a source document goes through the sync engine, which resolves its connector
-            // from the source's connection rather than from a container.
+            // Document.ContainerId carries COALESCE(container_id, source_id), so it parses
+            // even for a source-owned row — which is why source ownership is settled above,
+            // from doc.Owner, before this point. Reaching here with an unparseable value means
+            // the row has no usable owner at all.
             if (string.IsNullOrEmpty(doc.ContainerId) || !Guid.TryParse(doc.ContainerId, out var docContainerId))
                 throw new InvalidOperationException(
                     $"IngestByIdAsync: document {documentId} is not owned by a container. " +
@@ -526,6 +562,52 @@ public class IngestionPipeline : IKnowledgeIngester
 
         await using Stream stream = await connector.ReadFileAsync(jobPath, ct);
         return await IngestAsync(stream, options, ct);
+    }
+
+    /// <summary>
+    /// Reads a source-owned document through its connection's connector and ingests it.
+    /// </summary>
+    /// <remarks>
+    /// The path is used as the sync engine recorded it, without <c>ResolveJobPath</c>. That
+    /// method exists to turn a virtual container path into a real one; a source's listing
+    /// already yields the connector's own absolute form — an OS path for Filesystem, a remote
+    /// path for SFTP — and putting it through resolution again would rebase a path that is
+    /// already rooted.
+    /// </remarks>
+    private async Task<IngestionResult> IngestSourceDocumentAsync(
+        string documentId, Guid sourceId, IngestionOptions options, CancellationToken ct)
+    {
+        string path = options.Path ?? options.FileName
+            ?? throw new InvalidOperationException(
+                $"IngestByIdAsync: options must provide Path or FileName for document {documentId}");
+
+        Source source = await _sourceStore.GetAsync(sourceId, ct)
+            ?? throw new InvalidOperationException(
+                $"IngestByIdAsync: source {sourceId} not found for document {documentId}");
+
+        Connection connection = await _connectionStore.GetAsync(source.ConnectionId, ct)
+            ?? throw new InvalidOperationException(
+                $"IngestByIdAsync: connection {source.ConnectionId} not found for source {sourceId}");
+
+        // Only fetched when there is one to fetch, matching SourceSyncService. A key ring that
+        // cannot decrypt throws, and retrying will not help — so it surfaces as a failed job
+        // rather than being swallowed.
+        string? secret = connection.HasSecret
+            ? await _connectionStore.GetSecretAsync(connection.Id, ct)
+            : null;
+
+        IConnector connector = _connectorFactory.Create(source, connection, secret);
+        try
+        {
+            await using Stream stream = await connector.ReadFileAsync(path, ct);
+            return await IngestAsync(stream, options, ct);
+        }
+        finally
+        {
+            // SftpConnector holds an SSH session and S3Connector a socket pool. One job runs
+            // per file, so skipping this abandons a connection per document.
+            if (connector is IDisposable disposable) disposable.Dispose();
+        }
     }
 
     public async IAsyncEnumerable<IngestionProgress> IngestWithProgressAsync(
@@ -646,3 +728,5 @@ internal static class IngestionPipelineStrategyResolver
         return MarkdownExtensions.Contains(ext) ? "DocumentAware" : fallbackStrategy;
     }
 }
+
+

--- a/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
+++ b/src/Connapse.Ingestion/Pipeline/IngestionPipeline.cs
@@ -52,6 +52,13 @@ public class IngestionPipeline : IKnowledgeIngester
     private static readonly string[] RemoteSignatureKeys = ["RemoteLastModified", "RemoteSize"];
 
     /// <summary>
+    /// How many times the sync engine has re-enqueued this document after a failure. Carried
+    /// across a failed attempt and cleared on a successful one, so a source that cannot be read
+    /// at all stops being retried while a transient fault still recovers.
+    /// </summary>
+    public const string SyncFailedAttemptsKey = "SyncFailedAttempts";
+
+    /// <summary>
     /// Initializes a new instance of <see cref="IngestionPipeline"/> with the required services and configuration providers.
     /// <summary>
     /// Initializes a new IngestionPipeline with the dependencies required to parse documents, split them into chunks, produce embeddings, and persist vectors and document state.
@@ -248,6 +255,17 @@ public class IngestionPipeline : IKnowledgeIngester
                     }
                 }
 
+                // Carried for the same reason, and one more: it is the only thing bounding the
+                // sync engine's retry of a failed document. Replacing the metadata here would
+                // reset the count on every attempt, and a source that can never be read — wrong
+                // credentials, a server that is gone — would be re-enqueued for ever, crowding
+                // out every other document's ingestion.
+                if (!metadata.ContainsKey(SyncFailedAttemptsKey) &&
+                    documentEntity.Metadata?.TryGetValue(SyncFailedAttemptsKey, out var attempts) == true)
+                {
+                    metadata[SyncFailedAttemptsKey] = attempts;
+                }
+
                 documentEntity.Metadata = metadata;
             }
             else
@@ -420,6 +438,10 @@ public class IngestionPipeline : IKnowledgeIngester
 
             // Update document status
             documentEntity.ChunkCount = chunks.Count;
+            // Cleared on success: the count exists to bound retries of a document that keeps
+            // failing, and this one just stopped failing.
+            documentEntity.Metadata?.Remove(SyncFailedAttemptsKey);
+
             documentEntity.Status = "Ready";
             documentEntity.ErrorMessage = null;
             documentEntity.LastIndexedAt = DateTime.UtcNow;

--- a/src/Connapse.Ingestion/Reindex/ReindexService.cs
+++ b/src/Connapse.Ingestion/Reindex/ReindexService.cs
@@ -432,29 +432,21 @@ public class ReindexService : IReindexService
         ReindexReason reason,
         CancellationToken ct)
     {
-        // Delete existing chunks and vectors before reindex
-        // The cascade delete will handle chunk_vectors
-        var existingChunks = await _context.Chunks
-            .Where(c => c.DocumentId == doc.Id)
-            .ToListAsync(ct);
-
-        if (existingChunks.Count > 0)
-        {
-            _context.Chunks.RemoveRange(existingChunks);
-            await _context.SaveChangesAsync(ct);
-
-            _logger.LogDebug(
-                "Removed {ChunkCount} existing chunks for document {DocumentId}",
-                existingChunks.Count,
-                doc.Id);
-        }
+        // The chunks stay where they are. IngestionPipeline purges them itself on a reindex,
+        // once the file has been read and the row updated — which is the only moment at which
+        // dropping them is safe. Deleting here instead meant every way the work could fail
+        // afterwards — the enqueue throwing, Hangfire being down, the SFTP server refusing the
+        // connection — left a document with no chunks and no job coming to rebuild them. The
+        // document stayed searchable-looking and returned nothing.
+        //
+        // ChunkCount is left alone for the same reason: it describes chunks that still exist.
 
         // Update document status
         var docEntity = await _context.Documents.FindAsync([doc.Id], ct);
+        string? previousStatus = docEntity?.Status;
         if (docEntity != null)
         {
             docEntity.Status = "Pending";
-            docEntity.ChunkCount = 0;
             await _context.SaveChangesAsync(ct);
         }
 
@@ -462,6 +454,19 @@ public class ReindexService : IReindexService
         var strategy = options.Strategy ?? Enum.Parse<ChunkingStrategy>(
             _chunkingSettings.CurrentValue.Strategy,
             ignoreCase: true);
+
+        // The owner the row actually has, read from the row. Nullable<Guid>.ToString() yields
+        // "" rather than throwing, so a source-owned document used to be enqueued with a blank
+        // ContainerId and no Owner at all — and the pipeline, seeing neither, routed it down
+        // the container branch and threw. By then the chunks above were already deleted, and
+        // the next sync saw an unchanged remote signature and did not restore them, so a
+        // forced reindex quietly removed source documents from search for good.
+        var owner = doc.SourceId is Guid sourceId
+            ? OwnerRef.ForSource(sourceId)
+            : doc.ContainerId is Guid containerId
+                ? OwnerRef.ForContainer(containerId)
+                : throw new InvalidOperationException(
+                    $"Document {doc.Id} has neither a container nor a source and cannot be reindexed.");
 
         // Create and enqueue ingestion job
         var job = new IngestionJob(
@@ -472,13 +477,32 @@ public class ReindexService : IReindexService
                 DocumentId: doc.Id.ToString(),
                 FileName: doc.FileName,
                 ContentType: doc.ContentType,
-                ContainerId: doc.ContainerId.ToString(),
+                ContainerId: owner.ContainerId?.ToString(),
                 Path: doc.Path,
                 Strategy: strategy,
-                Metadata: doc.Metadata),
+                Metadata: doc.Metadata)
+            {
+                Owner = owner,
+            },
             BatchId: batchId);
 
-        await _queue.EnqueueAsync(job, ct);
+        try
+        {
+            await _queue.EnqueueAsync(job, ct);
+        }
+        catch
+        {
+            // Pending means "a job is coming". If none is, the document is stranded: the sync
+            // engine skips Pending documents, so it would never be looked at again. Put the
+            // status back so the next cycle can.
+            if (docEntity != null && previousStatus != null)
+            {
+                docEntity.Status = previousStatus;
+                await _context.SaveChangesAsync(CancellationToken.None);
+            }
+
+            throw;
+        }
 
         _logger.LogInformation(
             "Enqueued document {DocumentId} ({FileName}) for reindex, reason: {Reason}",

--- a/src/Connapse.Storage/Connapse.Storage.csproj
+++ b/src/Connapse.Storage/Connapse.Storage.csproj
@@ -17,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="SSH.NET" Version="2026.0.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Connapse.Storage/ConnectionTesters/SftpConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/SftpConnectionTester.cs
@@ -1,0 +1,116 @@
+﻿using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Connectors;
+
+namespace Connapse.Storage.ConnectionTesters;
+
+/// <summary>
+/// What the SFTP connection form hands to <see cref="SftpConnectionTester"/>. The private key
+/// is passed rather than looked up, because the operator may be testing a key they have typed
+/// but not yet saved.
+/// </summary>
+public record SftpConnectionTestSettings
+{
+    public string Host { get; init; } = "";
+    public int Port { get; init; } = 22;
+    public string Username { get; init; } = "";
+    public string AllowedRoot { get; init; } = "";
+    public string PrivateKey { get; init; } = "";
+    public string? Passphrase { get; init; }
+
+    /// <summary>
+    /// The fingerprint already pinned, if any, so a test reports a mismatch the same way a sync
+    /// would rather than quietly succeeding against a different server.
+    /// </summary>
+    public string? PinnedHostKeyFingerprint { get; init; }
+}
+
+/// <summary>
+/// Opens a session, verifies the host key, and confirms the allowed root resolves.
+/// <para>
+/// Deliberately does not walk the tree. A test button that lists a large remote turns a
+/// configuration check into a minutes-long operation, and tells the operator nothing the root
+/// check has not already told them: if the root resolves and stays inside itself, the
+/// credential authenticated and the path exists.
+/// </para>
+/// </summary>
+public class SftpConnectionTester : IConnectionTester
+{
+    public async Task<ConnectionTestResult> TestConnectionAsync(
+        object settings, TimeSpan? timeout = null, CancellationToken ct = default)
+    {
+        if (settings is not SftpConnectionTestSettings s)
+            return new ConnectionTestResult { Success = false, Message = "Invalid settings type for the SFTP tester." };
+
+        TimeSpan budget = timeout ?? TimeSpan.FromSeconds(15);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(budget);
+
+        // No host key store: a test must never pin. Pinning is the sync's job, and doing it
+        // here would record a fingerprint from a form the operator has not saved.
+        using var connector = new SftpConnector(new SftpConnectorConfig
+        {
+            Host = s.Host,
+            Port = s.Port,
+            Username = s.Username,
+            AllowedRoot = s.AllowedRoot,
+            PinnedHostKeyFingerprint = s.PinnedHostKeyFingerprint,
+            Credential = new SftpCredential { PrivateKey = s.PrivateKey, Passphrase = s.Passphrase },
+
+            // The same budget the token carries, handed to the session itself. The token
+            // covers the awaits; this covers the waits inside SSH.NET that the token cannot
+            // reach. Without it a server that authenticates and then stalls its SFTP
+            // subsystem holds this scope — and its Blazor circuit — well past the timeout
+            // the operator was promised.
+            OperationTimeout = budget,
+        });
+
+        try
+        {
+            string resolved = await connector.ProbeAsync(cts.Token);
+
+            return new ConnectionTestResult
+            {
+                Success = true,
+                Message = $"Connected to {s.Host}:{s.Port} as {s.Username}. "
+                          + $"The allowed root resolved to {resolved} on the server."
+            };
+        }
+        catch (SftpHostKeyMismatchException ex)
+        {
+            // Surfaced on its own, because it is the one failure retrying cannot fix and the
+            // only one whose remedy is a decision rather than a correction.
+            return new ConnectionTestResult { Success = false, Message = ex.Message };
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            return new ConnectionTestResult
+            {
+                Success = false,
+                Message = $"Timed out reaching {s.Host}:{s.Port}. Connapse has to be able to open a "
+                          + "TCP connection to that address from where it runs — inside a container, "
+                          + "the host machine is not 'localhost'."
+            };
+        }
+        catch (Exception ex) when (ex is Renci.SshNet.Common.SshOperationTimeoutException
+                                      or TimeoutException)
+        {
+            // Reached the server, and it stopped answering partway through. Distinct from the
+            // timeout above, which never got a connection at all — the remedies have nothing
+            // in common, so saying "check that the address is reachable" here would send the
+            // operator after a problem they do not have.
+            return new ConnectionTestResult
+            {
+                Success = false,
+                Message = $"{s.Host}:{s.Port} accepted the connection but stopped responding. "
+                          + "The SSH service is running but its SFTP subsystem is not answering."
+            };
+        }
+        catch (Exception ex)
+        {
+            return new ConnectionTestResult { Success = false, Message = ex.Message };
+        }
+    }
+}
+

--- a/src/Connapse.Storage/Connections/ConnectionSshHostKeyStore.cs
+++ b/src/Connapse.Storage/Connections/ConnectionSshHostKeyStore.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using static Connapse.Core.Utilities.LogSanitizer;
+
+namespace Connapse.Storage.Connections;
+
+/// <summary>
+/// Pins an observed SSH host key onto its connection's <c>ConfigJson</c>.
+/// </summary>
+/// <remarks>
+/// A singleton, because <see cref="Connapse.Storage.Connectors.ConnectorFactory"/> is one and
+/// this is reached from a connector the factory built. <see cref="IConnectionStore"/> is
+/// scoped, so a scope is opened per write — affordable, because this writes exactly once per
+/// connection, on the first successful connect.
+/// </remarks>
+public class ConnectionSshHostKeyStore(
+    IServiceScopeFactory scopeFactory,
+    ILogger<ConnectionSshHostKeyStore> logger) : ISshHostKeyStore
+{
+    public const string FingerprintProperty = "hostKeyFingerprint";
+
+    public async Task RecordFingerprintAsync(
+        Guid connectionId, string fingerprint, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fingerprint);
+
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+
+        var connection = await store.GetAsync(connectionId, ct);
+        if (connection is null)
+        {
+            logger.LogWarning(
+                "Cannot pin a host key: connection {ConnectionId} no longer exists", connectionId);
+            return;
+        }
+
+        var config = ParseObject(connection.ConfigJson);
+        if (config is null)
+        {
+            logger.LogWarning(
+                "Cannot pin a host key: the configuration for connection {ConnectionId} is not a JSON object",
+                connectionId);
+            return;
+        }
+
+        // A fingerprint already present is left alone. The mismatch path refuses the
+        // connection rather than reaching here, so an arriving write against an existing
+        // value means two sync cycles raced — and the recorded value is the one every other
+        // cycle has been comparing against, so it wins.
+        if (config[FingerprintProperty] is JsonValue existing
+            && !string.IsNullOrWhiteSpace(existing.ToString()))
+        {
+            return;
+        }
+
+        config[FingerprintProperty] = fingerprint;
+
+        // Name is passed through unchanged rather than left null: UpdateConnectionRequest
+        // treats null as "leave alone" for the name too, but being explicit keeps this from
+        // depending on that.
+        await store.UpdateAsync(
+            connectionId,
+            new UpdateConnectionRequest(connection.Name, config.ToJsonString(), Secret: null),
+            ct);
+
+        logger.LogInformation(
+            "Pinned SSH host key {Fingerprint} to connection {ConnectionName} ({ConnectionId}) on first use",
+            Sanitize(fingerprint), Sanitize(connection.Name), connectionId);
+    }
+
+    /// <summary>
+    /// The connection's configuration as a mutable object, or null when it is not one.
+    /// </summary>
+    /// <remarks>
+    /// Null rather than a fresh empty object on purpose. Writing the fingerprint into a new
+    /// object would replace the host, port, username and allowed root with nothing, breaking
+    /// the connection outright to record a value that only matters while it works. Not
+    /// reachable in practice — the factory parses the same configuration to build the
+    /// connector at all — but the failure it would cause is bad enough to be explicit about.
+    /// </remarks>
+    private static JsonObject? ParseObject(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return [];
+
+        try
+        {
+            return JsonNode.Parse(json) as JsonObject;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Connapse.Storage/Connectors/ConnectorFactory.cs
+++ b/src/Connapse.Storage/Connectors/ConnectorFactory.cs
@@ -12,6 +12,7 @@ namespace Connapse.Storage.Connectors;
 /// </summary>
 public class ConnectorFactory(
     IOptionsMonitor<SourceSecuritySettings> sourceSecurity,
+    ISshHostKeyStore hostKeyStore,
     ILogger<ConnectorFactory> logger) : IConnectorFactory
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -30,7 +31,7 @@ public class ConnectorFactory(
     /// </summary>
     private readonly HashSet<string> _warnedUnrestricted = [];
 
-    public IConnector Create(Source source, Connection connection)
+    public IConnector Create(Source source, Connection connection, string? secret = null)
     {
         if (source.ConnectionId != connection.Id)
             throw new ArgumentException(
@@ -95,6 +96,36 @@ public class ConnectorFactory(
                 ExcludePatterns = Arr(scope, "excludePatterns"),
             }),
 
+            ConnectionProvider.Sftp => new SftpConnector(new SftpConnectorConfig
+            {
+                Host = Str(credential, "host")
+                    ?? throw new InvalidOperationException(
+                        $"Connection '{connection.Name}' has no host."),
+                Port = Int(credential, "port") ?? 22,
+                Username = Str(credential, "username")
+                    ?? throw new InvalidOperationException(
+                        $"Connection '{connection.Name}' has no username."),
+
+                // Unlike the Filesystem provider, the root is not resolved here. It names a
+                // directory on another machine, so the only place it can be resolved is the
+                // server — the connector does that on connect, through SSH_FXP_REALPATH.
+                // Resolving it locally is exactly the mistake SftpPathConfinement exists to
+                // avoid, and it would fail open rather than closed.
+                AllowedRoot = Str(credential, "allowedRoot")
+                    ?? throw new InvalidOperationException(
+                        $"Connection '{connection.Name}' has no allowedRoot."),
+
+                PinnedHostKeyFingerprint = Str(credential, "hostKeyFingerprint"),
+                Credential = SftpCredential.TryParse(secret)
+                    ?? throw new InvalidOperationException(
+                        $"Connection '{connection.Name}' has no usable SSH private key stored."),
+                ConnectionId = connection.Id,
+
+                SubPath = Str(scope, "subPath"),
+                IncludePatterns = Arr(scope, "includePatterns"),
+                ExcludePatterns = Arr(scope, "excludePatterns"),
+            }, hostKeyStore),
+
             _ => throw new NotSupportedException($"Unknown connection provider: {connection.Provider}")
         };
     }
@@ -105,6 +136,12 @@ public class ConnectorFactory(
             throw new InvalidOperationException(
                 $"{subject} is not a JSON object, so nothing in it can be read.");
     }
+
+    private static int? Int(JsonDocument doc, string name) =>
+        doc.RootElement.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+        && v.TryGetInt32(out int i)
+            ? i
+            : null;
 
     private static string? Str(JsonDocument doc, string name) =>
         doc.RootElement.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String

--- a/src/Connapse.Storage/Connectors/SftpConnector.cs
+++ b/src/Connapse.Storage/Connectors/SftpConnector.cs
@@ -1,0 +1,540 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
+using Renci.SshNet;
+using Renci.SshNet.Common;
+using Renci.SshNet.Sftp;
+
+namespace Connapse.Storage.Connectors;
+
+/// <summary>
+/// Read-only <see cref="IConnector"/> over SFTP.
+/// <para>
+/// The transport that answers "Connapse cannot see my files": the local filesystem connector
+/// needs the server process to share a disk with the data, which a container or a hosted
+/// deployment does not.
+/// </para>
+/// <para>
+/// <c>SupportsLiveWatch = false</c> — SFTP has no change notification of any kind, so this is
+/// list-and-diff on every poll. At a hundred thousand files that is minutes per scan, which
+/// is why the documentation says to point a source at a folder rather than a whole drive.
+/// </para>
+/// </summary>
+public sealed class SftpConnector : IConnector, IDisposable
+{
+    private readonly SftpConnectorConfig _config;
+    private readonly ISshHostKeyStore? _hostKeyStore;
+    private readonly SemaphoreSlim _connectGate = new(1, 1);
+    private readonly Regex[] _include;
+    private readonly Regex[] _exclude;
+
+    private SftpClient? _client;
+
+    /// <summary>The confined, server-resolved path this source reads from.</summary>
+    private string? _resolvedRoot;
+
+    /// <summary>
+    /// Set from the host key callback, read after the session is established. The callback
+    /// itself cannot record anything: it fires before authentication, and a key from a server
+    /// we then fail to authenticate to is not one to pin.
+    /// </summary>
+    private string? _observedFingerprint;
+
+    public SftpConnector(SftpConnectorConfig config, ISshHostKeyStore? hostKeyStore = null)
+    {
+        _config = config;
+        _hostKeyStore = hostKeyStore;
+        _include = CompileGlobs(config.IncludePatterns);
+        _exclude = CompileGlobs(config.ExcludePatterns);
+    }
+
+    public ConnectorType Type => ConnectorType.Sftp;
+
+    public bool SupportsLiveWatch => false;
+
+    internal SftpConnectorConfig Config => _config;
+
+    /// <summary>
+    /// Remote paths are already absolute and server-canonical by the time they leave
+    /// <see cref="ListFilesAsync"/>, so there is nothing to recombine.
+    /// </summary>
+    public string ResolveJobPath(string relativePath) => relativePath;
+
+    public IAsyncEnumerable<ConnectorFileEvent> WatchAsync(CancellationToken ct = default) =>
+        throw new NotSupportedException("SFTP has no change notification; this connector is list-and-diff only.");
+
+    public async Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(
+        string? prefix = null, CancellationToken ct = default)
+    {
+        var (client, root) = await EnsureConnectedAsync(ct);
+
+        string start = string.IsNullOrWhiteSpace(prefix)
+            ? root
+            : await ConfineDirectoryAsync(client, prefix, ct)
+              ?? throw new UnauthorizedAccessException(
+                  $"Prefix '{prefix}' resolves outside the connection's allowed root.");
+
+        var files = new List<ConnectorFile>();
+        await WalkAsync(client, start, files, ct);
+        return files;
+    }
+
+    public async Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
+    {
+        var (client, _) = await EnsureConnectedAsync(ct);
+
+        string confined = await ConfineFileAsync(client, path, ct)
+            ?? throw new UnauthorizedAccessException(
+                $"Path '{path}' resolves outside the connection's allowed root.");
+
+        await RefuseIfLinkAsync(client, confined, ct);
+
+        return await client.OpenAsync(confined, FileMode.Open, FileAccess.Read, ct);
+    }
+
+    /// <summary>
+    /// Opens the session, verifies the host key, and resolves the allowed root and subpath on
+    /// the server. Returns the resolved path this connector would read from.
+    /// </summary>
+    /// <remarks>
+    /// Exists for the connection test, which needs exactly the three things that go wrong —
+    /// reachability, authentication, and whether the root is really there — and none of the
+    /// walking. An explicit method rather than leaning on a side effect of
+    /// <see cref="ExistsAsync"/>, so a later change to that method cannot quietly turn the test
+    /// button into one that always passes.
+    /// </remarks>
+    public async Task<string> ProbeAsync(CancellationToken ct = default)
+    {
+        var (_, root) = await EnsureConnectedAsync(ct);
+        return root;
+    }
+
+    /// <summary>
+    /// Refuses a path whose final component is a symlink.
+    /// </summary>
+    /// <remarks>
+    /// Confinement canonicalises the <i>parent</i> and reattaches the name, so a link sitting at
+    /// the leaf passes every check made so far — the parent is inside the root and the name
+    /// carries no traversal — and <c>OpenAsync</c> would then follow it wherever it points.
+    /// <para>
+    /// Every leaf link is refused, not only those pointing outside. The walk already steps over
+    /// links rather than following them, so no path the ingestion queue holds is ever a link,
+    /// and nothing legitimate asks to read one. Resolving them here would make the read path
+    /// follow what the listing deliberately does not — two different answers to the same
+    /// question, which is how the local connector's #365 bug came about.
+    /// </para>
+    /// <para>
+    /// Asked of the <b>parent's listing</b>, not of the path. <c>GetAttributes</c> looks like
+    /// the obvious call and is the wrong one: SSH.NET canonicalises the path before issuing
+    /// LSTAT, so for a link it returns the <i>target's</i> attributes and reports
+    /// <c>IsSymbolicLink</c> as false. Verified against a real server — the first version of
+    /// this method used it and both link tests still passed through. A directory listing does
+    /// not follow links, which is why the walk can already tell them apart.
+    /// </para>
+    /// <para>
+    /// Costs one listing per read. Still check-then-open, so a link planted in the instant
+    /// between the two wins; closing that needs an anchored open, which SFTP has no verb for.
+    /// The same limit <see cref="PathConfinement"/> documents for local paths.
+    /// </para>
+    /// </remarks>
+    private static async Task RefuseIfLinkAsync(
+        SftpClient client, string confinedPath, CancellationToken ct)
+    {
+        int lastSlash = confinedPath.LastIndexOf(SftpPathConfinement.Separator);
+        string parent = lastSlash <= 0 ? "/" : confinedPath[..lastSlash];
+        string name = confinedPath[(lastSlash + 1)..];
+
+        ISftpFile? entry;
+        try
+        {
+            entry = await client.ListDirectoryAsync(parent, ct)
+                .FirstOrDefaultAsync(f => f.Name == name, ct);
+        }
+        catch (Exception ex) when (ex is SshException or IOException)
+        {
+            // A path we cannot inspect is a path we cannot vouch for.
+            throw new UnauthorizedAccessException(
+                $"Could not verify that '{confinedPath}' is an ordinary file.", ex);
+        }
+
+        if (entry is null)
+            throw new FileNotFoundException($"File not found at '{confinedPath}'.", confinedPath);
+
+        if (entry.IsSymbolicLink)
+            throw new UnauthorizedAccessException(
+                $"'{confinedPath}' is a symbolic link. Links are not followed, because the "
+                + "listing that produced this path steps over them.");
+    }
+
+    public async Task<bool> ExistsAsync(string path, CancellationToken ct = default)
+    {
+        var (client, _) = await EnsureConnectedAsync(ct);
+
+        string? confined = await ConfineFileAsync(client, path, ct);
+        if (confined is null) return false;
+
+        return await client.ExistsAsync(confined, ct);
+    }
+
+    // ── Walking ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Recursive listing that refuses to be partial.
+    /// </summary>
+    /// <remarks>
+    /// A directory that cannot be read <b>fails the whole listing</b> rather than contributing
+    /// nothing to it. This is the point worth being deliberate about: to the reconcile, a
+    /// quietly-short listing is indistinguishable from a mass deletion, so swallowing a
+    /// per-directory permission error is how a tightened ACL on one subtree turns into a
+    /// silent deletion of everything under it. The delete guard bounds that damage; it does
+    /// not prevent it, and it should not have to.
+    /// </remarks>
+    private async Task WalkAsync(SftpClient client, string directory, List<ConnectorFile> into, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        IEnumerable<ISftpFile> entries;
+        try
+        {
+            entries = await client.ListDirectoryAsync(directory, ct).ToListAsync(ct);
+        }
+        catch (Exception ex) when (ex is SshException or IOException)
+        {
+            throw new IOException(
+                $"Could not list '{directory}' on {_config.Host}. Refusing to return a partial "
+                + "listing, because a short listing is indistinguishable from a mass deletion.", ex);
+        }
+
+        foreach (var entry in entries)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (entry.Name is "." or "..")
+                continue;
+
+            // Links are skipped rather than followed, the same way the local connector skips
+            // reparse points (#365). Following one is the escape route out of the root, and
+            // resolving each through SSH_FXP_REALPATH would be a round trip per entry — real
+            // cost on a large tree, to reach a target that is either outside the root and must
+            // be refused, or inside it and already reached by the ordinary walk.
+            if (entry.IsSymbolicLink)
+                continue;
+
+            if (entry.IsDirectory)
+            {
+                await WalkAsync(client, entry.FullName, into, ct);
+                continue;
+            }
+
+            if (!entry.IsRegularFile)
+                continue;
+
+            if (!MatchesFilters(entry.Name))
+                continue;
+
+            into.Add(new ConnectorFile(
+                Path: entry.FullName,
+                SizeBytes: entry.Length,
+                LastModified: entry.LastWriteTimeUtc,
+                ContentType: null));
+        }
+    }
+
+    private bool MatchesFilters(string fileName)
+    {
+        if (_include.Length > 0 && !_include.Any(r => Matches(r, fileName)))
+            return false;
+
+        return !_exclude.Any(r => Matches(r, fileName));
+    }
+
+    /// <summary>
+    /// A pattern that times out is treated as not matching, and logged nowhere because there is
+    /// nothing to log to from here — but it must not take the sync down. Withholding a match is
+    /// the conservative direction for an include list; for an exclude list it means indexing a
+    /// file that was meant to be skipped, which is visible and recoverable.
+    /// </summary>
+    private static bool Matches(Regex regex, string fileName)
+    {
+        try
+        {
+            return regex.IsMatch(fileName);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Glob patterns compiled once per connector rather than once per file per pattern.
+    /// </summary>
+    /// <remarks>
+    /// This connector is documented as handling trees of a hundred thousand files, and the old
+    /// code built a fresh <see cref="Regex"/> inside the walk — so a source with three patterns
+    /// compiled three hundred thousand regexes per cycle.
+    /// <para>
+    /// The timeout matters more than the caching. <see cref="Regex.Escape"/> leaves the
+    /// substituted <c>.*</c> live, so a pattern like <c>*a*a*a*a*a*b</c> becomes nested
+    /// wildcards and backtracks catastrophically against a long run of <c>a</c>. Patterns come
+    /// from a source's scope, so one bad entry would hang that source's sync thread on every
+    /// cycle, for ever, with no way to see why.
+    /// </para>
+    /// </remarks>
+    private static Regex[] CompileGlobs(IReadOnlyList<string> patterns) =>
+        [.. patterns.Select(p => new Regex(
+            "^" + Regex.Escape(p).Replace(@"\*", ".*").Replace(@"\?", ".") + "$",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+            GlobMatchTimeout))];
+
+    private static readonly TimeSpan GlobMatchTimeout = TimeSpan.FromMilliseconds(250);
+
+    // ── Confinement ────────────────────────────────────────────────────────
+
+    private Task<string?> ConfineDirectoryAsync(SftpClient client, string candidate, CancellationToken ct) =>
+        SftpPathConfinement.ResolveWithinAsync(
+            new SftpRealPathResolver(client), _config.AllowedRoot, candidate, ct);
+
+    /// <summary>
+    /// Confines a file path by canonicalising its <i>parent</i> and reattaching the name.
+    /// </summary>
+    /// <remarks>
+    /// The server's <c>realpath</c> is only reachable through <c>ChangeDirectory</c> in this
+    /// library, and that only accepts directories. Canonicalising the parent is not a
+    /// weakening: every way out of the root runs through a directory — a <c>..</c> segment or
+    /// a symlinked ancestor — and both of those are in the parent. The leaf is checked for
+    /// separators instead, so it cannot smuggle a path component of its own.
+    /// </remarks>
+    private async Task<string?> ConfineFileAsync(SftpClient client, string candidate, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+            return null;
+
+        int lastSlash = candidate.LastIndexOf(SftpPathConfinement.Separator);
+        if (lastSlash <= 0)
+            return null;
+
+        string parent = candidate[..lastSlash];
+        string name = candidate[(lastSlash + 1)..];
+
+        // A name that is empty, a traversal, or carries its own separator is not a file name.
+        if (name.Length == 0 || name is "." or ".." || name.Contains(SftpPathConfinement.Separator))
+            return null;
+
+        string? resolvedParent = await ConfineDirectoryAsync(client, parent, ct);
+        if (resolvedParent is null)
+            return null;
+
+        return resolvedParent.TrimEnd(SftpPathConfinement.Separator)
+            + SftpPathConfinement.Separator + name;
+    }
+
+    // ── Session ────────────────────────────────────────────────────────────
+
+    private async Task<(SftpClient Client, string Root)> EnsureConnectedAsync(CancellationToken ct)
+    {
+        if (_client is { IsConnected: true } live && _resolvedRoot is not null)
+            return (live, _resolvedRoot);
+
+        await _connectGate.WaitAsync(ct);
+        try
+        {
+            if (_client is { IsConnected: true } stillLive && _resolvedRoot is not null)
+                return (stillLive, _resolvedRoot);
+
+            _client?.Dispose();
+            _client = null;
+            _resolvedRoot = null;
+
+            var client = new SftpClient(BuildConnectionInfo())
+            {
+                // Without this SSH.NET waits forever on an SFTP request. See the config's
+                // remarks: a cancellation token does not reach inside one.
+                OperationTimeout = _config.OperationTimeout,
+            };
+            client.HostKeyReceived += OnHostKeyReceived;
+
+            try
+            {
+                await client.ConnectAsync(ct);
+            }
+            catch (Exception ex)
+            {
+                client.Dispose();
+
+                // Refusing the key makes SSH.NET fail the handshake with a message about key
+                // exchange, which tells an operator nothing about what actually happened or
+                // what to do. Replace it with the one that names both fingerprints.
+                string? refusal = DescribeHostKeyRefusalIfAny();
+                throw refusal is null
+                    ? ex
+                    : new SftpHostKeyMismatchException(refusal, ex);
+            }
+
+            // Everything from here to the assignment can throw, and the client is already
+            // connected — so it has to be disposed on the way out or the session is orphaned.
+            //
+            // Not a theoretical leak. SourceSyncService builds a fresh connector every cycle
+            // and disposes it in a finally, but Dispose reads _client, which is still null
+            // until the assignment below. A source with a root that does not resolve, or a
+            // subPath that escapes it, would leak one SSH session and one socket every five
+            // minutes until the server hit MaxSessions and started refusing everyone —
+            // including every other source pointed at the same machine.
+            try
+            {
+                // Only now, with authentication behind us. A fingerprint captured in the
+                // callback and recorded there would pin whatever answered the address,
+                // authenticated or not.
+                await PinFingerprintIfNewAsync(ct);
+
+                string root = await ConfineDirectoryAsync(client, _config.AllowedRoot, ct)
+                    ?? throw new InvalidOperationException(
+                        $"The allowed root '{_config.AllowedRoot}' could not be resolved on {_config.Host}.");
+
+                string scoped = await SftpPathConfinement.CombineWithinAsync(
+                                    new SftpRealPathResolver(client), root, _config.SubPath, ct)
+                                ?? throw new InvalidOperationException(
+                                    $"The source's subPath '{_config.SubPath}' resolves outside the "
+                                    + $"connection's allowed root '{_config.AllowedRoot}'.");
+
+                _client = client;
+                _resolvedRoot = scoped;
+                return (client, scoped);
+            }
+            catch
+            {
+                client.HostKeyReceived -= OnHostKeyReceived;
+                client.Dispose();
+                throw;
+            }
+        }
+        finally
+        {
+            _connectGate.Release();
+        }
+    }
+
+    private ConnectionInfo BuildConnectionInfo()
+    {
+        var credential = _config.Credential
+            ?? throw new InvalidOperationException(
+                $"The SFTP connection for '{_config.Host}' has no private key stored.");
+
+        PrivateKeyFile key;
+        using (var keyStream = new MemoryStream(Encoding.UTF8.GetBytes(credential.PrivateKey)))
+        {
+            key = string.IsNullOrWhiteSpace(credential.Passphrase)
+                ? new PrivateKeyFile(keyStream)
+                : new PrivateKeyFile(keyStream, credential.Passphrase);
+        }
+
+        return new ConnectionInfo(
+            _config.Host,
+            _config.Port,
+            _config.Username,
+            new PrivateKeyAuthenticationMethod(_config.Username, key))
+        {
+            Timeout = _config.OperationTimeout,
+        };
+    }
+
+    /// <summary>
+    /// The callback SSH.NET raises before authentication. Handling it is not optional:
+    /// <see cref="HostKeyEventArgs.CanTrust"/> arrives already set to <c>true</c>, so a
+    /// connector that does not subscribe accepts every key any server presents, and looks
+    /// from the outside exactly like one that verifies.
+    /// </summary>
+    private void OnHostKeyReceived(object? sender, HostKeyEventArgs e)
+    {
+        string presented = SshHostKeyPolicy.FormatFingerprint(SHA256.HashData(e.HostKey));
+        _observedFingerprint = presented;
+
+        switch (SshHostKeyPolicy.Evaluate(_config.PinnedHostKeyFingerprint, presented))
+        {
+            case SshHostKeyDecision.Matches:
+            case SshHostKeyDecision.TrustOnFirstUse:
+                e.CanTrust = true;
+                break;
+
+            default:
+                e.CanTrust = false;
+                break;
+        }
+    }
+
+    private async Task PinFingerprintIfNewAsync(CancellationToken ct)
+    {
+        if (_hostKeyStore is null
+            || _config.ConnectionId == Guid.Empty
+            || _observedFingerprint is null
+            || !string.IsNullOrWhiteSpace(_config.PinnedHostKeyFingerprint))
+            return;
+
+        await _hostKeyStore.RecordFingerprintAsync(_config.ConnectionId, _observedFingerprint, ct);
+    }
+
+    /// <summary>
+    /// A refused host key surfaces from SSH.NET as a connection failure whose message does not
+    /// say why. This turns it into one that names both fingerprints and the fix.
+    /// </summary>
+    public string? DescribeHostKeyRefusalIfAny()
+    {
+        if (_observedFingerprint is null || string.IsNullOrWhiteSpace(_config.PinnedHostKeyFingerprint))
+            return null;
+
+        return SshHostKeyPolicy.Evaluate(_config.PinnedHostKeyFingerprint, _observedFingerprint)
+            is SshHostKeyDecision.Mismatch
+            ? SshHostKeyPolicy.DescribeMismatch(
+                _config.Host, _config.PinnedHostKeyFingerprint, _observedFingerprint)
+            : null;
+    }
+
+    public void Dispose()
+    {
+        if (_client is not null)
+        {
+            _client.HostKeyReceived -= OnHostKeyReceived;
+            _client.Dispose();
+            _client = null;
+        }
+
+        _connectGate.Dispose();
+    }
+}
+
+/// <summary>
+/// The server presented a host key that does not match the one pinned to the connection.
+/// <para>
+/// Its own type rather than a bare <see cref="InvalidOperationException"/>, because this is
+/// the one sync failure that is never transient: retrying cannot fix it, and an operator has
+/// to decide whether they performed the rekey themselves.
+/// </para>
+/// </summary>
+public class SftpHostKeyMismatchException(string message, Exception inner)
+    : Exception(message, inner);
+
+/// <summary>
+/// Adapts SSH.NET to <see cref="ISftpRealPathResolver"/>.
+/// </summary>
+/// <remarks>
+/// <c>SSH_FXP_REALPATH</c> has no public entry point in SSH.NET — <c>ISftpSession</c> keeps
+/// <c>GetCanonicalPath</c> internal. <c>ChangeDirectory</c> is the way to reach it: it issues
+/// the realpath request and leaves the resolved answer in <c>WorkingDirectory</c>. The design
+/// note that named <c>SftpClient.GetCanonicalPath</c> was wrong about the library's surface.
+/// <para>
+/// The consequence is that only directories can be canonicalised, which is why file paths are
+/// confined through their parent.
+/// </para>
+/// </remarks>
+internal sealed class SftpRealPathResolver(SftpClient client) : ISftpRealPathResolver
+{
+    public async Task<string> GetCanonicalPathAsync(string path, CancellationToken ct = default)
+    {
+        await client.ChangeDirectoryAsync(path, ct);
+        return client.WorkingDirectory;
+    }
+}
+

--- a/src/Connapse.Storage/Connectors/SftpConnectorConfig.cs
+++ b/src/Connapse.Storage/Connectors/SftpConnectorConfig.cs
@@ -1,0 +1,112 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Connapse.Storage.Connectors;
+
+/// <summary>
+/// The two secrets an SFTP connection needs, stored as one JSON object inside the single
+/// encrypted <c>SecretProtected</c> column.
+/// <para>
+/// An encrypted private key needs a passphrase to open it, which makes two secrets where the
+/// connection schema has one field. Packing them into the existing protected blob means one
+/// value to encrypt, one to decrypt, and no migration — where a second column would need
+/// both, plus a second thing to remember to protect.
+/// </para>
+/// </summary>
+public record SftpCredential
+{
+    [JsonPropertyName("privateKey")]
+    public string PrivateKey { get; init; } = "";
+
+    /// <summary>Null or blank when the key is not encrypted.</summary>
+    [JsonPropertyName("passphrase")]
+    public string? Passphrase { get; init; }
+
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>
+    /// Reads a credential out of a connection's decrypted secret. Returns null when there is
+    /// nothing stored, or when the blob is not the expected shape — the caller turns that
+    /// into a connect-time failure naming the connection, which is more use than a JSON
+    /// parse error surfacing from inside the sync loop.
+    /// </summary>
+    public static SftpCredential? TryParse(string? secret)
+    {
+        if (string.IsNullOrWhiteSpace(secret))
+            return null;
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<SftpCredential>(secret, Options);
+
+            return string.IsNullOrWhiteSpace(parsed?.PrivateKey) ? null : parsed;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Serialises a credential for storage. Used by the connection form rather than the
+    /// connector, but lives here so the shape is defined once.
+    /// </summary>
+    public string ToSecretJson() => JsonSerializer.Serialize(this, Options);
+}
+
+/// <summary>
+/// Everything an <see cref="SftpConnector"/> needs: where the server is, who to be, what the
+/// connection is bounded to, and what the source picked inside that.
+/// </summary>
+public record SftpConnectorConfig
+{
+    public string Host { get; init; } = "";
+
+    public int Port { get; init; } = 22;
+
+    public string Username { get; init; } = "";
+
+    /// <summary>
+    /// The connection's boundary, as an absolute remote path. Every path this connector
+    /// touches is confined beneath it, resolved on the server.
+    /// </summary>
+    public string AllowedRoot { get; init; } = "";
+
+    /// <summary>The source's scope within the root. Null or blank means the root itself.</summary>
+    public string? SubPath { get; init; }
+
+    public IReadOnlyList<string> IncludePatterns { get; init; } = [];
+
+    public IReadOnlyList<string> ExcludePatterns { get; init; } = [];
+
+    /// <summary>
+    /// The fingerprint this connection is pinned to, or null when nothing has been recorded
+    /// and the next successful connect should record one.
+    /// </summary>
+    public string? PinnedHostKeyFingerprint { get; init; }
+
+    public SftpCredential? Credential { get; init; }
+
+    /// <summary>
+    /// Which connection to pin a newly-observed fingerprint against. Empty when the connector
+    /// was built outside a stored connection, as the connection tester does, in which case
+    /// nothing is recorded.
+    /// </summary>
+    public Guid ConnectionId { get; init; }
+
+    /// <summary>
+    /// How long a single SFTP request may take before the session gives up, and how long the
+    /// initial handshake may take.
+    /// </summary>
+    /// <remarks>
+    /// A backstop, not the primary mechanism — cancellation tokens are. It covers the case a
+    /// token cannot: SSH.NET waits on its own semaphores inside a request, and a server that
+    /// answers the handshake and then stops answering leaves the caller holding an SSH session
+    /// and a socket with nothing to release them. The default is infinite, which is the wrong
+    /// default for a server nobody here controls.
+    /// </remarks>
+    public TimeSpan OperationTimeout { get; init; } = TimeSpan.FromMinutes(2);
+}

--- a/src/Connapse.Storage/Data/Entities/SourceEntity.cs
+++ b/src/Connapse.Storage/Data/Entities/SourceEntity.cs
@@ -19,6 +19,13 @@ public class SourceEntity
     public string? LastSyncError { get; set; }
     public int? SyncIntervalSeconds { get; set; } // null inherits the connection default
 
+    /// <summary>
+    /// How many deletions the last reconcile declined to apply, or null when none are pending.
+    /// Null rather than zero: the Sources page distinguishes "nothing pending" from "an
+    /// administrator decided", and zero would leave the approval button showing forever.
+    /// </summary>
+    public int? WithheldDeletions { get; set; }
+
     // Auto-generated summary (agent-optimized prose for routing)
     public string? Summary { get; set; }
     public DateTime? SummaryGeneratedAt { get; set; }

--- a/src/Connapse.Storage/Data/KnowledgeDbContext.cs
+++ b/src/Connapse.Storage/Data/KnowledgeDbContext.cs
@@ -540,6 +540,9 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
             entity.Property(e => e.SyncIntervalSeconds)
                 .HasColumnName("sync_interval_seconds");
 
+            entity.Property(e => e.WithheldDeletions)
+                .HasColumnName("withheld_deletions");
+
             entity.Property(e => e.Summary)
                 .HasColumnName("summary");
 

--- a/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
+++ b/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
@@ -1,4 +1,4 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.Data;
 using Connapse.Storage.Data.Entities;
@@ -259,6 +259,28 @@ public class PostgresDocumentStore : IDocumentStore
         await context.SaveChangesAsync(ct);
     }
 
+    public async Task MarkIngestionFailedAsync(
+        string documentId, string? errorMessage, CancellationToken ct = default)
+    {
+        if (!Guid.TryParse(documentId, out var guid))
+        {
+            _logger.LogWarning("Invalid document ID format: {DocumentId}", Sanitize(documentId));
+            return;
+        }
+
+        await using var context = await _factory.CreateDbContextAsync(ct);
+
+        var entity = await context.Documents.FirstOrDefaultAsync(d => d.Id == guid, ct);
+        if (entity is null) return;
+
+        entity.IngestionState = IngestionState.Failed;
+        entity.Status = "Failed";
+        if (!string.IsNullOrEmpty(errorMessage))
+            entity.ErrorMessage = errorMessage;
+
+        await context.SaveChangesAsync(ct);
+    }
+
     public async Task<IReadOnlyList<Guid>> FindContainersWithStaleSummariesAsync(CancellationToken ct = default)
     {
         await using var context = await _factory.CreateDbContextAsync(ct);
@@ -357,6 +379,13 @@ public class PostgresDocumentStore : IDocumentStore
             entity.Summary,
             entity.SummaryGeneratedAt,
             entity.SummaryContentHash,
-            entity.IngestionState);
+            entity.IngestionState)
+        {
+            // Which of the two columns is set, kept alongside the collapsed OwnerId above so a
+            // caller can tell a source-owned row from a container-owned one.
+            Owner = entity.SourceId is Guid sourceId
+                ? OwnerRef.ForSource(sourceId)
+                : OwnerRef.ForContainer(entity.ContainerId!.Value),
+        };
     }
 }

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -169,6 +169,10 @@ public static class ServiceCollectionExtensions
         services.Configure<SourceSecuritySettings>(
             configuration.GetSection(SourceSecuritySettings.SectionName));
 
+        // Pins an SFTP connection's host key on first use. Singleton to match the factory
+        // that reaches it, and it opens its own scope because IConnectionStore is scoped.
+        services.AddSingleton<ISshHostKeyStore, ConnectionSshHostKeyStore>();
+
         // Connector factory (singleton — shared S3 client and config must outlive requests)
         services.AddSingleton<ConnectorFactory>();
         services.AddSingleton<IConnectorFactory>(sp => sp.GetRequiredService<ConnectorFactory>());
@@ -180,6 +184,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<OllamaConnectionTester>();
         services.AddScoped<MinioConnectionTester>();
         services.AddScoped<S3ConnectionTester>();
+        services.AddScoped<SftpConnectionTester>();
         services.AddScoped<AzureBlobConnectionTester>();
         services.AddScoped<AwsSsoConnectionTester>();
         services.AddScoped<AzureAdConnectionTester>();

--- a/src/Connapse.Storage/Migrations/20260823212530_AddSourceWithheldDeletions.Designer.cs
+++ b/src/Connapse.Storage/Migrations/20260823212530_AddSourceWithheldDeletions.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Connapse.Storage.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -15,13 +16,15 @@ using Pgvector;
 namespace Connapse.Storage.Migrations
 {
     [DbContext(typeof(KnowledgeDbContext))]
-    partial class KnowledgeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260823212530_AddSourceWithheldDeletions")]
+    partial class AddSourceWithheldDeletions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.0")
+                .HasAnnotation("ProductVersion", "10.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.HasPostgresExtension(modelBuilder, "vector");

--- a/src/Connapse.Storage/Migrations/20260823212530_AddSourceWithheldDeletions.cs
+++ b/src/Connapse.Storage/Migrations/20260823212530_AddSourceWithheldDeletions.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Connapse.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSourceWithheldDeletions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "withheld_deletions",
+                table: "sources",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "withheld_deletions",
+                table: "sources");
+        }
+    }
+}

--- a/src/Connapse.Storage/Sources/PostgresSourceStore.cs
+++ b/src/Connapse.Storage/Sources/PostgresSourceStore.cs
@@ -284,5 +284,18 @@ public class PostgresSourceStore(
         Summary: entity.Summary,
         SummaryGeneratedAt: entity.SummaryGeneratedAt,
         SummaryDocSetHash: entity.SummaryDocSetHash,
-        DocumentCount: documentCount);
+        DocumentCount: documentCount,
+        WithheldDeletions: entity.WithheldDeletions);
+
+    public async Task UpdateWithheldDeletionsAsync(Guid id, int? withheld, CancellationToken ct = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(ct);
+
+        var entity = await context.Sources.FirstOrDefaultAsync(s => s.Id == id, ct);
+        if (entity is null) return;
+
+        entity.WithheldDeletions = withheld;
+        entity.UpdatedAt = DateTime.UtcNow;
+        await context.SaveChangesAsync(ct);
+    }
 }

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -162,6 +162,28 @@
                                 </td>
                             </tr>
                         }
+
+                        @if (source.WithheldDeletions is { } withheld && isAdmin)
+                        {
+                            <tr class="@(source.Enabled ? "" : "opacity-50")">
+                                @* Administrators only, matching the sync-error row: the count
+                                   is harmless, but the action it offers is destructive. *@
+                                <td colspan="7" class="pt-0 border-top-0">
+                                    <div class="alert alert-warning py-2 mb-0 small d-flex align-items-center justify-content-between">
+                                        <span>
+                                            <span class="bi-exclamation-triangle me-1"></span>
+                                            The last sync would have deleted <strong>@withheld</strong> document(s) —
+                                            more than expected, so they were kept. If the source really did lose them, apply the deletions.
+                                        </span>
+                                        <button class="btn btn-sm btn-outline-danger ms-3 text-nowrap"
+                                                @onclick="() => SyncNow(source, applyWithheldDeletions: true)"
+                                                disabled="@(!source.Enabled || syncing == source.Id)">
+                                            Apply deletions
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
                     }
                 </tbody>
             </table>
@@ -403,7 +425,7 @@
         builder.CloseElement();
     };
 
-    private async Task SyncNow(Source source)
+    private async Task SyncNow(Source source, bool applyWithheldDeletions = false)
     {
         message = null;
         syncing = source.Id;
@@ -417,7 +439,7 @@
                 return;
             }
 
-            var result = await SyncService.SyncSourceAsync(source, connection, CancellationToken.None);
+            var result = await SyncService.SyncSourceAsync(source, connection, CancellationToken.None, applyWithheldDeletions);
 
             if (result.AlreadyRunning)
             {
@@ -430,10 +452,14 @@
             }
             else
             {
-                await AuditLogger.LogAsync("source.synced", "source", source.Id.ToString(),
+                await AuditLogger.LogAsync(
+                    applyWithheldDeletions ? "source.deletions_applied" : "source.synced",
+                    "source", source.Id.ToString(),
                     new { source.Name, result.Upserted, result.Deleted });
 
-                Succeed($"'{source.Name}' synced — {result.Upserted} queued, {result.Deleted} removed.");
+                Succeed(result.WithheldDeletions > 0
+                    ? $"'{source.Name}' synced — {result.Upserted} queued, {result.WithheldDeletions} deletion(s) withheld."
+                    : $"'{source.Name}' synced — {result.Upserted} queued, {result.Deleted} removed.");
             }
 
             await LoadAsync();

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -261,13 +261,25 @@
                             <div class="form-text">Narrows the source to a subtree. Everything below it is indexed.</div>
                         </div>
                     }
-                    else if (selectedProvider is ConnectionProvider.Filesystem)
+                    @* SFTP shares this branch rather than getting its own. Its scope is the same
+                       shape — a subpath beneath the connection's root, plus patterns — and that
+                       was a deliberate choice when the provider was designed, so that this form,
+                       the preflight, and the scope summary each gained a case rather than a
+                       parallel implementation. *@
+                    else if (selectedProvider is ConnectionProvider.Filesystem or ConnectionProvider.Sftp)
                     {
                         <div class="mb-3">
                             <label class="form-label">Sub-path (optional)</label>
-                            <input class="form-control font-monospace" @bind="form.SubPath" placeholder="team-a" />
+                            <input class="form-control font-monospace" @bind="form.SubPath"
+                                   placeholder="@(selectedProvider is ConnectionProvider.Sftp ? "Documents" : "team-a")" />
                             <div class="form-text">
                                 Resolved beneath the connection's allowed root. Leave empty for the root itself.
+                                @if (selectedProvider is ConnectionProvider.Sftp)
+                                {
+                                    <text>
+                                        Resolved on the remote server, so a symlink cannot lead outside the root.
+                                    </text>
+                                }
                             </div>
                         </div>
 

--- a/src/Connapse.Web/Components/Settings/ConnectionForm.cs
+++ b/src/Connapse.Web/Components/Settings/ConnectionForm.cs
@@ -1,5 +1,7 @@
 using System.Text.Json.Nodes;
 using Connapse.Core;
+using Connapse.Core.Utilities;
+using Connapse.Storage.Connectors;
 
 namespace Connapse.Web.Components.Settings;
 
@@ -25,12 +27,137 @@ public sealed record ConnectionForm
     public string? StorageAccountName { get; set; }
     public string? ManagedIdentityClientId { get; set; }
 
-    // Filesystem
+    // Filesystem and SFTP both bound a source with a root, so this is shared.
     public string? AllowedRoot { get; set; }
+
+    // SFTP
+    public string? Host { get; set; }
+    public string? Port { get; set; }
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// The private key, entered once and never read back. <see cref="FromConnection"/> leaves
+    /// this null when editing, and a null value means "leave the stored secret alone" — the
+    /// same rule the store applies, so opening and saving a connection cannot wipe its key.
+    /// </summary>
+    public string? PrivateKey { get; set; }
+
+    /// <summary>Only needed when the private key is itself encrypted.</summary>
+    public string? Passphrase { get; set; }
+
+    /// <summary>
+    /// The pinned host key, shown so it can be checked against <c>ssh-keyscan</c>. Recorded by
+    /// the connector on first successful connect, never typed.
+    /// </summary>
+    public string? HostKeyFingerprint { get; set; }
+
+    /// <summary>
+    /// Set by the "forget" control. Clearing the pin re-arms trust on first use, which is how a
+    /// server that was legitimately rekeyed is accepted again.
+    /// </summary>
+    public bool ForgetHostKey { get; set; }
 
     /// <summary>Newline-separated in the UI; an array in the stored JSON.</summary>
     public string? AllowedLocations { get; set; }
 
+    /// <summary>
+    /// Providers whose credential is a cloud identity Connapse never holds, and which are
+    /// therefore bounded by <see cref="AllowedLocations"/> rather than a root.
+    /// <para>
+    /// Named rather than written as "not Filesystem". The old form used the negative, and
+    /// adding SFTP to the enum would have silently swept it into the cloud branch — offering a
+    /// bucket allowlist for a directory on a server, and no root at all.
+    /// </para>
+    /// </summary>
+    public bool IsCloudProvider =>
+        Provider is ConnectionProvider.S3 or ConnectionProvider.AzureBlob;
+
+
+    /// <summary>
+    /// Builds the connection the "Connect this computer" flow creates, from what the host's
+    /// setup command reported.
+    /// </summary>
+    /// <remarks>
+    /// Here rather than in the Razor component for the same reason the rest of this class is:
+    /// a dropped or mis-joined field produces a connection that points somewhere other than
+    /// intended, and the component has no test harness in this repository.
+    /// </remarks>
+    /// <param name="allowedRoot">
+    /// Any absolute path on the host, not merely somewhere under the home directory. Windows
+    /// OpenSSH applies no chroot, so a second drive is reachable as <c>/D:/…</c> and confining
+    /// the flow to the profile would rule out where most people actually keep things.
+    /// Blank falls back to the reported home directory.
+    /// </param>
+    public static ConnectionForm ForLocalMachine(
+        SftpHostSetupResult result, string host, string? allowedRoot, string privateKeyPem)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentException.ThrowIfNullOrWhiteSpace(privateKeyPem);
+
+        return new ConnectionForm
+        {
+            Name = $"{result.Username}@{host.Trim()}",
+            Provider = ConnectionProvider.Sftp,
+            Host = host.Trim(),
+            Port = "22",
+            Username = result.Username,
+            AllowedRoot = NormaliseRemoteRoot(allowedRoot, result.HomePath),
+            HostKeyFingerprint = result.Fingerprint,
+            PrivateKey = privateKeyPem,
+        };
+    }
+
+    /// <summary>
+    /// Cleans an operator-entered remote path into the form SFTP expects, falling back to
+    /// <paramref name="fallback"/> when nothing was entered.
+    /// </summary>
+    /// <remarks>
+    /// Never uses <see cref="System.IO.Path"/>: that applies the rules of whichever machine
+    /// Connapse runs on, which is a Linux container, to a path describing somebody else's
+    /// Windows box. SFTP paths are always '/'-separated, and Windows OpenSSH presents drives
+    /// as <c>/C:/Users/me</c> — a leading slash before the drive letter.
+    /// <para>
+    /// A Windows path pasted from Explorer is accepted and converted, because that is what an
+    /// operator will have on their clipboard.
+    /// </para>
+    /// </remarks>
+    public static string NormaliseRemoteRoot(string? entered, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(entered))
+            return fallback.TrimEnd('/');
+
+        string path = entered.Trim().Replace('\\', '/');
+
+        // "D:/Projects" pasted from Explorer needs the leading slash SFTP presents.
+        if (path.Length >= 2 && char.IsLetter(path[0]) && path[1] == ':')
+            path = "/" + path;
+
+        if (!path.StartsWith('/'))
+            path = "/" + path;
+
+        // A drive root trims to "/D:" rather than "", which is still the drive and not the
+        // filesystem root — so only trim when something remains beneath it.
+        string trimmed = path.TrimEnd('/');
+
+        return trimmed.Length == 0 ? "/" : trimmed;
+    }
+
+    /// <summary>
+    /// True when a root is broad enough to be worth a second look — a drive root, or the
+    /// filesystem root. Permitted, since an administrator may genuinely mean it, but the UI
+    /// should say what it implies.
+    /// </summary>
+    public static bool IsBroadRemoteRoot(string? root)
+    {
+        if (string.IsNullOrWhiteSpace(root)) return false;
+
+        string trimmed = root.Trim().TrimEnd('/');
+
+        // "/" and "/D:" — nothing beneath the drive or the filesystem root.
+        return trimmed.Length == 0
+            || (trimmed.Length == 3 && trimmed[0] == '/' && char.IsLetter(trimmed[1]) && trimmed[2] == ':');
+    }
 
     /// <summary>
     /// Reads a stored connection into an editable form. A config that cannot be parsed yields an
@@ -60,6 +187,16 @@ public sealed record ConnectionForm
         form.StorageAccountName = Str(node, "storageAccountName");
         form.ManagedIdentityClientId = Str(node, "managedIdentityClientId");
         form.AllowedRoot = Str(node, "allowedRoot");
+        form.Host = Str(node, "host");
+        form.Username = Str(node, "username");
+        form.HostKeyFingerprint = Str(node, "hostKeyFingerprint");
+
+        if (node["port"] is JsonValue port && port.TryGetValue<int>(out int portNumber))
+            form.Port = portNumber.ToString();
+
+        // PrivateKey and Passphrase are deliberately not populated. The store never returns a
+        // secret to a read model, and leaving them blank is what makes "save without retyping
+        // the key" work.
 
         if (node["allowedLocations"] is JsonArray arr)
         {
@@ -109,11 +246,26 @@ public sealed record ConnectionForm
             case ConnectionProvider.Filesystem:
                 node["allowedRoot"] = AllowedRoot?.Trim() ?? "";
                 break;
+
+            case ConnectionProvider.Sftp:
+                node["host"] = Host?.Trim() ?? "";
+                node["port"] = ParsePort(Port);
+                node["username"] = Username?.Trim() ?? "";
+                node["allowedRoot"] = AllowedRoot?.Trim() ?? "";
+
+                // Carried forward rather than rewritten. The connector owns this value — it
+                // records it on first connect and compares against it thereafter — so an
+                // ordinary save must not disturb it. Dropping it here would silently re-arm
+                // trust on first use on the next sync, which is the one thing pinning exists
+                // to prevent.
+                if (!ForgetHostKey && !Blank(HostKeyFingerprint))
+                    node["hostKeyFingerprint"] = HostKeyFingerprint!.Trim();
+                break;
         }
 
-        // Filesystem confinement is the allowed root plus the subpath check; allowedLocations is
-        // the cloud equivalent and does not apply to it.
-        if (Provider != ConnectionProvider.Filesystem)
+        // A root plus a subpath check is how the on-disk providers are bounded; allowedLocations
+        // is the cloud equivalent and does not apply to them.
+        if (IsCloudProvider)
         {
             var locations = ParseLocations(AllowedLocations);
             if (locations.Count > 0)
@@ -154,8 +306,32 @@ public sealed record ConnectionForm
             : (trimmed[..slash], trimmed[(slash + 1)..]);
     }
 
+    /// <summary>
+    /// The credential to store, or null to leave any existing one untouched.
+    /// </summary>
+    /// <remarks>
+    /// SFTP only, and that is the whole point. #371 removed the secret field from this form
+    /// because Connapse does not accept pasted cloud keys; an SSH key for a server you run is a
+    /// different thing from an AWS access key, but only if the distinction is enforced rather
+    /// than described. Returning null for every other provider is where it is enforced.
+    /// </remarks>
+    public string? ToSecretJson()
+    {
+        if (Provider != ConnectionProvider.Sftp || Blank(PrivateKey))
+            return null;
+
+        return new SftpCredential
+        {
+            PrivateKey = PrivateKey!.Trim(),
+            Passphrase = Blank(Passphrase) ? null : Passphrase
+        }.ToSecretJson();
+    }
+
     /// <summary>Returns the first problem with the form, or null when it is ready to save.</summary>
-    public string? Validate()
+    /// <param name="isNew">
+    /// A new SFTP connection must carry a key; an existing one may be saved without retyping it.
+    /// </param>
+    public string? Validate(bool isNew = true)
     {
         if (Blank(Name)) return "A name is required.";
 
@@ -163,9 +339,27 @@ public sealed record ConnectionForm
         {
             ConnectionProvider.Filesystem when Blank(AllowedRoot) => "Choose an allowed root.",
             ConnectionProvider.AzureBlob when Blank(StorageAccountName) => "A storage account is required.",
+
+            ConnectionProvider.Sftp when Blank(Host) => "A host is required.",
+            ConnectionProvider.Sftp when Blank(Username) => "A username is required.",
+            ConnectionProvider.Sftp when Blank(AllowedRoot) => "An allowed root is required.",
+            ConnectionProvider.Sftp when !Blank(Port) && ParsePort(Port) is < 1 or > 65535 =>
+                "The port must be between 1 and 65535.",
+            ConnectionProvider.Sftp when isNew && Blank(PrivateKey) => "A private key is required.",
+
             _ => null
         };
     }
+
+    /// <summary>
+    /// The configured port, or 22. Anything unparseable becomes 0, which
+    /// <see cref="Validate"/> then refuses — rather than silently falling back to 22 and
+    /// connecting somewhere the operator did not ask for.
+    /// </summary>
+    private static int ParsePort(string? raw) =>
+        string.IsNullOrWhiteSpace(raw) ? 22
+        : int.TryParse(raw.Trim(), out int port) ? port
+        : 0;
 
     private static string? Str(JsonObject node, string name) =>
         node[name] is JsonValue value && value.TryGetValue<string>(out var s) && !string.IsNullOrWhiteSpace(s)
@@ -174,3 +368,5 @@ public sealed record ConnectionForm
 
     private static bool Blank(string? s) => string.IsNullOrWhiteSpace(s);
 }
+
+

--- a/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
@@ -1,5 +1,7 @@
-@using Connapse.Core
+﻿@using Connapse.Core
 @using Connapse.Core.Interfaces
+@using Connapse.Core.Utilities
+@inject IJSRuntime JS
 @using Connapse.Storage.ConnectionTesters
 @using Connapse.Storage.Connectors
 @using Microsoft.Extensions.Options
@@ -10,6 +12,7 @@
 @inject IOptionsMonitor<SourceSecuritySettings> SourceSecurity
 @inject S3ConnectionTester S3Tester
 @inject AzureBlobConnectionTester AzureTester
+@inject SftpConnectionTester SftpTester
 
 @*
     Connections — the credential and filesystem-root boundary.
@@ -48,14 +51,223 @@
         </div>
     }
 
+    @* ── Connect this computer ─────────────────────────────────────── *@
+    @if (localSetup)
+    {
+        <div class="col-12">
+            <h5>Connect this computer</h5>
+            <p class="text-muted mb-0">
+                Connapse runs in a container, so it cannot see your files directly and cannot
+                configure your machine for you. It can do everything else: it has made a key,
+                and written the one command you need to run.
+            </p>
+        </div>
+
+        @* Step 1 *@
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <h6 class="card-title">1 · Run this on your computer</h6>
+                    <div class="btn-group btn-group-sm mb-2" role="group">
+                        @foreach (var p in Enum.GetValues<HostPlatform>())
+                        {
+                            <button type="button"
+                                    class="btn @(setupPlatform == p ? "btn-secondary" : "btn-outline-secondary")"
+                                    @onclick="() => SelectPlatform(p)">@PlatformLabel(p)</button>
+                        }
+                    </div>
+                    @if (setupPlatform == HostPlatform.Windows)
+                    {
+                        <div class="small text-muted mb-2">
+                            Open PowerShell with <strong>Run as Administrator</strong>, then paste this in.
+                        </div>
+                    }
+                    <textarea class="form-control font-monospace" rows="12" readonly
+                              style="font-size:.78rem">@setupScript</textarea>
+                    <button class="btn btn-sm btn-outline-secondary mt-2" @onclick="CopyScript">
+                        <span class="bi-clipboard me-1"></span> Copy command
+                    </button>
+                    <span class="small text-muted ms-2">
+                        Safe to run more than once.
+                    </span>
+
+                    @* The key is installed with restrict and a forced internal-sftp command, so it
+                       cannot open a shell or forward ports. That bounds the kind of access, not its
+                       reach: it still authenticates as this account, so an administrator account
+                       yields a key that can read the whole machine over SFTP. *@
+                    <div class="alert alert-secondary py-2 mt-2 mb-0 small">
+                        <span class="bi-shield-lock me-1"></span>
+                        The key is installed <strong>SFTP-only</strong> — no shell, no port forwarding.
+                        It still signs in as the account you run this under, so prefer an ordinary
+                        account over an administrator one: an administrator's SFTP session can read
+                        anything on the machine, whatever folder you pick below.
+                    </div>
+
+                    @* Naming it, because it is the part that reaches past Connapse. Turning on
+                       an SSH server affects every account on the machine and every way of
+                       signing in to it, not only the key installed above — so an operator who
+                       reads "adds one key" and nothing else has been told the smaller half. *@
+                    <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                        <span class="bi-exclamation-triangle me-1"></span>
+                        It also <strong>turns on this computer's SSH server</strong> and allows
+                        inbound port 22 from your local networks — the Docker network among them,
+                        which is how Connapse reaches you. Other accounts on the machine can then
+                        sign in over SSH too, by password if the host allows it. The command reports
+                        whether it does, and prints the one line that turns that off.
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        @* Step 2 *@
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <h6 class="card-title">2 · Paste back what it printed</h6>
+                    <textarea class="form-control font-monospace" rows="5" @bind="pastedResult"
+                              @bind:event="oninput"
+                              placeholder="@SftpHostSetup.BeginMarker&#10;user=…&#10;home=…&#10;fingerprint=…&#10;@SftpHostSetup.EndMarker"></textarea>
+                    <div class="form-text">
+                        The whole terminal output is fine — Connapse finds the block. This carries your
+                        username, your folder path, and the server's key fingerprint, so nothing has to
+                        be typed. The fingerprint arriving this way means the very first connection is
+                        verified rather than trusted.
+                    </div>
+
+                    @if (!string.IsNullOrWhiteSpace(pastedResult))
+                    {
+                        var parsed = SftpHostSetup.ParseResult(pastedResult);
+                        @if (parsed is null)
+                        {
+                            <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                <span class="bi-exclamation-triangle me-1"></span>
+                                No setup block found yet. Copy everything the command printed, including
+                                both <code>-----</code> marker lines.
+                            </div>
+                        }
+                        else
+                        {
+                            <div class="alert alert-success py-2 mt-2 mb-0 small">
+                                <span class="bi-check-circle me-1"></span>
+                                Read <strong>@parsed.Username</strong>, home <code>@parsed.HomePath</code>@(string.IsNullOrWhiteSpace(parsed.Fingerprint) ? "." : ", host key ")
+                                @if (!string.IsNullOrWhiteSpace(parsed.Fingerprint))
+                                {
+                                    <code>@parsed.Fingerprint</code><text>.</text>
+                                }
+                            </div>
+
+                            @if (string.IsNullOrWhiteSpace(parsed.Fingerprint))
+                            {
+                                @* Setup is finishable without it. Requiring one dead-ended the flow
+                                   with the host already configured and the key already installed. *@
+                                <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                    <span class="bi-exclamation-triangle me-1"></span>
+                                    No host key fingerprint came back, so the first connection will be
+                                    <strong>trusted</strong> rather than verified. Everything else is set up
+                                    and this is safe to continue with — re-running the command as
+                                    Administrator would capture it.
+                                </div>
+                            }
+                        }
+                    }
+                </div>
+            </div>
+        </div>
+
+        @* Step 3 *@
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <h6 class="card-title">3 · Choose what to index</h6>
+                    <div class="row g-3">
+                        <div class="col-md-8">
+                            <label class="form-label">Folder</label>
+                            <input class="form-control font-monospace" @bind="localRoot" @bind:event="oninput"
+                                   placeholder="@(LocalHome() ?? "/C:/Users/you")" />
+
+                            @if (LocalResult() is { } r)
+                            {
+                                <div class="mt-2 d-flex flex-wrap gap-1 align-items-center">
+                                    <span class="small text-muted me-1">Jump to:</span>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary py-0"
+                                            @onclick="() => localRoot = r.HomePath">Home</button>
+                                    @foreach (var drive in r.Drives)
+                                    {
+                                        <button type="button" class="btn btn-sm btn-outline-secondary py-0"
+                                                @onclick="() => localRoot = drive">@drive</button>
+                                    }
+                                </div>
+                            }
+
+                            <div class="form-text">
+                                Any folder on that machine, not only inside your profile — a second drive
+                                is <code>/D:/Projects</code>. Paths use forward slashes with a leading one
+                                before the drive letter; a path pasted from Explorer is converted for you.
+                                Sources you add later are confined beneath whatever you choose.
+                            </div>
+
+                            @if (ConnectionForm.IsBroadRemoteRoot(EffectiveRoot()))
+                            {
+                                <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                    <span class="bi-exclamation-triangle me-1"></span>
+                                    That is a whole drive. Every source on this connection could then reach
+                                    anything on it that <strong>@LocalResult()?.Username</strong> can read,
+                                    and Connapse indexes what it reads. Naming a folder costs nothing and
+                                    bounds it.
+                                </div>
+                            }
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Reachable at</label>
+                            <input class="form-control font-monospace" @bind="localHost" />
+                            <div class="form-text">
+                                <code>host.docker.internal</code> works on Docker Desktop. A Linux host needs
+                                <code>--add-host=host.docker.internal:host-gateway</code>.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12">
+            <button class="btn btn-primary me-2" @onclick="SaveLocalSetup" disabled="@(saving || !LocalSetupReady())">
+                @if (saving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                <span>Create connection</span>
+            </button>
+            <button class="btn btn-info me-2" @onclick="TestLocalSetup" disabled="@(testing || !LocalSetupReady())">
+                @if (testing) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                <span>Test first</span>
+            </button>
+            <button class="btn btn-secondary" @onclick="CancelLocalSetup">Cancel</button>
+        </div>
+
+        @if (testMessage is not null)
+        {
+            <div class="col-12">
+                <div class="alert @(testSuccess ? "alert-success" : "alert-danger") py-2 mb-0">
+                    <span class="@(testSuccess ? "bi-check-circle" : "bi-x-circle") me-2"></span>
+                    @testMessage
+                </div>
+            </div>
+        }
+    }
     @* ── List ──────────────────────────────────────────────────────── *@
-    @if (editing is null)
+    else if (editing is null)
     {
         <div class="col-12 d-flex justify-content-between align-items-center">
             <h5 class="mb-0">Connections</h5>
-            <button class="btn btn-primary btn-sm" @onclick="StartCreate">
-                <span class="bi-plus-lg me-1"></span> Add connection
-            </button>
+            <div>
+                @* The local case gets its own entry point rather than being a provider hidden
+                   inside "Add connection". It is the one most people want, and reaching it
+                   through a generic SFTP form means understanding SFTP first. *@
+                <button class="btn btn-outline-primary btn-sm me-2" @onclick="StartLocalSetup">
+                    <span class="bi-laptop me-1"></span> Connect this computer
+                </button>
+                <button class="btn btn-primary btn-sm" @onclick="StartCreate">
+                    <span class="bi-plus-lg me-1"></span> Add connection
+                </button>
+            </div>
         </div>
 
         <div class="col-12">
@@ -92,7 +304,25 @@
                                     <td class="small text-muted">@DescribeScope(c)</td>
                                     <td>@c.SourceCount</td>
                                     <td class="small">
-                                        @if (c.HasSecret)
+                                        @if (c.Provider == ConnectionProvider.Sftp)
+                                        {
+                                            @* SFTP is the one provider that legitimately stores a
+                                               credential: an SSH key for a server the operator runs,
+                                               not a cloud identity. *@
+                                            @if (c.HasSecret)
+                                            {
+                                                <span class="text-success" title="SSH key, encrypted at rest">
+                                                    <span class="bi-key-fill me-1"></span>SSH key
+                                                </span>
+                                            }
+                                            else
+                                            {
+                                                <span class="text-danger" title="This connection cannot authenticate">
+                                                    <span class="bi-exclamation-triangle me-1"></span>No key
+                                                </span>
+                                            }
+                                        }
+                                        else if (c.HasSecret)
                                         {
                                             @* Only reachable for a connection created before this tab
                                                existed. Shown rather than hidden so an operator can see
@@ -137,6 +367,7 @@
                 <option value="@ConnectionProvider.S3">Amazon S3</option>
                 <option value="@ConnectionProvider.AzureBlob">Azure Blob Storage</option>
                 <option value="@ConnectionProvider.Filesystem">Local filesystem</option>
+                <option value="@ConnectionProvider.Sftp">SFTP</option>
             </select>
             @if (!isNew)
             {
@@ -166,6 +397,101 @@
                 <label class="form-label">Managed identity client ID <span class="text-muted">(optional)</span></label>
                 <input class="form-control" @bind="form.ManagedIdentityClientId" placeholder="00000000-0000-0000-0000-000000000000" />
                 <div class="form-text">Selects a specific identity. Leave blank to use the default — which may have wider access.</div>
+            </div>
+        }
+        else if (form.Provider == ConnectionProvider.Sftp)
+        {
+            <div class="col-md-8">
+                <label class="form-label">Host</label>
+                <input class="form-control" @bind="form.Host" placeholder="files.example.com" />
+                <div class="form-text">
+                    To index files on the machine you are sitting at, run an SSH server there and use
+                    <code>host.docker.internal</code> — see
+                    <a href="https://github.com/Destrayon/Connapse/blob/main/docs/connectors.md" target="_blank" rel="noopener">the connector documentation</a>.
+                </div>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Port</label>
+                <input class="form-control" type="number" @bind="form.Port" placeholder="22" />
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label">Username</label>
+                <input class="form-control" @bind="form.Username" placeholder="connapse" />
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label">Allowed root</label>
+                @* Free text, and unlike the local filesystem provider it is not checked against
+                   Sources:Security:AllowedFilesystemRoots — that setting names directories on
+                   this machine, and this one names a directory on somebody else's. The bound
+                   that does apply is enforced on the server, through SSH_FXP_REALPATH. *@
+                <input class="form-control" @bind="form.AllowedRoot" placeholder="/srv/knowledge" />
+                <div class="form-text">
+                    Every source on this connection is confined beneath this directory, resolved on
+                    the server so a symlink cannot lead out of it. Windows OpenSSH presents drives
+                    with a leading slash, as in <code>/C:/Users/you/Documents</code>.
+                </div>
+            </div>
+
+            <div class="col-12">
+                <label class="form-label">
+                    Private key
+                    @if (!isNew)
+                    {
+                        <span class="text-muted">— leave blank to keep the stored key</span>
+                    }
+                </label>
+                <textarea class="form-control font-monospace" rows="5" @bind="form.PrivateKey"
+                          placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;…"></textarea>
+                <div class="form-text">
+                    Encrypted at rest and never shown again. This is an SSH key for a server you run —
+                    the rule that Connapse stores no cloud credentials is about AWS and Azure
+                    identities, which are not stored and are not asked for.
+                </div>
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label">Key passphrase <span class="text-muted">(optional)</span></label>
+                <input class="form-control" type="password" @bind="form.Passphrase"
+                       placeholder="Only if the key is encrypted" />
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label">Host key</label>
+                @if (string.IsNullOrWhiteSpace(form.HostKeyFingerprint))
+                {
+                    <div class="form-control-plaintext text-muted small">
+                        Not yet recorded — the first successful sync will trust and pin whatever this
+                        server presents.
+                    </div>
+                }
+                else
+                {
+                    <div class="input-group">
+                        <input class="form-control font-monospace" readonly value="@form.HostKeyFingerprint" />
+                        <button class="btn btn-outline-warning" type="button"
+                                @onclick="() => form.ForgetHostKey = !form.ForgetHostKey">
+                            @(form.ForgetHostKey ? "Keep" : "Forget")
+                        </button>
+                    </div>
+                    <div class="form-text">
+                        @if (form.ForgetHostKey)
+                        {
+                            <span class="text-warning">
+                                Will be cleared on save, and the next connection will trust whatever
+                                answers. Only do this if you rekeyed the server yourself.
+                            </span>
+                        }
+                        else
+                        {
+                            <span>
+                                Compare against <code>ssh-keyscan @(string.IsNullOrWhiteSpace(form.Host) ? "host" : form.Host) | ssh-keygen -lf -</code>.
+                                Syncing stops if this stops matching.
+                            </span>
+                        }
+                    </div>
+                }
             </div>
         }
         else
@@ -203,7 +529,7 @@
             </div>
         }
 
-        @if (form.Provider != ConnectionProvider.Filesystem)
+        @if (form.IsCloudProvider)
         {
             <div class="col-12">
                 <label class="form-label">
@@ -224,7 +550,7 @@
 
 
         @* ── Test ──────────────────────────────────────────────────── *@
-        @if (form.Provider != ConnectionProvider.Filesystem)
+        @if (form.IsCloudProvider)
         {
             <div class="col-md-6">
                 <label class="form-label">
@@ -246,7 +572,7 @@
                 <span>@(isNew ? "Create connection" : "Save changes")</span>
             </button>
             <button class="btn btn-secondary me-2" @onclick="CancelEdit">Cancel</button>
-            @if (form.Provider != ConnectionProvider.Filesystem)
+            @if (form.IsCloudProvider || form.Provider == ConnectionProvider.Sftp)
             {
                 <button class="btn btn-info" @onclick="Test" disabled="@testing">
                     @if (testing)
@@ -305,6 +631,139 @@
         loading = false;
     }
 
+    // ── Connect this computer ──────────────────────────────────────────────
+
+    private bool localSetup;
+    private HostPlatform setupPlatform = HostPlatform.Windows;
+    private SshKeyPair? localKeyPair;
+    private string setupScript = "";
+    private string? pastedResult;
+    private string localRoot = "";
+    private string localHost = "host.docker.internal";
+
+    private static string PlatformLabel(HostPlatform p) => p switch
+    {
+        HostPlatform.Windows => "Windows",
+        HostPlatform.MacOS => "macOS",
+        _ => "Linux",
+    };
+
+    private void StartLocalSetup()
+    {
+        // Generated once per visit, not per keystroke: the script embeds the public key, and
+        // regenerating would invalidate a command the operator may have already run.
+        localKeyPair = SshKeyPairGenerator.Generate($"connapse@{Environment.MachineName}");
+
+        localSetup = true;
+        editing = null;
+        pastedResult = null;
+        localRoot = "";
+        localHost = "host.docker.internal";
+        statusMessage = null;
+        testMessage = null;
+
+        RegenerateScript();
+    }
+
+    private void SelectPlatform(HostPlatform platform)
+    {
+        setupPlatform = platform;
+        RegenerateScript();
+    }
+
+    private void RegenerateScript() =>
+        setupScript = localKeyPair is null
+            ? ""
+            : SftpHostSetup.GenerateScript(localKeyPair.PublicKeyLine, setupPlatform);
+
+    private async Task CopyScript() =>
+        await JS.InvokeVoidAsync("navigator.clipboard.writeText", setupScript);
+
+    private SftpHostSetupResult? LocalResult() => SftpHostSetup.ParseResult(pastedResult);
+
+    private string? LocalHome() => LocalResult()?.HomePath;
+
+    /// <summary>What the connection would actually be bounded to, blank meaning the home folder.</summary>
+    private string? EffectiveRoot() =>
+        LocalResult() is { } r ? ConnectionForm.NormaliseRemoteRoot(localRoot, r.HomePath) : null;
+
+    private bool LocalSetupReady() =>
+        LocalResult() is not null && !string.IsNullOrWhiteSpace(localHost);
+
+    private ConnectionForm BuildLocalForm(SftpHostSetupResult result) =>
+        ConnectionForm.ForLocalMachine(result, localHost, localRoot, localKeyPair!.PrivateKeyPem);
+
+    private async Task TestLocalSetup()
+    {
+        if (LocalResult() is not { } result) return;
+
+        testing = true;
+        testMessage = null;
+        try
+        {
+            var form = BuildLocalForm(result);
+
+            var outcome = await SftpTester.TestConnectionAsync(new SftpConnectionTestSettings
+            {
+                Host = form.Host!,
+                Port = 22,
+                Username = form.Username!,
+                AllowedRoot = form.AllowedRoot!,
+                PrivateKey = form.PrivateKey!,
+                PinnedHostKeyFingerprint = form.HostKeyFingerprint,
+            }, TimeSpan.FromSeconds(15));
+
+            testSuccess = outcome.Success;
+            testMessage = outcome.Message;
+        }
+        catch (Exception ex)
+        {
+            testSuccess = false;
+            testMessage = ex.Message;
+        }
+        finally
+        {
+            testing = false;
+        }
+    }
+
+    private async Task SaveLocalSetup()
+    {
+        if (LocalResult() is not { } result) return;
+
+        saving = true;
+        try
+        {
+            var form = BuildLocalForm(result);
+
+            await ConnectionStore.CreateAsync(
+                new CreateConnectionRequest(
+                    form.Name.Trim(), ConnectionProvider.Sftp, form.ToConfigJson(), form.ToSecretJson()),
+                createdByUserId: null);
+
+            Succeed($"Connected. Add a source on '{form.Name}' to start indexing.");
+            CancelLocalSetup();
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Fail(ex.Message);
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private void CancelLocalSetup()
+    {
+        localSetup = false;
+        localKeyPair = null;
+        setupScript = "";
+        pastedResult = null;
+        testMessage = null;
+    }
+
     private void StartCreate()
     {
         editing = new Connection(Guid.Empty, "", ConnectionProvider.S3, null, null, DateTime.UtcNow, DateTime.UtcNow);
@@ -339,7 +798,7 @@
     {
         statusMessage = null;
 
-        if (form.Validate() is { } problem)
+        if (form.Validate(isNew) is { } problem)
         {
             Fail(problem);
             return;
@@ -350,10 +809,14 @@
         {
             string config = form.ToConfigJson();
 
+            // Null for every provider but SFTP, and null again for an SFTP connection saved
+            // without retyping its key — which the store reads as "leave the stored one alone".
+            string? secret = form.ToSecretJson();
+
             if (isNew)
             {
                 await ConnectionStore.CreateAsync(
-                    new CreateConnectionRequest(form.Name.Trim(), form.Provider, config, Secret: null),
+                    new CreateConnectionRequest(form.Name.Trim(), form.Provider, config, secret),
                     createdByUserId: null);
                 Succeed($"Connection '{form.Name.Trim()}' created.");
             }
@@ -362,7 +825,7 @@
                 // Null result means the row is gone — deleted from another session between this
                 // form opening and saving. Reporting "saved" there would be a lie.
                 var updated = await ConnectionStore.UpdateAsync(editing!.Id,
-                    new UpdateConnectionRequest(form.Name.Trim(), config, Secret: null));
+                    new UpdateConnectionRequest(form.Name.Trim(), config, secret));
 
                 if (updated is null)
                 {
@@ -427,6 +890,39 @@
 
         try
         {
+            if (form.Provider == ConnectionProvider.Sftp)
+            {
+                // Tested against the key in the form, not the stored one, so an operator can
+                // check a key before committing to it. Editing an existing connection without
+                // retyping the key therefore cannot be tested — said plainly rather than
+                // silently testing something else.
+                if (string.IsNullOrWhiteSpace(form.PrivateKey))
+                {
+                    testSuccess = false;
+                    testMessage = "Paste the private key to test. Testing uses the key in this form, "
+                                  + "not the stored one.";
+                    return;
+                }
+
+                var sftpResult = await SftpTester.TestConnectionAsync(new SftpConnectionTestSettings
+                {
+                    Host = form.Host?.Trim() ?? "",
+                    Port = int.TryParse(form.Port, out int p) ? p : 22,
+                    Username = form.Username?.Trim() ?? "",
+                    AllowedRoot = form.AllowedRoot?.Trim() ?? "",
+                    PrivateKey = form.PrivateKey.Trim(),
+                    Passphrase = NullIfBlank(form.Passphrase),
+
+                    // Honoured unless the operator has chosen to forget it, so a test reports a
+                    // changed host key the same way a sync would.
+                    PinnedHostKeyFingerprint = form.ForgetHostKey ? null : NullIfBlank(form.HostKeyFingerprint),
+                }, TimeSpan.FromSeconds(15));
+
+                testSuccess = sftpResult.Success;
+                testMessage = sftpResult.Message;
+                return;
+            }
+
             string? target = NullIfBlank(probeTarget) ?? form.FirstAllowedLocation();
             if (target is null)
             {
@@ -483,6 +979,7 @@
             ConnectionProvider.Filesystem => form.AllowedRoot ?? "—",
             ConnectionProvider.S3 => form.Region ?? "—",
             ConnectionProvider.AzureBlob => form.StorageAccountName ?? "—",
+            ConnectionProvider.Sftp => $"{form.Username}@{form.Host}:{form.AllowedRoot}",
             _ => "—"
         };
     }
@@ -501,3 +998,5 @@
         statusMessage = message;
     }
 }
+
+

--- a/src/Connapse.Web/Components/Settings/SourceForm.cs
+++ b/src/Connapse.Web/Components/Settings/SourceForm.cs
@@ -60,7 +60,11 @@ public sealed record SourceForm
                 if (!Blank(Prefix)) node["prefix"] = Prefix!.Trim();
                 break;
 
+            // One case for both. The SFTP scope was deliberately given the same shape as the
+            // filesystem one so that this form, the preflight and the scope summary each gained
+            // a provider here rather than a parallel implementation to keep in step.
             case ConnectionProvider.Filesystem:
+            case ConnectionProvider.Sftp:
                 // Always present, and empty means the root itself. ConnectorFactory treats a
                 // blank subPath as "the allowed root", so this is a meaningful value rather
                 // than a missing one.

--- a/src/Connapse.Web/Endpoints/SourceResponse.cs
+++ b/src/Connapse.Web/Endpoints/SourceResponse.cs
@@ -26,6 +26,12 @@ public record SourceResponse(
     DateTime CreatedAt,
     DateTime UpdatedAt,
     /// <summary>
+    /// How many deletions the last reconcile declined to apply, or null when none are pending.
+    /// Unlike <see cref="LastSyncError"/> this is not administrator-only: it is a count, and
+    /// names nothing about the remote's contents or structure.
+    /// </summary>
+    int? WithheldDeletions,
+    /// <summary>
     /// Populated for administrators only. A provider's failure text routinely echoes the
     /// thing that failed — "Access Denied for bucket payroll-data" — so returning it to
     /// every reader would give back exactly the infrastructure detail ScopeJson is withheld
@@ -51,5 +57,6 @@ public record SourceResponse(
         Summary: source.Summary,
         CreatedAt: source.CreatedAt,
         UpdatedAt: source.UpdatedAt,
+        WithheldDeletions: source.WithheldDeletions,
         LastSyncError: includeDiagnostics ? source.LastSyncError : null);
 }

--- a/src/Connapse.Web/Endpoints/SourcesEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/SourcesEndpoints.cs
@@ -193,7 +193,8 @@ public static class SourcesEndpoints
             [FromServices] IConnectionStore connectionStore,
             [FromServices] SourceSyncService syncService,
             [FromServices] IAuditLogger auditLogger,
-            CancellationToken ct) =>
+            [FromQuery] bool applyWithheldDeletions = false,
+            CancellationToken ct = default) =>
         {
             var source = await sourceStore.GetAsync(sourceId, ct);
             if (source is null)
@@ -206,7 +207,7 @@ public static class SourcesEndpoints
             if (connection is null)
                 return Results.BadRequest(new { error = $"Source '{source.Name}' references a missing connection" });
 
-            var result = await syncService.SyncSourceAsync(source, connection, ct);
+            var result = await syncService.SyncSourceAsync(source, connection, ct, applyWithheldDeletions);
 
             // Nothing went wrong — the scheduled cycle got there first. 409 rather than 200
             // so a script driving this does not read "0 upserted" as "nothing to do".
@@ -218,8 +219,10 @@ public static class SourcesEndpoints
                 });
             }
 
-            await auditLogger.LogAsync("source.synced", "source", sourceId.ToString(),
-                new { source.Name, result.Upserted, result.Deleted }, ct);
+            await auditLogger.LogAsync(
+                applyWithheldDeletions ? "source.deletions_applied" : "source.synced",
+                "source", source.Id.ToString(),
+                new { source.Name, result.Upserted, result.Deleted, result.WithheldDeletions }, ct);
 
             return Results.Ok(new
             {
@@ -227,7 +230,8 @@ public static class SourcesEndpoints
                 result.Deleted,
                 result.UsedDeltaPath,
                 result.RequiredResync,
-                result.Error
+                result.Error,
+                result.WithheldDeletions
             });
         })
         .WithName("SyncSource")

--- a/src/Connapse.Web/Services/SourceScopePreflight.cs
+++ b/src/Connapse.Web/Services/SourceScopePreflight.cs
@@ -55,6 +55,7 @@ public class SourceScopePreflight(IOptionsMonitor<SourceSecuritySettings> source
             ConnectionProvider.S3 => CheckLocation(credential, scope, "bucketName", "bucket", connection.Name),
             ConnectionProvider.AzureBlob => CheckLocation(credential, scope, "containerName", "blob container", connection.Name),
             ConnectionProvider.Filesystem => CheckRoot(credential, scope, connection.Name),
+            ConnectionProvider.Sftp => CheckSftpScope(credential, scope, connection.Name),
             _ => ScopePreflightResult.Refuse(
                 $"Connection '{connection.Name}' uses a provider this form does not understand.")
         };
@@ -86,6 +87,52 @@ public class SourceScopePreflight(IOptionsMonitor<SourceSecuritySettings> source
             _ => ScopePreflightResult.Refuse(
                 $"'{Join(container, prefix)}' is outside the locations connection '{connectionName}' permits.")
         };
+    }
+
+    /// <summary>
+    /// Checks an SFTP scope as far as it can be checked without a network call.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does <b>not</b> reuse <see cref="CheckRoot"/>. That path calls
+    /// <see cref="PathConfinement"/> and <see cref="SourceSecuritySettings.EvaluateRoot"/>, both
+    /// of which touch the local disk and read the deployment's own allowed-roots setting —
+    /// answers about the machine Connapse runs on, not the one being connected to. Against a
+    /// remote path they would resolve nothing and silently degrade to a lexical prefix check,
+    /// which is the mistake <c>SftpPathConfinement</c> exists to avoid.
+    /// <para>
+    /// So this catches only what is wrong on its face. The real confinement happens on the
+    /// server, through <c>SSH_FXP_REALPATH</c>, at the first connect — the same division of
+    /// labour as everywhere else here: this makes the obvious case legible early, and the
+    /// connector remains the thing that actually decides.
+    /// </para>
+    /// </remarks>
+    private static ScopePreflightResult CheckSftpScope(
+        JsonObject? credential, JsonObject scope, string connectionName)
+    {
+        if (string.IsNullOrWhiteSpace(Str(credential, "allowedRoot")))
+            return ScopePreflightResult.Refuse($"Connection '{connectionName}' has no allowed root configured.");
+
+        string? subPath = Str(scope, "subPath");
+        if (string.IsNullOrWhiteSpace(subPath))
+            return ScopePreflightResult.Allowed;
+
+        string cleaned = subPath.Replace('\\', '/');
+
+        if (cleaned.StartsWith('/'))
+        {
+            return ScopePreflightResult.Refuse(
+                "A sub-path is relative to the connection's allowed root, so it cannot start with '/'.");
+        }
+
+        // Refused on the segment, not on the substring: a file legitimately named "..config"
+        // contains ".." without being a traversal.
+        if (cleaned.Split('/').Any(segment => segment == ".."))
+        {
+            return ScopePreflightResult.Refuse(
+                "A sub-path cannot contain '..' — it must stay inside the connection's allowed root.");
+        }
+
+        return ScopePreflightResult.Allowed;
     }
 
     private ScopePreflightResult CheckRoot(JsonObject? credential, JsonObject scope, string connectionName)

--- a/src/Connapse.Web/Services/SourceSyncService.cs
+++ b/src/Connapse.Web/Services/SourceSyncService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
 using Connapse.Storage.Data;
 using Connapse.Storage.Data.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -92,7 +93,15 @@ public class SourceSyncService(
     /// Runs one sync cycle for one source. Never throws: a remote failure is recorded on the
     /// source and reported, so one unreachable provider cannot stall every other source.
     /// </summary>
-    internal async Task<SourceSyncResult> SyncSourceAsync(Source source, Connection connection, CancellationToken ct)
+    /// <param name="applyWithheldDeletions">
+    /// Applies deletions an administrator has already approved. The vanished set is recomputed
+    /// rather than replayed, so a source whose remote recovered in the meantime deletes
+    /// nothing — but it is capped at the count that was withheld, so a remote that degraded
+    /// further cannot have the larger set applied on the strength of the smaller approval.
+    /// Inert when nothing was withheld: the flag cannot lift a guard that never tripped.
+    /// </param>
+    internal async Task<SourceSyncResult> SyncSourceAsync(
+        Source source, Connection connection, CancellationToken ct, bool applyWithheldDeletions = false)
     {
         if (!source.Enabled)
             return new SourceSyncResult(0, 0, UsedDeltaPath: false, RequiredResync: false, Error: null);
@@ -127,7 +136,8 @@ public class SourceSyncService(
 
             return connector is ISyncCursorConnector cursorConnector
                 ? await SyncViaDeltaAsync(source, cursorConnector, sourceStore, scope.ServiceProvider, ct)
-                : await SyncViaListAndDiffAsync(source, connector, sourceStore, scope.ServiceProvider, ct);
+                : await SyncViaListAndDiffAsync(
+                    source, connector, sourceStore, scope.ServiceProvider, ct, applyWithheldDeletions);
         }
         catch (Exception ex)
         {
@@ -204,7 +214,8 @@ public class SourceSyncService(
     }
 
     private async Task<SourceSyncResult> SyncViaListAndDiffAsync(
-        Source source, IConnector connector, ISourceStore sourceStore, IServiceProvider sp, CancellationToken ct)
+        Source source, IConnector connector, ISourceStore sourceStore, IServiceProvider sp, CancellationToken ct,
+        bool applyWithheldDeletions = false)
     {
         IReadOnlyList<ConnectorFile> remote = await connector.ListFilesAsync(null, ct);
 
@@ -220,15 +231,65 @@ public class SourceSyncService(
         var remotePaths = remote.Select(f => f.Path).ToHashSet(StringComparer.Ordinal);
         var vanished = indexedPaths.Where(p => !remotePaths.Contains(p)).ToList();
 
+        // Upserts apply regardless. A source that trips the guard must keep ingesting new
+        // content, or the safety mechanism becomes the outage it exists to prevent.
         int upserted = await EnqueueAllAsync(source, remote, context, sp, ct);
-        int deleted = await DeleteByPathsAsync(source, vanished, context, sp, ct);
+
+        // An approval authorises the deletion set the administrator was shown a count of, not
+        // whatever the next listing happens to produce. Recomputing stays — a remote that
+        // recovered must still delete nothing — but the recomputed set may not *exceed* what
+        // was approved. Without that ceiling the override is unbounded in precisely the
+        // situation it is most likely to be used: a remote that is still degrading. Approve 40
+        // and the cycle could apply 1,000.
+        //
+        // Bound by count rather than by identity. The administrator never sees which paths —
+        // the page shows a number and a source is never browsable — so the consent being given
+        // is "delete what is missing, about this many", and a count expresses that honestly.
+        // Hashing the path set would invalidate approval on any ordinary churn, and would mean
+        // storing path-derived data this design deliberately keeps out of the database.
+        //
+        // Null when nothing was withheld, so the flag cannot lift a guard that never tripped:
+        // a first-ever sync carrying applyWithheldDeletions=true is still guarded.
+        int? approved = applyWithheldDeletions ? source.WithheldDeletions : null;
+
+        bool withhold = approved is null
+            ? DeletionGuard.ShouldWithhold(vanished.Count, indexedPaths.Count)
+            : vanished.Count > approved.Value;
+
+        int deleted = 0;
+        if (withhold)
+        {
+            if (approved is { } ceiling)
+            {
+                logger.LogWarning(
+                    "Source {SourceId} approval superseded: {Approved} deletion(s) were approved but "
+                    + "the listing now shows {Vanished} of {Indexed}; withholding pending fresh approval",
+                    source.Id, ceiling, vanished.Count, indexedPaths.Count);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "Source {SourceId} reconcile would delete {Vanished} of {Indexed} document(s); "
+                    + "withholding pending administrator approval",
+                    source.Id, vanished.Count, indexedPaths.Count);
+            }
+        }
+        else
+        {
+            deleted = await DeleteByPathsAsync(source, vanished, context, sp, ct);
+        }
+
+        await sourceStore.UpdateWithheldDeletionsAsync(
+            source.Id, withhold ? vanished.Count : null, ct);
 
         // No cursor to advance on this path, so record the outcome directly. The stored
         // cursor stays null, which is what marks this source as fallback-synced.
         await sourceStore.UpdateSyncStateAsync(
             source.Id, source.SyncCursor, SyncStatus.Succeeded, error: null, DateTime.UtcNow, ct);
 
-        return new SourceSyncResult(upserted, deleted, UsedDeltaPath: false, RequiredResync: false, Error: null);
+        return new SourceSyncResult(
+            upserted, deleted, UsedDeltaPath: false, RequiredResync: false, Error: null,
+            WithheldDeletions: withhold ? vanished.Count : 0);
     }
 
     /// <summary>

--- a/src/Connapse.Web/Services/SourceSyncService.cs
+++ b/src/Connapse.Web/Services/SourceSyncService.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Ingestion.Pipeline;
 using Connapse.Core.Utilities;
 using Connapse.Storage.Data;
 using Connapse.Storage.Data.Entities;
@@ -365,6 +366,27 @@ public class SourceSyncService(
 
             due.Add(file);
 
+            if (existing is { Status: "Failed" })
+            {
+                // Counted here rather than in the pipeline, because the pipeline may never run
+                // — a connector that cannot reach its remote throws before it. That is exactly
+                // the failure this bound exists to stop repeating, so the attempt has to be
+                // recorded at the moment it is made.
+                // Reset by a changed file, not merely incremented: the budget is per version.
+                // Carrying a spent one across an edit would let the fall-through above hand the
+                // new version a single attempt and then refuse it for ever.
+                int attempt = SignatureChanged(existing, file) ? 1 : FailedAttempts(existing) + 1;
+
+                var carried = new Dictionary<string, string>(existing.Metadata ?? [])
+                {
+                    [IngestionPipeline.SyncFailedAttemptsKey] =
+                        attempt.ToString(CultureInfo.InvariantCulture),
+                };
+
+                var tracked = await context.Documents.FirstOrDefaultAsync(d => d.Id == existing.Id, ct);
+                if (tracked is not null) tracked.Metadata = carried;
+            }
+
             if (existing is null)
             {
                 // A row staking this path, written before anything is enqueued. Until one
@@ -400,8 +422,8 @@ public class SourceSyncService(
         }
 
         // One round trip, and before any enqueue: a claim that did not persist must not have a
-        // job pointing at it.
-        if (claims.Count > 0)
+        // job pointing at it, and a retry that was not counted would not be bounded.
+        if (claims.Count > 0 || due.Count > 0)
             await context.SaveChangesAsync(ct);
 
         foreach (var file in due)
@@ -453,6 +475,20 @@ public class SourceSyncService(
     /// Decides whether an already-indexed document needs re-ingesting, by comparing the
     /// remote's size and modification time against the signature recorded last time.
     /// </summary>
+    /// <summary>
+    /// How many times a failing document is re-enqueued before the sync engine leaves it alone.
+    /// Hangfire retries each of those attempts three times itself, so this is not the whole
+    /// budget — it is the number of fresh starts.
+    /// </summary>
+    private const int MaxFailedSyncAttempts = 3;
+
+    private static int FailedAttempts(DocumentEntity existing) =>
+        existing.Metadata is not null
+        && existing.Metadata.TryGetValue(IngestionPipeline.SyncFailedAttemptsKey, out string? raw)
+        && int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int attempts)
+            ? attempts
+            : 0;
+
     private static bool HasRemoteChanged(DocumentEntity existing, ConnectorFile file)
     {
         // Already queued or mid-ingestion. Enqueueing again would race the in-flight job for
@@ -469,11 +505,28 @@ public class SourceSyncService(
         // briefly unreachable poisoned every document caught in the window, and no amount of
         // re-syncing recovered them.
         //
-        // The cost is a genuinely unparseable file being re-fetched every cycle. Bounded, and
-        // much the lesser evil: it fails before embedding, which is the part that costs money.
-        if (existing.Status is "Failed")
+        // Bounded, though (#404). "Retry regardless" assumed the failure was transient, and a
+        // failure that is not — credentials that are wrong, a server that is gone — then
+        // re-enqueued every file in the source on every cycle. Those jobs each carry Hangfire's
+        // own three retries, so the ingestion queue fills with work that cannot succeed and
+        // documents that would have ingested fine sit behind it. A source cannot be allowed to
+        // deny service to the rest of the instance by failing.
+        //
+        // Note the fall-through once the attempts are spent, rather than a flat refusal: an
+        // exhausted document is still re-ingested when the file itself changes. Someone who
+        // fixes the file upstream should not have to wait out a budget, or clear one by hand.
+        if (existing.Status is "Failed" && FailedAttempts(existing) < MaxFailedSyncAttempts)
             return true;
 
+        return SignatureChanged(existing, file);
+    }
+
+    /// <summary>
+    /// True when the remote's own view of the file differs from the one recorded at the last
+    /// ingestion — or when there is nothing recorded to compare against.
+    /// </summary>
+    private static bool SignatureChanged(DocumentEntity existing, ConnectorFile file)
+    {
         var metadata = existing.Metadata;
         string? lastModified = metadata?.GetValueOrDefault(RemoteLastModifiedKey);
         string? size = metadata?.GetValueOrDefault(RemoteSizeKey);

--- a/src/Connapse.Web/Services/SourceSyncService.cs
+++ b/src/Connapse.Web/Services/SourceSyncService.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Globalization;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
@@ -132,7 +132,20 @@ public class SourceSyncService(
         IConnector? connector = null;
         try
         {
-            connector = connectorFactory.Create(source, connection);
+            // Fetched here rather than in SyncAllAsync because the sync-now endpoint calls
+            // this method directly, and a credential that only the timer supplied would make
+            // "sync now" behave differently from the poll.
+            //
+            // Skipped entirely unless the connection actually stores one: HasSecret is on the
+            // read model, so the common providers cost no query and no decrypt per cycle. A
+            // key ring that cannot decrypt throws, which the catch below records as a sync
+            // failure — the right outcome, since retrying will not help.
+            string? secret = connection.HasSecret
+                ? await scope.ServiceProvider.GetRequiredService<IConnectionStore>()
+                    .GetSecretAsync(connection.Id, ct)
+                : null;
+
+            connector = connectorFactory.Create(source, connection, secret);
 
             return connector is ISyncCursorConnector cursorConnector
                 ? await SyncViaDeltaAsync(source, cursorConnector, sourceStore, scope.ServiceProvider, ct)
@@ -333,6 +346,9 @@ public class SourceSyncService(
         int count = 0;
         int skipped = 0;
 
+        var due = new List<ConnectorFile>();
+        var claims = new Dictionary<string, Guid>(StringComparer.Ordinal);
+
         foreach (var file in files)
         {
             existingByPath.TryGetValue(file.Path, out var existing);
@@ -347,7 +363,52 @@ public class SourceSyncService(
                 continue;
             }
 
-            string documentId = existing?.Id.ToString() ?? Guid.NewGuid().ToString();
+            due.Add(file);
+
+            if (existing is null)
+            {
+                // A row staking this path, written before anything is enqueued. Until one
+                // exists, "is this file already being worked on?" can only be answered from
+                // persisted documents — and the pipeline does not write one until the job
+                // actually runs. On a source whose ingestion outlasts the poll interval, every
+                // cycle therefore rediscovered the whole backlog as new, minted fresh ids, and
+                // enqueued it all again: the same files downloaded and embedded repeatedly,
+                // and a Hangfire queue growing faster than it drained.
+                //
+                // Status "Pending" is what the next cycle reads: HasRemoteChanged skips it.
+                claims[file.Path] = Guid.NewGuid();
+                context.Documents.Add(new DocumentEntity
+                {
+                    Id = claims[file.Path],
+                    SourceId = source.Id,
+                    FileName = Path.GetFileName(file.Path),
+                    ContentType = file.ContentType,
+                    Path = file.Path,
+                    ContentHash = string.Empty,
+                    SizeBytes = file.SizeBytes,
+                    Status = "Pending",
+                    CreatedAt = DateTime.UtcNow,
+
+                    // Deliberately no remote signature yet. It is what "already indexed at this
+                    // version" means, and writing it here would claim an ingestion that has not
+                    // happened — so a job that then failed would leave a document the next
+                    // cycle reads as up to date and never retries. The pipeline writes it once
+                    // it has the file.
+                    Metadata = [],
+                });
+            }
+        }
+
+        // One round trip, and before any enqueue: a claim that did not persist must not have a
+        // job pointing at it.
+        if (claims.Count > 0)
+            await context.SaveChangesAsync(ct);
+
+        foreach (var file in due)
+        {
+            existingByPath.TryGetValue(file.Path, out var existing);
+
+            string documentId = (existing?.Id ?? claims[file.Path]).ToString();
             string fileName = Path.GetFileName(file.Path);
 
             await queue.EnqueueAsync(new IngestionJob(

--- a/tests/Connapse.Core.Tests/Connectors/ConnectorCapabilityTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/ConnectorCapabilityTests.cs
@@ -31,9 +31,37 @@ public class ConnectorCapabilityTests
     [InlineData(typeof(S3Connector))]
     [InlineData(typeof(AzureBlobConnector))]
     [InlineData(typeof(FilesystemConnector))]
+    [InlineData(typeof(SftpConnector))]
     public void ExternalConnectors_AreNotWritable(Type connectorType)
     {
         typeof(IWritableConnector).IsAssignableFrom(connectorType)
             .Should().BeFalse("external storage is mirrored, never mutated through Connapse");
+    }
+
+    /// <summary>
+    /// SFTP has no change notification of any kind, so claiming live watch would put the sync
+    /// engine on a path that cannot work. It must say so, and WatchAsync must refuse rather
+    /// than return an empty sequence that looks like a quiet remote.
+    /// </summary>
+    [Fact]
+    public void SftpConnector_DoesNotClaimLiveWatch()
+    {
+        var connector = new SftpConnector(new SftpConnectorConfig { Host = "h", AllowedRoot = "/srv" });
+
+        connector.SupportsLiveWatch.Should().BeFalse();
+
+        Action act = () => connector.WatchAsync();
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    /// <summary>
+    /// A connector that holds a live SSH session must be disposable, or the sync loop leaks
+    /// one per source per cycle — the reason SourceSyncService disposes in a finally.
+    /// </summary>
+    [Fact]
+    public void SftpConnector_IsDisposable()
+    {
+        typeof(IDisposable).IsAssignableFrom(typeof(SftpConnector))
+            .Should().BeTrue("it owns an SSH session that a five-minute poll would otherwise abandon");
     }
 }

--- a/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
@@ -48,13 +48,16 @@ public class SourceConnectorFactoryTests
     /// recombination rather than the allowlist.
     /// </summary>
     private static ConnectorFactory BuildFactory(
-        SourceSecuritySettings settings, ILogger<ConnectorFactory>? logger = null)
+        SourceSecuritySettings settings,
+        ILogger<ConnectorFactory>? logger = null,
+        ISshHostKeyStore? hostKeyStore = null)
     {
         var monitor = Substitute.For<IOptionsMonitor<SourceSecuritySettings>>();
         monitor.CurrentValue.Returns(settings);
 
         return new ConnectorFactory(
             monitor,
+            hostKeyStore ?? Substitute.For<ISshHostKeyStore>(),
             logger ?? NullLogger<ConnectorFactory>.Instance);
     }
 
@@ -477,4 +480,155 @@ public class SourceConnectorFactoryTests
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*not a JSON object*");
     }
+
+    // ── SFTP ───────────────────────────────────────────────────────────────
+
+    private const string SftpConfig =
+        """{"host":"files.example.com","port":2222,"username":"connapse","allowedRoot":"/srv/knowledge"}""";
+
+    private static string SftpSecret(string? passphrase = null) => passphrase is null
+        ? """{"privateKey":"-----BEGIN OPENSSH PRIVATE KEY-----\nnot-a-real-key\n"}"""
+        : $$"""{"privateKey":"-----BEGIN OPENSSH PRIVATE KEY-----\nnot-a-real-key\n","passphrase":"{{passphrase}}"}""";
+
+    [Fact]
+    public void Create_SftpSource_RecombinesTheConnectionAndScope()
+    {
+        var connection = MakeConnection(ConnectionProvider.Sftp, SftpConfig);
+        var source = MakeSource(connection.Id,
+            """{"subPath":"docs","includePatterns":["*.md"],"excludePatterns":["*.tmp"]}""");
+
+        var connector = (SftpConnector)_factory.Create(source, connection, SftpSecret());
+
+        connector.Type.Should().Be(ConnectorType.Sftp);
+        connector.Config.Host.Should().Be("files.example.com");
+        connector.Config.Port.Should().Be(2222);
+        connector.Config.Username.Should().Be("connapse");
+        connector.Config.AllowedRoot.Should().Be("/srv/knowledge");
+        connector.Config.SubPath.Should().Be("docs");
+        connector.Config.IncludePatterns.Should().ContainSingle().Which.Should().Be("*.md");
+        connector.Config.ExcludePatterns.Should().ContainSingle().Which.Should().Be("*.tmp");
+        connector.Config.ConnectionId.Should().Be(connection.Id);
+    }
+
+    /// <summary>
+    /// The root names a directory on another machine, so the only place it can be resolved is
+    /// the server. Resolving it here would be the local-confinement mistake that
+    /// SftpPathConfinement exists to avoid, and it would fail open.
+    /// </summary>
+    [Fact]
+    public void Create_SftpSource_DoesNotResolveTheRootLocally()
+    {
+        var connection = MakeConnection(ConnectionProvider.Sftp, SftpConfig);
+        var source = MakeSource(connection.Id, """{"subPath":"docs"}""");
+
+        var connector = (SftpConnector)_factory.Create(source, connection, SftpSecret());
+
+        connector.Config.AllowedRoot.Should().Be("/srv/knowledge",
+            "the root must reach the connector verbatim, to be resolved on the server");
+        connector.Config.SubPath.Should().Be("docs",
+            "the subPath is confined against the server-resolved root, not combined here");
+    }
+
+    [Fact]
+    public void Create_SftpConnectionWithNoPort_DefaultsTo22()
+    {
+        var connection = MakeConnection(ConnectionProvider.Sftp,
+            """{"host":"h","username":"u","allowedRoot":"/srv"}""");
+        var source = MakeSource(connection.Id, "{}");
+
+        var connector = (SftpConnector)_factory.Create(source, connection, SftpSecret());
+
+        connector.Config.Port.Should().Be(22);
+    }
+
+    [Fact]
+    public void Create_SftpConnectionCarriesThePinnedFingerprint()
+    {
+        var connection = MakeConnection(ConnectionProvider.Sftp,
+            """{"host":"h","username":"u","allowedRoot":"/srv","hostKeyFingerprint":"SHA256:pinned"}""");
+        var source = MakeSource(connection.Id, "{}");
+
+        var connector = (SftpConnector)_factory.Create(source, connection, SftpSecret());
+
+        connector.Config.PinnedHostKeyFingerprint.Should().Be("SHA256:pinned");
+    }
+
+    [Fact]
+    public void Create_SftpConnectionWithNoFingerprint_LeavesItNullForFirstUse()
+    {
+        var connection = MakeConnection(ConnectionProvider.Sftp, SftpConfig);
+        var source = MakeSource(connection.Id, "{}");
+
+        var connector = (SftpConnector)_factory.Create(source, connection, SftpSecret());
+
+        connector.Config.PinnedHostKeyFingerprint.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_SftpCredentialWithPassphrase_IsCarriedThrough()
+    {
+        var connection = MakeConnection(ConnectionProvider.Sftp, SftpConfig);
+        var source = MakeSource(connection.Id, "{}");
+
+        var connector = (SftpConnector)_factory.Create(source, connection, SftpSecret("hunter2"));
+
+        connector.Config.Credential!.Passphrase.Should().Be("hunter2");
+        connector.Config.Credential.PrivateKey.Should().Contain("OPENSSH PRIVATE KEY");
+    }
+
+    [Theory]
+    [InlineData("""{"username":"u","allowedRoot":"/srv"}""")]
+    [InlineData("""{"host":"h","allowedRoot":"/srv"}""")]
+    [InlineData("""{"host":"h","username":"u"}""")]
+    public void Create_SftpConnectionMissingARequiredField_Throws(string config)
+    {
+        var connection = MakeConnection(ConnectionProvider.Sftp, config);
+        var source = MakeSource(connection.Id, "{}");
+
+        Action act = () => _factory.Create(source, connection, SftpSecret());
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// The failure has to be loud and name the connection. A connector built with no key
+    /// would fail later, from inside the sync loop, with whatever SSH.NET says about an
+    /// empty authentication method.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not json at all")]
+    [InlineData("""{"passphrase":"only"}""")]
+    [InlineData("""{"privateKey":""}""")]
+    public void Create_SftpSourceWithNoUsableKey_ThrowsNamingTheConnection(string? secret)
+    {
+        var connection = MakeConnection(ConnectionProvider.Sftp, SftpConfig);
+        var source = MakeSource(connection.Id, "{}");
+
+        Action act = () => _factory.Create(source, connection, secret);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*conn*");
+    }
+
+    /// <summary>
+    /// The no-stored-cloud-credentials position, asserted rather than assumed: adding a
+    /// secret parameter to the factory must not make one reachable by the cloud providers.
+    /// </summary>
+    [Theory]
+    [InlineData(ConnectionProvider.S3, """{"region":"eu-west-1"}""", """{"bucketName":"b"}""")]
+    [InlineData(ConnectionProvider.AzureBlob, """{"storageAccountName":"a"}""", """{"containerName":"c"}""")]
+    public void Create_CloudProviders_IgnoreASuppliedSecret(
+        ConnectionProvider provider, string config, string scope)
+    {
+        var connection = MakeConnection(provider, config);
+        var source = MakeSource(connection.Id, scope);
+
+        var withSecret = _factory.Create(source, connection, "a pasted access key");
+        var without = _factory.Create(source, connection);
+
+        withSecret.Type.Should().Be(without.Type,
+            "a secret must not change how a cloud connector authenticates");
+    }
 }
+

--- a/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
+++ b/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Connapse.Core;
+using Connapse.Core.Utilities;
 using Connapse.Web.Components.Settings;
 using FluentAssertions;
 using Xunit;
@@ -239,4 +240,315 @@ public class ConnectionFormTests
         new ConnectionForm { Name = "c", Provider = ConnectionProvider.S3 }
             .Validate().Should().BeNull();
     }
+
+    // ── SFTP ───────────────────────────────────────────────────────────────
+
+    private static ConnectionForm SftpForm() => new()
+    {
+        Name = "files",
+        Provider = ConnectionProvider.Sftp,
+        Host = "files.example.com",
+        Port = "2222",
+        Username = "connapse",
+        AllowedRoot = "/srv/knowledge",
+        PrivateKey = "-----BEGIN OPENSSH PRIVATE KEY-----\nkey\n",
+    };
+
+    [Fact]
+    public void Sftp_ConfigRoundTrips()
+    {
+        string json = SftpForm().ToConfigJson();
+        var back = ConnectionForm.FromConnection(Stored(ConnectionProvider.Sftp, json));
+
+        back.Host.Should().Be("files.example.com");
+        back.Port.Should().Be("2222");
+        back.Username.Should().Be("connapse");
+        back.AllowedRoot.Should().Be("/srv/knowledge");
+    }
+
+    [Fact]
+    public void Sftp_NoPort_DefaultsTo22InTheStoredConfig()
+    {
+        var form = SftpForm() with { Port = null };
+
+        JsonNode.Parse(form.ToConfigJson())!["port"]!.GetValue<int>().Should().Be(22);
+    }
+
+    /// <summary>
+    /// The pin belongs to the connector, which records it on first connect and compares against
+    /// it afterwards. An ordinary save must carry it through — dropping it would silently re-arm
+    /// trust on first use, which is the one thing pinning exists to prevent.
+    /// </summary>
+    [Fact]
+    public void Sftp_SavingAnExistingConnection_PreservesThePinnedHostKey()
+    {
+        var stored = Stored(ConnectionProvider.Sftp,
+            """{"host":"h","port":22,"username":"u","allowedRoot":"/srv","hostKeyFingerprint":"SHA256:pinned"}""");
+
+        var form = ConnectionForm.FromConnection(stored);
+        form.HostKeyFingerprint.Should().Be("SHA256:pinned");
+
+        JsonNode.Parse(form.ToConfigJson())!["hostKeyFingerprint"]!.GetValue<string>()
+            .Should().Be("SHA256:pinned");
+    }
+
+    [Fact]
+    public void Sftp_ForgettingTheHostKey_DropsItFromTheStoredConfig()
+    {
+        var stored = Stored(ConnectionProvider.Sftp,
+            """{"host":"h","port":22,"username":"u","allowedRoot":"/srv","hostKeyFingerprint":"SHA256:pinned"}""");
+
+        var form = ConnectionForm.FromConnection(stored);
+        form.ForgetHostKey = true;
+
+        JsonNode.Parse(form.ToConfigJson())!["hostKeyFingerprint"].Should().BeNull();
+    }
+
+    /// <summary>
+    /// A secret is never read back into the form, so an operator opening and saving a connection
+    /// must not wipe its key. Null means "leave the stored one alone", which is the store's own
+    /// rule.
+    /// </summary>
+    [Fact]
+    public void Sftp_FromConnection_LeavesTheKeyBlankSoSavingDoesNotWipeIt()
+    {
+        var form = ConnectionForm.FromConnection(
+            Stored(ConnectionProvider.Sftp, """{"host":"h","username":"u","allowedRoot":"/srv"}""", hasSecret: true));
+
+        form.PrivateKey.Should().BeNull();
+        form.ToSecretJson().Should().BeNull();
+    }
+
+    [Fact]
+    public void Sftp_SecretCarriesTheKeyAndPassphrase()
+    {
+        var form = SftpForm() with { Passphrase = "hunter2" };
+
+        var secret = JsonNode.Parse(form.ToSecretJson()!)!;
+
+        secret["privateKey"]!.GetValue<string>().Should().Contain("OPENSSH PRIVATE KEY");
+        secret["passphrase"]!.GetValue<string>().Should().Be("hunter2");
+    }
+
+    /// <summary>
+    /// #371 removed the secret field because Connapse does not accept pasted cloud keys. SFTP
+    /// brings it back for one provider only, and this is where that stays true.
+    /// </summary>
+    [Theory]
+    [InlineData(ConnectionProvider.S3)]
+    [InlineData(ConnectionProvider.AzureBlob)]
+    [InlineData(ConnectionProvider.Filesystem)]
+    public void NonSftpProviders_NeverProduceASecret(ConnectionProvider provider)
+    {
+        var form = new ConnectionForm
+        {
+            Name = "c",
+            Provider = provider,
+            StorageAccountName = "a",
+            AllowedRoot = "/data",
+
+            // Set deliberately: even with a key sitting in the form, these providers must not
+            // store one.
+            PrivateKey = "-----BEGIN OPENSSH PRIVATE KEY-----\nkey\n",
+        };
+
+        form.ToSecretJson().Should().BeNull();
+    }
+
+    /// <summary>
+    /// SFTP is bounded by a root, not by a bucket allowlist. Written as a positive check on the
+    /// cloud providers rather than "not Filesystem", which is what would have swept SFTP into
+    /// the wrong branch.
+    /// </summary>
+    [Fact]
+    public void Sftp_DoesNotWriteAllowedLocations()
+    {
+        var form = SftpForm() with { AllowedLocations = "some-bucket" };
+
+        JsonNode.Parse(form.ToConfigJson())!["allowedLocations"].Should().BeNull();
+    }
+
+    [Fact]
+    public void Sftp_IsNotACloudProvider()
+    {
+        SftpForm().IsCloudProvider.Should().BeFalse();
+        new ConnectionForm { Provider = ConnectionProvider.S3 }.IsCloudProvider.Should().BeTrue();
+        new ConnectionForm { Provider = ConnectionProvider.AzureBlob }.IsCloudProvider.Should().BeTrue();
+        new ConnectionForm { Provider = ConnectionProvider.Filesystem }.IsCloudProvider.Should().BeFalse();
+    }
+
+    // ── Connect this computer ──────────────────────────────────────────────
+
+    private static SftpHostSetupResult Reported(
+        string user = "Diviel",
+        string home = "/C:/Users/Diviel",
+        string fingerprint = "SHA256:hostkey") => new(user, home, fingerprint);
+
+    private const string GeneratedKey = "-----BEGIN RSA PRIVATE KEY-----\ngenerated\n";
+
+    [Fact]
+    public void ForLocalMachine_UsesEveryValueTheHostReported()
+    {
+        var form = ConnectionForm.ForLocalMachine(
+            Reported(), "host.docker.internal", "Documents", GeneratedKey);
+
+        form.Provider.Should().Be(ConnectionProvider.Sftp);
+        form.Username.Should().Be("Diviel");
+        form.Host.Should().Be("host.docker.internal");
+        form.Port.Should().Be("22");
+        form.HostKeyFingerprint.Should().Be("SHA256:hostkey");
+        form.PrivateKey.Should().Be(GeneratedKey);
+        form.Name.Should().Be("Diviel@host.docker.internal");
+    }
+
+    /// <summary>
+    /// The restriction that was there by accident. Windows OpenSSH applies no chroot, so a
+    /// second drive is perfectly reachable — and confining the flow to the profile would rule
+    /// out where most people actually keep things.
+    /// </summary>
+    [Fact]
+    public void ForLocalMachine_RootOnAnotherDrive_IsAllowed()
+    {
+        ConnectionForm.ForLocalMachine(Reported(), "h", "/D:/CodeProjects", GeneratedKey)
+            .AllowedRoot.Should().Be("/D:/CodeProjects");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ForLocalMachine_NoFolderChosen_UsesTheHomeDirectory(string? root)
+    {
+        ConnectionForm.ForLocalMachine(Reported(), "h", root, GeneratedKey)
+            .AllowedRoot.Should().Be("/C:/Users/Diviel");
+    }
+
+    /// <summary>
+    /// An operator will paste what Explorer shows them, because that is what is on the
+    /// clipboard. SFTP takes neither the backslashes nor the bare drive letter.
+    /// </summary>
+    [Theory]
+    [InlineData(@"D:\CodeProjects", "/D:/CodeProjects")]
+    [InlineData("D:/CodeProjects", "/D:/CodeProjects")]
+    [InlineData(@"C:\Users\Diviel\Documents", "/C:/Users/Diviel/Documents")]
+    public void NormaliseRemoteRoot_ConvertsAWindowsPathFromExplorer(string entered, string expected)
+    {
+        ConnectionForm.NormaliseRemoteRoot(entered, "/fallback").Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("/D:/Projects/", "/D:/Projects")]
+    [InlineData("/home/me/docs", "/home/me/docs")]
+    [InlineData("home/me", "/home/me")]
+    [InlineData("/", "/")]
+    public void NormaliseRemoteRoot_ProducesAnAbsoluteUnDoubledPath(string entered, string expected)
+    {
+        ConnectionForm.NormaliseRemoteRoot(entered, "/fallback").Should().Be(expected);
+    }
+
+    /// <summary>
+    /// A drive root trims to "/D:" and must stay that, not collapse to the filesystem root —
+    /// which would silently widen the connection from one drive to the whole machine.
+    /// </summary>
+    [Fact]
+    public void NormaliseRemoteRoot_DriveRoot_StaysTheDrive()
+    {
+        ConnectionForm.NormaliseRemoteRoot("/D:/", "/fallback").Should().Be("/D:");
+    }
+
+    [Theory]
+    [InlineData("/", true)]
+    [InlineData("/D:", true)]
+    [InlineData("/D:/", true)]
+    [InlineData("/C:/Users/Diviel", false)]
+    [InlineData("/D:/CodeProjects", false)]
+    [InlineData("/home/me", false)]
+    [InlineData(null, false)]
+    public void IsBroadRemoteRoot_FlagsWholeDrivesAndTheFilesystemRoot(string? root, bool expected)
+    {
+        ConnectionForm.IsBroadRemoteRoot(root).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The whole flow exists to avoid typing, so what it produces must be savable as-is.
+    /// </summary>
+    [Fact]
+    public void ForLocalMachine_ProducesAConnectionThatValidatesAndStoresItsKey()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        var form = ConnectionForm.ForLocalMachine(
+            Reported(), "host.docker.internal", "Documents", pair.PrivateKeyPem);
+
+        form.Validate(isNew: true).Should().BeNull();
+        form.ToSecretJson().Should().NotBeNull();
+
+        var config = JsonNode.Parse(form.ToConfigJson())!;
+        config["host"]!.GetValue<string>().Should().Be("host.docker.internal");
+        config["port"]!.GetValue<int>().Should().Be(22);
+        config["hostKeyFingerprint"]!.GetValue<string>().Should().Be("SHA256:hostkey");
+    }
+
+    /// <summary>
+    /// Carrying the fingerprint into the stored config is what makes the first connection
+    /// verified rather than trusted — the entire reason the operator pastes anything back.
+    /// </summary>
+    [Fact]
+    public void ForLocalMachine_PinsTheFingerprintBeforeTheFirstConnection()
+    {
+        var form = ConnectionForm.ForLocalMachine(
+            Reported(fingerprint: "SHA256:fromTheHost"), "h", null, GeneratedKey);
+
+        JsonNode.Parse(form.ToConfigJson())!["hostKeyFingerprint"]!.GetValue<string>()
+            .Should().Be("SHA256:fromTheHost");
+    }
+
+    [Theory]
+    [InlineData(nameof(ConnectionForm.Host))]
+    [InlineData(nameof(ConnectionForm.Username))]
+    [InlineData(nameof(ConnectionForm.AllowedRoot))]
+    public void Sftp_MissingARequiredField_IsRefused(string missing)
+    {
+        var form = SftpForm();
+
+        switch (missing)
+        {
+            case nameof(ConnectionForm.Host): form.Host = null; break;
+            case nameof(ConnectionForm.Username): form.Username = null; break;
+            case nameof(ConnectionForm.AllowedRoot): form.AllowedRoot = null; break;
+        }
+
+        form.Validate().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Sftp_NewConnectionWithoutAKey_IsRefused()
+    {
+        (SftpForm() with { PrivateKey = null }).Validate(isNew: true)
+            .Should().Be("A private key is required.");
+    }
+
+    [Fact]
+    public void Sftp_ExistingConnectionWithoutAKey_IsAllowed()
+    {
+        (SftpForm() with { PrivateKey = null }).Validate(isNew: false)
+            .Should().BeNull("an operator editing a connection should not have to retype the key");
+    }
+
+    /// <summary>
+    /// An unparseable port becomes 0 and is refused, rather than silently falling back to 22 and
+    /// connecting somewhere the operator did not ask for.
+    /// </summary>
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("0")]
+    [InlineData("70000")]
+    [InlineData("-1")]
+    public void Sftp_UnusablePort_IsRefused(string port)
+    {
+        (SftpForm() with { Port = port }).Validate()
+            .Should().Be("The port must be between 1 and 65535.");
+    }
 }
+
+

--- a/tests/Connapse.Core.Tests/Sources/DeletionGuardTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/DeletionGuardTests.cs
@@ -1,0 +1,45 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Sources;
+
+/// <summary>
+/// The boundary this guard draws is the whole of its behaviour, so it is pinned by example
+/// rather than described. Both terms of the rule are load-bearing: a percentage alone fires
+/// constantly on small sources, an absolute alone is meaningless on large ones.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DeletionGuardTests
+{
+    [Theory]
+    // Small sources clean themselves up: re-ingesting five files is cheap, and blocking
+    // them would make the guard fire on ordinary tidying.
+    [InlineData(5, 5, false)]
+    [InlineData(10, 10, false)]
+    // Losing everything from a source big enough to notice is suspicious.
+    [InlineData(15, 15, true)]
+    // Proportionality on large sources: 5% is plausible churn, 50% is not.
+    [InlineData(5_000, 100_000, false)]
+    [InlineData(50_000, 100_000, true)]
+    // Exactly at each bound, so an off-by-one in either term is caught.
+    [InlineData(10, 100, false)]
+    [InlineData(11, 100, true)]
+    // Nothing to delete is never withheld, including on an empty index.
+    [InlineData(0, 0, false)]
+    [InlineData(0, 100, false)]
+    public void ShouldWithhold_AtTheBoundaries_MatchesTheRule(int vanished, int indexed, bool expected)
+    {
+        DeletionGuard.ShouldWithhold(vanished, indexed).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ShouldWithhold_MoreVanishedThanIndexed_DoesNotThrow()
+    {
+        // Not reachable through SyncViaListAndDiffAsync, which derives vanished from the
+        // indexed set — but a predicate that throws on nonsense input would turn a caller
+        // bug into a failed sync rather than a logged oddity.
+        var act = () => DeletionGuard.ShouldWithhold(200, 100);
+
+        act.Should().NotThrow();
+    }
+}

--- a/tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using System.Text.Json;
 using Connapse.Core;
 using Connapse.Web.Components.Settings;
@@ -159,4 +160,66 @@ public class SourceFormTests
         var form = new SourceForm { Name = "n", ConnectionId = Guid.NewGuid(), Container = "b" };
         form.Validate(ConnectionProvider.S3).Should().BeNull();
     }
+    // ── SFTP ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The same scope shape as Filesystem, which was the point of designing it that way: this
+    /// form, the preflight and the summary each gain a provider rather than a parallel
+    /// implementation to keep in step.
+    /// </summary>
+    [Fact]
+    public void ToScopeJson_Sftp_ProducesTheSameShapeAsFilesystem()
+    {
+        var form = new SourceForm
+        {
+            Name = "s",
+            ConnectionId = Guid.NewGuid(),
+            SubPath = "Documents",
+            IncludePatterns = "*.md",
+            ExcludePatterns = "*.tmp",
+        };
+
+        var sftp = JsonNode.Parse(form.ToScopeJson(ConnectionProvider.Sftp))!.AsObject();
+        var filesystem = JsonNode.Parse(form.ToScopeJson(ConnectionProvider.Filesystem))!.AsObject();
+
+        sftp.ToJsonString().Should().Be(filesystem.ToJsonString());
+        sftp["subPath"]!.GetValue<string>().Should().Be("Documents");
+    }
+
+    /// <summary>
+    /// Blank means the connection's root itself, which ConnectorFactory reads as a real value
+    /// rather than a missing one — so the key must be present.
+    /// </summary>
+    [Fact]
+    public void ToScopeJson_SftpWithNoSubPath_StillWritesTheKey()
+    {
+        var form = new SourceForm { Name = "s", ConnectionId = Guid.NewGuid() };
+
+        JsonNode.Parse(form.ToScopeJson(ConnectionProvider.Sftp))!.AsObject()
+            .ContainsKey("subPath").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Before this, picking an SFTP connection threw out of the form. The throw is caught now
+    /// rather than tearing down the circuit, but an operator still could not create the source.
+    /// </summary>
+    [Fact]
+    public void ToScopeJson_Sftp_DoesNotThrow()
+    {
+        var form = new SourceForm { Name = "s", ConnectionId = Guid.NewGuid(), SubPath = "docs" };
+
+        Action act = () => form.ToScopeJson(ConnectionProvider.Sftp);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_Sftp_DoesNotRequireAContainerName()
+    {
+        var form = new SourceForm { Name = "s", ConnectionId = Guid.NewGuid() };
+
+        form.Validate(ConnectionProvider.Sftp).Should().BeNull(
+            "an SFTP source is bounded by a sub-path, not a bucket");
+    }
 }
+

--- a/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
@@ -268,4 +268,77 @@ public class SourceScopePreflightTests
 
         result.IsRefused.Should().BeFalse();
     }
+    // ── SFTP ───────────────────────────────────────────────────────────────
+
+    private const string SftpConn = """{"host":"h","port":22,"username":"u","allowedRoot":"/D:/CodeProjects"}""";
+
+    [Fact]
+    public void Check_SftpOrdinarySubPath_IsAllowed()
+    {
+        var result = Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":"Connapse"}""");
+
+        result.IsRefused.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Check_SftpNoSubPath_IsAllowed()
+    {
+        Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":""}""")
+            .IsRefused.Should().BeFalse("blank means the connection's root itself");
+    }
+
+    /// <summary>
+    /// A sub-path is relative to the connection's root, so an absolute one is nonsense rather
+    /// than a path — and the server would resolve it somewhere else entirely.
+    /// </summary>
+    [Fact]
+    public void Check_SftpAbsoluteSubPath_IsRefused()
+    {
+        Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":"/etc"}""")
+            .IsRefused.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("../secrets")]
+    [InlineData("docs/../../etc")]
+    [InlineData(@"docs\..\..\etc")]
+    public void Check_SftpTraversingSubPath_IsRefused(string subPath)
+    {
+        var scope = $$"""{"subPath":{{System.Text.Json.JsonSerializer.Serialize(subPath)}}}""";
+
+        Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), scope)
+            .IsRefused.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Refused on the segment, not the substring: a folder legitimately named "..config"
+    /// contains ".." without being a traversal, and refusing it would be wrong.
+    /// </summary>
+    [Fact]
+    public void Check_SftpSubPathContainingDotsInAName_IsAllowed()
+    {
+        Build().Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":"..config/notes"}""")
+            .IsRefused.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Check_SftpConnectionWithNoAllowedRoot_IsRefused()
+    {
+        Build().Check(Conn(ConnectionProvider.Sftp, """{"host":"h","username":"u"}"""), """{"subPath":"docs"}""")
+            .IsRefused.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The deployment's local allowed-roots setting governs the machine Connapse runs on. An
+    /// SFTP root names a directory on somebody else's, so it must not be judged against it —
+    /// doing so would refuse every remote path that happens not to exist locally.
+    /// </summary>
+    [Fact]
+    public void Check_SftpRoot_IsNotJudgedAgainstTheLocalAllowedRoots()
+    {
+        var preflight = Build("/srv/only-this-local-path");
+
+        preflight.Check(Conn(ConnectionProvider.Sftp, SftpConn), """{"subPath":"Connapse"}""")
+            .IsRefused.Should().BeFalse();
+    }
 }

--- a/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
@@ -1,0 +1,469 @@
+﻿using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class SftpHostSetupTests
+{
+    private const string Key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0example connapse";
+
+    // ── Script generation ──────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Linux)]
+    public void GenerateScript_EmbedsTheKeyAndBothMarkers(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain(Key);
+        script.Should().Contain(SftpHostSetup.BeginMarker);
+        script.Should().Contain(SftpHostSetup.EndMarker);
+    }
+
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Linux)]
+    public void GenerateScript_ReportsAllThreeFieldsConnapseNeeds(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain("user=");
+        script.Should().Contain("home=");
+        script.Should().Contain("fingerprint=");
+    }
+
+    /// <summary>
+    /// Idempotency is not a nicety here — the operator is told the command is safe to re-run,
+    /// and a duplicated key in <c>authorized_keys</c> is the kind of mess nobody goes looking
+    /// for.
+    /// </summary>
+    [Theory]
+    [InlineData(HostPlatform.Windows, "Select-String")]
+    [InlineData(HostPlatform.MacOS, "grep -qxF")]
+    [InlineData(HostPlatform.Linux, "grep -qxF")]
+    public void GenerateScript_AddsTheKeyOnlyIfAbsent(HostPlatform platform, string guard)
+    {
+        SftpHostSetup.GenerateScript(Key, platform).Should().Contain(guard);
+    }
+
+    /// <summary>
+    /// Somebody else's key in that file is not ours to remove.
+    /// </summary>
+    [Theory]
+    [InlineData(HostPlatform.Windows, "Add-Content")]
+    [InlineData(HostPlatform.MacOS, ">> ~/.ssh/authorized_keys")]
+    [InlineData(HostPlatform.Linux, ">> ~/.ssh/authorized_keys")]
+    public void GenerateScript_AppendsRatherThanOverwrites(HostPlatform platform, string append)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain(append);
+        script.Should().NotContain("Set-Content -Path $keyFile");
+
+        // A truncating redirect, meaning a single '>' not preceded by another. Asserting
+        // NotContain("> ~/.ssh/authorized_keys") does not work: that string is a substring of
+        // the appending ">> ~/.ssh/authorized_keys" and the check can never pass.
+        script.Should().NotMatchRegex(@"[^>]> ~/\.ssh/authorized_keys");
+    }
+
+    /// <summary>
+    /// The Windows failure that costs an hour: for an account in the Administrators group,
+    /// sshd ignores the profile's authorized_keys entirely and reads a machine-wide file whose
+    /// ACL it also insists on. A script that skips this produces authentication failures with
+    /// nothing to explain them.
+    /// </summary>
+    [Fact]
+    public void GenerateScript_Windows_HandlesTheAdministratorsAuthorizedKeysFile()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("administrators_authorized_keys");
+        script.Should().Contain("icacls", "sshd refuses the file unless its ACL is restricted");
+    }
+
+    /// <summary>
+    /// Verified against a real machine: an account that <em>is</em> in Administrators reports
+    /// False from the token check when the process is not elevated, because UAC filters the
+    /// SID out. Deciding on that alone writes the key to the profile's authorized_keys, which
+    /// sshd then ignores — an authentication failure with nothing to explain it.
+    /// </summary>
+    [Fact]
+    public void GenerateScript_Windows_AsksTheGroupRatherThanTheToken()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("Get-LocalGroupMember",
+            "actual membership, not what an unelevated token happens to carry");
+        script.Should().Contain("$_.SID.Value -eq $mySid",
+            "matched by SID, since names vary by domain and casing");
+    }
+
+    /// <summary>
+    /// Refusing early beats half-succeeding. Without elevation the steps leave SSH looking
+    /// configured when it is not.
+    /// </summary>
+    [Fact]
+    public void GenerateScript_Windows_StopsWhenNotElevated()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("WindowsBuiltInRole]::Administrator");
+        script.Should().Contain("Run as Administrator");
+    }
+
+    /// <summary>
+    /// Reading the fingerprint needs elevation and can still fail. By that point the key is
+    /// installed, so a throw would discard a setup that otherwise worked — the operator loses
+    /// verified-first-use, not the connection.
+    /// </summary>
+    [Fact]
+    public void GenerateScript_Windows_SurvivesAnUnreadableHostKey()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("$fingerprint = ''", "it must have a value even when reading fails");
+        script.Should().Contain("try {");
+        script.Should().Contain("} catch { }");
+    }
+
+    [Fact]
+    public void GenerateScript_Windows_InstallsAndEnablesTheServer()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("OpenSSH.Server");
+        script.Should().Contain("StartupType Automatic");
+        script.Should().Contain("LocalPort 22");
+    }
+
+    [Fact]
+    public void GenerateScript_MacOs_UsesRemoteLogin()
+    {
+        SftpHostSetup.GenerateScript(Key, HostPlatform.MacOS)
+            .Should().Contain("systemsetup -setremotelogin on");
+    }
+
+    /// <summary>Debian and Ubuntu name the unit `ssh`; most others name it `sshd`.</summary>
+    [Fact]
+    public void GenerateScript_Linux_HandlesEitherServiceName()
+    {
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Linux);
+
+        script.Should().Contain("--now sshd");
+        script.Should().Contain("--now ssh");
+    }
+
+    /// <summary>
+    /// The key is interpolated into a shell string, so anything that could close it must be
+    /// refused rather than escaped. SshKeyPairGenerator already guarantees this; the check is
+    /// here because this function would be the one exploited if that guarantee ever lapsed.
+    /// </summary>
+    [Theory]
+    [InlineData("ssh-rsa AAAA test\nrm -rf /")]
+    [InlineData("ssh-rsa AAAA'; Remove-Item -Recurse C:\\ ;'")]
+    [InlineData("ssh-rsa AAAA\"malicious\"")]
+    public void GenerateScript_KeyContainingQuotesOrNewlines_IsRefused(string hostile)
+    {
+        Action act = () => SftpHostSetup.GenerateScript(hostile, HostPlatform.Windows);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void GenerateScript_AGeneratedKeyIsAlwaysAccepted()
+    {
+        var pair = SshKeyPairGenerator.Generate("my machine");
+
+        foreach (var platform in Enum.GetValues<HostPlatform>())
+        {
+            Action act = () => SftpHostSetup.GenerateScript(pair.PublicKeyLine, platform);
+            act.Should().NotThrow();
+        }
+    }
+
+    // ── Parsing the result ─────────────────────────────────────────────────
+
+    private static string Block(
+        string user = "Diviel",
+        string home = "/C:/Users/Diviel",
+        string fingerprint = "SHA256:abc123") =>
+        $"""
+        {SftpHostSetup.BeginMarker}
+        user={user}
+        home={home}
+        fingerprint={fingerprint}
+        {SftpHostSetup.EndMarker}
+        """;
+
+    [Fact]
+    public void ParseResult_ReadsAllThreeFields()
+    {
+        var result = SftpHostSetup.ParseResult(Block());
+
+        result.Should().NotBeNull();
+        result!.Username.Should().Be("Diviel");
+        result.HomePath.Should().Be("/C:/Users/Diviel");
+        result.Fingerprint.Should().Be("SHA256:abc123");
+    }
+
+    /// <summary>
+    /// The realistic paste. Nobody selects exactly the block — they grab the whole terminal,
+    /// prompts and echoed command included.
+    /// </summary>
+    [Fact]
+    public void ParseResult_IgnoresEverythingOutsideTheMarkers()
+    {
+        string messy = $"""
+        PS C:\Users\Diviel> .\setup.ps1
+        Path          : C:\
+        Online        : True
+
+        {Block()}
+
+        Copy the block above, including both marker lines, back into Connapse.
+        PS C:\Users\Diviel>
+        """;
+
+        var result = SftpHostSetup.ParseResult(messy);
+
+        result.Should().NotBeNull();
+        result!.Username.Should().Be("Diviel");
+    }
+
+    /// <summary>
+    /// Terminals wrap, indent, and add carriage returns, and none of that is the operator's
+    /// fault. Field names and values are both trimmed, so padding around the '=' is fine.
+    /// </summary>
+    [Fact]
+    public void ParseResult_ToleratesWindowsLineEndingsAndStrayWhitespace()
+    {
+        string block = Block().Replace("\n", "\r\n").Replace("user=", "  user =  ");
+
+        var result = SftpHostSetup.ParseResult(block);
+
+        result.Should().NotBeNull();
+        result!.Username.Should().Be("Diviel");
+    }
+
+    [Fact]
+    public void ParseResult_ToleratesCarriageReturns()
+    {
+        SftpHostSetup.ParseResult(Block().Replace("\n", "\r\n"))!
+            .Username.Should().Be("Diviel");
+    }
+
+    /// <summary>
+    /// A fingerprint typed by hand often loses the prefix. Adding it back beats failing later,
+    /// where the only symptom is a refused connection with no hint that the stored value was
+    /// merely the wrong shape.
+    /// </summary>
+    [Fact]
+    public void ParseResult_FingerprintWithoutThePrefix_GetsItBack()
+    {
+        SftpHostSetup.ParseResult(Block(fingerprint: "abc123"))!
+            .Fingerprint.Should().Be("SHA256:abc123");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("just some text the operator pasted by mistake")]
+    public void ParseResult_WithoutABlock_IsNull(string? pasted)
+    {
+        SftpHostSetup.ParseResult(pasted).Should().BeNull();
+    }
+
+    /// <summary>
+    /// Loose key=value lines with no markers must not be accepted — that would take a paste
+    /// from somewhere else entirely and configure a connection out of it.
+    /// </summary>
+    [Fact]
+    public void ParseResult_FieldsWithoutMarkers_IsNull()
+    {
+        SftpHostSetup.ParseResult("user=x\nhome=/y\nfingerprint=SHA256:z").Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseResult_MarkersInTheWrongOrder_IsNull()
+    {
+        SftpHostSetup.ParseResult(
+            $"{SftpHostSetup.EndMarker}\nuser=x\nhome=/y\nfingerprint=z\n{SftpHostSetup.BeginMarker}")
+            .Should().BeNull();
+    }
+
+    /// <summary>
+    /// The identifying fields only. The fingerprint used to be required too, which dead-ended the
+    /// flow when it could not be read — see
+    /// <see cref="ParseResult_WithoutAFingerprint_StillParses"/>.
+    /// </summary>
+    [Theory]
+    [InlineData("user")]
+    [InlineData("home")]
+    public void ParseResult_MissingAnyField_IsNull(string omit)
+    {
+        string block = string.Join('\n',
+            Block().Split('\n').Where(l => !l.TrimStart().StartsWith(omit + "=")));
+
+        SftpHostSetup.ParseResult(block).Should().BeNull();
+    }
+
+    /// <summary>
+    /// The whole point of the round trip: these are the values Connapse cannot know, and the
+    /// Windows home path is the one that would otherwise be written wrong by hand.
+    /// </summary>
+    [Fact]
+    public void ParseResult_WindowsHomePath_KeepsItsLeadingSlash()
+    {
+        SftpHostSetup.ParseResult(Block(home: "/C:/Users/Diviel"))!
+            .HomePath.Should().StartWith("/C:/");
+    }
+    // ── The installed key is restricted (Codex review on #405) ─────────────
+
+    /// <summary>
+    /// A bare entry grants everything the account can do — interactive shell, port forwarding,
+    /// agent forwarding. Connapse only reads files, and its path confinement is an application
+    /// rule: it bounds what Connapse does with the key, not what the key can do. Anyone holding
+    /// the stored private half is not bound by it at all.
+    /// </summary>
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Linux)]
+    public void GenerateScript_InstallsTheKeyRestrictedToSftp(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain("restrict,", "restrict disables PTY, port, agent and X11 forwarding");
+        script.Should().Contain("""command="internal-sftp" """.TrimEnd(),
+            "a forced command replaces whatever the client asks for, so a shell request gets SFTP");
+        script.Should().Contain($"restrict,command=\"internal-sftp\" {Key}",
+            "the restrictions must prefix the key on the same authorized_keys line");
+    }
+
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Linux)]
+    public void GenerateScript_NeverInstallsABareKey(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        // The key must never appear without its restrictions immediately before it.
+        foreach (int index in AllIndexesOf(script, Key))
+        {
+            script[..index].Should().EndWith(SftpHostSetup.KeyRestrictions,
+                "an unrestricted copy of the key would defeat the restricted one");
+        }
+    }
+
+    private static IEnumerable<int> AllIndexesOf(string haystack, string needle)
+    {
+        for (int i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + 1, StringComparison.Ordinal))
+        {
+            yield return i;
+        }
+    }
+
+    // ── A missing fingerprint must not dead-end the flow ───────────────────
+
+    /// <summary>
+    /// Reading the fingerprint needs elevation and can still fail, by which point sshd is running
+    /// and the key is installed. Requiring one here left the operator with a configured host, an
+    /// authorized key, and no way to finish or undo.
+    /// </summary>
+    [Fact]
+    public void ParseResult_WithoutAFingerprint_StillParses()
+    {
+        string block = $"""
+        {SftpHostSetup.BeginMarker}
+        user=Diviel
+        home=/C:/Users/Diviel
+        fingerprint=
+        {SftpHostSetup.EndMarker}
+        """;
+
+        var result = SftpHostSetup.ParseResult(block);
+
+        result.Should().NotBeNull();
+        result!.Username.Should().Be("Diviel");
+        result.Fingerprint.Should().BeEmpty("blank means trust on first use, which is defined behaviour");
+    }
+
+    [Fact]
+    public void ParseResult_FingerprintLineAbsentEntirely_StillParses()
+    {
+        string block = $"""
+        {SftpHostSetup.BeginMarker}
+        user=Diviel
+        home=/C:/Users/Diviel
+        {SftpHostSetup.EndMarker}
+        """;
+
+        SftpHostSetup.ParseResult(block)!.Fingerprint.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The identifying fields are still required: without a username or home path there is no
+    /// connection to build, and guessing either would point somewhere wrong.
+    /// </summary>
+    [Theory]
+    [InlineData("user")]
+    [InlineData("home")]
+    public void ParseResult_MissingAnIdentifyingField_IsStillNull(string omit)
+    {
+        string block = string.Join('\n',
+            $"""
+            {SftpHostSetup.BeginMarker}
+            user=Diviel
+            home=/C:/Users/Diviel
+            fingerprint=SHA256:abc
+            {SftpHostSetup.EndMarker}
+            """.Split('\n').Where(l => !l.TrimStart().StartsWith(omit + "=")));
+
+        SftpHostSetup.ParseResult(block).Should().BeNull();
+    }
+
+    [Fact]
+    public void GenerateScript_SaysSoWhenTheFingerprintCouldNotBeRead()
+    {
+        SftpHostSetup.GenerateScript(Key, HostPlatform.Windows)
+            .Should().Contain("could not be read",
+                "a silent empty fingerprint would look like the script half-worked");
+    }
+
+    [Fact]
+    public void GenerateScript_Windows_ScopesTheFirewallRuleToLocalSubnets()
+    {
+        // An unscoped New-NetFirewallRule accepts port 22 from any address on any profile —
+        // the rest of a hotel network, and the internet on any host whose router forwards it.
+        // Nothing about indexing local files needs that, and the operator is not being asked.
+        string script = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows);
+
+        script.Should().Contain("-RemoteAddress LocalSubnet",
+            "the rule must not accept port 22 from arbitrary networks");
+        script.Should().Contain("New-NetFirewallRule");
+    }
+
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.Linux)]
+    [InlineData(HostPlatform.MacOS)]
+    public void GenerateScript_ReportsWhetherTheHostStillAcceptsPasswords(HostPlatform platform)
+    {
+        // The restrictions on Connapse's key bind that key alone. Turning on sshd exposes every
+        // other account too, and by password if the host allows it — which the operator cannot
+        // know unless the script says so.
+        string script = SftpHostSetup.GenerateScript(Key, platform);
+
+        script.Should().Contain("PasswordAuthentication",
+            "enabling SSH without naming the host's password policy hides half the change");
+        script.Should().Contain("accepts SSH logins by password");
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/SftpPathConfinementTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SftpPathConfinementTests.cs
@@ -1,0 +1,278 @@
+﻿using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+/// <summary>
+/// The resolver stands in for the remote server's <c>SSH_FXP_REALPATH</c>. It is what makes
+/// these tests meaningful: the escapes below are ones a purely lexical check would pass, and
+/// they are only caught because resolution happens where the symlinks actually live.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SftpPathConfinementTests
+{
+    /// <summary>
+    /// A server whose symlink table is supplied by the test. Anything not named resolves by
+    /// collapsing "." and ".." segments, the way a real server would.
+    /// </summary>
+    private sealed class FakeServer(Dictionary<string, string>? links = null) : ISftpRealPathResolver
+    {
+        private readonly Dictionary<string, string> _links = links ?? [];
+
+        public HashSet<string> Unresolvable { get; } = [];
+
+        public Task<string> GetCanonicalPathAsync(string path, CancellationToken ct = default) =>
+            Task.FromResult(Resolve(path));
+
+        private string Resolve(string path)
+        {
+            if (Unresolvable.Contains(path))
+                throw new InvalidOperationException($"The server refused to resolve '{path}'.");
+
+            var stack = new List<string>();
+
+            foreach (string segment in path.Split('/', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (segment == ".") continue;
+
+                if (segment == "..")
+                {
+                    if (stack.Count > 0) stack.RemoveAt(stack.Count - 1);
+                    continue;
+                }
+
+                stack.Add(segment);
+
+                // A link is followed the moment the walk reaches it, which is what makes an
+                // ancestor link an escape even when the leaf itself is an ordinary file.
+                string soFar = "/" + string.Join('/', stack);
+                if (_links.TryGetValue(soFar, out string? target))
+                {
+                    stack.Clear();
+                    stack.AddRange(target.Split('/', StringSplitOptions.RemoveEmptyEntries));
+                }
+            }
+
+            return "/" + string.Join('/', stack);
+        }
+    }
+
+    [Fact]
+    public async Task CombineWithin_OrdinarySubPath_Resolves()
+    {
+        var server = new FakeServer();
+
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "docs/reports"))
+            .Should().Be("/srv/knowledge/docs/reports");
+    }
+
+    [Fact]
+    public async Task CombineWithin_NoSubPath_ResolvesToTheRoot()
+    {
+        var server = new FakeServer();
+
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", null))
+            .Should().Be("/srv/knowledge");
+    }
+
+    [Fact]
+    public async Task CombineWithin_DotDotEscape_IsRefused()
+    {
+        var server = new FakeServer();
+
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "../../etc"))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CombineWithin_DotDotThatStaysInside_IsAllowed()
+    {
+        var server = new FakeServer();
+
+        // Refusing this would be over-strict: it resolves back inside the root.
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "docs/../reports"))
+            .Should().Be("/srv/knowledge/reports");
+    }
+
+    [Fact]
+    public async Task CombineWithin_AbsoluteSubPath_IsRefused()
+    {
+        var server = new FakeServer();
+
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "/etc/shadow"))
+            .Should().BeNull();
+    }
+
+    /// <summary>
+    /// The case a lexical check passes and this exists to catch: the string never leaves the
+    /// root, and the escape only appears once the server resolves the link.
+    /// </summary>
+    [Fact]
+    public async Task CombineWithin_ServerSideSymlinkPointingOutside_IsRefused()
+    {
+        var server = new FakeServer(new() { ["/srv/knowledge/escape"] = "/etc" });
+
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "escape"))
+            .Should().BeNull();
+    }
+
+    /// <summary>
+    /// The subtle half: the leaf is an ordinary file, so asking it about links reveals
+    /// nothing. Only its parent gives the escape away.
+    /// </summary>
+    [Fact]
+    public async Task CombineWithin_SymlinkedAncestorWithOrdinaryLeaf_IsRefused()
+    {
+        var server = new FakeServer(new() { ["/srv/knowledge/escape"] = "/etc" });
+
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "escape/shadow"))
+            .Should().BeNull();
+    }
+
+    /// <summary>
+    /// A link inside the root that points back inside it is legitimate and must not be
+    /// refused just for being a link — the check is about where a path lands, not how it got
+    /// there.
+    /// </summary>
+    [Fact]
+    public async Task CombineWithin_SymlinkPointingBackInsideTheRoot_IsAllowed()
+    {
+        var server = new FakeServer(new() { ["/srv/knowledge/shortcut"] = "/srv/knowledge/docs" });
+
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "shortcut/a.md"))
+            .Should().Be("/srv/knowledge/docs/a.md");
+    }
+
+    /// <summary>
+    /// A root that is itself a symlink must not make contained paths look like escapes.
+    /// Both sides are canonicalised for exactly this reason.
+    /// </summary>
+    [Fact]
+    public async Task CombineWithin_SymlinkedRoot_StillConfinesAgainstTheResolvedRoot()
+    {
+        var server = new FakeServer(new() { ["/srv/knowledge"] = "/mnt/vol1/knowledge" });
+
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "docs"))
+            .Should().Be("/mnt/vol1/knowledge/docs");
+    }
+
+    /// <summary>
+    /// The nginx `alias` off-by-slash bug: a sibling sharing a name prefix is not inside.
+    /// </summary>
+    [Fact]
+    public void IsWithin_SiblingSharingANamePrefix_IsOutside()
+    {
+        SftpPathConfinement.IsWithin("/data", "/data-other/secrets").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsWithin_TheRootItself_IsInside()
+    {
+        SftpPathConfinement.IsWithin("/data", "/data").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsWithin_TrailingSeparatorOnTheRoot_DoesNotChangeTheAnswer()
+    {
+        SftpPathConfinement.IsWithin("/data/", "/data/x").Should().BeTrue();
+        SftpPathConfinement.IsWithin("/data/", "/data").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Case is compared ordinally even though a Windows OpenSSH server is case-insensitive
+    /// underneath. Refusing a legitimate path is visible and fixable; admitting an escape is
+    /// silent, so this deliberately takes the visible failure.
+    /// </summary>
+    [Fact]
+    public void IsWithin_DifferingCase_IsOutside()
+    {
+        SftpPathConfinement.IsWithin("/C:/Users/me", "/c:/users/me/docs").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsWithin_WindowsStyleRoot_ConfinesNormally()
+    {
+        SftpPathConfinement.IsWithin("/C:/Users/me/docs", "/C:/Users/me/docs/a.md").Should().BeTrue();
+        SftpPathConfinement.IsWithin("/C:/Users/me/docs", "/C:/Users/me/private").Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A path the server will not resolve is one we cannot vouch for, so it is refused rather
+    /// than compared as an unverified string.
+    /// </summary>
+    [Fact]
+    public async Task CombineWithin_ServerRefusesToResolve_IsRefused()
+    {
+        var server = new FakeServer();
+        server.Unresolvable.Add("/srv/knowledge/docs");
+
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "docs"))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CombineWithin_ServerRefusesToResolveTheRoot_IsRefused()
+    {
+        var server = new FakeServer();
+        server.Unresolvable.Add("/srv/knowledge");
+
+        (await SftpPathConfinement.CombineWithinAsync(server, "/srv/knowledge", "docs"))
+            .Should().BeNull();
+    }
+
+    /// <summary>
+    /// A server that answered the handshake and then went quiet. Real ones do this: sshd is up
+    /// and authenticating, its SFTP subsystem is wedged or the box is thrashing.
+    /// </summary>
+    private sealed class StallingServer : ISftpRealPathResolver
+    {
+        public async Task<string> GetCanonicalPathAsync(string path, CancellationToken ct = default)
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+            return path;
+        }
+    }
+
+    [Fact]
+    public async Task ResolveWithin_ServerStopsAnswering_ObservesCancellation()
+    {
+        // The reason this seam is asynchronous. Canonicalisation used to go through SSH.NET's
+        // blocking ChangeDirectory, which no token can interrupt — so a connection test's
+        // 15-second budget covered the handshake and then waited indefinitely on the very
+        // request that stalls, holding its Blazor circuit and SSH session open.
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        Func<Task> act = async () => await SftpPathConfinement.ResolveWithinAsync(
+            new StallingServer(), "/srv/knowledge", "/srv/knowledge/docs", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "cancellation must reach the round-trip, not just the awaits around it");
+    }
+
+    [Fact]
+    public void SftpConnectorConfig_OperationTimeout_IsFinite()
+    {
+        // SSH.NET's own default is infinite. A session that inherits that has no way back from
+        // a server that stops answering: nothing releases the SSH session or its socket, and
+        // SourceSyncService builds a connector every cycle.
+        var config = new Connapse.Storage.Connectors.SftpConnectorConfig();
+
+        config.OperationTimeout.Should().BePositive().And.NotBe(Timeout.InfiniteTimeSpan);
+    }
+
+    [Fact]
+    public async Task ResolveWithin_Cancellation_IsNotSwallowedAsAnUnresolvablePath()
+    {
+        // The catch that refuses paths the server will not resolve must not also swallow a
+        // cancelled one: returning null there would report "outside the allowed root" for a
+        // path nobody ever asked about, and the caller would never learn it timed out.
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        Func<Task> act = async () => await SftpPathConfinement.CombineWithinAsync(
+            new StallingServer(), "/srv/knowledge", "docs", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/SshHostKeyPolicyTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SshHostKeyPolicyTests.cs
@@ -1,0 +1,123 @@
+using System.Security.Cryptography;
+using System.Text;
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class SshHostKeyPolicyTests
+{
+    private const string Presented = "SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG";
+
+    [Fact]
+    public void Evaluate_NothingPinned_TrustsOnFirstUse()
+    {
+        SshHostKeyPolicy.Evaluate(null, Presented)
+            .Should().Be(SshHostKeyDecision.TrustOnFirstUse);
+    }
+
+    /// <summary>
+    /// Clearing the recorded fingerprint is the documented way to accept a legitimate rekey,
+    /// so a blank value must re-arm trust on first use rather than read as a mismatch.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Evaluate_ClearedFingerprint_ReArmsTrustOnFirstUse(string pinned)
+    {
+        SshHostKeyPolicy.Evaluate(pinned, Presented)
+            .Should().Be(SshHostKeyDecision.TrustOnFirstUse);
+    }
+
+    [Fact]
+    public void Evaluate_SamePinnedKey_Matches()
+    {
+        SshHostKeyPolicy.Evaluate(Presented, Presented)
+            .Should().Be(SshHostKeyDecision.Matches);
+    }
+
+    [Fact]
+    public void Evaluate_DifferentKey_IsAMismatch()
+    {
+        SshHostKeyPolicy.Evaluate("SHA256:somethingelse", Presented)
+            .Should().Be(SshHostKeyDecision.Mismatch);
+    }
+
+    /// <summary>
+    /// Base64 is case-significant, so two fingerprints differing only in case are two
+    /// different keys. Normalising case here would let a mismatch through.
+    /// </summary>
+    [Fact]
+    public void Evaluate_SameKeyInDifferentCase_IsAMismatch()
+    {
+        SshHostKeyPolicy.Evaluate(Presented.ToUpperInvariant(), Presented)
+            .Should().Be(SshHostKeyDecision.Mismatch);
+    }
+
+    [Fact]
+    public void Evaluate_StoredWithSurroundingWhitespace_StillMatches()
+    {
+        SshHostKeyPolicy.Evaluate($"  {Presented}\n", Presented)
+            .Should().Be(SshHostKeyDecision.Matches);
+    }
+
+    /// <summary>
+    /// The format has to survive a copy-paste comparison against
+    /// <c>ssh-keyscan host | ssh-keygen -lf -</c>, which prints unpadded base64.
+    /// </summary>
+    [Fact]
+    public void FormatFingerprint_MatchesTheOpenSshShape()
+    {
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes("a host key blob"));
+
+        string formatted = SshHostKeyPolicy.FormatFingerprint(hash);
+
+        formatted.Should().StartWith("SHA256:");
+        formatted.Should().NotEndWith("=");
+        formatted.Should().Be("SHA256:" + Convert.ToBase64String(hash).TrimEnd('='));
+    }
+
+    [Fact]
+    public void FormatFingerprint_RoundTripsThroughEvaluate()
+    {
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes("stable"));
+
+        string first = SshHostKeyPolicy.FormatFingerprint(hash);
+        string second = SshHostKeyPolicy.FormatFingerprint(hash);
+
+        SshHostKeyPolicy.Evaluate(first, second).Should().Be(SshHostKeyDecision.Matches);
+    }
+
+    [Fact]
+    public void FormatFingerprint_DifferentKeys_ProduceDifferentFingerprints()
+    {
+        string a = SshHostKeyPolicy.FormatFingerprint(SHA256.HashData("one"u8));
+        string b = SshHostKeyPolicy.FormatFingerprint(SHA256.HashData("two"u8));
+
+        SshHostKeyPolicy.Evaluate(a, b).Should().Be(SshHostKeyDecision.Mismatch);
+    }
+
+    [Fact]
+    public void FormatFingerprint_EmptyHash_Throws()
+    {
+        Action act = () => SshHostKeyPolicy.FormatFingerprint(ReadOnlySpan<byte>.Empty);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    /// <summary>
+    /// The operator's next step is deciding whether this was their own rekey, so both
+    /// fingerprints have to be in the message.
+    /// </summary>
+    [Fact]
+    public void DescribeMismatch_NamesBothFingerprintsAndTheHost()
+    {
+        string message = SshHostKeyPolicy.DescribeMismatch("files.example.com", "SHA256:old", "SHA256:new");
+
+        message.Should().Contain("files.example.com");
+        message.Should().Contain("SHA256:old");
+        message.Should().Contain("SHA256:new");
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/SshKeyPairGeneratorTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SshKeyPairGeneratorTests.cs
@@ -1,0 +1,133 @@
+using System.Security.Cryptography;
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+/// <summary>
+/// These cover shape and safety. The encoding itself is only genuinely proven by
+/// <c>SftpConnectorIntegrationTests.GeneratedKeyPair_AuthenticatesAgainstARealServer</c>,
+/// because a wrong encoding produces a well-formed line that simply fails to authenticate.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SshKeyPairGeneratorTests
+{
+    [Fact]
+    public void Generate_ProducesAPrivateKeyInTheFormSshNetReads()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        pair.PrivateKeyPem.Should().StartWith("-----BEGIN RSA PRIVATE KEY-----");
+        pair.PrivateKeyPem.Should().Contain("-----END RSA PRIVATE KEY-----");
+    }
+
+    [Fact]
+    public void Generate_ProducesASingleAuthorizedKeysLine()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        pair.PublicKeyLine.Should().StartWith("ssh-rsa ");
+        pair.PublicKeyLine.Should().NotContain("\n");
+        pair.PublicKeyLine.Split(' ').Should().HaveCount(3, "algorithm, key, comment");
+    }
+
+    [Fact]
+    public void Generate_UsesTheRequestedKeySize()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        using var rsa = RSA.Create();
+        rsa.ImportFromPem(pair.PrivateKeyPem);
+
+        rsa.KeySize.Should().Be(SshKeyPairGenerator.KeySizeBits);
+    }
+
+    [Fact]
+    public void Generate_PublicHalfMatchesThePrivateHalf()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+
+        using var rsa = RSA.Create();
+        rsa.ImportFromPem(pair.PrivateKeyPem);
+
+        SshKeyPairGenerator.FormatPublicKey(rsa).Should().Be(pair.PublicKeyLine);
+    }
+
+    [Fact]
+    public void Generate_EachCallProducesADifferentKey()
+    {
+        SshKeyPairGenerator.Generate().PublicKeyLine
+            .Should().NotBe(SshKeyPairGenerator.Generate().PublicKeyLine);
+    }
+
+    [Fact]
+    public void Generate_CommentAppearsAsTheLabel()
+    {
+        SshKeyPairGenerator.Generate("my-laptop").PublicKeyLine
+            .Should().EndWith(" my-laptop");
+    }
+
+    /// <summary>
+    /// The comment is the final field on the line, so a newline in it would end the entry
+    /// and let whatever followed be parsed as a second authorized key. Connection names reach
+    /// here, and they are operator-supplied.
+    /// </summary>
+    [Fact]
+    public void Generate_CommentCannotInjectASecondAuthorizedKey()
+    {
+        var pair = SshKeyPairGenerator.Generate("ok\nssh-rsa AAAAB3NzaC1yc2EAAAADAQAB attacker");
+
+        pair.PublicKeyLine.Should().NotContain("\n");
+        pair.PublicKeyLine.Split('\n').Should().HaveCount(1);
+        pair.PublicKeyLine.Should().NotContain("attacker\n");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\n\r")]
+    public void Generate_BlankComment_FallsBackToADefaultLabel(string comment)
+    {
+        SshKeyPairGenerator.Generate(comment).PublicKeyLine
+            .Should().EndWith(" connapse");
+    }
+
+    /// <summary>
+    /// An mpint is signed, so a modulus whose top bit is set needs a leading zero byte. A
+    /// 3072-bit RSA modulus always has its top bit set, so this path runs every time — and if
+    /// it were wrong, every generated key would fail to authenticate.
+    /// </summary>
+    [Fact]
+    public void FormatPublicKey_ModulusIsEncodedAsAPositiveMpint()
+    {
+        var pair = SshKeyPairGenerator.Generate();
+        byte[] blob = Convert.FromBase64String(pair.PublicKeyLine.Split(' ')[1]);
+
+        var reader = new BlobReader(blob);
+
+        System.Text.Encoding.ASCII.GetString(reader.Next()).Should().Be("ssh-rsa");
+        reader.Next().Should().NotBeEmpty("the exponent must be present");
+
+        byte[] modulus = reader.Next();
+        modulus[0].Should().Be(0, "a 3072-bit modulus has its top bit set and needs the sign byte");
+        (modulus.Length - 1).Should().Be(SshKeyPairGenerator.KeySizeBits / 8);
+    }
+
+    /// <summary>Walks the length-prefixed fields of an SSH key blob.</summary>
+    private sealed class BlobReader(byte[] blob)
+    {
+        private int _offset;
+
+        public byte[] Next()
+        {
+            int length = System.Buffers.Binary.BinaryPrimitives.ReadInt32BigEndian(
+                blob.AsSpan(_offset, 4));
+            _offset += 4;
+
+            byte[] value = blob[_offset..(_offset + length)];
+            _offset += length;
+            return value;
+        }
+    }
+}

--- a/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
+++ b/tests/Connapse.Ingestion.Tests/Pipeline/IngestionPipelineTests.cs
@@ -44,9 +44,20 @@ public class IngestionPipelineTests
     private readonly IOptionsMonitor<EmbeddingSettings> _embeddingSettings;
     private readonly ILogger<IngestionPipeline> _logger;
 
+    // Fields rather than inline substitutes, so a test can say what the store returns. The
+    // source-routing tests need to: which branch IngestByIdAsync takes is decided by them.
+    private readonly IDocumentStore _documentStore;
+    private readonly ISourceStore _sourceStore;
+    private readonly IConnectionStore _connectionStore;
+    private readonly IConnectorFactory _connectorFactory;
+
     public IngestionPipelineTests()
     {
         _fileSystem = Substitute.For<IKnowledgeFileSystem>();
+        _documentStore = Substitute.For<IDocumentStore>();
+        _sourceStore = Substitute.For<ISourceStore>();
+        _connectionStore = Substitute.For<IConnectionStore>();
+        _connectorFactory = Substitute.For<IConnectorFactory>();
         _embeddingProvider = Substitute.For<IEmbeddingProvider>();
         _vectorStore = Substitute.For<IVectorStore>();
         _logger = NullLogger<IngestionPipeline>.Instance;
@@ -98,7 +109,10 @@ public class IngestionPipelineTests
             new EmbeddingCache(dbContext),
             Substitute.For<IContainerStore>(),
             Substitute.For<IManagedStorageProvider>(),
-            Substitute.For<IDocumentStore>(),
+            _documentStore,
+            _sourceStore,
+            _connectionStore,
+            _connectorFactory,
             _logger);
 
     private static KnowledgeDbContext CreateInMemoryContext()
@@ -265,6 +279,66 @@ public class IngestionPipelineTests
     /// <summary>
     /// Wrapper stream that reports CanSeek = false to test non-seekable stream handling.
     /// </summary>
+    // ── Source routing when the caller supplies no owner (#405 review) ─────────────
+
+    /// <summary>
+    /// Stands up the three stores IngestByIdAsync consults on the source path, and returns
+    /// the connector it should end up reading through.
+    /// </summary>
+    private IConnector ArrangeSourceDocument(string documentId, Guid sourceId, string path)
+    {
+        var connectionId = Guid.NewGuid();
+
+        _documentStore.GetAsync(documentId, Arg.Any<CancellationToken>())
+            .Returns(new Document(
+                documentId, sourceId.ToString(), "test.txt", "text/plain", path,
+                SizeBytes: 12, CreatedAt: DateTime.UtcNow, Metadata: new Dictionary<string, string>())
+            {
+                // What PostgresDocumentStore.MapToModel records: ContainerId carries
+                // COALESCE(container_id, source_id), so only this distinguishes the two.
+                Owner = OwnerRef.ForSource(sourceId),
+            });
+
+        _sourceStore.GetAsync(sourceId, Arg.Any<CancellationToken>())
+            .Returns(new Source(
+                sourceId, "src", null, connectionId, "{}", DateTime.UtcNow, DateTime.UtcNow));
+
+        _connectionStore.GetAsync(connectionId, Arg.Any<CancellationToken>())
+            .Returns(new Connection(
+                connectionId, "conn", ConnectionProvider.Filesystem, "{}", null,
+                DateTime.UtcNow, DateTime.UtcNow));
+
+        var connector = Substitute.For<IConnector>();
+        connector.ReadFileAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<Stream>(new MemoryStream("Test content"u8.ToArray())));
+
+        _connectorFactory.Create(Arg.Any<Source>(), Arg.Any<Connection>(), Arg.Any<string?>())
+            .Returns(connector);
+
+        return connector;
+    }
+
+    [Fact]
+    public async Task IngestByIdAsync_SourceOwnedDocumentWithNoOwnerInOptions_ReadsThroughTheSourceConnector()
+    {
+        // ReindexService enqueued jobs this way before #405: no Owner, and a ContainerId that
+        // is blank because Nullable<Guid>.ToString() returns "". The pipeline then took the
+        // container branch and threw — after the reindex had already deleted the document's
+        // chunks, and with the remote signature still matching so no later sync restored them.
+        using var dbContext = CreateInMemoryContext();
+        var pipeline = CreatePipeline(dbContext);
+
+        string documentId = Guid.NewGuid().ToString();
+        var sourceId = Guid.NewGuid();
+        IConnector connector = ArrangeSourceDocument(documentId, sourceId, "/remote/test.txt");
+
+        await pipeline.IngestByIdAsync(
+            documentId,
+            new IngestionOptions(DocumentId: documentId, FileName: "test.txt", Path: "/remote/test.txt"));
+
+        await connector.Received(1).ReadFileAsync("/remote/test.txt", Arg.Any<CancellationToken>());
+    }
+
     private sealed class NonSeekableStream : Stream
     {
         private readonly Stream _inner;

--- a/tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj
+++ b/tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj
@@ -18,12 +18,15 @@
       ScpClient.Download()'s recursive mode, where a malicious server returns filenames
       containing "../" and the client writes outside the target directory.
 
-      Nothing here is exposed: SSH.NET is test-only, and no Connapse code calls SCP at all.
-      The reference exists so `dotnet build` stops reporting a high-severity advisory on every
-      run — a standing warning that is not actionable trains people to ignore the ones that are.
+      This used to say SSH.NET was test-only. That stopped being true when the SFTP connector
+      landed: Connapse.Storage now references it directly, on the same patched version. The
+      advisory is still not reachable, because it is in the SCP client and nothing here calls
+      SCP — but "test-only" was the wrong reason, and a stale reason is worse than none.
+
       Remove this once Testcontainers ships a version that references 2026.0.0 or later.
     -->
     <PackageReference Include="SSH.NET" Version="2026.0.0" />
+    <PackageReference Include="Testcontainers" Version="4.3.0" />
     <PackageReference Include="Testcontainers.Azurite" Version="4.3.0" />
     <PackageReference Include="Testcontainers.LocalStack" Version="4.3.0" />
     <PackageReference Include="Testcontainers.Minio" Version="4.3.0" />

--- a/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
@@ -63,7 +63,7 @@ public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
     /// </summary>
     private sealed class FixedConnectorFactory(IConnector connector) : IConnectorFactory
     {
-        public IConnector Create(Source source, Connection connection) => connector;
+        public IConnector Create(Source source, Connection connection, string? secret = null) => connector;
     }
 
     private async Task<SourceSyncResult> SyncWithConnectorAsync(

--- a/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
@@ -1,4 +1,4 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.Data;
 using Connapse.Web.Services;
@@ -76,7 +76,7 @@ public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
         var service = new SourceSyncService(
             scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>(),
             new FixedConnectorFactory(connector),
-            scope.ServiceProvider.GetRequiredService<IIngestionQueue>(),
+            new RecordingIngestionQueue(),
             scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<SourceSyncService>());
 
         return await service.SyncSourceAsync(

--- a/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/DeleteGuardIntegrationTests.cs
@@ -1,0 +1,380 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Data;
+using Connapse.Web.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class DeleteGuardIntegrationTests(SharedWebAppFixture fixture)
+{
+    private static string ShortName(string prefix) => $"{prefix}-{Guid.NewGuid():N}"[..20];
+
+    private async Task<Source> SeedSourceAsync()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+
+        var connection = await connections.CreateAsync(
+            new CreateConnectionRequest(ShortName("conn"), ConnectionProvider.S3, """{"region":"us-east-1"}"""),
+            createdByUserId: null);
+
+        return await sources.CreateAsync(
+            new CreateSourceRequest(ShortName("src"), connection.Id, """{"bucketName":"b"}"""));
+    }
+
+    /// <summary>
+    /// Inserts <paramref name="count"/> source-owned documents directly via SQL, following the
+    /// raw-insert pattern in OwnerBridgeSchemaTests: <c>IDocumentStore.StoreAsync</c> always
+    /// populates <c>container_id</c> and so cannot express a source-owned row.
+    /// </summary>
+    private async Task SeedDocumentsAsync(Guid sourceId, int count)
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var context = await dbFactory.CreateDbContextAsync();
+
+        for (int i = 0; i < count; i++)
+        {
+            string path = $"/doc-{i}.md";
+
+            // status = 'Ready': these rows represent already-indexed documents, not ones
+            // mid-ingestion. Left at the column's 'Pending' default, HasRemoteChanged's
+            // in-flight check would treat every one of them as already queued and skip it
+            // regardless of remote signature, which would make a reconcile's upsert count
+            // always zero here.
+            await context.Database.ExecuteSqlRawAsync(
+                "INSERT INTO documents (id, container_id, source_id, file_name, path, content_hash, size_bytes, status, created_at) "
+                + "VALUES ({0}, NULL, {1}, {2}, {3}, '', 1, 'Ready', now())",
+                Guid.NewGuid(), sourceId, $"doc-{i}.md", path);
+        }
+    }
+
+    /// <summary>
+    /// Hands the service a fixed connector, following <c>FixedConnectorFactory</c> in
+    /// SourceSyncIntegrationTests, which exists for exactly this purpose.
+    /// </summary>
+    private sealed class FixedConnectorFactory(IConnector connector) : IConnectorFactory
+    {
+        public IConnector Create(Source source, Connection connection) => connector;
+    }
+
+    private async Task<SourceSyncResult> SyncWithConnectorAsync(
+        Source source, IConnector connector, bool applyWithheldDeletions = false)
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+        var connection = (await connections.GetAsync(source.ConnectionId))!;
+
+        var service = new SourceSyncService(
+            scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>(),
+            new FixedConnectorFactory(connector),
+            scope.ServiceProvider.GetRequiredService<IIngestionQueue>(),
+            scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<SourceSyncService>());
+
+        return await service.SyncSourceAsync(
+            source, connection, CancellationToken.None, applyWithheldDeletions);
+    }
+
+    /// <summary>
+    /// A connector whose listing is empty, without erroring — the shape a narrowed bucket
+    /// policy or an unmounted directory actually takes. Before the guard this deleted every
+    /// document the source owned.
+    /// </summary>
+    private sealed class EmptyListingConnector : IConnector
+    {
+        public ConnectorType Type => ConnectorType.S3;
+        public bool SupportsLiveWatch => false;
+        public string ResolveJobPath(string relativePath) => "/" + relativePath.TrimStart('/');
+        public Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<ConnectorFile>>([]);
+        public Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
+            => Task.FromResult<Stream>(new MemoryStream());
+        public Task<bool> ExistsAsync(string path, CancellationToken ct = default) => Task.FromResult(false);
+        public IAsyncEnumerable<ConnectorFileEvent> WatchAsync(CancellationToken ct = default)
+            => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A connector whose listing is a fixed, non-empty set of files, following
+    /// <see cref="EmptyListingConnector"/>'s shape. Used where a test needs the remote to
+    /// report specific paths rather than nothing.
+    /// </summary>
+    private sealed class FixedListingConnector(IReadOnlyList<ConnectorFile> files) : IConnector
+    {
+        public ConnectorType Type => ConnectorType.S3;
+        public bool SupportsLiveWatch => false;
+        public string ResolveJobPath(string relativePath) => "/" + relativePath.TrimStart('/');
+        public Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
+            => Task.FromResult(files);
+        public Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
+            => Task.FromResult<Stream>(new MemoryStream());
+        public Task<bool> ExistsAsync(string path, CancellationToken ct = default) => Task.FromResult(false);
+        public IAsyncEnumerable<ConnectorFileEvent> WatchAsync(CancellationToken ct = default)
+            => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task Sync_ListingCollapsesToEmpty_WithholdsDeletionsAndKeepsDocuments()
+    {
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        var result = await SyncWithConnectorAsync(source, new EmptyListingConnector());
+
+        result.Deleted.Should().Be(0, "an empty listing is not evidence that 40 files were deleted");
+        result.WithheldDeletions.Should().Be(40);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().HaveCount(40);
+
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().Be(40);
+    }
+
+    [Fact]
+    public async Task Sync_WithOverride_AppliesTheWithheldDeletions()
+    {
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        await SyncWithConnectorAsync(source, new EmptyListingConnector());
+
+        // Reloaded, because the approval path reads the withheld count off the source it is
+        // given and the first cycle only wrote it to the database. Both real callers — the
+        // sync route and the Sources page — load the source immediately before syncing, so
+        // passing the stale object here would test something no caller does.
+        var reloaded = await ReloadAsync(source.Id);
+        var result = await SyncWithConnectorAsync(reloaded, new EmptyListingConnector(), applyWithheldDeletions: true);
+
+        result.Deleted.Should().Be(40);
+        result.WithheldDeletions.Should().Be(0);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().BeEmpty();
+
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        (await sources.GetAsync(source.Id))!.WithheldDeletions
+            .Should().BeNull("the pending decision is resolved, so the button must stop showing");
+    }
+
+    [Fact]
+    public async Task Sync_WhileWithholding_UpsertsStillApply()
+    {
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        // 5 of the 40 indexed paths are still reported by the remote. The raw-SQL seed above
+        // writes no remote signature metadata, so HasRemoteChanged treats every one of them as
+        // changed and they are re-enqueued — that is what proves upserts still apply here, not
+        // just that the connector returned something. The other 35 paths are absent from the
+        // remote and are what trips the guard.
+        var remoteFiles = Enumerable.Range(0, 5)
+            .Select(i => new ConnectorFile($"/doc-{i}.md", 1, DateTime.UtcNow, "text/markdown"))
+            .ToList();
+
+        var result = await SyncWithConnectorAsync(source, new FixedListingConnector(remoteFiles));
+
+        result.Upserted.Should().Be(5,
+            "a source that trips the guard must keep ingesting new content, or the safety " +
+            "mechanism becomes the outage it exists to prevent");
+        result.Deleted.Should().Be(0);
+        result.WithheldDeletions.Should().Be(35);
+    }
+
+    [Fact]
+    public async Task Sync_WithOverride_AfterRemoteRecovered_RecomputesAndDeletesNothing()
+    {
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        // First cycle: the listing collapses to empty and all 40 are withheld.
+        await SyncWithConnectorAsync(source, new EmptyListingConnector());
+
+        // Second cycle, with the override: the remote has recovered and reports all 40 files
+        // again. An implementation that stored and replayed the vanished set from the first
+        // cycle would delete all 40 here; one that recomputes deletes nothing.
+        var allFiles = Enumerable.Range(0, 40)
+            .Select(i => new ConnectorFile($"/doc-{i}.md", 1, DateTime.UtcNow, "text/markdown"))
+            .ToList();
+
+        var result = await SyncWithConnectorAsync(
+            source, new FixedListingConnector(allFiles), applyWithheldDeletions: true);
+
+        result.Deleted.Should().Be(0,
+            "approving re-runs the sync rather than replaying the earlier list, so a remote " +
+            "that recovered in the meantime must delete nothing");
+        result.WithheldDeletions.Should().Be(0);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().HaveCount(40);
+    }
+
+    [Fact]
+    public async Task Sync_SmallDeletionSet_AppliesWithoutWithholding()
+    {
+        // Five of five is below the floor: small sources must stay able to tidy themselves.
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 5);
+
+        var result = await SyncWithConnectorAsync(source, new EmptyListingConnector());
+
+        result.Deleted.Should().Be(5);
+        result.WithheldDeletions.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task UpdateWithheldDeletionsAsync_RoundTripsTheCount()
+    {
+        var source = await SeedSourceAsync();
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+
+        (await sources.GetAsync(source.Id))!.WithheldDeletions
+            .Should().BeNull("a source with nothing pending must not claim a count of zero");
+
+        await sources.UpdateWithheldDeletionsAsync(source.Id, 42);
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().Be(42);
+
+        // Clearing must return to null, not zero: the UI distinguishes "nothing pending"
+        // from "a decision was made", and zero would leave the button showing forever.
+        await sources.UpdateWithheldDeletionsAsync(source.Id, null);
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetSource_AfterWithholding_ReportsTheCount()
+    {
+        var source = await SeedSourceAsync();
+
+        using (var scope = fixture.Factory.Services.CreateScope())
+        {
+            var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+            await sources.UpdateWithheldDeletionsAsync(source.Id, 40);
+        }
+
+        var response = await fixture.AdminClient.GetAsync($"/api/sources/{source.Id}");
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = System.Text.Json.JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("withheldDeletions").GetInt32().Should().Be(40);
+    }
+
+    [Fact]
+    public async Task GetSource_WithNothingWithheld_ReportsNull()
+    {
+        // Null rather than 0, because the page keys the approval button off "is there a
+        // pending decision" — a zero would leave it showing forever.
+        var source = await SeedSourceAsync();
+
+        var response = await fixture.AdminClient.GetAsync($"/api/sources/{source.Id}");
+        var body = await response.Content.ReadAsStringAsync();
+
+        using var doc = System.Text.Json.JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("withheldDeletions").ValueKind
+            .Should().Be(System.Text.Json.JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task Sync_WithOverrideButNothingWithheld_StillAppliesTheGuard()
+    {
+        // The flag must not lift a guard that never tripped. Otherwise a caller passing
+        // applyWithheldDeletions=true on a source's very first sync bypasses the guard
+        // entirely, and nobody ever sees a count to approve.
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        var result = await SyncWithConnectorAsync(
+            source, new EmptyListingConnector(), applyWithheldDeletions: true);
+
+        result.Deleted.Should().Be(0, "no approval exists, so the guard still applies");
+        result.WithheldDeletions.Should().Be(40);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().HaveCount(40);
+    }
+
+    [Fact]
+    public async Task Sync_WithOverride_AfterRemoteDegradedFurther_WithholdsAgain()
+    {
+        // The asymmetry in "recompute rather than replay": recomputing is safer when the
+        // remote recovered, and *more* dangerous when it degraded further. An administrator
+        // shown 20 must not have 40 applied because the listing worsened between reading the
+        // number and pressing the button. The approval is a ceiling, not a licence.
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        // First cycle: half the files are still visible, so 20 vanish and are withheld.
+        var stillPresent = Enumerable.Range(0, 20)
+            .Select(i => new ConnectorFile($"/doc-{i}.md", 1, DateTime.UtcNow, "text/markdown"))
+            .ToList();
+
+        var withheld = await SyncWithConnectorAsync(source, new FixedListingConnector(stillPresent));
+        withheld.WithheldDeletions.Should().Be(20, "20 of 40 vanished, which trips the guard");
+
+        // The administrator approves those 20 — but by the time the cycle runs, the remote has
+        // gone completely dark and all 40 now look deleted.
+        var reloaded = await ReloadAsync(source.Id);
+        var approval = await SyncWithConnectorAsync(
+            reloaded, new EmptyListingConnector(), applyWithheldDeletions: true);
+
+        approval.Deleted.Should().Be(0, "40 exceeds the 20 that were approved");
+        approval.WithheldDeletions.Should().Be(40, "the larger set is re-withheld for fresh approval");
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        (await documents.ListAsync(source.Id, take: int.MaxValue)).Should().HaveCount(40);
+    }
+
+    [Fact]
+    public async Task Sync_WithOverride_AfterRemotePartlyRecovered_AppliesTheSmallerSet()
+    {
+        // The other side of the ceiling: fewer deletions than approved is within what the
+        // administrator sanctioned, so it applies rather than needing a second approval.
+        var source = await SeedSourceAsync();
+        await SeedDocumentsAsync(source.Id, count: 40);
+
+        var withheld = await SyncWithConnectorAsync(source, new EmptyListingConnector());
+        withheld.WithheldDeletions.Should().Be(40);
+
+        var mostReturned = Enumerable.Range(0, 35)
+            .Select(i => new ConnectorFile($"/doc-{i}.md", 1, DateTime.UtcNow, "text/markdown"))
+            .ToList();
+
+        var reloaded = await ReloadAsync(source.Id);
+        var approval = await SyncWithConnectorAsync(
+            reloaded, new FixedListingConnector(mostReturned), applyWithheldDeletions: true);
+
+        approval.Deleted.Should().Be(5, "5 is within the 40 approved");
+        approval.WithheldDeletions.Should().Be(0);
+
+        using var scope = fixture.Factory.Services.CreateScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        (await sources.GetAsync(source.Id))!.WithheldDeletions.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Re-reads a source so its <c>WithheldDeletions</c> reflects the previous cycle. The
+    /// approval path reads that count off the passed-in source, and both real callers load it
+    /// fresh immediately before syncing.
+    /// </summary>
+    private async Task<Source> ReloadAsync(Guid sourceId)
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var sources = scope.ServiceProvider.GetRequiredService<ISourceStore>();
+        return (await sources.GetAsync(sourceId))!;
+    }
+}

--- a/tests/Connapse.Integration.Tests/RecordingIngestionQueue.cs
+++ b/tests/Connapse.Integration.Tests/RecordingIngestionQueue.cs
@@ -1,0 +1,53 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Records what a sync enqueued, and stops there.
+/// </summary>
+/// <remarks>
+/// The sync tests assert on what the service decided — upserted and deleted counts, the rows it
+/// claimed, the owner a job carries. None of them need the job to run. Handing them the real
+/// queue meant every sync left a Hangfire job behind that resolved a live S3 connector, and CI
+/// has no AWS credentials: each one spent roughly three quarters of a second exhausting the
+/// credential chain, failed, and was retried three more times.
+/// <para>
+/// That is background work, so it did not fail the test that created it. It failed the ones
+/// that came after: with a hundred-odd of them churning through the shared ingestion queue, an
+/// ordinary container upload waited nearly six minutes to be picked up and its test timed out
+/// at sixty seconds. Tests that never asked for ingestion should not be able to do that.
+/// </para>
+/// </remarks>
+internal class RecordingIngestionQueue : IIngestionQueue
+{
+    public List<IngestionJob> Jobs { get; } = [];
+
+    public virtual Task EnqueueAsync(IngestionJob job, CancellationToken ct = default)
+    {
+        Jobs.Add(job);
+        return Task.CompletedTask;
+    }
+
+    public Task<IngestionJob?> DequeueAsync(CancellationToken ct = default) =>
+        Task.FromResult<IngestionJob?>(null);
+
+    public Task<IngestionJobStatus?> GetStatusAsync(string jobId) =>
+        Task.FromResult<IngestionJobStatus?>(null);
+
+    public Task<bool> CancelJobForDocumentAsync(string documentId) => Task.FromResult(false);
+
+    public int QueueDepth => Jobs.Count;
+
+    public void UpdateJobStatus(
+        string jobId, IngestionJobState state, IngestionPhase? currentPhase = null,
+        double percentComplete = 0, string? errorMessage = null)
+    { }
+
+    public IReadOnlyDictionary<string, IngestionJobStatus> GetAllStatuses() =>
+        new Dictionary<string, IngestionJobStatus>();
+
+    public void RegisterJobCancellation(string jobId, CancellationTokenSource cts) { }
+
+    public void UnregisterJobCancellation(string jobId) { }
+}

--- a/tests/Connapse.Integration.Tests/SftpConnectorIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SftpConnectorIntegrationTests.cs
@@ -1,0 +1,575 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
+using System.Text;
+using Connapse.Storage.Connectors;
+using Renci.SshNet;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// The SFTP connector against a real OpenSSH server.
+/// <para>
+/// Every confinement test here is one a lexical prefix check would pass. That is deliberate:
+/// the connector's whole reason for having its own path handling, rather than reusing
+/// <c>PathConfinement</c>, is that the local helper degrades to exactly such a check when it
+/// is handed a remote path — and degrades silently.
+/// </para>
+/// </summary>
+[Trait("Category", "Integration")]
+public class SftpConnectorIntegrationTests : IAsyncLifetime
+{
+    private readonly SftpServerFixture _server = new();
+
+    /// <summary>The connection's boundary, as an SFTP client sees it.</summary>
+    private const string AllowedRoot = "/data";
+
+    public async Task InitializeAsync()
+    {
+        await _server.InitializeAsync();
+
+        await _server.CreateDirectoryAsync("/data/docs");
+        await _server.WriteFileAsync("/data/a.md", "alpha");
+        await _server.WriteFileAsync("/data/docs/b.md", "bravo");
+        await _server.WriteFileAsync("/data/docs/skip.tmp", "temporary");
+
+        // Outside the allowed root, inside the account's chroot — what an escape reaches.
+        await _server.CreateDirectoryAsync("/secret");
+        await _server.WriteFileAsync("/secret/keys.txt", "do not index me");
+    }
+
+    public async Task DisposeAsync() => await _server.DisposeAsync();
+
+    private SftpConnector Connect(
+        string? subPath = null,
+        string? pinned = null,
+        ISshHostKeyStore? hostKeyStore = null,
+        IReadOnlyList<string>? include = null,
+        IReadOnlyList<string>? exclude = null,
+        Guid connectionId = default) =>
+        new(new SftpConnectorConfig
+        {
+            Host = _server.Host,
+            Port = _server.Port,
+            Username = SftpServerFixture.Username,
+            AllowedRoot = AllowedRoot,
+            SubPath = subPath,
+            PinnedHostKeyFingerprint = pinned,
+            IncludePatterns = include ?? [],
+            ExcludePatterns = exclude ?? [],
+            Credential = new SftpCredential { PrivateKey = _server.PrivateKeyPem },
+            ConnectionId = connectionId,
+        }, hostKeyStore);
+
+    // ── Listing and reading ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListFiles_WalksTheTreeBeneathTheRoot()
+    {
+        using var connector = Connect();
+
+        var files = await connector.ListFilesAsync();
+
+        files.Select(f => f.Path).Should().BeEquivalentTo(
+            "/data/a.md", "/data/docs/b.md", "/data/docs/skip.tmp");
+    }
+
+    [Fact]
+    public async Task ListFiles_ReportsSizeAndModifiedTime()
+    {
+        using var connector = Connect();
+
+        var file = (await connector.ListFilesAsync()).Single(f => f.Path == "/data/a.md");
+
+        file.SizeBytes.Should().Be(5);
+        file.LastModified.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public async Task ListFiles_HonoursExcludePatterns()
+    {
+        using var connector = Connect(exclude: ["*.tmp"]);
+
+        (await connector.ListFilesAsync()).Select(f => f.Path)
+            .Should().BeEquivalentTo("/data/a.md", "/data/docs/b.md");
+    }
+
+    /// <summary>
+    /// Split out because the combined test only ever passed an exclude pattern, so include
+    /// filtering was named but never exercised — and an include list that matched nothing would
+    /// have emptied a source silently.
+    /// </summary>
+    [Fact]
+    public async Task ListFiles_HonoursIncludePatterns()
+    {
+        using var connector = Connect(include: ["*.md"]);
+
+        (await connector.ListFilesAsync()).Select(f => f.Path)
+            .Should().BeEquivalentTo("/data/a.md", "/data/docs/b.md");
+    }
+
+    [Fact]
+    public async Task ListFiles_IncludeAndExcludeTogether_ApplyBoth()
+    {
+        await _server.WriteFileAsync("/data/draft.md", "draft");
+
+        using var connector = Connect(include: ["*.md"], exclude: ["draft.*"]);
+
+        (await connector.ListFilesAsync()).Select(f => f.Path)
+            .Should().BeEquivalentTo("/data/a.md", "/data/docs/b.md");
+    }
+
+    /// <summary>
+    /// A pattern crafted to backtrack catastrophically. Compiled with a match timeout, so it
+    /// gives up instead of pinning the sync thread for this source on every cycle for ever.
+    /// Patterns come from a source's scope, so one bad entry is replayed indefinitely.
+    /// </summary>
+    [Fact]
+    public async Task ListFiles_PathologicalGlob_DoesNotHangTheSync()
+    {
+        await _server.WriteFileAsync("/data/" + new string('a', 90) + ".md", "x");
+
+        using var connector = Connect(exclude: ["*a*a*a*a*a*a*a*a*a*a*b"]);
+
+        var listing = connector.ListFilesAsync();
+
+        (await listing.WaitAsync(TimeSpan.FromSeconds(60))).Should().NotBeEmpty(
+            "the timeout must bound the match rather than the sync waiting on it");
+    }
+
+    [Fact]
+    public async Task ListFiles_WithASubPath_ScopesToIt()
+    {
+        using var connector = Connect(subPath: "docs");
+
+        (await connector.ListFilesAsync()).Select(f => f.Path)
+            .Should().BeEquivalentTo("/data/docs/b.md", "/data/docs/skip.tmp");
+    }
+
+    [Fact]
+    public async Task ReadFile_ReturnsTheContent()
+    {
+        using var connector = Connect();
+
+        await using var stream = await connector.ReadFileAsync("/data/docs/b.md");
+        using var reader = new StreamReader(stream);
+
+        (await reader.ReadToEndAsync()).Should().Be("bravo");
+    }
+
+    [Fact]
+    public async Task Exists_IsTrueForAFileInsideTheRootAndFalseOutside()
+    {
+        using var connector = Connect();
+
+        (await connector.ExistsAsync("/data/a.md")).Should().BeTrue();
+        (await connector.ExistsAsync("/secret/keys.txt")).Should().BeFalse();
+    }
+
+    // ── Confinement ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubPathContainingDotDot_IsRefused()
+    {
+        using var connector = Connect(subPath: "../secret");
+
+        Func<Task> act = () => connector.ListFilesAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// The case that justifies resolving on the server. The string
+    /// <c>/data/escape</c> never leaves the root, and only the server knows it is a link.
+    /// </summary>
+    [Fact]
+    public async Task SubPathThroughAServerSideSymlink_IsRefused()
+    {
+        await _server.CreateSymlinkAsync("/data/escape", "/secret");
+
+        using var connector = Connect(subPath: "escape");
+
+        Func<Task> act = () => connector.ListFilesAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// A link inside the tree is stepped over rather than followed, so its target never
+    /// reaches the index — even when the link itself is inside the root.
+    /// </summary>
+    [Fact]
+    public async Task ListFiles_DoesNotFollowSymlinksOutOfTheRoot()
+    {
+        await _server.CreateSymlinkAsync("/data/escape", "/secret");
+
+        using var connector = Connect();
+
+        var paths = (await connector.ListFilesAsync()).Select(f => f.Path).ToList();
+
+        paths.Should().NotContain(p => p.Contains("keys.txt"),
+            "following the link would index a file outside the connection's allowed root");
+        paths.Should().Contain("/data/a.md", "the ordinary tree must still be walked");
+    }
+
+    /// <summary>
+    /// The leaf itself being a link, rather than an ancestor. Confinement canonicalises the
+    /// parent and reattaches the name, so the parent check passes and the name is not a
+    /// traversal — nothing so far has looked at what the leaf actually is.
+    /// </summary>
+    /// <remarks>
+    /// The walk never lists a symlink, so this is only reachable when a file that was listed as
+    /// regular is swapped for a link before it is read. Narrow, but it is the same shape as the
+    /// escape the ancestor check exists to stop.
+    /// </remarks>
+    [Fact]
+    public async Task ReadFile_LeafIsASymlinkPointingOutsideTheRoot_IsRefused()
+    {
+        await _server.CreateSymlinkAsync("/data/looks-ordinary.md", "/secret/keys.txt");
+
+        using var connector = Connect();
+
+        Func<Task> act = () => connector.ReadFileAsync("/data/looks-ordinary.md");
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    /// <summary>
+    /// Refused even when the target is inside the root, and the consistency is the point: the
+    /// walk steps over links, so no path the ingestion queue holds is ever one. Resolving them
+    /// here would make the read path follow what the listing deliberately does not — two
+    /// answers to the same question, which is exactly how #365 happened locally.
+    /// </summary>
+    [Fact]
+    public async Task ReadFile_LeafIsASymlinkPointingInsideTheRoot_IsAlsoRefused()
+    {
+        await _server.CreateSymlinkAsync("/data/alias.md", "/data/a.md");
+
+        using var connector = Connect();
+
+        Func<Task> act = () => connector.ReadFileAsync("/data/alias.md");
+
+        (await act.Should().ThrowAsync<UnauthorizedAccessException>())
+            .WithMessage("*symbolic link*");
+    }
+
+    /// <summary>
+    /// And the ordinary case still works, so the check above cannot have made every read fail.
+    /// </summary>
+    [Fact]
+    public async Task ReadFile_OrdinaryFile_IsUnaffectedByTheLinkCheck()
+    {
+        using var connector = Connect();
+
+        await using var stream = await connector.ReadFileAsync("/data/a.md");
+        using var reader = new StreamReader(stream);
+
+        (await reader.ReadToEndAsync()).Should().Be("alpha");
+    }
+
+    [Fact]
+    public async Task ReadFile_OutsideTheRoot_IsRefused()
+    {
+        using var connector = Connect();
+
+        Func<Task> act = () => connector.ReadFileAsync("/secret/keys.txt");
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ReadFile_TraversingOutOfTheRoot_IsRefused()
+    {
+        using var connector = Connect();
+
+        Func<Task> act = () => connector.ReadFileAsync("/data/../secret/keys.txt");
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    // ── Listing completeness ───────────────────────────────────────────────
+
+    /// <summary>
+    /// The failure mode the delete guard exists to bound, prevented one level lower. A
+    /// listing that quietly omits an unreadable subtree is indistinguishable, to the
+    /// reconcile, from every file under it having been deleted.
+    /// </summary>
+    [Fact]
+    public async Task ListFiles_UnreadableDirectory_FailsRatherThanReturningFewerFiles()
+    {
+        await _server.MakeUnreadableAsync("/data/docs");
+
+        using var connector = Connect();
+
+        Func<Task> act = () => connector.ListFilesAsync();
+
+        (await act.Should().ThrowAsync<IOException>())
+            .WithMessage("*partial listing*");
+    }
+
+    // ── Generated key pairs ────────────────────────────────────────────────
+
+    /// <summary>
+    /// The test that makes <see cref="SshKeyPairGenerator"/> trustworthy.
+    /// </summary>
+    /// <remarks>
+    /// A wrong <c>authorized_keys</c> encoding produces a line that looks entirely correct
+    /// and simply fails to authenticate, with nothing anywhere pointing at the cause. Unit
+    /// tests can check the blob's structure but cannot tell you whether a real OpenSSH server
+    /// accepts it. This installs a generated public key the way the setup command will, and
+    /// connects with the matching private half.
+    /// </remarks>
+    [Fact]
+    public async Task GeneratedKeyPair_AuthenticatesAgainstARealServer()
+    {
+        var pair = SshKeyPairGenerator.Generate("connapse-generated");
+        await _server.AuthorizeKeyAsync(pair.PublicKeyLine);
+
+        using var connector = new SftpConnector(new SftpConnectorConfig
+        {
+            Host = _server.Host,
+            Port = _server.Port,
+            Username = SftpServerFixture.Username,
+            AllowedRoot = AllowedRoot,
+            Credential = new SftpCredential { PrivateKey = pair.PrivateKeyPem },
+        });
+
+        (await connector.ListFilesAsync()).Should().NotBeEmpty(
+            "a generated pair must authenticate, or the setup flow hands operators a key that "
+            + "silently does not work");
+    }
+
+    /// <summary>
+    /// The restrictions the setup command installs must not break the thing they protect.
+    /// </summary>
+    /// <remarks>
+    /// <c>restrict</c> plus a forced <c>internal-sftp</c> command is what stops the stored key
+    /// being usable for an interactive shell or port forwarding. It is also exactly the kind of
+    /// hardening that silently locks out the legitimate user — so this installs the key the way
+    /// the generated script does, prefix and all, and proves SFTP still works through it.
+    /// <para>
+    /// This covers the failure that would actually be ours: an option OpenSSH does not accept
+    /// makes the whole entry invalid and nothing authenticates. That it also <i>enforces</i> the
+    /// restriction is OpenSSH's contract, and is not asserted here — a test for it was written
+    /// and removed, because <c>atmoz/sftp</c> gives the account no shell to begin with, so it
+    /// passed identically with the restrictions stripped out and proved nothing.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task RestrictedKeyEntry_StillAuthenticatesAndLists()
+    {
+        var pair = SshKeyPairGenerator.Generate("connapse-restricted");
+        await _server.AuthorizeKeyAsync(SftpHostSetup.KeyRestrictions + pair.PublicKeyLine);
+
+        using var connector = new SftpConnector(new SftpConnectorConfig
+        {
+            Host = _server.Host,
+            Port = _server.Port,
+            Username = SftpServerFixture.Username,
+            AllowedRoot = AllowedRoot,
+            Credential = new SftpCredential { PrivateKey = pair.PrivateKeyPem },
+        });
+
+        (await connector.ListFilesAsync()).Should().NotBeEmpty(
+            "the hardening must not lock out the access it exists to bound");
+    }
+
+    /// <summary>
+    /// The negative half. Without it the test above could pass because the server accepts
+    /// anything — the fixture's own key is already authorized, so a generated key that was
+    /// never really used would look identical.
+    /// </summary>
+    [Fact]
+    public async Task GeneratedKeyPair_NotInstalledOnTheServer_IsRefused()
+    {
+        var pair = SshKeyPairGenerator.Generate("never-installed");
+
+        using var connector = new SftpConnector(new SftpConnectorConfig
+        {
+            Host = _server.Host,
+            Port = _server.Port,
+            Username = SftpServerFixture.Username,
+            AllowedRoot = AllowedRoot,
+            Credential = new SftpCredential { PrivateKey = pair.PrivateKeyPem },
+        });
+
+        Func<Task> act = () => connector.ListFilesAsync();
+
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    // ── Verified first use ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// The check that keeps the setup wizard honest, and the one most likely to break without
+    /// anyone noticing.
+    /// </summary>
+    /// <remarks>
+    /// The generated setup command reads the fingerprint with <c>ssh-keygen -l</c> on the host
+    /// and the operator pastes it into Connapse. If that format ever disagreed with what
+    /// <see cref="SshHostKeyPolicy"/> stores, every wizard-configured connection would refuse
+    /// to connect — or worse, silently fall back to trusting whatever answered. Nothing else
+    /// compares the two sides.
+    /// </remarks>
+    [Fact]
+    public async Task FingerprintReadOnTheHost_MatchesWhatTheConnectorWouldRecord()
+    {
+        string fromTheHost = await _server.ReadHostKeyFingerprintAsync();
+        string fromTheConnector = await ObserveFingerprintAsync();
+
+        fromTheHost.Should().Be(fromTheConnector,
+            "the setup command and the connector must agree on the fingerprint format");
+    }
+
+    /// <summary>
+    /// The point of the round trip: with the fingerprint supplied out of band, the very first
+    /// connection is authenticated rather than trusted.
+    /// </summary>
+    [Fact]
+    public async Task PinSuppliedBeforeTheFirstConnect_IsHonouredOnThatConnect()
+    {
+        string fingerprint = await _server.ReadHostKeyFingerprintAsync();
+        var store = new RecordingHostKeyStore();
+
+        using var connector = Connect(
+            pinned: fingerprint, hostKeyStore: store, connectionId: Guid.NewGuid());
+
+        (await connector.ListFilesAsync()).Should().NotBeEmpty();
+
+        store.Recorded.Should().BeEmpty(
+            "nothing is trusted on first use when the pin was already known");
+    }
+
+    /// <summary>
+    /// The half that makes the above worth anything. A wrong fingerprint must stop the
+    /// <em>first</em> connection — if it only took effect from the second, the wizard would be
+    /// decoration.
+    /// </summary>
+    [Fact]
+    public async Task WrongPinSuppliedBeforeTheFirstConnect_RefusesThatConnect()
+    {
+        var store = new RecordingHostKeyStore();
+
+        using var connector = Connect(
+            pinned: "SHA256:aFingerprintFromSomewhereElse",
+            hostKeyStore: store,
+            connectionId: Guid.NewGuid());
+
+        Func<Task> act = () => connector.ListFilesAsync();
+
+        await act.Should().ThrowAsync<SftpHostKeyMismatchException>();
+        store.Recorded.Should().BeEmpty("a refused server must not have its key recorded");
+    }
+
+    // ── Host key pinning ───────────────────────────────────────────────────
+
+    /// <summary>Records what was pinned, so a test can assert on it.</summary>
+    private sealed class RecordingHostKeyStore : ISshHostKeyStore
+    {
+        public List<(Guid ConnectionId, string Fingerprint)> Recorded { get; } = [];
+
+        public Task RecordFingerprintAsync(Guid connectionId, string fingerprint, CancellationToken ct = default)
+        {
+            Recorded.Add((connectionId, fingerprint));
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task FirstConnect_RecordsTheHostKeyFingerprint()
+    {
+        var store = new RecordingHostKeyStore();
+        var connectionId = Guid.NewGuid();
+
+        using var connector = Connect(hostKeyStore: store, connectionId: connectionId);
+        await connector.ListFilesAsync();
+
+        store.Recorded.Should().ContainSingle()
+            .Which.Should().Match<(Guid Id, string Fingerprint)>(
+                r => r.Id == connectionId && r.Fingerprint.StartsWith("SHA256:"));
+    }
+
+    /// <summary>
+    /// Pinning is first-use only. Re-recording on every cycle would make the stored value
+    /// track whatever answered most recently, which is the opposite of pinning.
+    /// </summary>
+    [Fact]
+    public async Task ConnectWithAMatchingPin_RecordsNothingFurther()
+    {
+        string fingerprint = await ObserveFingerprintAsync();
+        var store = new RecordingHostKeyStore();
+
+        using var connector = Connect(pinned: fingerprint, hostKeyStore: store, connectionId: Guid.NewGuid());
+        await connector.ListFilesAsync();
+
+        store.Recorded.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Asserted on the specific exception and its message, not just "something threw". An
+    /// unreachable server also throws, so a loose assertion here would pass whether or not
+    /// the host key was ever checked.
+    /// </summary>
+    [Fact]
+    public async Task ConnectWithAMismatchedPin_IsRefused()
+    {
+        using var connector = Connect(pinned: "SHA256:definitelyNotTheServersKey");
+
+        Func<Task> act = () => connector.ListFilesAsync();
+
+        (await act.Should().ThrowAsync<SftpHostKeyMismatchException>())
+            .WithMessage("*SHA256:definitelyNotTheServersKey*",
+                "the operator has to see which key was expected")
+            .And.Message.Should().Contain("clear the recorded fingerprint",
+                "and what to do if the rekey was theirs");
+    }
+
+    /// <summary>
+    /// The realistic attack, and the one trust-on-first-use is chosen to catch: the address
+    /// worked yesterday and something else answers today.
+    /// </summary>
+    [Fact]
+    public async Task AfterTheServerRekeys_APinnedConnectionIsRefused()
+    {
+        string original = await ObserveFingerprintAsync();
+
+        await _server.RegenerateHostKeysAsync();
+
+        using var connector = Connect(pinned: original);
+
+        Func<Task> act = () => connector.ListFilesAsync();
+
+        (await act.Should().ThrowAsync<SftpHostKeyMismatchException>())
+            .WithMessage($"*{original}*", "the fingerprint that was trusted must be named");
+    }
+
+    /// <summary>
+    /// Clearing the recorded fingerprint is the documented way to accept a rekey, so the same
+    /// server must connect again once nothing is pinned.
+    /// </summary>
+    [Fact]
+    public async Task AfterTheServerRekeys_ClearingThePinLetsItConnectAgain()
+    {
+        await _server.RegenerateHostKeysAsync();
+
+        using var connector = Connect(pinned: null);
+
+        (await connector.ListFilesAsync()).Should().NotBeEmpty();
+    }
+
+    private async Task<string> ObserveFingerprintAsync()
+    {
+        var store = new RecordingHostKeyStore();
+
+        using var connector = Connect(hostKeyStore: store, connectionId: Guid.NewGuid());
+        await connector.ListFilesAsync();
+
+        return store.Recorded.Single().Fingerprint;
+    }
+}
+
+
+
+

--- a/tests/Connapse.Integration.Tests/SftpServerFixture.cs
+++ b/tests/Connapse.Integration.Tests/SftpServerFixture.cs
@@ -1,0 +1,186 @@
+using System.Security.Cryptography;
+using System.Text;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// A real OpenSSH server in a container, so the SFTP connector is exercised against the
+/// protocol rather than a mock.
+/// <para>
+/// This is what makes the confinement tests worth anything. The escape that matters is a
+/// symlink resolved <b>server-side</b>, and no fake can tell you whether the code asked the
+/// server to resolve it or resolved it locally against the machine running the tests — which
+/// is the bug the whole design is arranged to avoid.
+/// </para>
+/// <para>
+/// The key pair is generated per run rather than committed. A private key in the repository
+/// is a private key in the repository, however loudly the file name says "test".
+/// </para>
+/// </summary>
+public sealed class SftpServerFixture : IAsyncLifetime
+{
+    /// <summary>
+    /// The account inside the container. Its home is the chroot, so everything below appears
+    /// to an SFTP client as if it were at the filesystem root.
+    /// </summary>
+    public const string Username = "tester";
+
+    private const string Home = $"/home/{Username}";
+
+    private IContainer _container = null!;
+
+    /// <summary>PKCS#1 PEM, the form the connection form will accept from an operator.</summary>
+    public string PrivateKeyPem { get; private set; } = null!;
+
+    public string Host => _container.Hostname;
+
+    public int Port => _container.GetMappedPublicPort(22);
+
+    public async Task InitializeAsync()
+    {
+        using var rsa = RSA.Create(3072);
+        PrivateKeyPem = rsa.ExportRSAPrivateKeyPem();
+
+        _container = new ContainerBuilder()
+            .WithImage("atmoz/sftp:alpine")
+            .WithPortBinding(22, assignRandomHostPort: true)
+
+            // No password field at all: the account exists for key authentication only, which
+            // is what the connector does.
+            .WithCommand($"{Username}::1001")
+
+            // atmoz/sftp folds every *.pub under .ssh/keys into authorized_keys on start.
+            .WithResourceMapping(
+                Encoding.ASCII.GetBytes(ToOpenSshPublicKey(rsa)),
+                $"{Home}/.ssh/keys/generated.pub")
+
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(22))
+            .Build();
+
+        await _container.StartAsync();
+    }
+
+    public async Task DisposeAsync() => await _container.DisposeAsync();
+
+    // ── Seeding ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Runs a shell command as root inside the container. Paths here are real container
+    /// paths; an SFTP client sees them with <see cref="Home"/> stripped off the front.
+    /// </summary>
+    public async Task<string> ExecAsync(string command)
+    {
+        var result = await _container.ExecAsync(["sh", "-c", command]);
+
+        if (result.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"Setup command failed ({result.ExitCode}): {command}\n{result.Stderr}");
+
+        return result.Stdout;
+    }
+
+    /// <summary>Creates a directory the SFTP account can read, named as the client sees it.</summary>
+    public Task CreateDirectoryAsync(string sftpPath) =>
+        ExecAsync($"mkdir -p '{Home}{sftpPath}' && chown -R {Username} '{Home}{sftpPath}'");
+
+    /// <summary>Writes a file, named as the client sees it.</summary>
+    public Task WriteFileAsync(string sftpPath, string content) =>
+        ExecAsync(
+            $"mkdir -p \"$(dirname '{Home}{sftpPath}')\" && "
+            + $"printf '%s' '{content}' > '{Home}{sftpPath}' && "
+            + $"chown {Username} '{Home}{sftpPath}'");
+
+    /// <summary>
+    /// Creates a symlink. <paramref name="target"/> is interpreted inside the chroot, so an
+    /// absolute target like <c>/secret</c> resolves to the account's own tree — which is the
+    /// escape being tested: outside the connection's allowed root, still inside the chroot.
+    /// </summary>
+    public Task CreateSymlinkAsync(string sftpPath, string target) =>
+        ExecAsync($"ln -s '{target}' '{Home}{sftpPath}' && chown -h {Username} '{Home}{sftpPath}'");
+
+    /// <summary>Makes a directory unreadable by the SFTP account.</summary>
+    public Task MakeUnreadableAsync(string sftpPath) =>
+        ExecAsync($"chown root '{Home}{sftpPath}' && chmod 700 '{Home}{sftpPath}'");
+
+    /// <summary>
+    /// Appends a public key to the account's <c>authorized_keys</c>, the way the generated
+    /// setup command does on a real host. Lets a test prove a Connapse-generated key pair
+    /// actually authenticates.
+    /// </summary>
+    public Task AuthorizeKeyAsync(string publicKeyLine) =>
+        ExecAsync(
+            $"mkdir -p '{Home}/.ssh' && "
+            + $"printf '%s\\n' '{publicKeyLine}' >> '{Home}/.ssh/authorized_keys' && "
+            + $"chown -R {Username} '{Home}/.ssh' && "
+            + $"chmod 700 '{Home}/.ssh' && chmod 600 '{Home}/.ssh/authorized_keys'");
+
+    /// <summary>
+    /// Reads the server's host key fingerprint the way the generated setup command does —
+    /// with <c>ssh-keygen -l</c>, on the machine itself, never over the network.
+    /// </summary>
+    /// <remarks>
+    /// This is the out-of-band channel that makes verified-first-use possible, so a test using
+    /// it is testing the real mechanism rather than a stand-in.
+    /// </remarks>
+    public async Task<string> ReadHostKeyFingerprintAsync()
+    {
+        string output = await ExecAsync(
+            "ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null "
+            + "|| ssh-keygen -lf /etc/ssh/ssh_host_rsa_key.pub");
+
+        return output.Split(' ', StringSplitOptions.RemoveEmptyEntries)[1].Trim();
+    }
+
+    /// <summary>
+    /// Replaces the server's host keys and restarts sshd, so the next connection presents a
+    /// different key. This is what a rekey looks like to a client, and what an interposition
+    /// looks like too — the connector cannot tell them apart, which is the point of pinning.
+    /// </summary>
+    public async Task RegenerateHostKeysAsync()
+    {
+        await ExecAsync(
+            "rm -f /etc/ssh/ssh_host_*_key* && "
+            + "ssh-keygen -A && "
+            + "kill -HUP 1 2>/dev/null; pkill -HUP sshd 2>/dev/null; true");
+
+        // sshd re-reads its keys on the next accept, but the restart is not instantaneous and
+        // there is no readiness signal for "now serving the new key".
+        await Task.Delay(TimeSpan.FromSeconds(2));
+    }
+
+    // ── Key encoding ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Encodes an RSA public key in the format <c>authorized_keys</c> expects: the algorithm
+    /// name, exponent and modulus, each length-prefixed, then base64.
+    /// </summary>
+    private static string ToOpenSshPublicKey(RSA rsa)
+    {
+        RSAParameters p = rsa.ExportParameters(includePrivateParameters: false);
+
+        using var buffer = new MemoryStream();
+        WriteLengthPrefixed(buffer, "ssh-rsa"u8.ToArray());
+        WriteLengthPrefixed(buffer, ToMpint(p.Exponent!));
+        WriteLengthPrefixed(buffer, ToMpint(p.Modulus!));
+
+        return $"ssh-rsa {Convert.ToBase64String(buffer.ToArray())} connapse-integration-test\n";
+    }
+
+    private static void WriteLengthPrefixed(Stream stream, byte[] data)
+    {
+        Span<byte> length = stackalloc byte[4];
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32BigEndian(length, data.Length);
+        stream.Write(length);
+        stream.Write(data);
+    }
+
+    /// <summary>
+    /// SSH multiple-precision integers are signed, so a value whose top bit is set needs a
+    /// leading zero byte or it reads as negative.
+    /// </summary>
+    private static byte[] ToMpint(byte[] value) =>
+        value.Length > 0 && value[0] >= 0x80 ? [0, .. value] : value;
+}

--- a/tests/Connapse.Integration.Tests/SourceIngestionOwnershipTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceIngestionOwnershipTests.cs
@@ -224,7 +224,7 @@ public class SourceIngestionOwnershipTests(SharedWebAppFixture fixture)
             Owner = OwnerRef.ForSource(sourceId)
         }, CancellationToken.None);
 
-        var queue = new CapturingIngestionQueue();
+        var queue = new RecordingIngestionQueue();
         await using var ctx = await factory.CreateDbContextAsync();
         var reindex = new ReindexService(
             ctx,
@@ -337,42 +337,10 @@ public class SourceIngestionOwnershipTests(SharedWebAppFixture fixture)
     }
 
     /// <summary>A queue that is down, which is the failure the test above is about.</summary>
-    private sealed class ThrowingIngestionQueue : CapturingIngestionQueue
+    private sealed class ThrowingIngestionQueue : RecordingIngestionQueue
     {
         public override Task EnqueueAsync(IngestionJob job, CancellationToken ct = default) =>
             throw new InvalidOperationException("the queue is unavailable");
     }
 
-    private class CapturingIngestionQueue : IIngestionQueue
-    {
-        public List<IngestionJob> Jobs { get; } = [];
-
-        public virtual Task EnqueueAsync(IngestionJob job, CancellationToken ct = default)
-        {
-            Jobs.Add(job);
-            return Task.CompletedTask;
-        }
-
-        public Task<IngestionJob?> DequeueAsync(CancellationToken ct = default) =>
-            Task.FromResult<IngestionJob?>(null);
-
-        public Task<IngestionJobStatus?> GetStatusAsync(string jobId) =>
-            Task.FromResult<IngestionJobStatus?>(null);
-
-        public Task<bool> CancelJobForDocumentAsync(string documentId) => Task.FromResult(false);
-
-        public int QueueDepth => Jobs.Count;
-
-        public void UpdateJobStatus(
-            string jobId, IngestionJobState state, IngestionPhase? currentPhase = null,
-            double percentComplete = 0, string? errorMessage = null)
-        { }
-
-        public IReadOnlyDictionary<string, IngestionJobStatus> GetAllStatuses() =>
-            new Dictionary<string, IngestionJobStatus>();
-
-        public void RegisterJobCancellation(string jobId, CancellationTokenSource cts) { }
-
-        public void UnregisterJobCancellation(string jobId) { }
-    }
 }

--- a/tests/Connapse.Integration.Tests/SourceIngestionOwnershipTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceIngestionOwnershipTests.cs
@@ -1,9 +1,12 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Ingestion.Reindex;
 using Connapse.Storage.Data;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Connapse.Integration.Tests;
@@ -200,5 +203,176 @@ public class SourceIngestionOwnershipTests(SharedWebAppFixture fixture)
 
         doc.Metadata!["RemoteLastModified"].Should().Be("2026-08-16T00:00:00.0000000Z");
         doc.Metadata["RemoteSize"].Should().Be("1234");
+    }
+
+    [Fact]
+    public async Task ForcedReindex_OfSourceOwnedDocument_EnqueuesItAsSourceOwned()
+    {
+        // The reindex deletes a document's chunks before enqueueing it. If the job it then
+        // enqueues cannot be routed, the chunks are gone for good: the pipeline throws, and
+        // the next sync sees an unchanged remote signature and does not re-ingest the file.
+        // So what the job carries is the whole safety property here.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        Guid sourceId = await SeedSourceAsync(scope.ServiceProvider);
+
+        var pipeline = scope.ServiceProvider.GetRequiredService<IKnowledgeIngester>();
+        using var content = new MemoryStream("content to be force-reindexed"u8.ToArray());
+        var created = await pipeline.IngestAsync(content, new IngestionOptions(
+            FileName: "reindexed.md", ContentType: "text/markdown", Path: "/reindexed.md")
+        {
+            Owner = OwnerRef.ForSource(sourceId)
+        }, CancellationToken.None);
+
+        var queue = new CapturingIngestionQueue();
+        await using var ctx = await factory.CreateDbContextAsync();
+        var reindex = new ReindexService(
+            ctx,
+            scope.ServiceProvider.GetRequiredService<IKnowledgeFileSystem>(),
+            scope.ServiceProvider.GetRequiredService<IManagedStorageProvider>(),
+            scope.ServiceProvider.GetRequiredService<IContainerStore>(),
+            queue,
+            scope.ServiceProvider.GetRequiredService<IOptionsMonitor<ChunkingSettings>>(),
+            scope.ServiceProvider.GetRequiredService<IOptionsMonitor<EmbeddingSettings>>(),
+            NullLogger<ReindexService>.Instance);
+
+        await reindex.ReindexAsync(
+            new ReindexOptions { Force = true, DocumentIds = [created.DocumentId] },
+            CancellationToken.None);
+
+        IngestionJob job = queue.Jobs.Should().ContainSingle().Subject;
+        job.Options.Owner.Should().Be(OwnerRef.ForSource(sourceId),
+            "the pipeline routes source documents by Owner, and nothing else on the job says so");
+        job.Options.ContainerId.Should().BeNull(
+            "Nullable<Guid>.ToString() yields \"\", which reads as a container id that is merely blank");
+    }
+
+    [Fact]
+    public async Task ForcedReindex_WhenTheEnqueueFails_LeavesTheDocumentSearchable()
+    {
+        // The reindex used to delete a document's chunks up front. Everything that could go
+        // wrong afterwards — Hangfire down, the SFTP server refusing the connection — then left
+        // a document that looked indexed and matched nothing, with no job coming to rebuild it.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        Guid sourceId = await SeedSourceAsync(scope.ServiceProvider);
+
+        var pipeline = scope.ServiceProvider.GetRequiredService<IKnowledgeIngester>();
+        using var content = new MemoryStream("content that must survive a failed reindex"u8.ToArray());
+        var created = await pipeline.IngestAsync(content, new IngestionOptions(
+            FileName: "survives.md", ContentType: "text/markdown", Path: "/survives.md")
+        {
+            Owner = OwnerRef.ForSource(sourceId)
+        }, CancellationToken.None);
+
+        var documentId = Guid.Parse(created.DocumentId);
+        await using var ctx = await factory.CreateDbContextAsync();
+        int chunksBefore = await ctx.Chunks.CountAsync(c => c.DocumentId == documentId);
+        chunksBefore.Should().BeGreaterThan(0, "the test is meaningless without an index to lose");
+
+        var reindex = new ReindexService(
+            ctx,
+            scope.ServiceProvider.GetRequiredService<IKnowledgeFileSystem>(),
+            scope.ServiceProvider.GetRequiredService<IManagedStorageProvider>(),
+            scope.ServiceProvider.GetRequiredService<IContainerStore>(),
+            new ThrowingIngestionQueue(),
+            scope.ServiceProvider.GetRequiredService<IOptionsMonitor<ChunkingSettings>>(),
+            scope.ServiceProvider.GetRequiredService<IOptionsMonitor<EmbeddingSettings>>(),
+            NullLogger<ReindexService>.Instance);
+
+        var result = await reindex.ReindexAsync(
+            new ReindexOptions { Force = true, DocumentIds = [created.DocumentId] },
+            CancellationToken.None);
+
+        result.FailedCount.Should().Be(1, "the enqueue threw and that is not a success");
+
+        await using var after = await factory.CreateDbContextAsync();
+        (await after.Chunks.CountAsync(c => c.DocumentId == documentId))
+            .Should().Be(chunksBefore, "a reindex that never started must not cost the old index");
+
+        var doc = await after.Documents.AsNoTracking().SingleAsync(d => d.Id == documentId);
+        doc.Status.Should().NotBe("Pending",
+            "Pending means a job is coming; the sync engine skips those, so it would strand the document");
+    }
+
+    [Fact]
+    public async Task IngestionFailure_LeavesAStatusTheSyncEngineWillLookAtAgain()
+    {
+        // A reindex sets Status to "Pending" and a source job then fails before the pipeline
+        // loads the row — the SFTP server refused the connection, say. Only ingestion_state was
+        // written, so Status stayed "Pending", and HasRemoteChanged skips Pending documents on
+        // the assumption a job is still coming. Nothing was, and the document stopped updating
+        // even when its remote did.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        Guid sourceId = await SeedSourceAsync(scope.ServiceProvider);
+
+        var pipeline = scope.ServiceProvider.GetRequiredService<IKnowledgeIngester>();
+        using var content = new MemoryStream("a document whose next sync fails"u8.ToArray());
+        var created = await pipeline.IngestAsync(content, new IngestionOptions(
+            FileName: "stranded.md", ContentType: "text/markdown", Path: "/stranded.md")
+        {
+            Owner = OwnerRef.ForSource(sourceId)
+        }, CancellationToken.None);
+
+        var documentId = Guid.Parse(created.DocumentId);
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+
+        await using (var pending = await factory.CreateDbContextAsync())
+        {
+            var row = await pending.Documents.SingleAsync(d => d.Id == documentId);
+            row.Status = "Pending";
+            await pending.SaveChangesAsync();
+        }
+
+        await store.MarkIngestionFailedAsync(created.DocumentId, "the server refused the connection");
+
+        await using var after = await factory.CreateDbContextAsync();
+        var doc = await after.Documents.AsNoTracking().SingleAsync(d => d.Id == documentId);
+
+        doc.Status.Should().Be("Failed",
+            "the sync engine reads Status, and skips anything still marked Pending");
+        doc.IngestionState.Should().Be(IngestionState.Failed);
+        doc.ErrorMessage.Should().Contain("refused");
+    }
+
+    /// <summary>A queue that is down, which is the failure the test above is about.</summary>
+    private sealed class ThrowingIngestionQueue : CapturingIngestionQueue
+    {
+        public override Task EnqueueAsync(IngestionJob job, CancellationToken ct = default) =>
+            throw new InvalidOperationException("the queue is unavailable");
+    }
+
+    private class CapturingIngestionQueue : IIngestionQueue
+    {
+        public List<IngestionJob> Jobs { get; } = [];
+
+        public virtual Task EnqueueAsync(IngestionJob job, CancellationToken ct = default)
+        {
+            Jobs.Add(job);
+            return Task.CompletedTask;
+        }
+
+        public Task<IngestionJob?> DequeueAsync(CancellationToken ct = default) =>
+            Task.FromResult<IngestionJob?>(null);
+
+        public Task<IngestionJobStatus?> GetStatusAsync(string jobId) =>
+            Task.FromResult<IngestionJobStatus?>(null);
+
+        public Task<bool> CancelJobForDocumentAsync(string documentId) => Task.FromResult(false);
+
+        public int QueueDepth => Jobs.Count;
+
+        public void UpdateJobStatus(
+            string jobId, IngestionJobState state, IngestionPhase? currentPhase = null,
+            double percentComplete = 0, string? errorMessage = null)
+        { }
+
+        public IReadOnlyDictionary<string, IngestionJobStatus> GetAllStatuses() =>
+            new Dictionary<string, IngestionJobStatus>();
+
+        public void RegisterJobCancellation(string jobId, CancellationTokenSource cts) { }
+
+        public void UnregisterJobCancellation(string jobId) { }
     }
 }

--- a/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
@@ -188,7 +188,7 @@ public class SourceSyncIntegrationTests(SharedWebAppFixture fixture)
         return new SourceSyncService(
             sp.GetRequiredService<IServiceScopeFactory>(),
             factory,
-            sp.GetRequiredService<IIngestionQueue>(),
+            new RecordingIngestionQueue(),
             sp.GetRequiredService<ILoggerFactory>().CreateLogger<SourceSyncService>());
     }
 

--- a/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
@@ -177,7 +177,7 @@ public class SourceSyncIntegrationTests(SharedWebAppFixture fixture)
     /// </summary>
     private sealed class FixedConnectorFactory(IConnector connector) : IConnectorFactory
     {
-        public IConnector Create(Source source, Connection connection) => connector;
+        public IConnector Create(Source source, Connection connection, string? secret = null) => connector;
     }
 
     private static SourceSyncService BuildService(IServiceProvider sp, IConnector connector)
@@ -205,6 +205,59 @@ public class SourceSyncIntegrationTests(SharedWebAppFixture fixture)
         result.UsedDeltaPath.Should().BeFalse("this connector has no delta API");
         result.Upserted.Should().Be(2);
         connector.ListCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SyncSourceAsync_SecondPollBeforeIngestionDrains_DoesNotEnqueueTheSameFilesAgain()
+    {
+        // "Is this file already being worked on?" used to be answerable only from persisted
+        // documents, and the pipeline does not write one until the job actually runs. On a
+        // source whose ingestion takes longer than the poll interval — a large SFTP tree is
+        // exactly that — every cycle rediscovered the entire backlog as new, minted fresh
+        // document ids, and enqueued it all over again. The same files downloaded and embedded
+        // repeatedly, and a queue growing faster than it could drain.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+
+        var connector = new FakeListConnector(File("/a.md"), File("/b.md"));
+        var service = BuildService(scope.ServiceProvider, connector);
+
+        var first = await service.SyncSourceAsync(source, connection, CancellationToken.None);
+        first.Upserted.Should().Be(2);
+
+        // Nothing has drained the queue in between — the second poll sees exactly what the
+        // first one did.
+        var second = await service.SyncSourceAsync(source, connection, CancellationToken.None);
+
+        second.Upserted.Should().Be(0,
+            "the files are already claimed and queued; enqueueing them again duplicates the work");
+
+        await using var after = await factory.CreateDbContextAsync();
+        (await after.Documents.CountAsync(d => d.SourceId == source.Id))
+            .Should().Be(2, "two remote files must not become four document rows");
+    }
+
+    [Fact]
+    public async Task SyncSourceAsync_ClaimedButNotYetIngested_CarriesNoRemoteSignature()
+    {
+        // The signature means "indexed at this version of the remote". Writing it on the claim
+        // would assert an ingestion that has not happened, so a job that then failed would
+        // leave a document the next cycle reads as up to date and never retries.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+
+        var service = BuildService(scope.ServiceProvider, new FakeListConnector(File("/claim.md")));
+        await service.SyncSourceAsync(source, connection, CancellationToken.None);
+
+        await using var after = await factory.CreateDbContextAsync();
+        var claim = await after.Documents.AsNoTracking()
+            .SingleAsync(d => d.SourceId == source.Id && d.Path == "/claim.md");
+
+        claim.Status.Should().Be("Pending");
+        claim.Metadata.Should().NotContainKey("RemoteLastModified");
+        claim.Metadata.Should().NotContainKey("RemoteSize");
     }
 
     [Fact]

--- a/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
@@ -1,7 +1,8 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text.Json;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Ingestion.Pipeline;
 using Connapse.Storage.Data;
 using Connapse.Web.Services;
 using FluentAssertions;
@@ -258,6 +259,88 @@ public class SourceSyncIntegrationTests(SharedWebAppFixture fixture)
         claim.Status.Should().Be("Pending");
         claim.Metadata.Should().NotContainKey("RemoteLastModified");
         claim.Metadata.Should().NotContainKey("RemoteSize");
+    }
+
+    [Fact]
+    public async Task SyncSourceAsync_DocumentThatKeepsFailing_StopsBeingRetried()
+    {
+        // #400 made a Failed document retry regardless of its signature, so a transient fault
+        // could not poison it permanently. That assumed the failure was transient. One that is
+        // not — wrong credentials, a server that is gone — then re-enqueued every file in the
+        // source on every cycle, each carrying Hangfire's own three retries, until the ingestion
+        // queue was full of work that could not succeed and ordinary uploads sat behind it.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+
+        var file = File("/keeps-failing.md");
+        var service = BuildService(scope.ServiceProvider, new FakeListConnector(file));
+
+        // The claim from the first cycle, left as a job that failed and never wrote chunks.
+        (await service.SyncSourceAsync(source, connection, CancellationToken.None)).Upserted.Should().Be(1);
+        await MarkFailedAsync(dbFactory, source.Id, file);
+
+        var upserts = new List<int>();
+        for (int cycle = 0; cycle < 5; cycle++)
+        {
+            upserts.Add((await service.SyncSourceAsync(source, connection, CancellationToken.None)).Upserted);
+            await MarkFailedAsync(dbFactory, source.Id, file, keepAttempts: true);
+        }
+
+        upserts.Should().BeEquivalentTo(new[] { 1, 1, 1, 0, 0 }, o => o.WithStrictOrdering(),
+            "three fresh starts, then the sync engine leaves it alone");
+    }
+
+    [Fact]
+    public async Task SyncSourceAsync_FailedDocumentWhoseRemoteChanged_IsRetriedAgain()
+    {
+        // The bound is per version of the file. Someone who fixes the file upstream should not
+        // have to wait, or clear anything by hand.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+
+        var file = File("/fixed-upstream.md");
+        var service = BuildService(scope.ServiceProvider, new FakeListConnector(file));
+        await service.SyncSourceAsync(source, connection, CancellationToken.None);
+
+        // Exhausted: Failed, with the attempts already spent.
+        await MarkFailedAsync(dbFactory, source.Id, file, attempts: 3);
+        (await service.SyncSourceAsync(source, connection, CancellationToken.None)).Upserted
+            .Should().Be(0, "the bound must actually bind before the reset means anything");
+
+        // Same path, edited upstream.
+        var edited = new ConnectorFile(file.Path, file.SizeBytes + 500, DateTime.UtcNow, file.ContentType);
+        var afterEdit = BuildService(scope.ServiceProvider, new FakeListConnector(edited));
+
+        (await afterEdit.SyncSourceAsync(source, connection, CancellationToken.None)).Upserted
+            .Should().Be(1, "a changed file is a new attempt, not a continuation of the old one");
+    }
+
+    /// <summary>
+    /// Leaves the document the way a failed ingestion does: Failed, with the remote signature
+    /// already written — which is what made the signature comparison skip it before #400.
+    /// </summary>
+    private static async Task MarkFailedAsync(
+        IDbContextFactory<KnowledgeDbContext> dbFactory, Guid sourceId, ConnectorFile file,
+        int? attempts = null, bool keepAttempts = false)
+    {
+        await using var ctx = await dbFactory.CreateDbContextAsync();
+        var doc = await ctx.Documents.SingleAsync(d => d.SourceId == sourceId && d.Path == file.Path);
+
+        var metadata = new Dictionary<string, string>(
+            keepAttempts ? doc.Metadata ?? new Dictionary<string, string>() : new Dictionary<string, string>())
+        {
+            [SourceSyncService.RemoteLastModifiedKey] = file.LastModified.ToString("O"),
+            [SourceSyncService.RemoteSizeKey] = file.SizeBytes.ToString(CultureInfo.InvariantCulture),
+        };
+
+        if (attempts is int fixedAttempts)
+            metadata[IngestionPipeline.SyncFailedAttemptsKey] = fixedAttempts.ToString(CultureInfo.InvariantCulture);
+
+        doc.Status = "Failed";
+        doc.Metadata = metadata;
+        await ctx.SaveChangesAsync();
     }
 
     [Fact]

--- a/tests/Connapse.Integration.Tests/SourceSyncS3IntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceSyncS3IntegrationTests.cs
@@ -149,15 +149,20 @@ public class SourceSyncS3IntegrationTests(SharedWebAppFixture fixture) : IAsyncL
             .Create(source, connection).ListFilesAsync(null, CancellationToken.None);
         var file = listed.Single();
 
+        // An UPDATE, because the sync claimed this path before enqueueing it and the row is
+        // already there — which is what the pipeline finds too, and why it takes its existing-
+        // document branch rather than inserting a second row for the same path.
         await using (var seed = await dbFactory.CreateDbContextAsync())
         {
-            await seed.Database.ExecuteSqlRawAsync(
+            int updated = await seed.Database.ExecuteSqlRawAsync(
                 """
-                INSERT INTO documents (id, container_id, source_id, file_name, path, content_hash, size_bytes, status, created_at, metadata)
-                VALUES ({0}, NULL, {1}, 'stable.md', {2}, '', {3}, 'Ready', now(), {4}::jsonb)
+                UPDATE documents SET status = 'Ready', metadata = {2}::jsonb
+                WHERE source_id = {0} AND path = {1}
                 """,
-                Guid.NewGuid(), source.Id, file.Path, file.SizeBytes,
+                source.Id, file.Path,
                 $$"""{"{{SourceSyncService.RemoteLastModifiedKey}}":"{{file.LastModified:O}}","{{SourceSyncService.RemoteSizeKey}}":"{{file.SizeBytes}}"}""");
+
+            updated.Should().Be(1, "the first cycle must have claimed the path");
         }
 
         var second = await service.SyncSourceAsync(source, connection, CancellationToken.None);

--- a/tests/Connapse.Integration.Tests/SourceSyncS3IntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceSyncS3IntegrationTests.cs
@@ -1,4 +1,4 @@
-using Amazon.S3.Model;
+﻿using Amazon.S3.Model;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.Data;
@@ -78,7 +78,7 @@ public class SourceSyncS3IntegrationTests(SharedWebAppFixture fixture) : IAsyncL
         sp.GetRequiredService<IServiceScopeFactory>(),
         // The real factory, not a fake — this is what the test exists to cover.
         sp.GetRequiredService<IConnectorFactory>(),
-        sp.GetRequiredService<IIngestionQueue>(),
+        new RecordingIngestionQueue(),
         sp.GetRequiredService<ILoggerFactory>().CreateLogger<SourceSyncService>());
 
     [Fact]

--- a/tests/Connapse.Integration.Tests/SourcesEndpointsTests.cs
+++ b/tests/Connapse.Integration.Tests/SourcesEndpointsTests.cs
@@ -5,8 +5,10 @@ using System.Text.Json;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Identity.Data.Entities;
+using Connapse.Storage.Data;
 using FluentAssertions;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -113,6 +115,35 @@ public class SourcesEndpointsTests(SharedWebAppFixture fixture) : IAsyncLifetime
             name = name ?? ShortName("src"),
             connectionId,
             scopeJson = """{"bucketName":"b","prefix":"team/"}""",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return created.GetProperty("id").GetGuid();
+    }
+
+    /// <summary>
+    /// A filesystem connection rooted at a real local directory, used where a sync test needs
+    /// the route to reach a working connector rather than time out against a fake S3 region.
+    /// </summary>
+    private async Task<Guid> SeedFilesystemConnectionAsync(string rootPath)
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var connections = scope.ServiceProvider.GetRequiredService<IConnectionStore>();
+        string configJson = JsonSerializer.Serialize(new { allowedRoot = rootPath });
+        var connection = await connections.CreateAsync(
+            new CreateConnectionRequest(ShortName("fsconn"), ConnectionProvider.Filesystem, configJson),
+            createdByUserId: null);
+        return connection.Id;
+    }
+
+    private async Task<Guid> CreateFilesystemSourceAsync(Guid connectionId, string? name = null)
+    {
+        var response = await Admin.PostAsJsonAsync("/api/sources", new
+        {
+            name = name ?? ShortName("src"),
+            connectionId,
+            scopeJson = "{}",
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -321,6 +352,85 @@ public class SourcesEndpointsTests(SharedWebAppFixture fixture) : IAsyncLifetime
         var response = await Admin.PostAsync($"/api/sources/{sourceId}/sync", null);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SyncSource_EnabledWithNoQueryString_BindsSuccessfully()
+    {
+        // A non-nullable [FromQuery] parameter with no default makes minimal-API binding fail
+        // before the handler runs, which also produces 400 — the same status the disabled
+        // check above returns. The source here is enabled, so a 400 can only mean binding
+        // failed, unlike the test above where a 400 is ambiguous.
+        string root = Directory.CreateTempSubdirectory("connapse-sync-test-").FullName;
+        try
+        {
+            Guid connectionId = await SeedFilesystemConnectionAsync(root);
+            Guid sourceId = await CreateFilesystemSourceAsync(connectionId);
+
+            var response = await Admin.PostAsync($"/api/sources/{sourceId}/sync", null);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK,
+                "an enabled source with no query string must reach the handler, not fail binding");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SyncSource_ApplyWithheldDeletionsTrue_ReachesTheOverridePathAndReportsWithheldCount()
+    {
+        string root = Directory.CreateTempSubdirectory("connapse-sync-test-").FullName;
+        try
+        {
+            Guid connectionId = await SeedFilesystemConnectionAsync(root);
+            Guid sourceId = await CreateFilesystemSourceAsync(connectionId);
+            await SeedSourceDocumentsAsync(sourceId, count: 40);
+
+            // The directory is empty, so all 40 documents vanish — well past the guard's
+            // threshold — and the default (no query string) call must withhold rather than
+            // delete them.
+            var withheldResponse = await Admin.PostAsync($"/api/sources/{sourceId}/sync", null);
+            withheldResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            var withheldBody = await withheldResponse.Content.ReadFromJsonAsync<JsonElement>();
+            withheldBody.GetProperty("deleted").GetInt32().Should().Be(0);
+            withheldBody.GetProperty("withheldDeletions").GetInt32().Should().Be(40,
+                "the sync response is the one place an admin sees why deletions were withheld");
+
+            // ?applyWithheldDeletions=true must reach the override path and actually apply them.
+            var appliedResponse = await Admin.PostAsync(
+                $"/api/sources/{sourceId}/sync?applyWithheldDeletions=true", null);
+            appliedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            var appliedBody = await appliedResponse.Content.ReadFromJsonAsync<JsonElement>();
+            appliedBody.GetProperty("deleted").GetInt32().Should().Be(40);
+            appliedBody.GetProperty("withheldDeletions").GetInt32().Should().Be(0);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Inserts <paramref name="count"/> source-owned documents directly via SQL, following the
+    /// raw-insert pattern in DeleteGuardIntegrationTests: <c>IDocumentStore.StoreAsync</c>
+    /// always populates <c>container_id</c> and so cannot express a source-owned row.
+    /// </summary>
+    private async Task SeedSourceDocumentsAsync(Guid sourceId, int count)
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var context = await dbFactory.CreateDbContextAsync();
+
+        for (int i = 0; i < count; i++)
+        {
+            string path = $"/doc-{i}.md";
+            await context.Database.ExecuteSqlRawAsync(
+                "INSERT INTO documents (id, container_id, source_id, file_name, path, content_hash, size_bytes, created_at) "
+                + "VALUES ({0}, NULL, {1}, {2}, {3}, '', 1, now())",
+                Guid.NewGuid(), sourceId, $"doc-{i}.md", path);
+        }
     }
 
     // ── No enumeration surface ────────────────────────────────────────────


### PR DESCRIPTION
Closes #386, #387, #395, #398, #400, #404, #405.

Adds SFTP as a source provider, and carries two groups of general fixes found alongside it.

## SFTP

A connector that confines every path on the server rather than lexically. `PathConfinement`
does local disk I/O, so pointed at a remote path it silently degrades to a prefix check — the
bug #365 fixed locally. `SftpPathConfinement` resolves through `SSH_FXP_REALPATH` instead, so
`..` segments and symlinks collapse where they actually mean something.

Host keys are trust-on-first-use, then pinned. SSH.NET's `HostKeyEventArgs.CanTrust` arrives
already `true`, so a connector that does not subscribe accepts every key any server presents
and looks from the outside exactly like one that verifies.

Guided setup generates the key pair in-process, writes the command for the operator's platform,
and reads back what only their machine knows. The key is installed with `restrict` and a forced
`internal-sftp` command, and the firewall rule is scoped to local subnets — which still covers
the Docker and WSL switches a container reaches its host through.

Connections stay Admin-UI only. There is no REST, CLI, or MCP route that creates one.

## Source-sync fixes

**Deletion guard (#385)** — a sync that lists a fraction of what it listed last time withholds
the deletions rather than applying them, so a permissions change or a half-answered listing
cannot empty an index.

**Path claiming** — sync decided whether a file was new from persisted documents, and nothing
persists one until ingestion runs. A source whose ingestion outlasted the poll interval
rediscovered its whole backlog every cycle and enqueued it again. A path is now claimed with a
Pending row before its job is enqueued.

## Reindex fixes

These are not SFTP-specific. The reindex bug applied to container documents too.

**A reindex no longer destroys the index it is replacing.** It deleted every chunk before
enqueueing anything — and the delete was redundant, since `IngestionPipeline` purges stale
chunks itself after the file has been read. Every failure in between lost the index with
nothing coming to rebuild it.

**Ownership routing** — reindex jobs carried `ContainerId: doc.ContainerId.ToString()`, which is
`""` for a source-owned row, and no `Owner`. The pipeline threw after the chunks were gone.
`Document` gained an `Owner` field, because `ContainerId` carries
`COALESCE(container_id, source_id)` and cannot tell the two apart.

**Failure status** — a job dying before the pipeline wrote only `ingestion_state`, leaving
`Status` at "Pending", which the sync engine reads as a job still on its way. It now records
"Failed", which is what #403's retry rule needs to see.

## Verification

1,070 unit tests, 382 integration tests, 0 build warnings. Every fix above was confirmed
load-bearing by neutralising it and watching its test fail.

Three rounds of Codex adversarial review across the stack; findings fixed in
`cbb13d9`, `0e8c04b`, and `33565e0`.

One migration, `AddSourceWithheldDeletions`, appended after main's latest with no reordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SFTP as a read-only source with guided local setup, SSH-key credentials, host-key verification, path restrictions, filtering, and connection testing.
  * Added safeguards that withhold unexpectedly large deletion sets, display pending deletions, and allow administrators to approve them.
* **Bug Fixes**
  * Improved ingestion failure reporting and source ownership handling.
  * Prevented duplicate enqueueing and preserved searchable content when reindexing fails.
* **Documentation**
  * Expanded connector guidance and added research and implementation documentation for SFTP, filesystem access, and deletion safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->