### PR TITLE
feat(web): an Admin nav section, and identity providers on their own page

### DIFF
--- a/src/Connapse.Web/Components/Layout/NavMenu.razor
+++ b/src/Connapse.Web/Components/Layout/NavMenu.razor
@@ -39,30 +39,55 @@
                     </NavLink>
                 </div>
 
+                @* Everything an administrator alone can reach, behind one labelled disclosure.
+                   The block had grown to five unlabelled entries sitting directly under the
+                   ones everybody sees, so nothing marked where the administrative surface
+                   began.
+
+                   A <details> element rather than a toggle with a handler: this is the layout,
+                   which renders statically, and a handler here would need an interactive render
+                   mode on every page that uses it. The browser does the toggling. Open by
+                   default, because a collapsed group hides the only route to these pages. *@
                 <AuthorizeView Roles="Owner,Admin" Context="adminContext">
-                    @* Beside Settings rather than inside it: a connection is an entity an
-                       administrator creates and deletes, not a preference they adjust, and it is
-                       what every source is built on. *@
-                    <div class="nav-item px-3">
-                        <NavLink class="nav-link" href="connections">
-                            <span class="nav-icon bi-plug-fill" aria-hidden="true"></span> Connections
-                        </NavLink>
-                    </div>
-                    <div class="nav-item px-3">
-                        <NavLink class="nav-link" href="settings" Match="NavLinkMatch.All">
-                            <span class="nav-icon bi-gear-fill" aria-hidden="true"></span> Settings
-                        </NavLink>
-                    </div>
-                    <div class="nav-item px-3">
-                        <NavLink class="nav-link" href="admin/users">
-                            <span class="nav-icon bi-people-fill" aria-hidden="true"></span> Users
-                        </NavLink>
-                    </div>
-                    <div class="nav-item px-3">
-                        <NavLink class="nav-link" href="admin/agents">
-                            <span class="nav-icon bi-robot" aria-hidden="true"></span> Agents
-                        </NavLink>
-                    </div>
+                    <details class="nav-group" open>
+                        <summary class="nav-group-summary">
+                            <span class="nav-icon bi-shield-lock-fill" aria-hidden="true"></span> Admin
+                        </summary>
+
+                        @* Beside Settings rather than inside it: a connection is an entity an
+                           administrator creates and deletes, not a preference they adjust, and
+                           it is what every source is built on. *@
+                        <div class="nav-item px-3">
+                            <NavLink class="nav-link" href="connections">
+                                <span class="nav-icon bi-plug-fill" aria-hidden="true"></span> Connections
+                            </NavLink>
+                        </div>
+
+                        @* Its own entry rather than a Settings tab. An identity provider decides
+                           who may sign in and what they may search; a connection decides what
+                           Connapse itself may read. Listed beside embedding and chunking, the
+                           two read as though they configured ingestion. *@
+                        <div class="nav-item px-3">
+                            <NavLink class="nav-link" href="admin/identity-providers">
+                                <span class="nav-icon bi-person-badge-fill" aria-hidden="true"></span> Identity Providers
+                            </NavLink>
+                        </div>
+                        <div class="nav-item px-3">
+                            <NavLink class="nav-link" href="settings" Match="NavLinkMatch.All">
+                                <span class="nav-icon bi-gear-fill" aria-hidden="true"></span> Settings
+                            </NavLink>
+                        </div>
+                        <div class="nav-item px-3">
+                            <NavLink class="nav-link" href="admin/users">
+                                <span class="nav-icon bi-people-fill" aria-hidden="true"></span> Users
+                            </NavLink>
+                        </div>
+                        <div class="nav-item px-3">
+                            <NavLink class="nav-link" href="admin/agents">
+                                <span class="nav-icon bi-robot" aria-hidden="true"></span> Agents
+                            </NavLink>
+                        </div>
+                    </details>
                 </AuthorizeView>
             </nav>
 

--- a/src/Connapse.Web/Components/Layout/NavMenu.razor.css
+++ b/src/Connapse.Web/Components/Layout/NavMenu.razor.css
@@ -92,6 +92,68 @@
     margin: 0.75rem 1rem;
 }
 
