### PR TITLE
feat(web): guided SFTP setup for a server, not only this computer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,3 +145,11 @@ MINIO_ROOT_PASSWORD=connapse_dev_secret
 # - For any networked deployment, CHANGE ALL CREDENTIALS
 # - See SECURITY.md for full security considerations
 # - For the full configuration reference, see docs/deployment.md
+
+# DNS suffix your network hands out, so an SFTP connection can name a machine by its short
+# name — "fileserver" rather than "fileserver.example.lan". Find it on Windows with
+# `Get-DnsClient | Where-Object ConnectionSpecificSuffix`, or on Linux in /etc/resolv.conf.
+#
+# Leave blank unless you need it. An address or a fully-qualified name works without it, and
+# the guided SFTP setup reports both.
+CONNAPSE_DNS_SEARCH=

--- a/.env.example
+++ b/.env.example
@@ -145,11 +145,3 @@ MINIO_ROOT_PASSWORD=connapse_dev_secret
 # - For any networked deployment, CHANGE ALL CREDENTIALS
 # - See SECURITY.md for full security considerations
 # - For the full configuration reference, see docs/deployment.md
-
-# DNS suffix your network hands out, so an SFTP connection can name a machine by its short
-# name — "fileserver" rather than "fileserver.example.lan". Find it on Windows with
-# `Get-DnsClient | Where-Object ConnectionSpecificSuffix`, or on Linux in /etc/resolv.conf.
-#
-# Leave blank unless you need it. An address or a fully-qualified name works without it, and
-# the guided SFTP setup reports both.
-CONNAPSE_DNS_SEARCH=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,19 +75,22 @@ services:
     volumes:
       - appdata:/app/appdata
 
-    # Uncomment when an SFTP connection has to reach a machine by its short name.
+    # Lets an SFTP connection reach a machine by its short name — "fileserver" rather than
+    # "fileserver.example.lan" or an address. Set CONNAPSE_DNS_SEARCH in .env to the DNS suffix
+    # your network hands out; leave it unset and nothing changes.
     #
-    # A workstation resolves "myserver" because its DNS client appends a connection-specific
-    # suffix — "myserver.example.lan" — before asking. A container has no search domain, so it
-    # looks up exactly the string it was given and finds nothing. Docker Desktop stopped copying
-    # the host's search domains into containers in 2.1.0.0 (docker/for-mac#3814), so this has to
-    # be stated rather than inherited.
+    # A workstation resolves the short name because its DNS client appends a connection-specific
+    # suffix before asking. A container has no search domain — Docker Desktop stopped copying the
+    # host's in 2.1.0.0 (docker/for-mac#3814) — so it looks up exactly what it was given.
     #
-    # Left commented rather than driven by an empty variable, which writes a bare "search" line
-    # into the container's resolv.conf. Using the address, or the fully-qualified name, needs
-    # none of this — the guided SFTP setup reports both.
-    # dns_search:
-    #   - example.lan
+    # The ndots option is not optional here, and it is the part that is easy to get wrong. Docker
+    # writes "options ndots:0" into the container, which tells the resolver every name is already
+    # complete; the search list is then never consulted for a single-label name and dns_search on
+    # its own does nothing. Measured: with a search domain and ndots:0 the short name still fails,
+    # and with ndots:1 it resolves.
+    dns_search: "${CONNAPSE_DNS_SEARCH:-}"
+    dns_opt:
+      - ndots:1
 
     depends_on:
       postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,23 +75,6 @@ services:
     volumes:
       - appdata:/app/appdata
 
-    # Lets an SFTP connection reach a machine by its short name — "fileserver" rather than
-    # "fileserver.example.lan" or an address. Set CONNAPSE_DNS_SEARCH in .env to the DNS suffix
-    # your network hands out; leave it unset and nothing changes.
-    #
-    # A workstation resolves the short name because its DNS client appends a connection-specific
-    # suffix before asking. A container has no search domain — Docker Desktop stopped copying the
-    # host's in 2.1.0.0 (docker/for-mac#3814) — so it looks up exactly what it was given.
-    #
-    # The ndots option is not optional here, and it is the part that is easy to get wrong. Docker
-    # writes "options ndots:0" into the container, which tells the resolver every name is already
-    # complete; the search list is then never consulted for a single-label name and dns_search on
-    # its own does nothing. Measured: with a search domain and ndots:0 the short name still fails,
-    # and with ndots:1 it resolves.
-    dns_search: "${CONNAPSE_DNS_SEARCH:-}"
-    dns_opt:
-      - ndots:1
-
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,21 @@ services:
       Identity__Jwt__Secret: ${Identity__Jwt__Secret:-}
     volumes:
       - appdata:/app/appdata
+
+    # Uncomment when an SFTP connection has to reach a machine by its short name.
+    #
+    # A workstation resolves "myserver" because its DNS client appends a connection-specific
+    # suffix — "myserver.example.lan" — before asking. A container has no search domain, so it
+    # looks up exactly the string it was given and finds nothing. Docker Desktop stopped copying
+    # the host's search domains into containers in 2.1.0.0 (docker/for-mac#3814), so this has to
+    # be stated rather than inherited.
+    #
+    # Left commented rather than driven by an empty variable, which writes a bare "search" line
+    # into the container's resolv.conf. Using the address, or the fully-qualified name, needs
+    # none of this — the guided SFTP setup reports both.
+    # dns_search:
+    #   - example.lan
+
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -239,7 +239,7 @@ SFTP is the answer. Run an SSH server on the machine holding the files and let C
 
 ### Guided setup
 
-Settings → Connections has two buttons that do all of this for you: **Connect this computer** and **Connect a server**. Both run the same three steps — Connapse generates a key pair, writes one command, and reads back what the command printed — and both end in a working connection with nothing typed but the folder you want.
+Settings → Connections has two buttons that do all of this for you: **Connect this computer** and **Connect a server**. Both run the same three steps — Connapse generates a key pair, writes one command, and reads back what the command printed. Setting up your own computer leaves you nothing to type but the folder; a server also needs the address Connapse can reach it at, which the machine itself cannot know.
 
 The difference is only what the command does when it runs:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -231,14 +231,35 @@ The guard bounds a single reconcile, not the source's history. A listing that pe
 
 ---
 
-## Indexing files on your own machine
+## Indexing files on a machine Connapse cannot see
 
 The Filesystem connector needs the server process to see a path on its own disk. In Docker the container's filesystem is not yours, and on a hosted deployment there is no shared disk at all — so "point Connapse at my Documents folder" has no answer through that connector.
 
 SFTP is the answer. Run an SSH server on the machine holding the files and let Connapse connect to it.
 
+### Guided setup
+
+Settings → Connections has two buttons that do all of this for you: **Connect this computer** and **Connect a server**. Both run the same three steps — Connapse generates a key pair, writes one command, and reads back what the command printed — and both end in a working connection with nothing typed but the folder you want.
+
+The difference is only what the command does when it runs:
+
+| | Connect this computer | Connect a server |
+|---|---|---|
+| SSH server | installs and starts it if absent | assumes it — you are running the command over it |
+| Firewall | opens inbound TCP 22 to local subnets | untouched |
+| Privilege | administrator or `sudo` throughout | only if the account turns out to be a Windows administrator |
+| Address | defaults to `host.docker.internal` | you supply it |
+
+Everything about authorisation is identical. The key is installed with `restrict` and a forced `internal-sftp` command, so it can open no shell and forward no ports. The host key fingerprint comes back in the pasted block rather than off the wire, which is what makes the first connection verified rather than merely trusted. And both report whether the host still accepts password logins, without changing it — that setting governs every account on the machine, and is not Connapse's to decide.
+
+**Connapse never installs the key itself.** There is no "give us the password and we will run `ssh-copy-id`" path, and there will not be one: it would mean handling a credential for a machine Connapse does not own, and connections deliberately store no secret Connapse did not generate.
+
+### By hand
+
+The guided flow does nothing you cannot do yourself, and on a host you administer differently — a shared jump box, a NAS, anything with its own key management — doing it yourself is often simpler:
+
 1. **Enable an SSH server.** OpenSSH Server is an optional feature on Windows, Remote Login on macOS, `sshd` on Linux.
-2. **Add a public key** to that account's `authorized_keys`, and give Connapse the matching private key.
+2. **Add a public key** to that account's `authorized_keys`, and give Connapse the matching private key. Prefix it with `restrict,command="internal-sftp"` unless you want that key to be able to do more than Connapse needs.
 3. **Create an SFTP connection** under Settings → Connections, pointing at the machine with an `allowedRoot` of the folder you want reachable.
 4. **Create a source** on that connection naming a `subPath` within it.
 

--- a/src/Connapse.Core/Interfaces/IContainerHostResolver.cs
+++ b/src/Connapse.Core/Interfaces/IContainerHostResolver.cs
@@ -1,0 +1,44 @@
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// What an address the operator typed turns into, and whether it changed on the way.
+/// </summary>
+/// <param name="Host">The address Connapse should actually dial.</param>
+/// <param name="Rewritten">
+/// True when <paramref name="Host"/> is not what was asked for. Callers surface this rather than
+/// swallowing it: an address that silently becomes a different address is the kind of thing that
+/// is impossible to debug six months later.
+/// </param>
+/// <param name="Reason">Why it changed, phrased for the operator. Null when nothing changed.</param>
+public record HostResolution(string Host, bool Rewritten, string? Reason);
+
+/// <summary>
+/// Translates an address as the operator understands it into one Connapse can actually reach
+/// from wherever it happens to be running.
+/// </summary>
+/// <remarks>
+/// This exists for exactly one problem, and it is worth being precise about which. A LAN address
+/// needs no translation — a container reaches <c>192.168.1.50</c> perfectly well, because Docker
+/// routes outbound traffic through the host. A hostname cannot be translated at all: it either
+/// resolves from the container's DNS or it does not, and nothing here can change that.
+/// <para>
+/// Loopback is the sole address whose meaning depends on who is asking. To the operator it means
+/// the machine in front of them; inside a container it means the container. That one is
+/// deterministic, so it is worth fixing — and it is worth fixing <i>only</i> when Connapse is
+/// containerised, since running directly on the host makes loopback correct and the rewrite
+/// wrong.
+/// </para>
+/// </remarks>
+public interface IContainerHostResolver
+{
+    /// <summary>
+    /// True when Connapse is running inside a container, and loopback therefore does not mean
+    /// what the operator means by it.
+    /// </summary>
+    bool IsContainerised { get; }
+
+    /// <summary>
+    /// Returns the address to dial. Unchanged unless it is loopback and Connapse is containerised.
+    /// </summary>
+    HostResolution Resolve(string? host);
+}

--- a/src/Connapse.Core/Utilities/ContainerHostPolicy.cs
+++ b/src/Connapse.Core/Utilities/ContainerHostPolicy.cs
@@ -1,4 +1,4 @@
-using Connapse.Core.Interfaces;
+﻿using Connapse.Core.Interfaces;
 
 namespace Connapse.Core.Utilities;
 
@@ -25,9 +25,12 @@ public static class ContainerHostPolicy
     /// True when <paramref name="host"/> names the machine asking, rather than a machine.
     /// </summary>
     /// <remarks>
-    /// Covers the IPv4 loopback <i>range</i>, not just <c>127.0.0.1</c>: every address in
-    /// 127.0.0.0/8 is loopback, and <c>127.0.1.1</c> in particular is what Debian puts in
-    /// /etc/hosts for the machine's own name.
+    /// Parsed rather than matched against a list of spellings, because there are more spellings
+    /// than are obvious. Every address in 127.0.0.0/8 is loopback, not only <c>127.0.0.1</c> —
+    /// Debian puts <c>127.0.1.1</c> in /etc/hosts for the machine's own name — and <c>::1</c>
+    /// can equally be written <c>0:0:0:0:0:0:0:1</c>. Parsing gets all of them, and gets the
+    /// other direction right too: <c>127.0.0.1.example.com</c> is an ordinary hostname somebody
+    /// can own, and a prefix check would claim it.
     /// </remarks>
     public static bool IsLoopback(string? host)
     {
@@ -35,16 +38,14 @@ public static class ContainerHostPolicy
         if (trimmed.Length == 0) return false;
 
         if (trimmed.Equals("localhost", StringComparison.OrdinalIgnoreCase)) return true;
-        if (trimmed is "::1" or "[::1]") return true;
 
-        // 127.x.y.z, checked by parsing rather than by prefix: "127.0.0.1.example.com" is a
-        // perfectly ordinary hostname that starts with "127.".
-        string[] octets = trimmed.Split('.');
-        if (octets.Length != 4) return false;
+        // A URL-style bracketed literal is not something IPAddress.TryParse accepts, and it is
+        // how an IPv6 address is written anywhere a port might follow it.
+        if (trimmed.StartsWith('[') && trimmed.EndsWith(']'))
+            trimmed = trimmed[1..^1];
 
-        if (!byte.TryParse(octets[0], out byte first) || first != 127) return false;
-
-        return octets.Skip(1).All(o => byte.TryParse(o, out _));
+        return System.Net.IPAddress.TryParse(trimmed, out var address)
+               && System.Net.IPAddress.IsLoopback(address);
     }
 
     /// <summary>

