### PR TITLE
fix(web): restore the Connections page work left behind by #408

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1186,7 +1186,7 @@ Base path: `/api/sources`
 
 A **source** is an external system Connapse mirrors read-only — an S3 bucket, an Azure Blob container, or a filesystem directory. It is searchable but never browsable and never writable. See [connectors.md](connectors.md) for the connection/source model.
 
-**Connections have no REST surface.** They hold the credential boundary and are managed in Settings > Connections by administrators only. Sources are scoped inside a connection an administrator already approved, which is why they do have routes.
+**Connections have no REST surface.** They hold the credential boundary and are managed on the Connections page by administrators only. Sources are scoped inside a connection an administrator already approved, which is why they do have routes.
 
 | Method | Route | Role |
 |--------|-------|------|
@@ -1280,7 +1280,7 @@ Reconcile a container's managed storage against the document table. Lists stored
 }
 ```
 
-> **Changed in v0.4.0.** `POST /api/containers/test-connection` was removed — it validated connector config before creating a container, which no longer happens. Connection testing lives in Settings > Connections. This route also no longer talks to any external system: external syncing is `POST /api/sources/{id}/sync`.
+> **Changed in v0.4.0.** `POST /api/containers/test-connection` was removed — it validated connector config before creating a container, which no longer happens. Connection testing lives on the Connections page. This route also no longer talks to any external system: external syncing is `POST /api/sources/{id}/sync`.
 
 ---
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -38,7 +38,7 @@ Deleting a container deletes its stored objects, so it must be empty first.
 
 A connection holds **how to authenticate** and **what the credential is allowed to reach**. It never holds a bucket name — that is the source's job.
 
-Connections are created and edited in **Settings > Connections**, by administrators, in the UI only. There is no REST route for them, and that is deliberate: see [Why connections are UI-only](#why-connections-are-ui-only).
+Connections are created and edited on the **Connections** page, by administrators, in the UI only. There is no REST route for them, and that is deliberate: see [Why connections are UI-only](#why-connections-are-ui-only).
 
 ### No stored cloud credentials
 
@@ -239,7 +239,7 @@ SFTP is the answer. Run an SSH server on the machine holding the files and let C
 
 ### Guided setup
 
-Settings → Connections has two buttons that do all of this for you: **Connect this computer** and **Connect a server**. Both run the same three steps — Connapse generates a key pair, writes one command, and reads back what the command printed. Setting up your own computer leaves you nothing to type but the folder; a server also needs the address Connapse can reach it at, which the machine itself cannot know.
+The Connections page has two buttons that do all of this for you: **Connect this computer** and **Connect a server**. Both run the same three steps — Connapse generates a key pair, writes one command, and reads back what the command printed. Setting up your own computer leaves you nothing to type but the folder; a server also needs the address Connapse can reach it at, which the machine itself cannot know.
 
 The difference is only what the command does when it runs:
 
@@ -260,7 +260,7 @@ The guided flow does nothing you cannot do yourself, and on a host you administe
 
 1. **Enable an SSH server.** OpenSSH Server is an optional feature on Windows, Remote Login on macOS, `sshd` on Linux.
 2. **Add a public key** to that account's `authorized_keys`, and give Connapse the matching private key. Prefix it with `restrict,command="internal-sftp"` unless you want that key to be able to do more than Connapse needs.
-3. **Create an SFTP connection** under Settings → Connections, pointing at the machine with an `allowedRoot` of the folder you want reachable.
+3. **Create an SFTP connection** on the Connections page, pointing at the machine with an `allowedRoot` of the folder you want reachable.
 4. **Create a source** on that connection naming a `subPath` within it.
 
 Three things worth knowing before you spend an hour on them:

--- a/src/Connapse.Web/Components/Layout/NavMenu.razor
+++ b/src/Connapse.Web/Components/Layout/NavMenu.razor
@@ -1,4 +1,4 @@
-<div class="top-row ps-3 navbar navbar-dark">
+﻿<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">
             <img src="connapse-logo.svg" alt="Connapse" class="navbar-logo" />
@@ -40,6 +40,14 @@
                 </div>
 
                 <AuthorizeView Roles="Owner,Admin" Context="adminContext">
+                    @* Beside Settings rather than inside it: a connection is an entity an
+                       administrator creates and deletes, not a preference they adjust, and it is
+                       what every source is built on. *@
+                    <div class="nav-item px-3">
+                        <NavLink class="nav-link" href="connections">
+                            <span class="nav-icon bi-plug-fill" aria-hidden="true"></span> Connections
+                        </NavLink>
+                    </div>
                     <div class="nav-item px-3">
                         <NavLink class="nav-link" href="settings" Match="NavLinkMatch.All">
                             <span class="nav-icon bi-gear-fill" aria-hidden="true"></span> Settings

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -1,4 +1,6 @@
-﻿@using Connapse.Core
+﻿@page "/connections"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@using Connapse.Core
 @using Connapse.Core.Interfaces
 @using Connapse.Core.Utilities
 @inject IJSRuntime JS
@@ -18,18 +20,26 @@
 @*
     Connections — the credential and filesystem-root boundary.
 
-    This tab looks like its siblings but is not built like them. Every other settings tab edits
-    one strongly-typed record through IOptionsMonitor and hands it back via OnSave; this one is
-    entity CRUD over IConnectionStore. Matching the visual pattern without the data pattern is
-    deliberate.
+    Its own page rather than a settings tab, and gated to administrators. Every settings tab
+    edits one strongly-typed record through IOptionsMonitor and hands it back via OnSave; this
+    is entity CRUD over IConnectionStore, and it sits beside Sources in the navigation because
+    that is what it feeds.
 
     Connections are managed here and nowhere else: there is no REST, CLI, or MCP route that
     creates or edits one. The authority a connection confers is the same class of thing as a
     cloud credential, which this project does not accept over an API. See
     docs/research/programmatic-source-configuration-safety-2026-08-17.md.
+
+    RequireAdmin matches that: a connection names a filesystem root or a cloud identity, and
+    every source built on it inherits that reach.
 *@
 
+<PageTitle>Connections - Connapse</PageTitle>
+
 <div class="row g-3">
+    <div class="col-12">
+        <h1 class="mb-1"><span class="bi-plug-fill me-2"></span>Connections</h1>
+    </div>
     <div class="col-12">
         <div class="alert alert-info">
             <span class="bi-info-circle me-2"></span>

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -1,4 +1,5 @@
 ﻿@page "/connections"
+@rendermode InteractiveServer
 @attribute [Authorize(Policy = "RequireAdmin")]
 @using Connapse.Core
 @using Connapse.Core.Interfaces

--- a/src/Connapse.Web/Components/Pages/Settings.razor
+++ b/src/Connapse.Web/Components/Pages/Settings.razor
@@ -1,4 +1,4 @@
-@page "/settings"
+﻿@page "/settings"
 @attribute [Authorize(Policy = "RequireAdmin")]
 @using Connapse.Core
 @using Connapse.Core.Interfaces
@@ -90,13 +90,6 @@
                 Summary
             </button>
         </li>
-        <li class="nav-item" role="presentation">
-            <button class="nav-link @(activeTab == "connections" ? "active" : "")"
-                    @onclick='() => activeTab = "connections"'
-                    type="button">
-                Connections
-            </button>
-        </li>
     </ul>
 
     <!-- Tab Content -->
@@ -135,12 +128,6 @@
                                 Settings="summarySettings"
                                 ResolvedModelPlaceholder="@LlmOptions.CurrentValue.Model" />
             <button class="btn btn-primary mt-3" @onclick="SaveSummarySettings">Save Summary Settings</button>
-        }
-        else if (activeTab == "connections")
-        {
-            @* No Settings/OnSave pair: connections are entities in their own store, not a
-               settings record, so this tab loads and saves itself. *@
-            <ConnectionsSettingsTab />
         }
     </div>
 </div>

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -39,8 +39,8 @@
         @if (isAdmin)
         {
             <div class="d-flex gap-2">
-                <a class="btn btn-outline-secondary" href="/settings">
-                    <span class="bi-gear me-1"></span> Connections
+                <a class="btn btn-outline-secondary" href="/connections">
+                    <span class="bi-plug me-1"></span> Connections
                 </a>
                 <button class="btn btn-primary" @onclick="BeginCreate" disabled="@(connections.Count == 0)">
                     <span class="bi-plus-lg me-1"></span> New source
@@ -55,7 +55,7 @@
            attach it to would open a modal whose first field has no options. *@
         <div class="alert alert-info">
             <span class="bi-info-circle me-2"></span>
-            No connections yet. <a href="/settings" class="alert-link">Add one</a> before creating a source —
+            No connections yet. <a href="/connections" class="alert-link">Add one</a> before creating a source —
             a connection holds the credential, a source picks a scope inside it.
         </div>
     }

--- a/tests/Connapse.Web.Tests/Components/ConnectionsPageAuthorizationTests.cs
+++ b/tests/Connapse.Web.Tests/Components/ConnectionsPageAuthorizationTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Web.Tests.Components;
+
+/// <summary>
+/// Connections is the credential and filesystem-root boundary: a connection names a cloud
+/// identity or a directory on somebody's machine, and every source built on it inherits that
+/// reach. Moving it out of Settings moved it out from behind Settings' own gate, so the page
+/// has to carry one itself.
+/// </summary>
+/// <remarks>
+/// Reflection over the compiled component rather than a rendered circuit. It cannot prove a
+/// request is refused — an anonymous GET being redirected to /login shows that, and does not
+/// distinguish an editor from an administrator — but it does catch the attribute being dropped
+/// or weakened, which is the way this protection would realistically be lost.
+/// </remarks>
+public class ConnectionsPageAuthorizationTests
+{
+    private static readonly Type Page =
+        typeof(Connapse.Web.Components.Pages.Connections);
+
+    [Fact]
+    public void ConnectionsPage_IsRoutable()
+    {
+        Page.GetCustomAttributes(typeof(RouteAttribute), inherit: true)
+            .Cast<RouteAttribute>()
+            .Select(r => r.Template)
+            .Should().Contain("/connections");
+    }
+
+    [Fact]
+    public void ConnectionsPage_RequiresAnAdministrator()
+    {
+        var authorize = Page
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .Cast<AuthorizeAttribute>()
+            .ToList();
+
+        authorize.Should().ContainSingle("the page is reachable directly by URL, not only via a link");
+
+        authorize[0].Policy.Should().Be("RequireAdmin",
+            "a bare [Authorize] would let any signed-in viewer create a connection");
+    }
+
+    [Fact]
+    public void ConnectionsPage_GateMatchesTheSettingsPageItLeft()
+    {
+        // It was previously protected by Settings' own attribute. Whatever else changes, it must
+        // not have become easier to reach by being moved.
+        var settings = typeof(Connapse.Web.Components.Pages.Settings)
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .Cast<AuthorizeAttribute>()
+            .Single();
+
+        var connections = Page
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .Cast<AuthorizeAttribute>()
+            .Single();
+
+        connections.Policy.Should().Be(settings.Policy);
+    }
+}

--- a/tests/Connapse.Web.Tests/Components/ConnectionsPageAuthorizationTests.cs
+++ b/tests/Connapse.Web.Tests/Components/ConnectionsPageAuthorizationTests.cs
@@ -102,7 +102,7 @@ public class ConnectionsPageAuthorizationTests
             }
         }
 
-        private static string RepositoryRoot()
+        internal static string RepositoryRoot()
         {
             var dir = new DirectoryInfo(AppContext.BaseDirectory);
             while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Connapse.slnx")))
@@ -110,5 +110,54 @@ public class ConnectionsPageAuthorizationTests
 
             return dir?.FullName ?? throw new InvalidOperationException("Repository root not found.");
         }
+    }
+
+    /// <summary>
+    /// A page whose controls do anything needs a render mode of its own.
+    /// </summary>
+    /// <remarks>
+    /// Connections was a component inside Settings and inherited its interactivity. Moved to its
+    /// own page it inherited nothing, rendered statically, and every button went dead — the page
+    /// looked completely normal and simply did not respond. Nothing else caught it: it compiles,
+    /// it renders, it authorizes, and the markup is unchanged. Only using it finds this, which is
+    /// why it is worth a test that covers every page rather than the one that went wrong.
+    /// </remarks>
+    public class InteractivePageRenderModeTests
+    {
+        public static TheoryData<string> PagesWithControls()
+        {
+            var data = new TheoryData<string>();
+            string pages = PagesDirectory();
+
+            foreach (string file in Directory.EnumerateFiles(pages, "*.razor", SearchOption.AllDirectories))
+            {
+                string text = File.ReadAllText(file);
+
+                // Routable, and wires up at least one event. A static page with no handlers is
+                // fine without a render mode, and cheaper to serve.
+                if (text.Contains("@page ", StringComparison.Ordinal) &&
+                    (text.Contains("@onclick", StringComparison.Ordinal) ||
+                     text.Contains("@bind", StringComparison.Ordinal)))
+                {
+                    data.Add(Path.GetRelativePath(pages, file));
+                }
+            }
+
+            return data;
+        }
+
+        [Theory]
+        [MemberData(nameof(PagesWithControls))]
+        public void APageWithControls_DeclaresARenderMode(string relativePath)
+        {
+            string path = Path.Combine(PagesDirectory(), relativePath);
+
+            File.ReadAllText(path).Should().Contain("@rendermode",
+                $"{relativePath} has handlers, and without a render mode they never run");
+        }
+
+        private static string PagesDirectory() => Path.Combine(
+            SourcesPageConnectionLinkTests.RepositoryRoot(),
+            "src", "Connapse.Web", "Components", "Pages");
     }
 }

--- a/tests/Connapse.Web.Tests/Components/ConnectionsPageAuthorizationTests.cs
+++ b/tests/Connapse.Web.Tests/Components/ConnectionsPageAuthorizationTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
 using FluentAssertions;
 using Xunit;
@@ -61,5 +61,54 @@ public class ConnectionsPageAuthorizationTests
             .Single();
 
         connections.Policy.Should().Be(settings.Policy);
+    }
+
+    /// <summary>
+    /// The Sources page links to Connections and offers a button to create one. Both belong to
+    /// administrators, and both used to point at /settings, where the page no longer lives.
+    /// </summary>
+    /// <remarks>
+    /// Read from the source file rather than a rendered component. Markup this simple has no
+    /// seam worth testing through, and the two mistakes worth catching — a link left pointing at
+    /// the old location, and a control escaping its isAdmin block — are both visible in the text.
+    /// </remarks>
+    public class SourcesPageConnectionLinkTests
+    {
+        private static readonly string Markup = File.ReadAllText(
+            Path.Combine(RepositoryRoot(), "src", "Connapse.Web", "Components", "Pages", "Sources.razor"));
+
+        [Fact]
+        public void SourcesPage_LinksToTheConnectionsPage()
+        {
+            Markup.Should().Contain("href=\"/connections\"");
+            Markup.Should().NotContain("href=\"/settings\"",
+                "Connections moved out of Settings, so a link there lands on a page without it");
+        }
+
+        [Fact]
+        public void SourcesPage_OffersConnectionsOnlyToAdministrators()
+        {
+            // Every mention sits inside an isAdmin block. Checked by counting rather than by
+            // parsing: a Viewer offered a button to a page they cannot open is a dead end, and
+            // one offered a "New source" button has no connection to attach it to anyway.
+            int connectionsLinks = Markup.Split("href=\"/connections\"").Length - 1;
+
+            connectionsLinks.Should().Be(2, "the header button and the empty-state link");
+
+            foreach (string fragment in Markup.Split("href=\"/connections\"")[..^1])
+            {
+                fragment.Should().Contain("isAdmin",
+                    "a link to an administrator-only page must not be shown to everyone");
+            }
+        }
+
+        private static string RepositoryRoot()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Connapse.slnx")))
+                dir = dir.Parent;
+
+            return dir?.FullName ?? throw new InvalidOperationException("Repository root not found.");
+        }
     }
 }


### PR DESCRIPTION
## What

Cherry-picks the three commits that PR #408 left behind:

- `9649539` refactor(web): give Connections its own page, gated to administrators
- `6ca29db` fix(web): point the Sources page at Connections, not Settings
- `a15a764` fix(web): restore interactivity on the Connections page

## Why

#408 squash-merged an earlier snapshot of `feature/407-remote-sftp-setup`, so the tail of that branch never reached `main`. The work was written, reviewed and manually tested — but against a server built from the local branch, which is why the gap went unnoticed.

Without it, `main` still has Connections as a tab inside Settings, the Sources page still links to `/settings`, and `ConnectionsPageAuthorizationTests.cs` does not exist.

## How

No new work. `git diff` between this branch and the original branch tip is empty across `src/`, `tests/` and `docs/`, so the content is exactly what was reviewed on #408.

The third commit is worth noting on its own: moving a component to a page dropped its `@rendermode InteractiveServer`, because a page does not inherit one from its parent the way a component does. Every control on the page rendered normally and silently did nothing. The test added alongside it walks every routable page that wires up `@onclick` or `@bind` and asserts it declares a render mode.

## Verification

`dotnet build` clean, 0 warnings.

Closes #409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Connections page to the main navigation for administrators.
  * Moved connection management from Settings to the Connections page.
  * Updated Sources page links and empty states to direct administrators to Connections.

* **Access Control**
  * Restricted the Connections page to administrators.

* **Documentation**
  * Updated connection-management guidance and navigation references throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->