+/* The administrator-only group. A rule above it rather than a box around it: the entries
+   inside are the same kind of thing as the ones above, and a border would read as a
+   different control. */
+.nav-group {
+    border-top: 1px solid var(--bs-border-color);
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+}
+
+.nav-group-summary {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-nav);
+    opacity: 0.65;
+    cursor: pointer;
+    list-style: none;
+    user-select: none;
+}
+
+.nav-group-summary:hover {
+    opacity: 1;
+}
+
+/* Both are needed: Safari uses the pseudo-element, everything else honours list-style. */
+.nav-group-summary::-webkit-details-marker {
+    display: none;
+}
+
+/* The disclosure triangle, drawn on the trailing edge so the label lines up with the
+   icons of the entries below it. */
+.nav-group-summary::after {
+    content: "";
+    margin-left: auto;
+    width: 0.4rem;
+    height: 0.4rem;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    transform: rotate(45deg);
+    transition: transform 0.15s;
+}
+
+.nav-group[open] > .nav-group-summary::after {
+    transform: rotate(-135deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .nav-group-summary::after {
+        transition: none;
+    }
+}
+
+/* Without this the first entry in the group inherits the 1rem top padding meant to
+   separate the very first item in the menu from the logo. */
+.nav-group .nav-item:first-of-type {
+    padding-top: 0;
+}
+
 .nav-user-info {
     padding: 0.5rem 0;
     display: flex;

--- a/src/Connapse.Web/Components/Pages/IdentityProviders.razor
+++ b/src/Connapse.Web/Components/Pages/IdentityProviders.razor
@@ -1,0 +1,127 @@
+@page "/admin/identity-providers"
+@attribute [Authorize(Policy = "RequireAdmin")]
+@using Connapse.Core
+@using Connapse.Core.Interfaces
+@using Connapse.Web.Components.Settings
+@using Connapse.Storage.Settings
+@using Microsoft.Extensions.Options
+@inject ISettingsStore SettingsStore
+@inject ISettingsReloader ReloadService
+@inject IOptionsMonitor<AwsSsoSettings> AwsSsoOptions
+@inject IOptionsMonitor<AzureAdSettings> AzureAdOptions
+@rendermode InteractiveServer
+
+@*
+    Identity providers — who may sign in, and what they may search.
+
+    Its own page rather than two tabs in Settings. Listed beside embedding, chunking and
+    search, AWS SSO and Azure AD read as though they configured ingestion, which is the
+    opposite of what they do: an identity provider authenticates a person, while a
+    Connection holds the credential Connapse's own background sync reads with.
+
+    The two cannot be merged. SourceSyncService is a BackgroundService on a timer with no
+    user present, and IAM Identity Center requires an interactive browser sign-in, so an
+    SSO session can never drive a sync.
+
+    Providers stay settings records rather than entities: there is one Identity Center
+    instance and one AD tenant per organisation, and promoting them would need a migration
+    and secret storage, reopening the epic #348 review of which surfaces may create
+    credential-bearing configuration.
+*@
+
+<PageTitle>Identity Providers - Connapse</PageTitle>
+
+<div class="container-fluid py-4">
+    <h1 class="mb-1">
+        <span class="bi-person-badge-fill me-2"></span>
+        Identity Providers
+    </h1>
+    <p class="text-muted">
+        Who can sign into Connapse, and which cloud identity their search results are scoped
+        against. This is separate from <a href="/connections">Connections</a>, which hold the
+        credentials Connapse reads your files with.
+    </p>
+
+    @if (!string.IsNullOrEmpty(saveMessage))
+    {
+        <div class="alert @(saveSuccess ? "alert-success" : "alert-danger") alert-dismissible fade show" role="alert">
+            @saveMessage
+            <button type="button" class="btn-close" @onclick="() => saveMessage = null"></button>
+        </div>
+    }
+
+    <ul class="nav nav-tabs mb-4" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link @(activeTab == "awssso" ? "active" : "")"
+                    @onclick='() => activeTab = "awssso"'
+                    type="button">
+                AWS SSO
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link @(activeTab == "azuread" ? "active" : "")"
+                    @onclick='() => activeTab = "azuread"'
+                    type="button">
+                Azure AD
+            </button>
+        </li>
+    </ul>
+
+    <div class="tab-content">
+        @if (activeTab == "awssso")
+        {
+            <AwsSsoSettingsTab Settings="awsSsoSettings" OnSave="SaveAwsSsoSettings" />
+        }
+        else if (activeTab == "azuread")
+        {
+            <AzureAdSettingsTab Settings="azureAdSettings" OnSave="SaveAzureAdSettings" />
+        }
+    </div>
+</div>
+
+@code {
+    private string activeTab = "awssso";
+    private string? saveMessage;
+    private bool saveSuccess;
+
+    private AwsSsoSettings awsSsoSettings = new();
+    private AzureAdSettings azureAdSettings = new();
+
+    protected override void OnInitialized()
+    {
+        // CurrentValue rather than the injected value: it reflects the PostgreSQL settings
+        // table, which overrides appsettings.json, and reloads without a restart.
+        awsSsoSettings = AwsSsoOptions.CurrentValue;
+        azureAdSettings = AzureAdOptions.CurrentValue;
+    }
+
+    // The category keys are unchanged from when these tabs lived in Settings. Renaming them
+    // would orphan whatever is already in the settings table.
+    private Task SaveAwsSsoSettings(AwsSsoSettings settings)
+    {
+        awsSsoSettings = settings;
+        return SaveSettings("awssso", settings);
+    }
+
+    private Task SaveAzureAdSettings(AzureAdSettings settings)
+    {
+        azureAdSettings = settings;
+        return SaveSettings("azuread", settings);
+    }
+
+    private async Task SaveSettings<T>(string category, T settings) where T : class
+    {
+        try
+        {
+            await SettingsStore.SaveAsync(category, settings);
+            ReloadService.Reload();
+            saveMessage = $"{category} settings saved successfully!";
+            saveSuccess = true;
+        }
+        catch (Exception ex)
+        {
+            saveMessage = $"Failed to save {category} settings: {ex.Message}";
+            saveSuccess = false;
+        }
+    }
+}

--- a/src/Connapse.Web/Components/Pages/Settings.razor
+++ b/src/Connapse.Web/Components/Pages/Settings.razor
@@ -11,8 +11,6 @@
 @inject IOptionsMonitor<SearchSettings> SearchOptions
 @inject IOptionsMonitor<LlmSettings> LlmOptions
 @inject IOptionsMonitor<UploadSettings> UploadOptions
-@inject IOptionsMonitor<AwsSsoSettings> AwsSsoOptions
-@inject IOptionsMonitor<AzureAdSettings> AzureAdOptions
 @inject IOptionsMonitor<SummarySettings> SummaryOptions
 @rendermode InteractiveServer
 
@@ -70,20 +68,6 @@
             </button>
         </li>
         <li class="nav-item" role="presentation">
-            <button class="nav-link @(activeTab == "awssso" ? "active" : "")"
-                    @onclick='() => activeTab = "awssso"'
-                    type="button">
-                AWS SSO
-            </button>
-        </li>
-        <li class="nav-item" role="presentation">
-            <button class="nav-link @(activeTab == "azuread" ? "active" : "")"
-                    @onclick='() => activeTab = "azuread"'
-                    type="button">
-                Azure AD
-            </button>
-        </li>
-        <li class="nav-item" role="presentation">
             <button class="nav-link @(activeTab == "summary" ? "active" : "")"
                     @onclick='() => activeTab = "summary"'
                     type="button">
@@ -114,14 +98,6 @@
         {
             <UploadSettingsTab Settings="uploadSettings" OnSave="SaveUploadSettings" />
         }
-        else if (activeTab == "awssso")
-        {
-            <AwsSsoSettingsTab Settings="awsSsoSettings" OnSave="SaveAwsSsoSettings" />
-        }
-        else if (activeTab == "azuread")
-        {
-            <AzureAdSettingsTab Settings="azureAdSettings" OnSave="SaveAzureAdSettings" />
-        }
         else if (activeTab == "summary")
         {
             <SummarySettingsTab @ref="summaryTabRef"
@@ -142,8 +118,6 @@
     private SearchSettings searchSettings = new();
     private LlmSettings llmSettings = new();
     private UploadSettings uploadSettings = new();
-    private AwsSsoSettings awsSsoSettings = new();
-    private AzureAdSettings azureAdSettings = new();
     private SummarySettings summarySettings = new();
     private SummarySettingsTab? summaryTabRef;
 
@@ -155,8 +129,6 @@
         searchSettings = SearchOptions.CurrentValue;
         llmSettings = LlmOptions.CurrentValue;
         uploadSettings = UploadOptions.CurrentValue;
-        awsSsoSettings = AwsSsoOptions.CurrentValue;
-        azureAdSettings = AzureAdOptions.CurrentValue;
         summarySettings = SummaryOptions.CurrentValue;
     }
 
@@ -188,18 +160,6 @@
     {
         await SaveSettings("upload", settings);
         uploadSettings = settings;
-    }
-
-    private async Task SaveAwsSsoSettings(AwsSsoSettings settings)
-    {
-        await SaveSettings("awssso", settings);
-        awsSsoSettings = settings;
-    }
-
-    private async Task SaveAzureAdSettings(AzureAdSettings settings)
-    {
-        await SaveSettings("azuread", settings);
-        azureAdSettings = settings;
     }
 
     private async Task SaveSummarySettings()

--- a/tests/Connapse.Web.Tests/Components/ConnectionsPageAuthorizationTests.cs
+++ b/tests/Connapse.Web.Tests/Components/ConnectionsPageAuthorizationTests.cs
@@ -17,6 +17,7 @@ namespace Connapse.Web.Tests.Components;
 /// distinguish an editor from an administrator — but it does catch the attribute being dropped
 /// or weakened, which is the way this protection would realistically be lost.
 /// </remarks>
+[Trait("Category", "Unit")]
 public class ConnectionsPageAuthorizationTests
 {
     private static readonly Type Page =
@@ -72,6 +73,7 @@ public class ConnectionsPageAuthorizationTests
     /// seam worth testing through, and the two mistakes worth catching — a link left pointing at
     /// the old location, and a control escaping its isAdmin block — are both visible in the text.
     /// </remarks>
+    [Trait("Category", "Unit")]
     public class SourcesPageConnectionLinkTests
     {
         private static readonly string Markup = File.ReadAllText(
@@ -122,6 +124,7 @@ public class ConnectionsPageAuthorizationTests
     /// it renders, it authorizes, and the markup is unchanged. Only using it finds this, which is
     /// why it is worth a test that covers every page rather than the one that went wrong.
     /// </remarks>
+    [Trait("Category", "Unit")]
     public class InteractivePageRenderModeTests
     {
         public static TheoryData<string> PagesWithControls()

--- a/tests/Connapse.Web.Tests/Components/IdentityProvidersPageTests.cs
+++ b/tests/Connapse.Web.Tests/Components/IdentityProvidersPageTests.cs
@@ -1,0 +1,186 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Web.Tests.Components;
+
+/// <summary>
+/// Identity providers decide who may sign into Connapse and which cloud identity their search
+/// is scoped against. They moved out of Settings, and so out from behind Settings' own gate.
+/// </summary>
+/// <remarks>
+/// Reflection over the compiled component rather than a rendered circuit, matching
+/// <see cref="ConnectionsPageAuthorizationTests"/>. It cannot prove a request is refused, but it
+/// catches the attribute being dropped or weakened, which is how this protection would
+/// realistically be lost.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class IdentityProvidersPageTests
+{
+    private static readonly Type Page =
+        typeof(Connapse.Web.Components.Pages.IdentityProviders);
+
+    [Fact]
+    public void IdentityProvidersPage_IsRoutable()
+    {
+        Page.GetCustomAttributes(typeof(RouteAttribute), inherit: true)
+            .Cast<RouteAttribute>()
+            .Select(r => r.Template)
+            .Should().Contain("/admin/identity-providers");
+    }
+
+    [Fact]
+    public void IdentityProvidersPage_RequiresAnAdministrator()
+    {
+        var authorize = Page
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .Cast<AuthorizeAttribute>()
+            .ToList();
+
+        authorize.Should().ContainSingle("the page is reachable directly by URL, not only via the nav");
+
+        authorize[0].Policy.Should().Be("RequireAdmin",
+            "these settings decide who can sign in at all — a bare [Authorize] would expose them "
+            + "to every signed-in viewer");
+    }
+
+    [Fact]
+    public void IdentityProvidersPage_GateMatchesTheSettingsPageItLeft()
+    {
+        var settings = typeof(Connapse.Web.Components.Pages.Settings)
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .Cast<AuthorizeAttribute>()
+            .Single();
+
+        Page.GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .Cast<AuthorizeAttribute>()
+            .Single()
+            .Policy.Should().Be(settings.Policy,
+                "being moved must not have made it easier to reach");
+    }
+
+    /// <summary>
+    /// The settings-table keys the two tabs save under.
+    /// </summary>
+    /// <remarks>
+    /// The one change here that would fail silently rather than loudly. Settings are stored by
+    /// category string in PostgreSQL; renaming a key on the way out of Settings.razor would not
+    /// break the build or lose the tab, it would just start writing to a row nothing reads, and
+    /// an administrator's configured issuer URL would appear to revert.
+    /// </remarks>
+    [Theory]
+    [InlineData("awssso")]
+    [InlineData("azuread")]
+    public void IdentityProvidersPage_KeepsTheSettingsKeysItInherited(string category)
+    {
+        string markup = File.ReadAllText(Path.Combine(
+            PageTestPaths.RepositoryRoot(),
+            "src", "Connapse.Web", "Components", "Pages", "IdentityProviders.razor"));
+
+        markup.Should().Contain($"SaveSettings(\"{category}\"",
+            "renaming the category orphans whatever is already stored under the old one");
+    }
+
+    /// <summary>
+    /// Settings must not keep a tab whose body was removed.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class SettingsPageTests
+    {
+        private static readonly string Markup = File.ReadAllText(Path.Combine(
+            PageTestPaths.RepositoryRoot(),
+            "src", "Connapse.Web", "Components", "Pages", "Settings.razor"));
+
+        [Theory]
+        [InlineData("awssso")]
+        [InlineData("azuread")]
+        public void SettingsPage_NoLongerOffersTheIdentityProviderTabs(string tab)
+        {
+            // A leftover button with no matching body is the realistic half-finished move: it
+            // compiles, renders, and selects a tab that draws nothing at all.
+            Markup.Should().NotContain(tab,
+                "the tab moved to /admin/identity-providers");
+        }
+
+        [Theory]
+        [InlineData("AwsSsoSettingsTab")]
+        [InlineData("AzureAdSettingsTab")]
+        public void SettingsPage_NoLongerRendersTheIdentityProviderComponents(string component)
+        {
+            Markup.Should().NotContain(component);
+        }
+    }
+
+    /// <summary>
+    /// The administrator-only entries live in one labelled group in the nav.
+    /// </summary>
+    /// <remarks>
+    /// Read from the source file rather than a rendered layout. The two mistakes worth catching
+    /// — an entry escaping the group, and the group escaping its role check — are both visible
+    /// in the text, and rendering NavMenu needs an authentication state provider for a component
+    /// with no seam otherwise worth testing through.
+    /// </remarks>
+    [Trait("Category", "Unit")]
+    public class AdminNavGroupTests
+    {
+        private static readonly string Markup = File.ReadAllText(Path.Combine(
+            PageTestPaths.RepositoryRoot(),
+            "src", "Connapse.Web", "Components", "Layout", "NavMenu.razor"));
+
+        public static TheoryData<string> AdminRoutes() =>
+            new() { "connections", "admin/identity-providers", "settings", "admin/users", "admin/agents" };
+
+        [Theory]
+        [MemberData(nameof(AdminRoutes))]
+        public void EveryAdminEntry_SitsInsideTheAdminGroup(string route)
+        {
+            int link = Markup.IndexOf($"href=\"{route}\"", StringComparison.Ordinal);
+            link.Should().BePositive($"the nav should link to {route}");
+
+            int groupOpen = Markup.IndexOf("<details class=\"nav-group\"", StringComparison.Ordinal);
+            int groupClose = Markup.IndexOf("</details>", StringComparison.Ordinal);
+
+            groupOpen.Should().BePositive("the admin entries belong in one labelled group");
+            link.Should().BeInRange(groupOpen, groupClose,
+                $"{route} is administrator-only and belongs inside the group");
+        }
+
+        [Fact]
+        public void TheAdminGroup_SitsInsideTheRoleCheck()
+        {
+            // The group is a presentation device. If it drifted outside AuthorizeView it would
+            // still look correct to an administrator while showing a viewer a list of pages
+            // every one of which refuses them.
+            int roleCheck = Markup.IndexOf(
+                "<AuthorizeView Roles=\"Owner,Admin\"", StringComparison.Ordinal);
+            int groupOpen = Markup.IndexOf("<details class=\"nav-group\"", StringComparison.Ordinal);
+
+            roleCheck.Should().BePositive();
+            groupOpen.Should().BeGreaterThan(roleCheck);
+        }
+
+        [Fact]
+        public void TheAdminGroup_NeedsNoRenderMode()
+        {
+            // NavMenu is in the layout and renders statically. A toggle driven by @onclick would
+            // silently do nothing — the same failure that took the Connections page down — so the
+            // disclosure is a <details> element the browser operates itself.
+            Markup.Should().NotContain("@onclick",
+                "the layout has no render mode, so a handler here would never run");
+        }
+    }
+}
+
+/// <summary>Shared path helper for tests that read component source rather than render it.</summary>
+internal static class PageTestPaths
+{
+    public static string RepositoryRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Connapse.slnx")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Repository root not found.");
+    }
+}


### PR DESCRIPTION
## What

1. **Identity Providers becomes its own page** at `/admin/identity-providers`, taking the AWS SSO and Azure AD tabs out of Settings.
2. **An `Admin` group in the nav**, holding Connections, Identity Providers, Settings, Users and Agents.

## Why

Two things in Connapse say "AWS" and the UI never distinguished them:

| Concept | Answers | Whose identity |
|---|---|---|
| Identity provider | Who may sign in, and what they may search | A person's |
| Connection | What Connapse's own background sync may read | The machine's |

They cannot be merged. `SourceSyncService` is a `BackgroundService` on a 5-minute timer with no user present, and IAM Identity Center requires an interactive browser sign-in, so an SSO session can never drive a sync. But listed as flat tabs beside `embedding`, `chunking` and `search`, AWS SSO and Azure AD read as though they configured ingestion.

The admin group is the other half: that block had grown to five unlabelled entries directly under the ones every signed-in user sees, so nothing marked where the administrative surface began.

## How

**The disclosure is a `<details>` element, not a toggle with a handler.** `NavMenu` is in the layout, which renders statically — an `@onclick` there would compile, render, and never fire. That is exactly the bug that left every control on the Connections page dead (`a15a764`, restored in #411), so there is a test asserting `NavMenu.razor` contains no `@onclick` at all.

**Providers stay settings records rather than becoming entities.** Cardinality is one Identity Center instance and one AD tenant per organisation, and promoting them would need a migration plus secret storage, reopening the epic #348 review of which surfaces may create credential-bearing config. If a third provider type lands later, the page is already the right home for it.

**The `awssso` and `azuread` category keys are carried over unchanged.** Renaming one would not break the build or lose the tab — it would quietly start writing to a row nothing reads, and an administrator's configured issuer URL would appear to revert. There is a test pinning both.

## A test-suite gap found on the way

`ConnectionsPageAuthorizationTests` and its nested classes carried no `[Trait("Category", "Unit")]`. CI filters on exactly that, so it was running **8 of this project's tests instead of 35** — including none of the render-mode theory, which exists precisely because that bug already shipped once. Both files are now tagged; that is the `+3` lines on the existing test file.

## Size

489 changed lines, over the 300 guideline. 186 of them are the new test file and 62 are CSS. The two halves are not separable at a real seam — the nav group links to the page — so splitting would mean a PR that adds a link to a page that does not exist yet.

## Verification

- `dotnet build` clean, 0 warnings.
- 1,162 unit tests green (`--filter "Category=Unit"`), up from 1,135 discovered before the tagging fix.
- Run in Docker: `/`, `/connections`, `/settings` and `/admin/identity-providers` all answer, the new route redirects anonymous callers to login rather than 404ing, and the container log is clean.

Not verified: the group's appearance when signed in as a non-admin. The role check is `AuthorizeView Roles="Owner,Admin"`, unchanged from what already wrapped these entries, and a test asserts the group sits inside it.

Closes #410