--- a/src/Connapse.Core/Utilities/ContainerHostPolicy.cs
+++ b/src/Connapse.Core/Utilities/ContainerHostPolicy.cs
@@ -1,0 +1,67 @@
+using Connapse.Core.Interfaces;
+
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// The rewrite rules themselves, with no opinion about whether Connapse is in a container.
+/// </summary>
+/// <remarks>
+/// Split from <see cref="IContainerHostResolver"/> so the rules can be tested without an
+/// environment to fake. Whether we are containerised is a fact about the process; what to do
+/// about it is a decision, and only the decision is interesting to test.
+/// </remarks>
+public static class ContainerHostPolicy
+{
+    /// <summary>
+    /// The name Docker Desktop resolves to the host machine from inside a container. On Linux
+    /// hosts it exists only when the container was started with
+    /// <c>--add-host=host.docker.internal:host-gateway</c>, which is why the rewrite is
+    /// surfaced to the operator rather than applied quietly — if it is not going to resolve,
+    /// they need to know that is what they are now depending on.
+    /// </summary>
+    public const string DockerHostAlias = "host.docker.internal";
+
+    /// <summary>
+    /// True when <paramref name="host"/> names the machine asking, rather than a machine.
+    /// </summary>
+    /// <remarks>
+    /// Covers the IPv4 loopback <i>range</i>, not just <c>127.0.0.1</c>: every address in
+    /// 127.0.0.0/8 is loopback, and <c>127.0.1.1</c> in particular is what Debian puts in
+    /// /etc/hosts for the machine's own name.
+    /// </remarks>
+    public static bool IsLoopback(string? host)
+    {
+        string trimmed = (host ?? string.Empty).Trim();
+        if (trimmed.Length == 0) return false;
+
+        if (trimmed.Equals("localhost", StringComparison.OrdinalIgnoreCase)) return true;
+        if (trimmed is "::1" or "[::1]") return true;
+
+        // 127.x.y.z, checked by parsing rather than by prefix: "127.0.0.1.example.com" is a
+        // perfectly ordinary hostname that starts with "127.".
+        string[] octets = trimmed.Split('.');
+        if (octets.Length != 4) return false;
+
+        if (!byte.TryParse(octets[0], out byte first) || first != 127) return false;
+
+        return octets.Skip(1).All(o => byte.TryParse(o, out _));
+    }
+
+    /// <summary>
+    /// The address to dial, given whether Connapse is containerised.
+    /// </summary>
+    public static HostResolution Resolve(string? host, bool containerised)
+    {
+        string trimmed = (host ?? string.Empty).Trim();
+
+        if (!containerised || !IsLoopback(trimmed))
+            return new HostResolution(trimmed, Rewritten: false, Reason: null);
+
+        return new HostResolution(
+            DockerHostAlias,
+            Rewritten: true,
+            Reason: $"Connapse runs in a container, where '{trimmed}' is the container itself "
+                    + $"rather than your machine. Using {DockerHostAlias} instead, which is how a "
+                    + "container reaches the host it runs on.");
+    }
+}

--- a/src/Connapse.Core/Utilities/SftpHostSetup.cs
+++ b/src/Connapse.Core/Utilities/SftpHostSetup.cs
@@ -4,6 +4,25 @@
 public enum HostPlatform { Windows, MacOS, Linux }
 
 /// <summary>
+/// Which machine the setup command is going to be run on.
+/// </summary>
+/// <remarks>
+/// The difference is not cosmetic. Setting up the operator's own machine means bringing an SSH
+/// server into existence — installing it, starting it, opening a port. A server they are
+/// already connected to over SSH needs none of that, and doing it anyway would demand
+/// administrator for work that installing a key into a user's own <c>authorized_keys</c> does
+/// not need.
+/// </remarks>
+public enum SftpSetupTarget
+{
+    /// <summary>The machine running the browser. May need an SSH server before it can be read.</summary>
+    ThisComputer,
+
+    /// <summary>A host the operator already reaches over SSH. Only the key is installed.</summary>
+    RemoteServer,
+}
+
+/// <summary>
 /// What the setup command reported back. Every field comes from the host, because the host
 /// is the only place that knows it — which is the reason for the round trip at all.
 /// </summary>
@@ -88,7 +107,10 @@ public static class SftpHostSetup
     /// from a URL — the operator should be able to see exactly what they are agreeing to at
     /// the moment they agree to it.
     /// </remarks>
-    public static string GenerateScript(string publicKeyLine, HostPlatform platform)
+    public static string GenerateScript(
+        string publicKeyLine,
+        HostPlatform platform,
+        SftpSetupTarget target = SftpSetupTarget.ThisComputer)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(publicKeyLine);
 
@@ -104,49 +126,95 @@ public static class SftpHostSetup
 
         return platform switch
         {
-            HostPlatform.Windows => WindowsScript(entry),
-            HostPlatform.MacOS => UnixScript(entry, macOs: true),
-            HostPlatform.Linux => UnixScript(entry, macOs: false),
+            HostPlatform.Windows => WindowsScript(entry, target),
+            HostPlatform.MacOS => UnixScript(entry, macOs: true, target),
+            HostPlatform.Linux => UnixScript(entry, macOs: false, target),
             _ => throw new ArgumentOutOfRangeException(nameof(platform)),
         };
     }
 
-    private static string WindowsScript(string publicKeyLine) =>
-        $$"""
-        # Connapse — allow this computer to be indexed. Run in PowerShell as Administrator.
+    private static string WindowsScript(string publicKeyLine, SftpSetupTarget target)
+    {
+        bool local = target == SftpSetupTarget.ThisComputer;
+
+        // Bringing an SSH server into existence, which is only the local machine's problem. A
+        // server reached over SSH is already running one — that is how the operator is about to
+        // paste this into it.
+        string serve = local
+            ? """
+              # Stop if not elevated, rather than half-succeeding.
+              #    Without elevation the steps below fail in ways that leave SSH looking configured
+              #    while it is not, and the symptom is an authentication failure with nothing to
+              #    explain it.
+              if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+                       ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+                  Write-Host 'Run this in a PowerShell window opened with "Run as Administrator".' -ForegroundColor Red
+                  return
+              }
+
+              # Make sure an SSH server is installed and running.
+              if (-not (Get-Service sshd -ErrorAction SilentlyContinue)) {
+                  Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 | Out-Null
+              }
+              Set-Service -Name sshd -StartupType Automatic
+              if ((Get-Service sshd).Status -ne 'Running') { Start-Service sshd }
+
+              # Reachable from this machine's own networks, and no further. An unscoped rule would
+              # also accept port 22 from whatever else is on a hotel or cafe network, and from the
+              # internet on any host whose router forwards the port — a much larger change than
+              # "let Connapse read my files", made silently while the operator was doing something
+              # else. LocalSubnet still covers the Docker and WSL virtual switches, which is how a
+              # Connapse container reaches its host.
+              if (-not (Get-NetFirewallRule -Name 'Connapse-SFTP-In-TCP' -ErrorAction SilentlyContinue)) {
+                  New-NetFirewallRule -Name 'Connapse-SFTP-In-TCP' -DisplayName 'Connapse SFTP (sshd)' `
+                      -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 `
+                      -Profile Any -RemoteAddress LocalSubnet | Out-Null
+                  Write-Host 'Opened inbound TCP 22 to this machine''s local subnets only.' -ForegroundColor Cyan
+              }
+
+              """
+            : "";
+
+        // Elevation is demanded up front locally, because installing the server needs it
+        // regardless. Remotely only one branch does — the machine-wide file an administrator
+        // account's keys go in — so the membership question is asked first and elevation is
+        // required only if the answer makes it necessary. Demanding it unconditionally would
+        // put an administrator prompt in front of a step that writes one line into the
+        // operator's own home directory.
+        string elevate = local
+            ? """
+                  # Domain-joined machines can refuse that cmdlet. Elevated, the token is unfiltered
+                  # and this is accurate — and the elevation check above guarantees we are elevated.
+                  $isAdmin = ([Security.Principal.WindowsIdentity]::GetCurrent()).Groups.Value -contains 'S-1-5-32-544'
+              """
+            : """
+                  # Unelevated, the token has the Administrators SID filtered out of it, so it
+                  # cannot answer this — and guessing "not an administrator" would write the key
+                  # where sshd will not read it. Say so instead.
+                  if (-not $elevated) {
+                      Write-Host 'Could not read the Administrators group. Re-run this in a PowerShell window opened with "Run as Administrator".' -ForegroundColor Red
+                      return
+                  }
+                  $isAdmin = ([Security.Principal.WindowsIdentity]::GetCurrent()).Groups.Value -contains 'S-1-5-32-544'
+              """;
+
+        string adminNeedsElevation = local
+            ? ""
+            : """
+
+              if ($isAdmin -and -not $elevated) {
+                  Write-Host 'This account is in the Administrators group, so sshd reads its keys from a machine-wide file that only administrators may write.' -ForegroundColor Red
+                  Write-Host 'Re-run this in a PowerShell window opened with "Run as Administrator".' -ForegroundColor Red
+                  return
+              }
+
+              """;
+
+        return $$"""
+        # Connapse — {{(local ? "allow this computer to be indexed. Run in PowerShell as Administrator." : "allow this server to be indexed. Run in PowerShell on the server itself.")}}
         # Safe to run more than once.
 
-        # 0. Stop if not elevated, rather than half-succeeding.
-        #    Without elevation the steps below fail in ways that leave SSH looking configured
-        #    while it is not, and the symptom is an authentication failure with nothing to
-        #    explain it.
-        if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
-                 ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-            Write-Host 'Run this in a PowerShell window opened with "Run as Administrator".' -ForegroundColor Red
-            return
-        }
-
-        # 1. Make sure an SSH server is installed and running.
-        if (-not (Get-Service sshd -ErrorAction SilentlyContinue)) {
-            Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 | Out-Null
-        }
-        Set-Service -Name sshd -StartupType Automatic
-        if ((Get-Service sshd).Status -ne 'Running') { Start-Service sshd }
-
-        # Reachable from this machine's own networks, and no further. An unscoped rule would
-        # also accept port 22 from whatever else is on a hotel or cafe network, and from the
-        # internet on any host whose router forwards the port — a much larger change than
-        # "let Connapse read my files", made silently while the operator was doing something
-        # else. LocalSubnet still covers the Docker and WSL virtual switches, which is how a
-        # Connapse container reaches its host.
-        if (-not (Get-NetFirewallRule -Name 'Connapse-SFTP-In-TCP' -ErrorAction SilentlyContinue)) {
-            New-NetFirewallRule -Name 'Connapse-SFTP-In-TCP' -DisplayName 'Connapse SFTP (sshd)' `
-                -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 `
-                -Profile Any -RemoteAddress LocalSubnet | Out-Null
-            Write-Host 'Opened inbound TCP 22 to this machine''s local subnets only.' -ForegroundColor Cyan
-        }
-
-        # 2. Work out which authorized_keys file sshd will actually read.
+        {{serve}}# Work out which authorized_keys file sshd will actually read.
         #    For an account in the Administrators group it is NOT the one in your profile —
         #    sshd_config redirects those to a machine-wide file with a locked-down ACL. This
         #    is the single most common reason Windows SSH keys silently fail to authenticate.
@@ -156,15 +224,15 @@ public static class SftpHostSetup
         #    an account that genuinely is a member — and the key would then be written where
         #    sshd will never look.
         $mySid = ([Security.Principal.WindowsIdentity]::GetCurrent()).User.Value
+        $elevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+                    ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
         try {
             $isAdmin = $null -ne (Get-LocalGroupMember -Group 'Administrators' -ErrorAction Stop |
                                   Where-Object { $_.SID.Value -eq $mySid })
         } catch {
-            # Domain-joined machines can refuse that cmdlet. Elevated, the token is unfiltered
-            # and this is accurate — and step 0 guarantees we are elevated.
-            $isAdmin = ([Security.Principal.WindowsIdentity]::GetCurrent()).Groups.Value -contains 'S-1-5-32-544'
+        {{elevate}}
         }
-
+        {{adminNeedsElevation}}
         if ($isAdmin) {
             $keyFile = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'
         } else {
@@ -174,7 +242,7 @@ public static class SftpHostSetup
         New-Item -ItemType Directory -Force -Path (Split-Path $keyFile) | Out-Null
         if (-not (Test-Path $keyFile)) { New-Item -ItemType File -Path $keyFile | Out-Null }
 
-        # 3. Add Connapse's key, but only once, and without disturbing any other key present.
+        # Add Connapse's key, but only once, and without disturbing any other key present.
         $key = '{{publicKeyLine}}'
         if (-not (Select-String -Path $keyFile -SimpleMatch -Pattern $key -Quiet)) {
             Add-Content -Path $keyFile -Value $key
@@ -185,7 +253,7 @@ public static class SftpHostSetup
             icacls $keyFile /inheritance:r /grant 'SYSTEM:F' 'Administrators:F' | Out-Null
         }
 
-        # 4. Say whether this host still accepts passwords over SSH.
+        # Say whether this host still accepts passwords over SSH.
         #    The restrictions on Connapse's key bind that key and nothing else, so they do not
         #    make the host key-only. Reported rather than changed: turning off password
         #    authentication is a decision about every account on the machine, and making it
@@ -199,7 +267,7 @@ public static class SftpHostSetup
             $passwordAuth = if ($setting) { $setting.Matches[0].Groups[1].Value } else { 'yes' }
         }
 
-        # 5. Report back what only this machine knows.
+        # Report back what only this machine knows.
         #    Wrapped, because the key is already installed by this point and a failure to read
         #    the fingerprint must not throw away a setup that otherwise worked. An empty
         #    fingerprint costs the operator verified-first-use, not the connection.
@@ -233,42 +301,52 @@ public static class SftpHostSetup
             Write-Host "To allow keys only, set 'PasswordAuthentication no' in $sshdConfig and run: Restart-Service sshd" -ForegroundColor Yellow
         }
         """;
+    }
 
-    private static string UnixScript(string publicKeyLine, bool macOs)
+    private static string UnixScript(string publicKeyLine, bool macOs, SftpSetupTarget target)
     {
-        string enable = macOs
-            ? """
-              # 1. Turn on Remote Login, which is what serves SFTP on macOS.
-              sudo systemsetup -setremotelogin on
-              """
-            : """
-              # 1. Make sure an SSH server is installed and running.
-              #    The unit is 'ssh' on Debian and Ubuntu, 'sshd' most other places.
-              sudo systemctl enable --now sshd 2>/dev/null || sudo systemctl enable --now ssh
-              """;
+        // Only the local machine may still need its SSH server switched on, and only that step
+        // needs sudo. Installing a key into the operator's own ~/.ssh does not, so a remote
+        // script asks for no privilege at all.
+        string enable = target == SftpSetupTarget.RemoteServer
+            ? ""
+            : macOs
+                ? """
+                  # Turn on Remote Login, which is what serves SFTP on macOS.
+                  sudo systemsetup -setremotelogin on
+
+                  """
+                : """
+                  # Make sure an SSH server is installed and running.
+                  #    The unit is 'ssh' on Debian and Ubuntu, 'sshd' most other places.
+                  sudo systemctl enable --now sshd 2>/dev/null || sudo systemctl enable --now ssh
+
+                  """;
+
+        string headline = target == SftpSetupTarget.RemoteServer
+            ? "allow this server to be indexed. Run it on the server itself."
+            : "allow this computer to be indexed.";
 
         // $$ so a single brace is literal — the awk program below needs them, and doubling
         // every interpolation is the lesser evil against escaping the shell.
         return $$"""
-        # Connapse — allow this computer to be indexed. Safe to run more than once.
+        # Connapse — {{headline}} Safe to run more than once.
 
-        {{enable}}
-
-        # 2. Add Connapse's key, but only once, and without disturbing any other key present.
+        {{enable}}# Add Connapse's key, but only once, and without disturbing any other key present.
         mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys
         chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys
 
         KEY='{{publicKeyLine}}'
         grep -qxF "$KEY" ~/.ssh/authorized_keys || echo "$KEY" >> ~/.ssh/authorized_keys
 
-        # 3. Say whether this host still accepts passwords over SSH.
+        # Say whether this host still accepts passwords over SSH.
         #    The restrictions on Connapse's key bind that key and nothing else, so they do not
         #    make the host key-only. Reported rather than changed: turning off password
         #    authentication is a decision about every account on the machine.
         #    OpenSSH defaults this to yes when the directive is absent or commented out.
         PASSWORD_AUTH=$(awk 'tolower($1)=="passwordauthentication" {v=$2} END {print (v?v:"yes")}'                         /etc/ssh/sshd_config 2>/dev/null || echo unknown)
 
-        # 4. Report back what only this machine knows.
+        # Report back what only this machine knows.
         HOSTKEY=$(ls /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null || ls /etc/ssh/ssh_host_rsa_key.pub)
         FINGERPRINT=$(ssh-keygen -lf "$HOSTKEY" | awk '{print $2}')
 

--- a/src/Connapse.Core/Utilities/SftpHostSetup.cs
+++ b/src/Connapse.Core/Utilities/SftpHostSetup.cs
@@ -44,13 +44,25 @@ public enum SftpSetupTarget
 /// nobody asked.
 /// </para>
 /// </param>
+/// <param name="Addresses">
+/// Names and addresses this machine believes it can be reached on — its hostname first, then its
+/// non-loopback IPv4 addresses. Filtered on the host, which is the only place that can tell a
+/// usable address from a useless one.
+/// <para>
+/// Suggestions, not answers. Whether Connapse can reach any of them depends on where Connapse
+/// runs, and a machine cannot know that about itself.
+/// </para>
+/// </param>
 public record SftpHostSetupResult(
     string Username,
     string HomePath,
     string Fingerprint,
-    IReadOnlyList<string>? Drives = null)
+    IReadOnlyList<string>? Drives = null,
+    IReadOnlyList<string>? Addresses = null)
 {
     public IReadOnlyList<string> Drives { get; init; } = Drives ?? [];
+
+    public IReadOnlyList<string> Addresses { get; init; } = Addresses ?? [];
 }
 
 /// <summary>
@@ -283,12 +295,26 @@ public static class SftpHostSetup
         # keep things and a second drive is entirely normal.
         $drives = (Get-PSDrive -PSProvider FileSystem | ForEach-Object { "/$($_.Name):/" }) -join ','
 
+        # Addresses Connapse might reach this machine on. Filtered here for the same reason the
+        # drives are listed here: only this machine can tell a usable address from a useless one.
+        # Loopback answers to nobody else, 169.254.x means DHCP failed, and Hyper-V and WSL leave
+        # virtual adapters behind that route nowhere from outside.
+        $addresses = ''
+        try {
+            $addresses = (Get-NetIPAddress -AddressFamily IPv4 -ErrorAction Stop |
+                          Where-Object { $_.IPAddress -notmatch '^(127\.|169\.254\.)' -and
+                                         $_.InterfaceAlias -notmatch 'Loopback|WSL|Hyper-V|vEthernet' } |
+                          Select-Object -ExpandProperty IPAddress -Unique) -join ','
+        } catch { }
+
         Write-Host ''
         Write-Host '{{BeginMarker}}'
         Write-Host "user=$env:USERNAME"
         Write-Host "home=/$($env:USERPROFILE -replace '\\','/')"
         Write-Host "drives=$drives"
         Write-Host "fingerprint=$fingerprint"
+        Write-Host "host=$env:COMPUTERNAME"
+        Write-Host "addresses=$addresses"
         Write-Host '{{EndMarker}}'
         Write-Host ''
         Write-Host 'Copy the block above, including both marker lines, back into Connapse.'
@@ -350,6 +376,28 @@ public static class SftpHostSetup
         HOSTKEY=$(ls /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null || ls /etc/ssh/ssh_host_rsa_key.pub)
         FINGERPRINT=$(ssh-keygen -lf "$HOSTKEY" | awk '{print $2}')
 
+        # Addresses Connapse might reach this machine on. Filtered here rather than in the UI,
+        # because this is the only place that can tell a usable address from a useless one:
+        # loopback answers only to this machine, 169.254.x means DHCP failed, and 172.17.x is
+        # this machine's own Docker bridge. Suggesting any of them would waste the operator's
+        # time proving they do not work.
+        #
+        # 'ip' on Linux, 'ifconfig' on macOS. Chosen on whether the first produced anything
+        # rather than on its exit status: a pipeline reports the status of its last command, so
+        # 'ip ... | awk | cut || ifconfig' would take the status of cut, which succeeds on empty
+        # input, and the fallback would never run. Neither failing is fatal — an empty list
+        # costs a suggestion, not the setup.
+        ADDRESSES=$(ip -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1)
+        [ -z "$ADDRESSES" ] && ADDRESSES=$(hostname -I 2>/dev/null | tr ' ' '\n')
+        [ -z "$ADDRESSES" ] && ADDRESSES=$(ifconfig 2>/dev/null | awk '/inet /{print $2}')
+
+        # 172.17 only, not the whole of 172.16/12: that range is a normal private network and a
+        # server legitimately living on 172.20.x should not have its real address hidden. Docker's
+        # default bridge is the specific thing worth dropping.
+        ADDRESSES=$(printf '%s\n' "$ADDRESSES" \
+                    | grep -Ev '^(127\.|169\.254\.|172\.17\.)' \
+                    | grep -E '^[0-9]' | sort -u | paste -sd, -)
+
         # The markers go through %s rather than being the format string themselves. They begin
         # with dashes, and printf reads a leading '-' as an option — bash rejected the end
         # marker outright, so the block came back unterminated and would not parse. The begin
@@ -358,6 +406,8 @@ public static class SftpHostSetup
         printf 'user=%s\n' "$(whoami)"
         printf 'home=%s\n' "$HOME"
         printf 'fingerprint=%s\n' "$FINGERPRINT"
+        printf 'host=%s\n' "$(hostname 2>/dev/null)"
+        printf 'addresses=%s\n' "$ADDRESSES"
         printf '%s\n\n' '{{EndMarker}}'
         echo 'Copy the block above, including both marker lines, back into Connapse.'
 
@@ -395,6 +445,8 @@ public static class SftpHostSetup
 
         string? user = null, home = null, fingerprint = null;
         IReadOnlyList<string> drives = [];
+        string? reportedHost = null;
+        IReadOnlyList<string> addresses = [];
 
         foreach (string raw in body.Split('\n', StringSplitOptions.RemoveEmptyEntries))
         {
@@ -417,6 +469,16 @@ public static class SftpHostSetup
                 case "drives":
                     drives = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                     break;
+
+                // Also optional, and for the same reason: an older command did not send these,
+                // and a machine whose address lookup found nothing still set itself up correctly.
+                case "host":
+                    reportedHost = value;
+                    break;
+
+                case "addresses":
+                    addresses = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    break;
             }
         }
 
@@ -429,9 +491,16 @@ public static class SftpHostSetup
         // Blank already has a defined meaning everywhere else: SshHostKeyPolicy reads it as
         // trust-on-first-use. So an absent fingerprint costs the stronger verified-first-use and
         // nothing else, which the panel says plainly rather than silently accepting.
+        // Hostname first: it survives a DHCP lease changing, which an address does not. Both are
+        // only suggestions, so ordering them by which is likelier to keep working is the whole
+        // of the judgement being made here.
+        IReadOnlyList<string> candidates = reportedHost is null
+            ? addresses
+            : [reportedHost, .. addresses.Where(a => !string.Equals(a, reportedHost, StringComparison.OrdinalIgnoreCase))];
+
         return user is null || home is null
             ? null
-            : new SftpHostSetupResult(user, home, fingerprint ?? string.Empty, drives);
+            : new SftpHostSetupResult(user, home, fingerprint ?? string.Empty, drives, candidates);
     }
 
     /// <summary>

--- a/src/Connapse.Core/Utilities/SftpHostSetup.cs
+++ b/src/Connapse.Core/Utilities/SftpHostSetup.cs
@@ -350,11 +350,15 @@ public static class SftpHostSetup
         HOSTKEY=$(ls /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null || ls /etc/ssh/ssh_host_rsa_key.pub)
         FINGERPRINT=$(ssh-keygen -lf "$HOSTKEY" | awk '{print $2}')
 
-        printf '\n{{BeginMarker}}\n'
+        # The markers go through %s rather than being the format string themselves. They begin
+        # with dashes, and printf reads a leading '-' as an option — bash rejected the end
+        # marker outright, so the block came back unterminated and would not parse. The begin
+        # marker only escaped it because a leading \n put a character in front of the dashes.
+        printf '\n%s\n' '{{BeginMarker}}'
         printf 'user=%s\n' "$(whoami)"
         printf 'home=%s\n' "$HOME"
         printf 'fingerprint=%s\n' "$FINGERPRINT"
-        printf '{{EndMarker}}\n\n'
+        printf '%s\n\n' '{{EndMarker}}'
         echo 'Copy the block above, including both marker lines, back into Connapse.'
 
         if [ "$PASSWORD_AUTH" != "no" ]; then

--- a/src/Connapse.Core/Utilities/SftpHostSetup.cs
+++ b/src/Connapse.Core/Utilities/SftpHostSetup.cs
@@ -314,6 +314,11 @@ public static class SftpHostSetup
         Write-Host "drives=$drives"
         Write-Host "fingerprint=$fingerprint"
         Write-Host "host=$env:COMPUTERNAME"
+        # As above: the short name resolves for a client that appends a suffix, and not for one
+        # that does not.
+        $fqdn = ''
+        try { $fqdn = [System.Net.Dns]::GetHostEntry($env:COMPUTERNAME).HostName } catch { }
+        Write-Host "fqdn=$fqdn"
         Write-Host "addresses=$addresses"
         Write-Host '{{EndMarker}}'
         Write-Host ''
@@ -406,7 +411,12 @@ public static class SftpHostSetup
         printf 'user=%s\n' "$(whoami)"
         printf 'home=%s\n' "$HOME"
         printf 'fingerprint=%s\n' "$FINGERPRINT"
+        # Short name and fully-qualified name both, because they are not interchangeable from
+        # somewhere else on the network. A workstation resolves 'divielserver' only because its
+        # DNS client appends a connection-specific suffix; a container has no search domain and
+        # looks up exactly what it is given, so the short name fails there while the FQDN works.
         printf 'host=%s\n' "$(hostname 2>/dev/null)"
+        printf 'fqdn=%s\n' "$(hostname -f 2>/dev/null)"
         printf 'addresses=%s\n' "$ADDRESSES"
         printf '%s\n\n' '{{EndMarker}}'
         echo 'Copy the block above, including both marker lines, back into Connapse.'
@@ -446,6 +456,7 @@ public static class SftpHostSetup
         string? user = null, home = null, fingerprint = null;
         IReadOnlyList<string> drives = [];
         string? reportedHost = null;
+        string? fqdn = null;
         IReadOnlyList<string> addresses = [];
 
         foreach (string raw in body.Split('\n', StringSplitOptions.RemoveEmptyEntries))
@@ -476,6 +487,10 @@ public static class SftpHostSetup
                     reportedHost = value;
                     break;
 
+                case "fqdn":
+                    fqdn = value;
+                    break;
+
                 case "addresses":
                     addresses = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                     break;
@@ -491,12 +506,26 @@ public static class SftpHostSetup
         // Blank already has a defined meaning everywhere else: SshHostKeyPolicy reads it as
         // trust-on-first-use. So an absent fingerprint costs the stronger verified-first-use and
         // nothing else, which the panel says plainly rather than silently accepting.
-        // Hostname first: it survives a DHCP lease changing, which an address does not. Both are
-        // only suggestions, so ordering them by which is likelier to keep working is the whole
-        // of the judgement being made here.
-        IReadOnlyList<string> candidates = reportedHost is null
-            ? addresses
-            : [reportedHost, .. addresses.Where(a => !string.Equals(a, reportedHost, StringComparison.OrdinalIgnoreCase))];
+        // Ordered by what is likeliest to work from wherever Connapse runs, which is not the
+        // same as what works from the operator's desk. The fully-qualified name comes first: it
+        // survives a DHCP lease changing, and unlike the short name it does not depend on the
+        // resolver appending a search domain — a container's does not. The short name comes
+        // last for exactly that reason, kept because it is the one the operator recognises.
+        List<string> ordered = [];
+        void Offer(string? candidate)
+        {
+            if (!string.IsNullOrWhiteSpace(candidate) &&
+                !ordered.Contains(candidate, StringComparer.OrdinalIgnoreCase))
+            {
+                ordered.Add(candidate);
+            }
+        }
+
+        Offer(fqdn);
+        foreach (string address in addresses) Offer(address);
+        Offer(reportedHost);
+
+        IReadOnlyList<string> candidates = ordered;
 
         return user is null || home is null
             ? null

--- a/src/Connapse.Storage/Connapse.Storage.csproj
+++ b/src/Connapse.Storage/Connapse.Storage.csproj
@@ -37,6 +37,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Connapse.Core.Tests" />
+    <InternalsVisibleTo Include="Connapse.Storage.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Connapse.Storage/ConnectionTesters/SftpConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/SftpConnectionTester.cs
@@ -1,6 +1,7 @@
 ﻿using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.Connectors;
+using System.Net.Sockets;
 
 namespace Connapse.Storage.ConnectionTesters;
 
@@ -36,6 +37,25 @@ public record SftpConnectionTestSettings
 /// </summary>
 public class SftpConnectionTester : IConnectionTester
 {
+    /// <summary>
+    /// The name-resolution failure inside <paramref name="error"/>, or null if it is not one.
+    /// </summary>
+    /// <remarks>
+    /// Searched through the whole chain rather than checked on the outermost exception: SSH.NET
+    /// wraps the socket failure, so the type that says what actually went wrong is never the one
+    /// caught. Matched on the error code, not on the message, which is localised.
+    /// </remarks>
+    internal static SocketException? FindHostNotFound(Exception? error)
+    {
+        for (Exception? current = error; current is not null; current = current.InnerException)
+        {
+            if (current is SocketException { SocketErrorCode: SocketError.HostNotFound } socket)
+                return socket;
+        }
+
+        return null;
+    }
+
     public async Task<ConnectionTestResult> TestConnectionAsync(
         object settings, TimeSpan? timeout = null, CancellationToken ct = default)
     {
@@ -105,6 +125,26 @@ public class SftpConnectionTester : IConnectionTester
                 Success = false,
                 Message = $"{s.Host}:{s.Port} accepted the connection but stopped responding. "
                           + "The SSH service is running but its SFTP subsystem is not answering."
+            };
+        }
+        catch (Exception ex) when (FindHostNotFound(ex) is not null)
+        {
+            // Worth separating from every other connection failure, because it is the one whose
+            // symptom contradicts the operator's own experience: the name works from their
+            // desktop and not from here, so "no such host" reads as Connapse being wrong.
+            //
+            // It is not. A workstation appends a connection-specific DNS suffix before asking —
+            // "server" is looked up as "server.example.lan" — and a container has no search
+            // domain, so it looks up exactly what it was given. Docker stopped copying the
+            // host's search domains into containers, so the difference is by design.
+            return new ConnectionTestResult
+            {
+                Success = false,
+                Message = $"'{s.Host}' did not resolve from inside Connapse. A short name often "
+                          + "works on your own machine and not here: your computer appends a DNS "
+                          + "suffix before looking it up, and a container does not. Use the "
+                          + "address, or the fully-qualified name — the guided setup reports "
+                          + "both — or set dns_search in docker-compose.yml."
             };
         }
         catch (Exception ex)

--- a/src/Connapse.Storage/ConnectionTesters/SftpConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/SftpConnectionTester.cs
@@ -137,14 +137,19 @@ public class SftpConnectionTester : IConnectionTester
             // "server" is looked up as "server.example.lan" — and a container has no search
             // domain, so it looks up exactly what it was given. Docker stopped copying the
             // host's search domains into containers, so the difference is by design.
+            //
+            // The remedy given is the one that needs no configuration anywhere. Making the short
+            // name itself work is possible but fiddly enough not to be worth recommending: it
+            // takes a search domain *and* an ndots override, since Docker sets ndots:0 and the
+            // search list is then never consulted for a single-label name.
             return new ConnectionTestResult
             {
                 Success = false,
                 Message = $"'{s.Host}' did not resolve from inside Connapse. A short name often "
-                          + "works on your own machine and not here: your computer appends a DNS "
-                          + "suffix before looking it up, and a container does not. Use the "
-                          + "address, or the fully-qualified name — the guided setup reports "
-                          + "both — or set dns_search in docker-compose.yml."
+                          + "works on your own machine and not here: your computer adds your "
+                          + "network's domain before looking it up, and a container does not. Use "
+                          + "the address, or the full name including the domain — the guided setup "
+                          + "reports both."
             };
         }
         catch (Exception ex)

--- a/src/Connapse.Web/Components/Settings/ConnectionForm.cs
+++ b/src/Connapse.Web/Components/Settings/ConnectionForm.cs
@@ -89,8 +89,14 @@ public sealed record ConnectionForm
     /// the flow to the profile would rule out where most people actually keep things.
     /// Blank falls back to the reported home directory.
     /// </param>
+    /// <param name="port">
+    /// The SSH port, blank meaning 22. Its own parameter rather than something parsed back out of
+    /// <paramref name="host"/>: splitting on a colon is wrong the moment the host is an IPv6
+    /// literal, and the form has room for a second field.
+    /// </param>
     public static ConnectionForm ForGuidedSetup(
-        SftpHostSetupResult result, string host, string? allowedRoot, string privateKeyPem)
+        SftpHostSetupResult result, string host, string? allowedRoot, string privateKeyPem,
+        string? port = null)
     {
         ArgumentNullException.ThrowIfNull(result);
         ArgumentException.ThrowIfNullOrWhiteSpace(host);
@@ -101,7 +107,7 @@ public sealed record ConnectionForm
             Name = $"{result.Username}@{host.Trim()}",
             Provider = ConnectionProvider.Sftp,
             Host = host.Trim(),
-            Port = "22",
+            Port = string.IsNullOrWhiteSpace(port) ? "22" : port.Trim(),
             Username = result.Username,
             AllowedRoot = NormaliseRemoteRoot(allowedRoot, result.HomePath),
             HostKeyFingerprint = result.Fingerprint,

--- a/src/Connapse.Web/Components/Settings/ConnectionForm.cs
+++ b/src/Connapse.Web/Components/Settings/ConnectionForm.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using Connapse.Core;
 using Connapse.Core.Utilities;
 using Connapse.Storage.Connectors;
@@ -74,8 +74,9 @@ public sealed record ConnectionForm
 
 
     /// <summary>
-    /// Builds the connection the "Connect this computer" flow creates, from what the host's
-    /// setup command reported.
+    /// Builds the connection the guided setup creates, from what the host's setup command
+    /// reported. The same for a remote server as for the operator's own machine: only the
+    /// script differs between them, never the connection it produces.
     /// </summary>
     /// <remarks>
     /// Here rather than in the Razor component for the same reason the rest of this class is:
@@ -88,7 +89,7 @@ public sealed record ConnectionForm
     /// the flow to the profile would rule out where most people actually keep things.
     /// Blank falls back to the reported home directory.
     /// </param>
-    public static ConnectionForm ForLocalMachine(
+    public static ConnectionForm ForGuidedSetup(
         SftpHostSetupResult result, string host, string? allowedRoot, string privateKeyPem)
     {
         ArgumentNullException.ThrowIfNull(result);

--- a/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
@@ -269,7 +269,7 @@
                                 </div>
                             }
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-3">
                             <label class="form-label">Reachable at</label>
                             <input class="form-control font-monospace" @bind="localHost"
                                    placeholder="@(RemoteTarget ? "files.example.com" : "host.docker.internal")" />
@@ -295,8 +295,7 @@
                                     <text>
                                         The hostname or address <em>Connapse</em> can reach the server at, which
                                         is not always the one you use — a container on a different network may
-                                        need the address rather than the short name. Add <code>:port</code> only
-                                        if it is not 22.
+                                        need the address rather than the short name.
                                     </text>
                                 }
                                 else
@@ -307,6 +306,10 @@
                                     </text>
                                 }
                             </div>
+                        </div>
+                        <div class="col-md-1">
+                            <label class="form-label">Port</label>
+                            <input class="form-control" type="number" @bind="localPort" placeholder="22" />
                         </div>
                     </div>
                 </div>
@@ -770,6 +773,9 @@
     private string localRoot = "";
     private string localHost = "host.docker.internal";
 
+    /// <summary>Blank means 22, which is what almost every host answers on.</summary>
+    private string localPort = "";
+
     private static string PlatformLabel(HostPlatform p) => p switch
     {
         HostPlatform.Windows => "Windows",
@@ -797,6 +803,7 @@
         pastedResult = null;
         localRoot = "";
         localHost = DefaultHost();
+        localPort = "";
         statusMessage = null;
         testMessage = null;
 
@@ -812,6 +819,12 @@
         if (setupTarget == target) return;
 
         setupTarget = target;
+
+        // The pasted block describes the machine the previous command ran on, and switching
+        // target means a different machine. Keeping it would let someone set up their own
+        // computer, switch to "Another server", type a server's address, and save a connection
+        // whose key was never installed there — a form that looks complete and cannot connect.
+        pastedResult = null;
 
         // Only when it is still the other target's guess. Something typed is theirs to keep.
         if (string.IsNullOrWhiteSpace(localHost) || localHost == "host.docker.internal")
@@ -852,7 +865,8 @@
     /// </summary>
     private ConnectionForm BuildLocalForm(SftpHostSetupResult result) =>
         ConnectionForm.ForGuidedSetup(
-            result, HostResolver.Resolve(localHost).Host, localRoot, localKeyPair!.PrivateKeyPem);
+            result, HostResolver.Resolve(localHost).Host, localRoot, localKeyPair!.PrivateKeyPem,
+            localPort);
 
     private async Task TestLocalSetup()
     {
@@ -867,7 +881,7 @@
             var outcome = await SftpTester.TestConnectionAsync(new SftpConnectionTestSettings
             {
                 Host = HostResolver.Resolve(form.Host).Host,
-                Port = 22,
+                Port = int.TryParse(form.Port, out int guidedPort) ? guidedPort : 22,
                 Username = form.Username!,
                 AllowedRoot = form.AllowedRoot!,
                 PrivateKey = form.PrivateKey!,

--- a/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
@@ -55,19 +55,43 @@
     @if (localSetup)
     {
         <div class="col-12">
-            <h5>Connect this computer</h5>
+            <h5>@(RemoteTarget ? "Connect a server" : "Connect this computer")</h5>
             <p class="text-muted mb-0">
-                Connapse runs in a container, so it cannot see your files directly and cannot
-                configure your machine for you. It can do everything else: it has made a key,
-                and written the one command you need to run.
+                @if (RemoteTarget)
+                {
+                    <text>
+                        Connapse cannot configure a machine it does not run on, and will not sign in
+                        with a password to try. It can do everything either side of that: it has made
+                        a key, and written the one command to run on the server.
+                    </text>
+                }
+                else
+                {
+                    <text>
+                        Connapse runs in a container, so it cannot see your files directly and cannot
+                        configure your machine for you. It can do everything else: it has made a key,
+                        and written the one command you need to run.
+                    </text>
+                }
             </p>
+
+            @* Switchable after the fact, because the two buttons are a starting point rather
+               than a commitment, and the steps below are the same either way. *@
+            <div class="btn-group btn-group-sm mt-2" role="group">
+                <button type="button"
+                        class="btn @(RemoteTarget ? "btn-outline-secondary" : "btn-secondary")"
+                        @onclick="() => SelectTarget(SftpSetupTarget.ThisComputer)">This computer</button>
+                <button type="button"
+                        class="btn @(RemoteTarget ? "btn-secondary" : "btn-outline-secondary")"
+                        @onclick="() => SelectTarget(SftpSetupTarget.RemoteServer)">Another server</button>
+            </div>
         </div>
 
         @* Step 1 *@
         <div class="col-12">
             <div class="card">
                 <div class="card-body">
-                    <h6 class="card-title">1 · Run this on your computer</h6>
+                    <h6 class="card-title">1 · Run this on @(RemoteTarget ? "the server" : "your computer")</h6>
                     <div class="btn-group btn-group-sm mb-2" role="group">
                         @foreach (var p in Enum.GetValues<HostPlatform>())
                         {
@@ -79,7 +103,18 @@
                     @if (setupPlatform == HostPlatform.Windows)
                     {
                         <div class="small text-muted mb-2">
-                            Open PowerShell with <strong>Run as Administrator</strong>, then paste this in.
+                            @if (RemoteTarget)
+                            {
+                                <text>
+                                    Open PowerShell on the server and paste this in. It only asks for
+                                    <strong>Run as Administrator</strong> if that account turns out to be one,
+                                    and says so if it does.
+                                </text>
+                            }
+                            else
+                            {
+                                <text>Open PowerShell with <strong>Run as Administrator</strong>, then paste this in.</text>
+                            }
                         </div>
                     }
                     <textarea class="form-control font-monospace" rows="12" readonly
@@ -107,14 +142,30 @@
                        an SSH server affects every account on the machine and every way of
                        signing in to it, not only the key installed above — so an operator who
                        reads "adds one key" and nothing else has been told the smaller half. *@
-                    <div class="alert alert-warning py-2 mt-2 mb-0 small">
-                        <span class="bi-exclamation-triangle me-1"></span>
-                        It also <strong>turns on this computer's SSH server</strong> and allows
-                        inbound port 22 from your local networks — the Docker network among them,
-                        which is how Connapse reaches you. Other accounts on the machine can then
-                        sign in over SSH too, by password if the host allows it. The command reports
-                        whether it does, and prints the one line that turns that off.
-                    </div>
+                    @if (RemoteTarget)
+                    {
+                        @* The remote script starts no service and opens no port — it cannot need
+                           to, since the operator is already connected over SSH to run it. Saying
+                           otherwise here would describe a change that is not being made. *@
+                        <div class="alert alert-secondary py-2 mt-2 mb-0 small">
+                            <span class="bi-info-circle me-1"></span>
+                            This <strong>changes nothing but that one account's keys</strong>. It starts
+                            no service and opens no port — the server is already serving SSH, or you
+                            could not run this on it. It does report whether the host still accepts
+                            password logins, which matters more on a server than on a laptop.
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                            <span class="bi-exclamation-triangle me-1"></span>
+                            It also <strong>turns on this computer's SSH server</strong> and allows
+                            inbound port 22 from your local networks — the Docker network among them,
+                            which is how Connapse reaches you. Other accounts on the machine can then
+                            sign in over SSH too, by password if the host allows it. The command reports
+                            whether it does, and prints the one line that turns that off.
+                        </div>
+                    }
                 </div>
             </div>
         </div>
@@ -219,10 +270,25 @@
                         </div>
                         <div class="col-md-4">
                             <label class="form-label">Reachable at</label>
-                            <input class="form-control font-monospace" @bind="localHost" />
+                            <input class="form-control font-monospace" @bind="localHost"
+                                   placeholder="@(RemoteTarget ? "files.example.com" : "host.docker.internal")" />
                             <div class="form-text">
-                                <code>host.docker.internal</code> works on Docker Desktop. A Linux host needs
-                                <code>--add-host=host.docker.internal:host-gateway</code>.
+                                @if (RemoteTarget)
+                                {
+                                    <text>
+                                        The hostname or address <em>Connapse</em> can reach the server at, which
+                                        is not always the one you use — a container on a different network may
+                                        need the address rather than the short name. Add <code>:port</code> only
+                                        if it is not 22.
+                                    </text>
+                                }
+                                else
+                                {
+                                    <text>
+                                        <code>host.docker.internal</code> works on Docker Desktop. A Linux host needs
+                                        <code>--add-host=host.docker.internal:host-gateway</code>.
+                                    </text>
+                                }
                             </div>
                         </div>
                     </div>
@@ -261,8 +327,13 @@
                 @* The local case gets its own entry point rather than being a provider hidden
                    inside "Add connection". It is the one most people want, and reaching it
                    through a generic SFTP form means understanding SFTP first. *@
-                <button class="btn btn-outline-primary btn-sm me-2" @onclick="StartLocalSetup">
+                <button class="btn btn-outline-primary btn-sm me-2" @onclick="() => StartGuidedSetup(SftpSetupTarget.ThisComputer)">
                     <span class="bi-laptop me-1"></span> Connect this computer
+                </button>
+                @* Its own button rather than a mode buried inside the local one: an operator
+                   with a server in mind should not have to start by saying "this computer". *@
+                <button class="btn btn-outline-primary btn-sm me-2" @onclick="() => StartGuidedSetup(SftpSetupTarget.RemoteServer)">
+                    <span class="bi-hdd-network me-1"></span> Connect a server
                 </button>
                 <button class="btn btn-primary btn-sm" @onclick="StartCreate">
                     <span class="bi-plus-lg me-1"></span> Add connection
@@ -631,9 +702,10 @@
         loading = false;
     }
 
-    // ── Connect this computer ──────────────────────────────────────────────
+    // ── Guided setup: this computer, or a server ───────────────────────────
 
     private bool localSetup;
+    private SftpSetupTarget setupTarget = SftpSetupTarget.ThisComputer;
     private HostPlatform setupPlatform = HostPlatform.Windows;
     private SshKeyPair? localKeyPair;
     private string setupScript = "";
@@ -648,19 +720,45 @@
         _ => "Linux",
     };
 
-    private void StartLocalSetup()
+    private bool RemoteTarget => setupTarget == SftpSetupTarget.RemoteServer;
+
+    /// <summary>
+    /// Where Connapse reaches the host, once the operator has not said. Only answerable for
+    /// their own machine — a server's address is something only they know.
+    /// </summary>
+    private string DefaultHost() => RemoteTarget ? "" : "host.docker.internal";
+
+    private void StartGuidedSetup(SftpSetupTarget target)
     {
         // Generated once per visit, not per keystroke: the script embeds the public key, and
         // regenerating would invalidate a command the operator may have already run.
         localKeyPair = SshKeyPairGenerator.Generate($"connapse@{Environment.MachineName}");
 
         localSetup = true;
+        setupTarget = target;
         editing = null;
         pastedResult = null;
         localRoot = "";
-        localHost = "host.docker.internal";
+        localHost = DefaultHost();
         statusMessage = null;
         testMessage = null;
+
+        RegenerateScript();
+    }
+
+    /// <summary>
+    /// Switches target mid-flow. Keeps the key pair, because the operator may already have run
+    /// the command — regenerating here would silently invalidate a host they had just set up.
+    /// </summary>
+    private void SelectTarget(SftpSetupTarget target)
+    {
+        if (setupTarget == target) return;
+
+        setupTarget = target;
+
+        // Only when it is still the other target's guess. Something typed is theirs to keep.
+        if (string.IsNullOrWhiteSpace(localHost) || localHost == "host.docker.internal")
+            localHost = DefaultHost();
 
         RegenerateScript();
     }
@@ -674,7 +772,7 @@
     private void RegenerateScript() =>
         setupScript = localKeyPair is null
             ? ""
-            : SftpHostSetup.GenerateScript(localKeyPair.PublicKeyLine, setupPlatform);
+            : SftpHostSetup.GenerateScript(localKeyPair.PublicKeyLine, setupPlatform, setupTarget);
 
     private async Task CopyScript() =>
         await JS.InvokeVoidAsync("navigator.clipboard.writeText", setupScript);
@@ -691,7 +789,7 @@
         LocalResult() is not null && !string.IsNullOrWhiteSpace(localHost);
 
     private ConnectionForm BuildLocalForm(SftpHostSetupResult result) =>
-        ConnectionForm.ForLocalMachine(result, localHost, localRoot, localKeyPair!.PrivateKeyPem);
+        ConnectionForm.ForGuidedSetup(result, localHost, localRoot, localKeyPair!.PrivateKeyPem);
 
     private async Task TestLocalSetup()
     {

--- a/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
@@ -10,6 +10,7 @@
 @inject IConnectionStore ConnectionStore
 @inject ISourceStore SourceStore
 @inject IOptionsMonitor<SourceSecuritySettings> SourceSecurity
+@inject IContainerHostResolver HostResolver
 @inject S3ConnectionTester S3Tester
 @inject AzureBlobConnectionTester AzureTester
 @inject SftpConnectionTester SftpTester
@@ -272,6 +273,22 @@
                             <label class="form-label">Reachable at</label>
                             <input class="form-control font-monospace" @bind="localHost"
                                    placeholder="@(RemoteTarget ? "files.example.com" : "host.docker.internal")" />
+
+                            @* What the machine said about itself, offered the same way its drives
+                               are. Suggestions rather than answers: whether any of them is
+                               reachable depends on where Connapse runs, which the machine
+                               reporting them cannot know. *@
+                            @if (LocalResult()?.Addresses is { Count: > 0 } candidates)
+                            {
+                                <div class="mt-2 d-flex flex-wrap gap-1 align-items-center">
+                                    <span class="small text-muted me-1">It reports:</span>
+                                    @foreach (var candidate in candidates)
+                                    {
+                                        <button type="button" class="btn btn-sm btn-outline-secondary py-0"
+                                                @onclick="() => localHost = candidate">@candidate</button>
+                                    }
+                                </div>
+                            }
                             <div class="form-text">
                                 @if (RemoteTarget)
                                 {
@@ -499,6 +516,17 @@
                     <code>host.docker.internal</code> — see
                     <a href="https://github.com/Destrayon/Connapse/blob/main/docs/connectors.md" target="_blank" rel="noopener">the connector documentation</a>.
                 </div>
+
+                @* Shown while they are still typing, rather than only in a failure message
+                   afterwards. The address is about to change under them, and finding that out
+                   from a saved connection is worse than being told now. *@
+                @if (HostResolver.Resolve(form.Host) is { Rewritten: true } preview)
+                {
+                    <div class="alert alert-info py-2 mt-2 mb-0 small">
+                        <span class="bi-arrow-left-right me-1"></span>
+                        Will be saved as <code>@preview.Host</code>. @preview.Reason
+                    </div>
+                }
             </div>
             <div class="col-md-4">
                 <label class="form-label">Port</label>
@@ -730,6 +758,9 @@
 
     // ── Guided setup: this computer, or a server ───────────────────────────
 
+    /// <summary>Set when a save rewrote the host, so the outcome can say so.</summary>
+    private string? hostRewriteNote;
+
     private bool localSetup;
     private SftpSetupTarget setupTarget = SftpSetupTarget.ThisComputer;
     private HostPlatform setupPlatform = HostPlatform.Windows;
@@ -814,8 +845,14 @@
     private bool LocalSetupReady() =>
         LocalResult() is not null && !string.IsNullOrWhiteSpace(localHost);
 
+    /// <summary>
+    /// Built with the address Connapse will actually dial, not the one typed. The guided flow
+    /// saves and tests through this, so resolving in one and not the other would let a test pass
+    /// against something the saved connection does not point at.
+    /// </summary>
     private ConnectionForm BuildLocalForm(SftpHostSetupResult result) =>
-        ConnectionForm.ForGuidedSetup(result, localHost, localRoot, localKeyPair!.PrivateKeyPem);
+        ConnectionForm.ForGuidedSetup(
+            result, HostResolver.Resolve(localHost).Host, localRoot, localKeyPair!.PrivateKeyPem);
 
     private async Task TestLocalSetup()
     {
@@ -829,7 +866,7 @@
 
             var outcome = await SftpTester.TestConnectionAsync(new SftpConnectionTestSettings
             {
-                Host = form.Host!,
+                Host = HostResolver.Resolve(form.Host).Host,
                 Port = 22,
                 Username = form.Username!,
                 AllowedRoot = form.AllowedRoot!,
@@ -931,6 +968,20 @@
         saving = true;
         try
         {
+            // Applied to the form itself, not just on the way to the store, so the operator ends
+            // up looking at the address their connection actually holds. Saving what was typed
+            // while testing something else would make the test meaningless: it would pass here
+            // and the sync would fail later, against an address nobody had ever tried.
+            if (form.Provider == ConnectionProvider.Sftp)
+            {
+                var resolvedHost = HostResolver.Resolve(form.Host);
+                if (resolvedHost.Rewritten)
+                {
+                    form.Host = resolvedHost.Host;
+                    hostRewriteNote = resolvedHost.Reason;
+                }
+            }
+
             string config = form.ToConfigJson();
 
             // Null for every provider but SFTP, and null again for an SFTP connection saved
@@ -942,7 +993,7 @@
                 await ConnectionStore.CreateAsync(
                     new CreateConnectionRequest(form.Name.Trim(), form.Provider, config, secret),
                     createdByUserId: null);
-                Succeed($"Connection '{form.Name.Trim()}' created.");
+                Succeed($"Connection '{form.Name.Trim()}' created.{HostRewriteSuffix()}");
             }
             else
             {
@@ -959,7 +1010,7 @@
                     return;
                 }
 
-                Succeed($"Connection '{form.Name.Trim()}' saved.");
+                Succeed($"Connection '{form.Name.Trim()}' saved.{HostRewriteSuffix()}");
             }
 
             editing = null;
@@ -1055,9 +1106,13 @@
                     return;
                 }
 
+                // What Connapse will actually dial, which is not always what was typed. See
+                // IContainerHostResolver: loopback means the container, not the operator's machine.
+                var resolved = HostResolver.Resolve(form.Host);
+
                 var sftpResult = await SftpTester.TestConnectionAsync(new SftpConnectionTestSettings
                 {
-                    Host = form.Host?.Trim() ?? "",
+                    Host = resolved.Host,
                     Port = int.TryParse(form.Port, out int p) ? p : 22,
                     Username = form.Username?.Trim() ?? "",
                     AllowedRoot = form.AllowedRoot?.Trim() ?? "",
@@ -1076,7 +1131,12 @@
                 string usedKey = string.IsNullOrWhiteSpace(form.PrivateKey)
                     ? "Using the stored key."
                     : "Using the key in this form.";
-                testMessage = $"{usedKey} {sftpResult.Message}";
+
+                // The rewrite is reported on success as well as failure. A test that passes
+                // against a different address than the one on screen is exactly the result an
+                // operator would misread.
+                string rewrite = resolved.Rewritten ? $" ({resolved.Reason})" : "";
+                testMessage = $"{usedKey} {sftpResult.Message}{rewrite}";
                 return;
             }
 
@@ -1142,6 +1202,16 @@
     }
 
     private static string? NullIfBlank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    /// <summary>Names the host rewrite in the outcome, and clears it so it is said once.</summary>
+    private string HostRewriteSuffix()
+    {
+        if (hostRewriteNote is null) return "";
+
+        string note = $" {hostRewriteNote}";
+        hostRewriteNote = null;
+        return note;
+    }
 
     private void Succeed(string message)
     {

--- a/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
@@ -326,14 +326,13 @@
             <div>
                 @* The local case gets its own entry point rather than being a provider hidden
                    inside "Add connection". It is the one most people want, and reaching it
-                   through a generic SFTP form means understanding SFTP first. *@
+                   through a generic SFTP form means understanding SFTP first.
+
+                   A server is the opposite: anyone setting one up already knows they want SFTP,
+                   so its offer of help lives inside the SFTP form rather than competing for
+                   room out here. *@
                 <button class="btn btn-outline-primary btn-sm me-2" @onclick="() => StartGuidedSetup(SftpSetupTarget.ThisComputer)">
                     <span class="bi-laptop me-1"></span> Connect this computer
-                </button>
-                @* Its own button rather than a mode buried inside the local one: an operator
-                   with a server in mind should not have to start by saying "this computer". *@
-                <button class="btn btn-outline-primary btn-sm me-2" @onclick="() => StartGuidedSetup(SftpSetupTarget.RemoteServer)">
-                    <span class="bi-hdd-network me-1"></span> Connect a server
                 </button>
                 <button class="btn btn-primary btn-sm" @onclick="StartCreate">
                     <span class="bi-plus-lg me-1"></span> Add connection
@@ -472,6 +471,26 @@
         }
         else if (form.Provider == ConnectionProvider.Sftp)
         {
+            @* Offered only when creating. Running it against a connection being edited would
+               replace the form with a flow that ends by creating a second one. *@
+            @if (isNew)
+            {
+                <div class="col-12">
+                    <div class="alert alert-primary d-flex flex-wrap align-items-center gap-2 py-2 mb-0">
+                        <span class="bi-magic"></span>
+                        <span class="flex-grow-1 small">
+                            Every field below can be filled in for you. Connapse will make a key, write
+                            one command to run on the server, and read back the username, home directory
+                            and host key fingerprint it prints.
+                        </span>
+                        <button type="button" class="btn btn-primary btn-sm"
+                                @onclick="() => StartGuidedSetup(SftpSetupTarget.RemoteServer)">
+                            <span class="bi-hdd-network me-1"></span> Set this up for me
+                        </button>
+                    </div>
+                </div>
+            }
+
             <div class="col-md-8">
                 <label class="form-label">Host</label>
                 <input class="form-control" @bind="form.Host" placeholder="files.example.com" />

--- a/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/ConnectionsSettingsTab.razor
@@ -538,6 +538,13 @@
                     Encrypted at rest and never shown again. This is an SSH key for a server you run —
                     the rule that Connapse stores no cloud credentials is about AWS and Azure
                     identities, which are not stored and are not asked for.
+                    @if (!isNew)
+                    {
+                        <text>
+                            <strong>Test connection</strong> uses the stored key when this is blank, so
+                            checking an existing connection does not mean retyping it.
+                        </text>
+                    }
                 </div>
             </div>
 
@@ -1000,6 +1007,30 @@
         }
     }
 
+    /// <summary>
+    /// The key a test should use: the one typed into the form, or the connection's stored one
+    /// when the field was left blank. Returns a problem message instead when neither is available.
+    /// </summary>
+    private async Task<(string? Key, string? Passphrase, string? Problem)> ResolveTestKeyAsync()
+    {
+        if (!string.IsNullOrWhiteSpace(form.PrivateKey))
+            return (form.PrivateKey.Trim(), NullIfBlank(form.Passphrase), null);
+
+        if (editing is null)
+            return (null, null, "Paste the private key to test this connection.");
+
+        string? secret = await ConnectionStore.GetSecretAsync(editing.Id);
+        if (string.IsNullOrWhiteSpace(secret))
+            return (null, null, "This connection has no stored key. Paste one to test.");
+
+        var credential = SftpCredential.TryParse(secret);
+        if (credential is null || string.IsNullOrWhiteSpace(credential.PrivateKey))
+            return (null, null, "The stored key could not be read. Paste a key to replace it.");
+
+        // A passphrase typed now is preferred: the operator may be correcting one that is wrong.
+        return (credential.PrivateKey, NullIfBlank(form.Passphrase) ?? credential.Passphrase, null);
+    }
+
     private async Task Test()
     {
         testing = true;
@@ -1009,15 +1040,18 @@
         {
             if (form.Provider == ConnectionProvider.Sftp)
             {
-                // Tested against the key in the form, not the stored one, so an operator can
-                // check a key before committing to it. Editing an existing connection without
-                // retyping the key therefore cannot be tested — said plainly rather than
-                // silently testing something else.
-                if (string.IsNullOrWhiteSpace(form.PrivateKey))
+                // A key typed into the form wins, so a new one can be checked before it is
+                // committed. Otherwise the stored one is used — the field says "leave blank to
+                // keep the stored key", and a test that then demanded the key back would be
+                // asking for something the operator was told they would never see again.
+                //
+                // The key never reaches the browser either way: this runs on the server, inside
+                // the circuit, and only the outcome is rendered.
+                (string? key, string? passphrase, string? problem) = await ResolveTestKeyAsync();
+                if (problem is not null)
                 {
                     testSuccess = false;
-                    testMessage = "Paste the private key to test. Testing uses the key in this form, "
-                                  + "not the stored one.";
+                    testMessage = problem;
                     return;
                 }
 
@@ -1027,8 +1061,8 @@
                     Port = int.TryParse(form.Port, out int p) ? p : 22,
                     Username = form.Username?.Trim() ?? "",
                     AllowedRoot = form.AllowedRoot?.Trim() ?? "",
-                    PrivateKey = form.PrivateKey.Trim(),
-                    Passphrase = NullIfBlank(form.Passphrase),
+                    PrivateKey = key!,
+                    Passphrase = passphrase,
 
                     // Honoured unless the operator has chosen to forget it, so a test reports a
                     // changed host key the same way a sync would.
@@ -1036,7 +1070,13 @@
                 }, TimeSpan.FromSeconds(15));
 
                 testSuccess = sftpResult.Success;
-                testMessage = sftpResult.Message;
+
+                // Which key was used, always. Two keys can be in play and they can disagree, so
+                // a bare "Connected" would leave the operator unsure what they just proved.
+                string usedKey = string.IsNullOrWhiteSpace(form.PrivateKey)
+                    ? "Using the stored key."
+                    : "Using the key in this form.";
+                testMessage = $"{usedKey} {sftpResult.Message}";
                 return;
             }
 

--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text.Json.Serialization;
 using Connapse.Background;
 using Connapse.Core;
@@ -147,6 +147,10 @@ builder.Services.AddScoped<ICloudScopeService, CloudScopeService>();
 // re-checks the same policy on every sync cycle, which is what catches an allowlist narrowed
 // after a source already exists.
 builder.Services.AddScoped<SourceScopePreflight>();
+
+// Singleton: whether this process is in a container cannot change while it runs, and the
+// resolver reads that once. See ContainerHostResolver.
+builder.Services.AddSingleton<IContainerHostResolver, ContainerHostResolver>();
 builder.Services.AddScoped<IUploadService, UploadService>();
 
 builder.Services.AddConnapseStorage(builder.Configuration);

--- a/src/Connapse.Web/Services/ContainerHostResolver.cs
+++ b/src/Connapse.Web/Services/ContainerHostResolver.cs
@@ -1,0 +1,56 @@
+using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
+
+namespace Connapse.Web.Services;
+
+/// <summary>
+/// Decides whether Connapse is containerised, then applies <see cref="ContainerHostPolicy"/>.
+/// </summary>
+/// <remarks>
+/// Two signals, because neither is guaranteed on its own. <c>DOTNET_RUNNING_IN_CONTAINER</c> is
+/// set by the official .NET base images but not by a hand-rolled Dockerfile on another base;
+/// <c>/.dockerenv</c> is created by Docker but not by every other runtime. Either one is enough,
+/// and the cost of being wrong is asymmetric: believing we are containerised when we are not
+/// rewrites loopback into a name that will not resolve, while believing the reverse merely
+/// leaves the operator where they already were.
+/// <para>
+/// Registered as a singleton and read once. Neither signal can change while the process runs,
+/// and touching the filesystem on every keystroke of a host field would be silly.
+/// </para>
+/// </remarks>
+public sealed class ContainerHostResolver : IContainerHostResolver
+{
+    public ContainerHostResolver()
+    {
+        IsContainerised = DetectContainer();
+    }
+
+    /// <summary>Test seam: lets a test state the environment rather than fake one.</summary>
+    internal ContainerHostResolver(bool isContainerised)
+    {
+        IsContainerised = isContainerised;
+    }
+
+    public bool IsContainerised { get; }
+
+    public HostResolution Resolve(string? host) =>
+        ContainerHostPolicy.Resolve(host, IsContainerised);
+
+    private static bool DetectContainer()
+    {
+        string? flag = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER");
+        if (bool.TryParse(flag, out bool inContainer) && inContainer)
+            return true;
+
+        try
+        {
+            return File.Exists("/.dockerenv");
+        }
+        catch
+        {
+            // A probe that cannot answer must not take the app down over a hint. Not
+            // containerised is the safe answer: it changes nothing the operator typed.
+            return false;
+        }
+    }
+}

--- a/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
+++ b/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using Connapse.Core;
 using Connapse.Core.Utilities;
 using Connapse.Web.Components.Settings;
@@ -387,9 +387,9 @@ public class ConnectionFormTests
     private const string GeneratedKey = "-----BEGIN RSA PRIVATE KEY-----\ngenerated\n";
 
     [Fact]
-    public void ForLocalMachine_UsesEveryValueTheHostReported()
+    public void ForGuidedSetup_UsesEveryValueTheHostReported()
     {
-        var form = ConnectionForm.ForLocalMachine(
+        var form = ConnectionForm.ForGuidedSetup(
             Reported(), "host.docker.internal", "Documents", GeneratedKey);
 
         form.Provider.Should().Be(ConnectionProvider.Sftp);
@@ -407,9 +407,9 @@ public class ConnectionFormTests
     /// out where most people actually keep things.
     /// </summary>
     [Fact]
-    public void ForLocalMachine_RootOnAnotherDrive_IsAllowed()
+    public void ForGuidedSetup_RootOnAnotherDrive_IsAllowed()
     {
-        ConnectionForm.ForLocalMachine(Reported(), "h", "/D:/CodeProjects", GeneratedKey)
+        ConnectionForm.ForGuidedSetup(Reported(), "h", "/D:/CodeProjects", GeneratedKey)
             .AllowedRoot.Should().Be("/D:/CodeProjects");
     }
 
@@ -417,9 +417,9 @@ public class ConnectionFormTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    public void ForLocalMachine_NoFolderChosen_UsesTheHomeDirectory(string? root)
+    public void ForGuidedSetup_NoFolderChosen_UsesTheHomeDirectory(string? root)
     {
-        ConnectionForm.ForLocalMachine(Reported(), "h", root, GeneratedKey)
+        ConnectionForm.ForGuidedSetup(Reported(), "h", root, GeneratedKey)
             .AllowedRoot.Should().Be("/C:/Users/Diviel");
     }
 
@@ -473,11 +473,11 @@ public class ConnectionFormTests
     /// The whole flow exists to avoid typing, so what it produces must be savable as-is.
     /// </summary>
     [Fact]
-    public void ForLocalMachine_ProducesAConnectionThatValidatesAndStoresItsKey()
+    public void ForGuidedSetup_ProducesAConnectionThatValidatesAndStoresItsKey()
     {
         var pair = SshKeyPairGenerator.Generate();
 
-        var form = ConnectionForm.ForLocalMachine(
+        var form = ConnectionForm.ForGuidedSetup(
             Reported(), "host.docker.internal", "Documents", pair.PrivateKeyPem);
 
         form.Validate(isNew: true).Should().BeNull();
@@ -494,9 +494,9 @@ public class ConnectionFormTests
     /// verified rather than trusted — the entire reason the operator pastes anything back.
     /// </summary>
     [Fact]
-    public void ForLocalMachine_PinsTheFingerprintBeforeTheFirstConnection()
+    public void ForGuidedSetup_PinsTheFingerprintBeforeTheFirstConnection()
     {
-        var form = ConnectionForm.ForLocalMachine(
+        var form = ConnectionForm.ForGuidedSetup(
             Reported(fingerprint: "SHA256:fromTheHost"), "h", null, GeneratedKey);
 
         JsonNode.Parse(form.ToConfigJson())!["hostKeyFingerprint"]!.GetValue<string>()

--- a/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
+++ b/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
@@ -387,6 +387,22 @@ public class ConnectionFormTests
     private const string GeneratedKey = "-----BEGIN RSA PRIVATE KEY-----\ngenerated\n";
 
     [Fact]
+    public void ForGuidedSetup_NoPortGiven_DefaultsTo22()
+    {
+        ConnectionForm.ForGuidedSetup(Reported(), "h", null, GeneratedKey).Port.Should().Be("22");
+        ConnectionForm.ForGuidedSetup(Reported(), "h", null, GeneratedKey, "  ").Port.Should().Be("22");
+    }
+
+    [Fact]
+    public void ForGuidedSetup_APortGiven_IsKept()
+    {
+        // Its own field rather than something split back out of the host: a colon means
+        // something else entirely once the host is an IPv6 literal.
+        ConnectionForm.ForGuidedSetup(Reported(), "h", null, GeneratedKey, "2222")
+            .Should().BeEquivalentTo(new { Host = "h", Port = "2222" });
+    }
+
+    [Fact]
     public void ForGuidedSetup_UsesEveryValueTheHostReported()
     {
         var form = ConnectionForm.ForGuidedSetup(

--- a/tests/Connapse.Core.Tests/Utilities/ContainerHostPolicyTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/ContainerHostPolicyTests.cs
@@ -1,0 +1,89 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+/// <summary>
+/// The one address whose meaning depends on who is asking. Everything else a container reaches
+/// exactly as the operator's machine does, so these tests are as much about what is left alone
+/// as about what is changed.
+/// </summary>
+[Trait("Category", "Unit")]
+public class ContainerHostPolicyTests
+{
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("LOCALHOST")]
+    [InlineData("  localhost  ")]
+    [InlineData("127.0.0.1")]
+    [InlineData("127.0.1.1")]
+    [InlineData("127.255.255.254")]
+    [InlineData("::1")]
+    [InlineData("[::1]")]
+    public void Resolve_LoopbackInAContainer_BecomesTheDockerHostAlias(string host)
+    {
+        var result = ContainerHostPolicy.Resolve(host, containerised: true);
+
+        result.Host.Should().Be(ContainerHostPolicy.DockerHostAlias);
+        result.Rewritten.Should().BeTrue();
+        result.Reason.Should().NotBeNullOrWhiteSpace("a silent rewrite is undebuggable later");
+    }
+
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("127.0.0.1")]
+    public void Resolve_LoopbackOutsideAContainer_IsLeftAlone(string host)
+    {
+        // Running under `dotnet run` on the host, loopback is exactly right and the alias would
+        // not resolve. The rewrite is only correct because of where Connapse happens to be.
+        var result = ContainerHostPolicy.Resolve(host, containerised: false);
+
+        result.Host.Should().Be(host);
+        result.Rewritten.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("192.168.1.50")]
+    [InlineData("10.0.0.7")]
+    [InlineData("172.20.5.5")]
+    [InlineData("files.example.com")]
+    [InlineData("myserver.local")]
+    [InlineData("host.docker.internal")]
+    public void Resolve_AnythingElse_IsLeftAlone(string host)
+    {
+        // A container reaches a LAN address perfectly well — Docker routes outbound traffic
+        // through the host — so there is nothing to translate. A hostname cannot be translated
+        // at all: it either resolves from the container's DNS or it does not.
+        ContainerHostPolicy.Resolve(host, containerised: true)
+            .Should().BeEquivalentTo(new { Host = host, Rewritten = false });
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1.example.com")]
+    [InlineData("127.example.com")]
+    [InlineData("localhost.example.com")]
+    [InlineData("127.0.0.256")]
+    [InlineData("127.0.0")]
+    public void IsLoopback_ThingsThatMerelyStartLikeLoopback_AreNot(string host)
+    {
+        // Prefix matching would claim all of these. "127.0.0.1.example.com" is an ordinary
+        // hostname somebody can absolutely own, and rewriting it would send Connapse to the
+        // wrong machine entirely.
+        ContainerHostPolicy.IsLoopback(host).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_NothingTyped_StaysNothing(string? host)
+    {
+        // Validation's job to complain about, not this one's — and rewriting a blank field into
+        // a real address would let an empty form save a connection pointing somewhere.
+        var result = ContainerHostPolicy.Resolve(host, containerised: true);
+
+        result.Host.Should().BeEmpty();
+        result.Rewritten.Should().BeFalse();
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/ContainerHostPolicyTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/ContainerHostPolicyTests.cs
@@ -1,4 +1,4 @@
-using Connapse.Core.Utilities;
+﻿using Connapse.Core.Utilities;
 using FluentAssertions;
 using Xunit;
 
@@ -21,6 +21,13 @@ public class ContainerHostPolicyTests
     [InlineData("127.255.255.254")]
     [InlineData("::1")]
     [InlineData("[::1]")]
+    [InlineData("0:0:0:0:0:0:0:1")]
+    [InlineData("[0:0:0:0:0:0:0:1]")]
+    [InlineData("::ffff:127.0.0.1")]
+    // inet_aton shorthand, which resolvers really do accept: `ssh 127.1` reaches localhost, so
+    // these are loopback and not merely things that look like it.
+    [InlineData("127.0.0")]
+    [InlineData("127.1")]
     public void Resolve_LoopbackInAContainer_BecomesTheDockerHostAlias(string host)
     {
         var result = ContainerHostPolicy.Resolve(host, containerised: true);
@@ -64,7 +71,6 @@ public class ContainerHostPolicyTests
     [InlineData("127.example.com")]
     [InlineData("localhost.example.com")]
     [InlineData("127.0.0.256")]
-    [InlineData("127.0.0")]
     public void IsLoopback_ThingsThatMerelyStartLikeLoopback_AreNot(string host)
     {
         // Prefix matching would claim all of these. "127.0.0.1.example.com" is an ordinary

--- a/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
@@ -564,4 +564,45 @@ public class SftpHostSetupTests
         SftpHostSetup.GenerateScript(Key, HostPlatform.Windows)
             .Should().Be(SftpHostSetup.GenerateScript(Key, HostPlatform.Windows, SftpSetupTarget.ThisComputer));
     }
+
+    [Theory]
+    [InlineData(HostPlatform.Linux, SftpSetupTarget.ThisComputer)]
+    [InlineData(HostPlatform.Linux, SftpSetupTarget.RemoteServer)]
+    [InlineData(HostPlatform.MacOS, SftpSetupTarget.ThisComputer)]
+    [InlineData(HostPlatform.MacOS, SftpSetupTarget.RemoteServer)]
+    public void GenerateScript_Unix_NeverPassesAMarkerAsAPrintfFormatString(
+        HostPlatform platform, SftpSetupTarget target)
+    {
+        // Both markers start with dashes, and printf reads a leading '-' as an option. As the
+        // format string the end marker made bash print "invalid option" instead of the marker,
+        // so the block came back unterminated and ParseResult refused it — with the host already
+        // configured and the key already installed. Asserting the marker merely *appears* in the
+        // script does not catch this: it appeared, as the thing that failed to print.
+        string script = SftpHostSetup.GenerateScript(Key, platform, target);
+
+        foreach (string line in script.Split('\n'))
+        {
+            string trimmed = line.Trim();
+            if (!trimmed.StartsWith("printf ", StringComparison.Ordinal)) continue;
+
+            string format = trimmed["printf ".Length..].TrimStart();
+            format = format.StartsWith('\'') ? format[1..] : format;
+
+            format.Should().NotStartWith("-",
+                $"printf would read this as an option, not text: {trimmed}");
+        }
+    }
+
+    [Theory]
+    [InlineData(HostPlatform.Linux)]
+    [InlineData(HostPlatform.MacOS)]
+    public void GenerateScript_Unix_EmitsBothMarkersThroughAStringPlaceholder(HostPlatform platform)
+    {
+        // The positive half of the rule above: the markers are arguments, which is what makes
+        // them survive their own leading dashes.
+        string script = SftpHostSetup.GenerateScript(Key, platform, SftpSetupTarget.RemoteServer);
+
+        script.Should().Contain($"'{SftpHostSetup.BeginMarker}'");
+        script.Should().Contain($"'{SftpHostSetup.EndMarker}'");
+    }
 }

--- a/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
@@ -609,9 +609,49 @@ public class SftpHostSetupTests
     // ── Addresses the host reports about itself ───────────────────────────────────
 
     [Fact]
-    public void ParseResult_ReportedHostAndAddresses_AreOfferedHostnameFirst()
+    public void ParseResult_ShortNameAndFqdn_OffersTheFqdnFirstAndTheShortNameLast()
     {
-        // Hostname first because it survives a DHCP lease changing and an address does not.
+        // The short name is the one the operator recognises and the one likeliest to fail: their
+        // workstation resolves it only because its DNS client appends a search suffix, and a
+        // container has none. So it stays in the list, at the bottom.
+        string block = $"""
+            {SftpHostSetup.BeginMarker}
+            user=diviel
+            home=/home/diviel
+            fingerprint=SHA256:abc
+            host=divielserver
+            fqdn=divielserver.attlocal.net
+            addresses=192.168.1.194
+            {SftpHostSetup.EndMarker}
+            """;
+
+        SftpHostSetup.ParseResult(block)!.Addresses
+            .Should().Equal("divielserver.attlocal.net", "192.168.1.194", "divielserver");
+    }
+
+    [Fact]
+    public void ParseResult_FqdnEqualsTheShortName_IsNotOfferedTwice()
+    {
+        // hostname -f falls back to the short name on a host with no domain configured.
+        string block = $"""
+            {SftpHostSetup.BeginMarker}
+            user=diviel
+            home=/home/diviel
+            fingerprint=SHA256:abc
+            host=fileserver
+            fqdn=fileserver
+            addresses=192.168.1.50
+            {SftpHostSetup.EndMarker}
+            """;
+
+        SftpHostSetup.ParseResult(block)!.Addresses.Should().Equal("fileserver", "192.168.1.50");
+    }
+
+    [Fact]
+    public void ParseResult_NoFqdnReported_OffersAddressesAheadOfTheShortName()
+    {
+        // With no fully-qualified name to lead with, an address beats the short name: it needs
+        // no resolver at all, where the short name needs one that appends a search suffix.
         string block = $"""
             {SftpHostSetup.BeginMarker}
             user=diviel
@@ -623,7 +663,7 @@ public class SftpHostSetupTests
             """;
 
         SftpHostSetup.ParseResult(block)!.Addresses
-            .Should().Equal("fileserver", "192.168.1.50", "10.8.0.3");
+            .Should().Equal("192.168.1.50", "10.8.0.3", "fileserver");
     }
 
     [Fact]

--- a/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
@@ -466,4 +466,102 @@ public class SftpHostSetupTests
             "enabling SSH without naming the host's password policy hides half the change");
         script.Should().Contain("accepts SSH logins by password");
     }
+
+    // ── Setting up a server the operator already reaches over SSH (#407) ───────────
+
+    /// <summary>
+    /// The five things that only make sense when the SSH server does not exist yet. A server
+    /// the operator is running this on is already serving SSH, so each of these would either
+    /// do nothing or change something they did not ask to have changed.
+    /// </summary>
+    public static TheoryData<string> PrivilegedSteps => new()
+    {
+        "Add-WindowsCapability",
+        "Set-Service",
+        "Start-Service",
+        "New-NetFirewallRule",
+    };
+
+    [Theory]
+    [MemberData(nameof(PrivilegedSteps))]
+    public void GenerateScript_Remote_DoesNotStandUpAnSshServer(string step)
+    {
+        string remote = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows, SftpSetupTarget.RemoteServer);
+
+        remote.Should().NotContain(step,
+            "the operator is already connected over SSH, so the server is running and the port is open");
+
+        SftpHostSetup.GenerateScript(Key, HostPlatform.Windows, SftpSetupTarget.ThisComputer)
+            .Should().Contain(step, "the local variant is the one that has to create all this");
+    }
+
+    [Theory]
+    [InlineData(HostPlatform.Linux)]
+    [InlineData(HostPlatform.MacOS)]
+    public void GenerateScript_RemoteUnix_NeedsNoPrivilege(HostPlatform platform)
+    {
+        // Writing one line into the operator's own ~/.ssh/authorized_keys is not privileged
+        // work, and asking for sudo on a machine they may not own is a real obstacle.
+        string remote = SftpHostSetup.GenerateScript(Key, platform, SftpSetupTarget.RemoteServer);
+
+        remote.Should().NotContain("sudo");
+        remote.Should().Contain("authorized_keys", "the key still has to be installed");
+    }
+
+    [Theory]
+    [InlineData(HostPlatform.Windows)]
+    [InlineData(HostPlatform.Linux)]
+    [InlineData(HostPlatform.MacOS)]
+    public void GenerateScript_Remote_StillInstallsTheKeyRestricted(HostPlatform platform)
+    {
+        // Everything the local variant does about *authorisation* is unchanged. Only the
+        // steps that bring a server into existence are dropped.
+        string remote = SftpHostSetup.GenerateScript(Key, platform, SftpSetupTarget.RemoteServer);
+
+        remote.Should().Contain(SftpHostSetup.KeyRestrictions.Trim(),
+            "an unrestricted key would grant a shell on someone else's server");
+        remote.Should().Contain(SftpHostSetup.BeginMarker);
+        remote.Should().Contain("fingerprint=", "verified first use is the whole point of the round trip");
+        remote.Should().Contain("PasswordAuthentication",
+            "a remote host is likelier to be internet-facing, not less");
+    }
+
+    [Fact]
+    public void GenerateScript_RemoteWindows_AsksForElevationOnlyWhenTheAccountIsAnAdministrator()
+    {
+        // The local script demands elevation up front because installing the SSH server needs
+        // it regardless. Remotely only one branch does — the machine-wide file an administrator
+        // account's keys go in — so demanding it unconditionally would put a UAC prompt in
+        // front of a step that writes one line into the operator's own home directory.
+        string remote = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows, SftpSetupTarget.RemoteServer);
+
+        remote.Should().Contain("if ($isAdmin -and -not $elevated)",
+            "elevation is demanded only once membership is known");
+        remote.Should().Contain("administrators_authorized_keys",
+            "which is the file that makes elevation necessary at all");
+
+        int guard = remote.IndexOf("$isAdmin -and -not $elevated", StringComparison.Ordinal);
+        int membership = remote.IndexOf("Get-LocalGroupMember", StringComparison.Ordinal);
+        guard.Should().BeGreaterThan(membership, "the question has to be asked before it is acted on");
+    }
+
+    [Fact]
+    public void GenerateScript_RemoteWindows_RefusesToGuessMembershipItCouldNotRead()
+    {
+        // UAC filters the Administrators SID out of an unelevated token, so falling back to a
+        // token check would answer "not an administrator" for an account that is one — and the
+        // key would go in a file sshd never reads, failing with nothing to explain it.
+        string remote = SftpHostSetup.GenerateScript(Key, HostPlatform.Windows, SftpSetupTarget.RemoteServer);
+
+        remote.Should().Contain("Could not read the Administrators group",
+            "refusing beats guessing wrong in the direction that fails silently");
+    }
+
+    [Fact]
+    public void GenerateScript_DefaultsToThisComputer()
+    {
+        // The two-argument form predates the target and is still what the local flow calls.
+        SftpHostSetup.GenerateScript(Key, HostPlatform.Windows)
+            .Should().Be(SftpHostSetup.GenerateScript(Key, HostPlatform.Windows, SftpSetupTarget.ThisComputer));
+    }
 }

--- a/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/SftpHostSetupTests.cs
@@ -605,4 +605,72 @@ public class SftpHostSetupTests
         script.Should().Contain($"'{SftpHostSetup.BeginMarker}'");
         script.Should().Contain($"'{SftpHostSetup.EndMarker}'");
     }
+
+    // ── Addresses the host reports about itself ───────────────────────────────────
+
+    [Fact]
+    public void ParseResult_ReportedHostAndAddresses_AreOfferedHostnameFirst()
+    {
+        // Hostname first because it survives a DHCP lease changing and an address does not.
+        string block = $"""
+            {SftpHostSetup.BeginMarker}
+            user=diviel
+            home=/home/diviel
+            fingerprint=SHA256:abc
+            host=fileserver
+            addresses=192.168.1.50,10.8.0.3
+            {SftpHostSetup.EndMarker}
+            """;
+
+        SftpHostSetup.ParseResult(block)!.Addresses
+            .Should().Equal("fileserver", "192.168.1.50", "10.8.0.3");
+    }
+
+    [Fact]
+    public void ParseResult_HostAlreadyAmongTheAddresses_IsNotOfferedTwice()
+    {
+        string block = $"""
+            {SftpHostSetup.BeginMarker}
+            user=diviel
+            home=/home/diviel
+            fingerprint=SHA256:abc
+            host=192.168.1.50
+            addresses=192.168.1.50,10.8.0.3
+            {SftpHostSetup.EndMarker}
+            """;
+
+        SftpHostSetup.ParseResult(block)!.Addresses.Should().Equal("192.168.1.50", "10.8.0.3");
+    }
+
+    [Fact]
+    public void ParseResult_NoAddressesReported_StillParses()
+    {
+        // An older setup command sent neither field, and a machine whose address lookup found
+        // nothing still installed the key correctly. Refusing the block would strand a host that
+        // is already configured — the same trap the optional fingerprint avoids.
+        string block = $"""
+            {SftpHostSetup.BeginMarker}
+            user=diviel
+            home=/home/diviel
+            fingerprint=SHA256:abc
+            {SftpHostSetup.EndMarker}
+            """;
+
+        var result = SftpHostSetup.ParseResult(block);
+
+        result.Should().NotBeNull();
+        result!.Addresses.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(HostPlatform.Linux)]
+    [InlineData(HostPlatform.MacOS)]
+    [InlineData(HostPlatform.Windows)]
+    public void GenerateScript_ReportsTheMachinesOwnNameAndAddresses(HostPlatform platform)
+    {
+        string script = SftpHostSetup.GenerateScript(Key, platform, SftpSetupTarget.RemoteServer);
+
+        script.Should().Contain("host=");
+        script.Should().Contain("addresses=");
+    }
 }

--- a/tests/Connapse.Storage.Tests/ConnectionTesters/SftpConnectionTesterTests.cs
+++ b/tests/Connapse.Storage.Tests/ConnectionTesters/SftpConnectionTesterTests.cs
@@ -63,6 +63,6 @@ public class SftpConnectionTesterTests
 
         result.Success.Should().BeFalse();
         result.Message.Should().Contain("did not resolve");
-        result.Message.Should().Contain("dns_search", "the remedy belongs with the diagnosis");
+        result.Message.Should().Contain("the address", "the remedy belongs with the diagnosis");
     }
 }

--- a/tests/Connapse.Storage.Tests/ConnectionTesters/SftpConnectionTesterTests.cs
+++ b/tests/Connapse.Storage.Tests/ConnectionTesters/SftpConnectionTesterTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Net.Sockets;
+using Connapse.Core.Utilities;
+using Connapse.Storage.ConnectionTesters;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Storage.Tests.ConnectionTesters;
+
+[Trait("Category", "Unit")]
+public class SftpConnectionTesterTests
+{
+    [Fact]
+    public void FindHostNotFound_WrappedByTheSshLibrary_IsStillFound()
+    {
+        // SSH.NET wraps the socket failure, so the exception actually caught never says what
+        // went wrong. Checking only the outermost one would miss every real occurrence.
+        var wrapped = new InvalidOperationException(
+            "Connection failed",
+            new AggregateException(
+                new SocketException((int)SocketError.HostNotFound)));
+
+        SftpConnectionTester.FindHostNotFound(wrapped).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void FindHostNotFound_ADifferentSocketFailure_IsNotMistakenForOne()
+    {
+        // A refused connection means the name resolved and nothing was listening — the opposite
+        // diagnosis, and telling that operator about DNS suffixes would send them the wrong way.
+        var refused = new SocketException((int)SocketError.ConnectionRefused);
+
+        SftpConnectionTester.FindHostNotFound(refused).Should().BeNull();
+    }
+
+    [Fact]
+    public void FindHostNotFound_NothingToFind_ReturnsNull()
+    {
+        SftpConnectionTester.FindHostNotFound(new TimeoutException()).Should().BeNull();
+        SftpConnectionTester.FindHostNotFound(null).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TestConnectionAsync_AHostThatCannotResolve_ExplainsWhyItWorksElsewhere()
+    {
+        // The failure whose symptom contradicts the operator's own experience: the name works
+        // from their desktop, so a bare "no such host" reads as Connapse being wrong.
+        //
+        // A real key, because the key is parsed before anything is dialled — a placeholder fails
+        // with "Invalid private key file" and never reaches the lookup this test is about.
+        var keyPair = SshKeyPairGenerator.Generate("test");
+
+        var result = await new SftpConnectionTester().TestConnectionAsync(
+            new SftpConnectionTestSettings
+            {
+                // .invalid is reserved by RFC 2606 and guaranteed never to resolve, so this
+                // cannot start passing because somebody registered a domain.
+                Host = "connapse-no-such-host.invalid",
+                Username = "nobody",
+                AllowedRoot = "/",
+                PrivateKey = keyPair.PrivateKeyPem,
+            },
+            TimeSpan.FromSeconds(10));
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("did not resolve");
+        result.Message.Should().Contain("dns_search", "the remedy belongs with the diagnosis");
+    }
+}


### PR DESCRIPTION
Closes #407.

## What changed

"Connect a server" sits beside "Connect this computer". Both run the same three steps —
Connapse generates a key pair, writes one command, reads back what it printed — and both end in
the same kind of connection. Only the script differs, and a toggle inside the panel switches
between them afterwards.

| | Connect this computer | Connect a server |
|---|---|---|
| SSH server | installs and starts it if absent | assumes it |
| Firewall | opens inbound TCP 22 to local subnets | untouched |
| Privilege | administrator / `sudo` throughout | only if the account is a Windows administrator |
| Address | defaults to `host.docker.internal` | supplied by the operator |

The remote script drops `Add-WindowsCapability`, `Set-Service`, `Start-Service`,
`New-NetFirewallRule` and the `systemctl`/`systemsetup` step. On Unix it needs no `sudo` at all.

## The Windows elevation change

The local script demands elevation up front because installing the server needs it regardless.
Remotely only one branch does — the machine-wide `administrators_authorized_keys` file — so
membership is read first and administrator is demanded only if the answer requires it. Otherwise
a UAC prompt would sit in front of a step that writes one line into the operator's own home
directory.

Where the group cannot be read unelevated, the script **stops rather than falling back to a
token check**. UAC filters the Administrators SID out of an unelevated token, so that check
answers "not an administrator" for an account that is one, and the key would be installed where
sshd never looks — failing later with nothing to explain it.

## Unchanged

The key is still installed with `restrict` and a forced `internal-sftp` command. The host key
fingerprint still comes back in the pasted block rather than off the wire, so the first
connection is verified rather than trusted. Both variants still report whether the host accepts
password logins without changing it.

Connapse still never installs the key itself over a password session, and `docs/connectors.md`
now says so where someone would look for it.

## Verification

1,082 unit tests, 384 integration, 0 warnings. All four script variants were rendered and read
before any assertion was written against them.

**Not verified:** the panel has not been seen rendering. Postgres is not exposed to the host in
the running compose stack, and bringing up the dev override would have restarted containers that
were in use. Razor compiles and the logic is tested, but the layout is unconfirmed — worth a look
before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guided SFTP setup for connecting either this computer or a remote server.
  * Added target-specific instructions, warnings, setup commands, and custom port support.
  * Remote setup installs the restricted key without changing SSH services, firewalls, or privileges.
  * Setup reports hostnames and reachable addresses for easier connections.
  * Added automatic host-address handling for containerized environments.

* **Bug Fixes**
  * Improved messaging when hostnames cannot be resolved from a container.

* **Documentation**
  * Updated SFTP guidance with separate workflows, security restrictions, host-key verification, and manual setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->