### PR TITLE
feat: guided AWS identity provider setup, via CloudShell

### DIFF
--- a/src/Connapse.Core/Utilities/AwsSsoSetup.cs
+++ b/src/Connapse.Core/Utilities/AwsSsoSetup.cs
@@ -1,0 +1,277 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// One IAM Identity Center instance the setup script found.
+/// </summary>
+/// <param name="Region">
+/// The region whose <c>sso-admin list-instances</c> returned it. The field people most often get
+/// wrong, and the one that cannot be derived from a legacy portal URL.
+/// </param>
+/// <param name="InstanceArn"><c>arn:aws:sso:::instance/ssoins-…</c>.</param>
+/// <param name="IdentityStoreId">
+/// <c>d-…</c>. Also the subdomain of the default access portal URL, which is why the portal URL
+/// can be derived rather than asked for.
+/// </param>
+/// <param name="PortalUrl">
+/// The access portal URL, used as the issuer URL when registering the OIDC client.
+/// <para>
+/// Derived from <paramref name="IdentityStoreId"/>, so it is a default rather than an answer: an
+/// organisation using a custom vanity domain has a different one, and only they know it.
+/// </para>
+/// </param>
+public record AwsSsoInstance(
+    string Region,
+    string InstanceArn,
+    string IdentityStoreId,
+    string PortalUrl);
+
+/// <summary>
+/// What the setup script reported.
+/// </summary>
+/// <param name="Instances">
+/// Every instance found, in the order the script printed them. Usually one — Identity Center is a
+/// single-region service per organisation — but multi-region replication gives one per region,
+/// and the administrator has to pick, because Connapse cannot know which their users sign in
+/// through.
+/// </param>
+/// <param name="MissingPermissions">
+/// Actions the caller was denied. Reported rather than inferred from an empty result, because
+/// "no permission to look" and "looked, found nothing" need different advice and produce the
+/// same empty list otherwise.
+/// </param>
+public record AwsSsoSetupResult(
+    IReadOnlyList<AwsSsoInstance> Instances,
+    IReadOnlyList<string>? MissingPermissions = null)
+{
+    public IReadOnlyList<string> MissingPermissions { get; init; } = MissingPermissions ?? [];
+}
+
+/// <summary>
+/// Builds the one command an administrator runs in AWS CloudShell to locate their IAM Identity
+/// Center instance, and reads back what it reports.
+/// <para>
+/// CloudShell rather than a credential field or a CloudFormation callback. It already holds
+/// temporary credentials from the administrator's console session, so nothing is created, pasted
+/// into Connapse, or stored — the copy-paste round trip <i>is</i> the credential boundary. A
+/// CloudFormation custom resource calling back into Connapse, which is how most services onboard
+/// an AWS account, cannot work for a self-hosted product that frequently has no public URL.
+/// </para>
+/// </summary>
+public static class AwsSsoSetup
+{
+    /// <summary>
+    /// Delimits the block the administrator pastes back. Deliberately unmistakable, because the
+    /// usual failure is pasting the whole terminal buffer, and that should still work.
+    /// </summary>
+    public const string BeginMarker = "----- BEGIN CONNAPSE AWS SETUP -----";
+
+    public const string EndMarker = "----- END CONNAPSE AWS SETUP -----";
+
+    /// <summary>
+    /// Regions the scan tries when the CloudShell session's own region has no instance.
+    /// </summary>
+    /// <remarks>
+    /// Not every AWS region — that would be a long serial scan for a service that exists in
+    /// exactly one place. These are the commercial regions Identity Center is commonly deployed
+    /// in, ordered roughly by how often that is true. A miss is not fatal: the script says it
+    /// scanned and found nothing, and the administrator can read their region off the console.
+    /// <para>
+    /// GovCloud and the China partitions are absent on purpose. They need different endpoints and
+    /// a different partition in the ARN, so a caller there needs a different script, not a longer
+    /// list.
+    /// </para>
+    /// </remarks>
+    public static readonly IReadOnlyList<string> CandidateRegions =
+    [
+        "us-east-1", "us-west-2", "us-east-2", "us-west-1",
+        "eu-west-1", "eu-central-1", "eu-west-2", "eu-north-1", "eu-west-3", "eu-south-1",
+        "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ap-northeast-2", "ap-south-1",
+        "ca-central-1", "sa-east-1", "ap-east-1", "me-south-1", "af-south-1"
+    ];
+
+    /// <summary>
+    /// The IAM actions the script calls. Read-only, and stated up front so the administrator can
+    /// check them against their own policy before running anything.
+    /// </summary>
+    public static readonly IReadOnlyList<string> RequiredPermissions =
+    [
+        "sso:ListInstances"
+    ];
+
+    /// <summary>
+    /// The command to paste into AWS CloudShell.
+    /// </summary>
+    /// <remarks>
+    /// Meant to be read before it is run. It is read-only — it lists Identity Center instances and
+    /// prints what it found — but it is shown in full rather than offered as a download or a pipe
+    /// from a URL, so the administrator can see exactly what they are agreeing to at the moment
+    /// they agree to it.
+    /// <para>
+    /// Targets CloudShell specifically, which is Amazon Linux with <c>bash</c> and the AWS CLI
+    /// already present and authenticated. It deliberately does not use <c>jq</c>: CloudShell ships
+    /// it, but the CLI's own <c>--query</c> does the same job without depending on that.
+    /// </para>
+    /// </remarks>
+    public static string GenerateScript()
+    {
+        string regions = string.Join(" ", CandidateRegions);
+
+        return $$"""
+        # Finds your IAM Identity Center instance. Read-only: it lists instances and prints
+        # what it found. Nothing is created, changed, or sent anywhere.
+
+        FOUND=""
+        DENIED=""
+
+        probe() {
+          # --output text with an explicit --query, rather than jq: CloudShell ships jq, but
+          # depending on it buys nothing the CLI cannot already do.
+          OUT=$(aws sso-admin list-instances \
+                  --region "$1" \
+                  --query 'Instances[].[InstanceArn,IdentityStoreId]' \
+                  --output text 2>&1)
+          STATUS=$?
+
+          if [ $STATUS -ne 0 ]; then
+            # A denial is worth reporting; anything else is this region simply not being the
+            # one, which is the expected outcome for all but one of them.
+            case "$OUT" in
+              *AccessDenied*|*UnauthorizedOperation*|*not\ authorized*)
+                DENIED="yes" ;;
+            esac
+            return
+          fi
+
+          [ -z "$OUT" ] && return
+
+          # Tab-separated, one instance per line. Held rather than printed so that the whole
+          # result block comes out together at the end.
+          while IFS=$(printf '\t') read -r ARN STORE; do
+            [ -z "$ARN" ] && continue
+            FOUND="${FOUND}${1}|${ARN}|${STORE}
+        "
+          done <<EOF
+        $OUT
+        EOF
+        }
+
+        # The session's own region first. For most people this is the answer and the scan
+        # below never runs.
+        HOME_REGION="${AWS_REGION:-$AWS_DEFAULT_REGION}"
+        [ -n "$HOME_REGION" ] && probe "$HOME_REGION"
+
+        # A sso:ListInstances denial is a property of the caller's policy, not of the region, so
+        # scanning the other nineteen would be nineteen more calls to be refused the same way.
+        if [ -z "$FOUND" ] && [ -z "$DENIED" ]; then
+          echo 'Not in this session default region; checking the others. This takes a moment.'
+          for R in {{regions}}; do
+            [ "$R" = "$HOME_REGION" ] && continue
+            probe "$R"
+            [ -n "$DENIED" ] && break
+            # Identity Center is one region per organisation. The exception is multi-region
+            # replication, which the administrator will know they have -- so stopping at the
+            # first hit is right for everyone else, and a full scan would be 20 sequential
+            # calls for nothing.
+            [ -n "$FOUND" ] && break
+          done
+        fi
+
+        # The markers go through %s rather than being the format string themselves. They begin
+        # with dashes, and printf reads a leading '-' as an option.
+        printf '\n%s\n' '{{BeginMarker}}'
+
+        if [ -n "$FOUND" ]; then
+          printf '%s' "$FOUND" | while IFS='|' read -r REGION ARN STORE; do
+            [ -z "$REGION" ] && continue
+            printf 'region=%s\n' "$REGION"
+            printf 'instanceArn=%s\n' "$ARN"
+            printf 'identityStoreId=%s\n' "$STORE"
+            # The default access portal URL is the identity store id as a subdomain. An
+            # organisation with a custom vanity domain has a different one, so Connapse offers
+            # this as a starting value rather than a fact.
+            printf 'portalUrl=https://%s.awsapps.com/start\n' "$STORE"
+          done
+        elif [ -n "$DENIED" ]; then
+          printf 'missingPermission=%s\n' 'sso:ListInstances'
+        fi
+
+        printf '%s\n\n' '{{EndMarker}}'
+        echo 'Copy the block above, including both marker lines, back into Connapse.'
+        """;
+    }
+
+    /// <summary>
+    /// Reads the block the setup command printed. Returns null when the text does not contain a
+    /// usable one.
+    /// </summary>
+    /// <remarks>
+    /// Tolerant on purpose. Administrators paste whole terminal buffers, with prompts, wrapping,
+    /// and the command echoed above the output — so this finds the markers rather than expecting
+    /// the text to begin at them, and ignores anything outside.
+    /// <para>
+    /// A block containing neither an instance nor a denial still parses, returning an empty
+    /// result. That is a real outcome — the scan ran and found nothing — and it needs to reach
+    /// the caller as such rather than as "you pasted the wrong thing".
+    /// </para>
+    /// </remarks>
+    public static AwsSsoSetupResult? ParseResult(string? pasted)
+    {
+        if (string.IsNullOrWhiteSpace(pasted))
+            return null;
+
+        int start = pasted.IndexOf(BeginMarker, StringComparison.Ordinal);
+        int end = pasted.IndexOf(EndMarker, StringComparison.Ordinal);
+
+        // Without both markers there is nothing to be confident about. Guessing at loose
+        // key=value lines would happily accept a paste from somewhere else entirely.
+        if (start < 0 || end < 0 || end <= start)
+            return null;
+
+        string body = pasted[(start + BeginMarker.Length)..end];
+
+        var instances = new List<AwsSsoInstance>();
+        var missing = new List<string>();
+
+        string? region = null, arn = null, store = null, portal = null;
+
+        // region starts each record, so meeting one again means the previous record is done.
+        void Flush()
+        {
+            if (region is null || arn is null || store is null)
+                return;
+
+            instances.Add(new AwsSsoInstance(
+                region, arn, store,
+                portal ?? $"https://{store}.awsapps.com/start"));
+
+            region = arn = store = portal = null;
+        }
+
+        foreach (string raw in body.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            string line = raw.Trim();
+            int split = line.IndexOf('=');
+            if (split <= 0) continue;
+
+            string name = line[..split].Trim();
+            string value = line[(split + 1)..].Trim();
+            if (value.Length == 0) continue;
+
+            switch (name)
+            {
+                case "region":
+                    Flush();
+                    region = value;
+                    break;
+                case "instanceArn": arn = value; break;
+                case "identityStoreId": store = value; break;
+                case "portalUrl": portal = value; break;
+                case "missingPermission": missing.Add(value); break;
+            }
+        }
+
+        Flush();
+
+        return new AwsSsoSetupResult(instances, missing);
+    }
+}

--- a/src/Connapse.Core/Utilities/AwsSsoSetup.cs
+++ b/src/Connapse.Core/Utilities/AwsSsoSetup.cs
@@ -311,8 +311,18 @@ public static class AwsSsoSetup
         if (string.IsNullOrWhiteSpace(pasted))
             return null;
 
-        int start = pasted.IndexOf(BeginMarker, StringComparison.Ordinal);
-        int end = pasted.IndexOf(EndMarker, StringComparison.Ordinal);
+        // The last pair, not the first.
+        //
+        // The script is pasted straight into CloudShell, which echoes every line back — and the
+        // script contains both marker literals, since printing them is its job. So a pasted
+        // terminal buffer holds the markers twice: once in the echoed source, once in the real
+        // output below it. Taking the first pair selects the echo, whose body is nothing but
+        // `printf 'region=%s\n' "$REGION"` lines. Those parse to no fields at all, so an
+        // administrator with a perfectly good instance was told there wasn't one.
+        int end = pasted.LastIndexOf(EndMarker, StringComparison.Ordinal);
+        int start = end < 0
+            ? -1
+            : pasted.LastIndexOf(BeginMarker, end, StringComparison.Ordinal);
 
         // Without both markers there is nothing to be confident about. Guessing at loose
         // key=value lines would happily accept a paste from somewhere else entirely.

--- a/src/Connapse.Core/Utilities/AwsSsoSetup.cs
+++ b/src/Connapse.Core/Utilities/AwsSsoSetup.cs
@@ -1,4 +1,4 @@
-namespace Connapse.Core.Utilities;
+﻿namespace Connapse.Core.Utilities;
 
 /// <summary>
 /// One IAM Identity Center instance the setup script found.
@@ -26,32 +26,41 @@ public record AwsSsoInstance(
     string PortalUrl);
 
 /// <summary>
-/// Where the account sits relative to AWS Organizations, which decides whether an instance can be
-/// created and what kind it would be.
+/// Where the account sits relative to AWS Organizations, which decides who can enable an instance
+/// and therefore what to tell someone whose scan found none.
 /// </summary>
+/// <remarks>
+/// Connapse needs an <b>organisation</b> instance specifically. Only that kind supports permission
+/// sets, and AWS is explicit that account instances "do not support permission sets and therefore
+/// do not support access to AWS accounts" — while Connapse scopes a signed-in user's search by
+/// calling <c>ListAccounts</c> for their accounts. An account instance would authenticate someone
+/// and then return nothing to scope by, which looks like a working connection and is not one.
+/// <para>
+/// So this is not a question of what AWS would permit. <c>sso-admin create-instance</c> only ever
+/// produces an account instance, which makes it the wrong tool regardless of who runs it; an
+/// organisation instance is enabled from the console, in the management account.
+/// </para>
+/// </remarks>
 public enum AwsAccountPosture
 {
     /// <summary>The script could not tell — usually no permission to call DescribeOrganization.</summary>
     Unknown = 0,
 
     /// <summary>
-    /// Not in an organisation. <c>CreateInstance</c> works here and produces the only instance the
-    /// account will have, which is unambiguously the right one.
+    /// Not in an organisation. There is no organisation to hold an organisation instance, so one
+    /// has to be started by creating an organisation first.
     /// </summary>
     Standalone = 1,
 
     /// <summary>
-    /// A member account inside an organisation. <c>CreateInstance</c> is permitted but produces an
-    /// <i>account</i> instance: no multi-account permissions, no organisation-wide application
-    /// assignment, no multi-region replication. Almost always the organisation already has an
-    /// instance and this would be a weaker parallel one.
+    /// A member account inside an organisation. The organisation instance, if there is one, belongs
+    /// to the management account — so whoever holds that account is who to ask.
     /// </summary>
     Member = 2,
 
     /// <summary>
-    /// The Organizations management account. <c>CreateInstance</c> is rejected outright here — an
-    /// organisation instance is enabled through the console, where the primary region and the
-    /// encryption key are chosen.
+    /// The Organizations management account: the one place an organisation instance can be enabled,
+    /// and the only posture that can fix an empty result without involving somebody else.
     /// </summary>
     Management = 3
 }
@@ -82,12 +91,16 @@ public record AwsSsoSetupResult(
     public IReadOnlyList<string> MissingPermissions { get; init; } = MissingPermissions ?? [];
 
     /// <summary>
-    /// Whether <see cref="AwsSsoSetup.GenerateCreateScript"/> would be accepted by AWS. Says
-    /// nothing about whether it is a good idea — for a member account it is permitted and usually
-    /// wrong, which is a judgement only the administrator can make.
+    /// Whether this account could enable an instance itself, rather than needing someone with
+    /// the management account to do it.
+    /// <para>
+    /// Only the management account can enable an <i>organisation</i> instance, and only that kind
+    /// supports permission sets — which is to say, access to AWS accounts. Connapse reads a
+    /// signed-in user's accounts through <c>ListAccounts</c> to scope their search, so an account
+    /// instance would authenticate and then return nothing to scope by.
+    /// </para>
     /// </summary>
-    public bool CanCreateInstance =>
-        Posture is AwsAccountPosture.Standalone or AwsAccountPosture.Member;
+    public bool CanEnableItself => Posture is AwsAccountPosture.Management;
 }
 
 /// <summary>
@@ -277,102 +290,6 @@ public static class AwsSsoSetup
         printf '\n%s\n\n' "$BLOCK"
         echo 'Copy the block above, including both marker lines, back into Connapse.'
         """;
-    }
-
-    /// <summary>
-    /// The command that creates an Identity Center instance, for an administrator who has decided
-    /// they want one.
-    /// </summary>
-    /// <param name="name">
-    /// The instance name. Constrained by AWS to <c>[\w+=,.@-]+</c>, so anything else is replaced
-    /// rather than passed through to fail in the shell.
-    /// </param>
-    /// <remarks>
-    /// Deliberately a second script rather than a branch inside <see cref="GenerateScript"/>. That
-    /// one is offered as read-only and the UI says so; folding a create into it would make the
-    /// claim false for everyone, including the people who only ever wanted to look.
-    /// <para>
-    /// It re-checks the posture itself instead of trusting what the first script reported. The two
-    /// runs are separated by however long the administrator spent reading, and the second is the
-    /// one that writes.
-    /// </para>
-    /// <para>
-    /// This creates an <i>account</i> instance. In the Organizations management account AWS rejects
-    /// the call outright: an organisation instance is enabled through the console, which is where
-    /// the primary region — unchangeable afterwards — and the encryption key are chosen.
-    /// </para>
-    /// </remarks>
-    public static string GenerateCreateScript(string? name = null)
-    {
-        string safe = SanitiseInstanceName(name);
-
-        return $$"""
-        # Creates an IAM Identity Center instance in THIS account. Unlike the previous command,
-        # this one makes a change.
-
-        ORG_OUT=$(aws organizations describe-organization \
-                    --query 'Organization.MasterAccountId' --output text 2>&1)
-        CALLER=$(aws sts get-caller-identity --query 'Account' --output text 2>/dev/null)
-
-        if [ "$ORG_OUT" = "$CALLER" ] && [ -n "$CALLER" ]; then
-          echo 'This is your AWS Organizations management account.'
-          echo 'AWS rejects CreateInstance here. Enable an organization instance from the console:'
-          echo '  https://console.aws.amazon.com/singlesignon/home'
-          echo 'You will choose a primary region, which CANNOT be changed afterwards.'
-          exit 1
-        fi
-
-        case "$ORG_OUT" in
-          *AWSOrganizationsNotInUse*) ;;
-          *)
-            # Permitted, and usually not what they want. Said plainly rather than blocked: the
-            # administrator knows their organisation and Connapse does not.
-            echo 'NOTE: this account belongs to an AWS Organization.'
-            echo 'What gets created is an ACCOUNT instance: no multi-account permissions, no'
-            echo 'organization-wide application assignment, no multi-region replication. If your'
-            echo 'organization already has an instance, this will be a separate, weaker one and'
-            echo 'your users will not be in it.'
-            echo ''
-            echo 'Press Ctrl-C now to stop, or wait 10 seconds to continue.'
-            sleep 10 ;;
-        esac
-
-        OUT=$(aws sso-admin create-instance --name '{{safe}}' \
-                --query 'InstanceArn' --output text 2>&1)
-
-        if [ $? -ne 0 ]; then
-          echo "Could not create the instance:"
-          printf '%s\n' "$OUT"
-          exit 1
-        fi
-
-        printf 'Created %s\n' "$OUT"
-        echo 'Now run the first command again to read it back into Connapse.'
-        """;
-    }
-
-    /// <summary>
-    /// Coerces an instance name to the character set AWS accepts, so a name with a space in it
-    /// fails validation here rather than inside the administrator's shell.
-    /// </summary>
-    public static string SanitiseInstanceName(string? name)
-    {
-        const string fallback = "Connapse";
-
-        if (string.IsNullOrWhiteSpace(name))
-            return fallback;
-
-        var cleaned = new string(name.Trim()
-            .Select(c => char.IsLetterOrDigit(c) || c is '_' or '+' or '=' or ',' or '.' or '@' or '-'
-                ? c
-                : '-')
-            .ToArray());
-
-        // 255 is the documented maximum. An all-punctuation name collapses to dashes, which is
-        // valid but meaningless, so an empty-after-trim result falls back too.
-        cleaned = cleaned.Trim('-');
-
-        return cleaned.Length == 0 ? fallback : cleaned[..Math.Min(cleaned.Length, 255)];
     }
 
     /// <summary>

--- a/src/Connapse.Core/Utilities/AwsSsoSetup.cs
+++ b/src/Connapse.Core/Utilities/AwsSsoSetup.cs
@@ -243,27 +243,38 @@ public static class AwsSsoSetup
           POSTURE="member"
         fi
 
+        # Built whole, then printed once.
+        #
+        # Pasting a multi-line script into an interactive shell makes it echo every line back,
+        # continuation prompts and all. Printing the block piece by piece let that echo land
+        # between the markers, so the thing the administrator is asked to check was half script.
+        # Capturing it first puts all the echo above the BEGIN marker, where it belongs.
+        #
         # The markers go through %s rather than being the format string themselves. They begin
         # with dashes, and printf reads a leading '-' as an option.
-        printf '\n%s\n' '{{BeginMarker}}'
-        printf 'accountType=%s\n' "$POSTURE"
+        BLOCK=$(
+          printf '%s\n' '{{BeginMarker}}'
+          printf 'accountType=%s\n' "$POSTURE"
 
-        if [ -n "$FOUND" ]; then
-          printf '%s' "$FOUND" | while IFS='|' read -r REGION ARN STORE; do
-            [ -z "$REGION" ] && continue
-            printf 'region=%s\n' "$REGION"
-            printf 'instanceArn=%s\n' "$ARN"
-            printf 'identityStoreId=%s\n' "$STORE"
-            # The default access portal URL is the identity store id as a subdomain. An
-            # organisation with a custom vanity domain has a different one, so Connapse offers
-            # this as a starting value rather than a fact.
-            printf 'portalUrl=https://%s.awsapps.com/start\n' "$STORE"
-          done
-        elif [ -n "$DENIED" ]; then
-          printf 'missingPermission=%s\n' 'sso:ListInstances'
-        fi
+          if [ -n "$FOUND" ]; then
+            printf '%s' "$FOUND" | while IFS='|' read -r REGION ARN STORE; do
+              [ -z "$REGION" ] && continue
+              printf 'region=%s\n' "$REGION"
+              printf 'instanceArn=%s\n' "$ARN"
+              printf 'identityStoreId=%s\n' "$STORE"
+              # The default access portal URL is the identity store id as a subdomain. An
+              # organisation with a custom vanity domain has a different one, so Connapse offers
+              # this as a starting value rather than a fact.
+              printf 'portalUrl=https://%s.awsapps.com/start\n' "$STORE"
+            done
+          elif [ -n "$DENIED" ]; then
+            printf 'missingPermission=%s\n' 'sso:ListInstances'
+          fi
 
-        printf '%s\n\n' '{{EndMarker}}'
+          printf '%s\n' '{{EndMarker}}'
+        )
+
+        printf '\n%s\n\n' "$BLOCK"
         echo 'Copy the block above, including both marker lines, back into Connapse.'
         """;
     }

--- a/src/Connapse.Core/Utilities/AwsSsoSetup.cs
+++ b/src/Connapse.Core/Utilities/AwsSsoSetup.cs
@@ -26,6 +26,37 @@ public record AwsSsoInstance(
     string PortalUrl);
 
 /// <summary>
+/// Where the account sits relative to AWS Organizations, which decides whether an instance can be
+/// created and what kind it would be.
+/// </summary>
+public enum AwsAccountPosture
+{
+    /// <summary>The script could not tell — usually no permission to call DescribeOrganization.</summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Not in an organisation. <c>CreateInstance</c> works here and produces the only instance the
+    /// account will have, which is unambiguously the right one.
+    /// </summary>
+    Standalone = 1,
+
+    /// <summary>
+    /// A member account inside an organisation. <c>CreateInstance</c> is permitted but produces an
+    /// <i>account</i> instance: no multi-account permissions, no organisation-wide application
+    /// assignment, no multi-region replication. Almost always the organisation already has an
+    /// instance and this would be a weaker parallel one.
+    /// </summary>
+    Member = 2,
+
+    /// <summary>
+    /// The Organizations management account. <c>CreateInstance</c> is rejected outright here — an
+    /// organisation instance is enabled through the console, where the primary region and the
+    /// encryption key are chosen.
+    /// </summary>
+    Management = 3
+}
+
+/// <summary>
 /// What the setup script reported.
 /// </summary>
 /// <param name="Instances">
@@ -39,11 +70,24 @@ public record AwsSsoInstance(
 /// "no permission to look" and "looked, found nothing" need different advice and produce the
 /// same empty list otherwise.
 /// </param>
+/// <param name="Posture">
+/// Only meaningful when <paramref name="Instances"/> is empty, which is the one case where what to
+/// do next depends on it.
+/// </param>
 public record AwsSsoSetupResult(
     IReadOnlyList<AwsSsoInstance> Instances,
-    IReadOnlyList<string>? MissingPermissions = null)
+    IReadOnlyList<string>? MissingPermissions = null,
+    AwsAccountPosture Posture = AwsAccountPosture.Unknown)
 {
     public IReadOnlyList<string> MissingPermissions { get; init; } = MissingPermissions ?? [];
+
+    /// <summary>
+    /// Whether <see cref="AwsSsoSetup.GenerateCreateScript"/> would be accepted by AWS. Says
+    /// nothing about whether it is a good idea — for a member account it is permitted and usually
+    /// wrong, which is a judgement only the administrator can make.
+    /// </summary>
+    public bool CanCreateInstance =>
+        Posture is AwsAccountPosture.Standalone or AwsAccountPosture.Member;
 }
 
 /// <summary>
@@ -176,9 +220,33 @@ public static class AwsSsoSetup
           done
         fi
 
+        # Where this account sits relative to Organizations. Only consulted when nothing was
+        # found, but probed unconditionally so the answer travels in the same block.
+        #
+        # A denial has to be told apart from "not in an organisation": both leave the query
+        # empty, and treating a denial as standalone would offer a create step that AWS rejects.
+        ORG_OUT=$(aws organizations describe-organization \
+                    --query 'Organization.MasterAccountId' --output text 2>&1)
+        ORG_STATUS=$?
+        CALLER=$(aws sts get-caller-identity --query 'Account' --output text 2>/dev/null)
+
+        if [ $ORG_STATUS -ne 0 ]; then
+          case "$ORG_OUT" in
+            *AWSOrganizationsNotInUse*) POSTURE="standalone" ;;
+            *) POSTURE="unknown" ;;
+          esac
+        elif [ -z "$CALLER" ]; then
+          POSTURE="unknown"
+        elif [ "$ORG_OUT" = "$CALLER" ]; then
+          POSTURE="management"
+        else
+          POSTURE="member"
+        fi
+
         # The markers go through %s rather than being the format string themselves. They begin
         # with dashes, and printf reads a leading '-' as an option.
         printf '\n%s\n' '{{BeginMarker}}'
+        printf 'accountType=%s\n' "$POSTURE"
 
         if [ -n "$FOUND" ]; then
           printf '%s' "$FOUND" | while IFS='|' read -r REGION ARN STORE; do
@@ -198,6 +266,102 @@ public static class AwsSsoSetup
         printf '%s\n\n' '{{EndMarker}}'
         echo 'Copy the block above, including both marker lines, back into Connapse.'
         """;
+    }
+
+    /// <summary>
+    /// The command that creates an Identity Center instance, for an administrator who has decided
+    /// they want one.
+    /// </summary>
+    /// <param name="name">
+    /// The instance name. Constrained by AWS to <c>[\w+=,.@-]+</c>, so anything else is replaced
+    /// rather than passed through to fail in the shell.
+    /// </param>
+    /// <remarks>
+    /// Deliberately a second script rather than a branch inside <see cref="GenerateScript"/>. That
+    /// one is offered as read-only and the UI says so; folding a create into it would make the
+    /// claim false for everyone, including the people who only ever wanted to look.
+    /// <para>
+    /// It re-checks the posture itself instead of trusting what the first script reported. The two
+    /// runs are separated by however long the administrator spent reading, and the second is the
+    /// one that writes.
+    /// </para>
+    /// <para>
+    /// This creates an <i>account</i> instance. In the Organizations management account AWS rejects
+    /// the call outright: an organisation instance is enabled through the console, which is where
+    /// the primary region — unchangeable afterwards — and the encryption key are chosen.
+    /// </para>
+    /// </remarks>
+    public static string GenerateCreateScript(string? name = null)
+    {
+        string safe = SanitiseInstanceName(name);
+
+        return $$"""
+        # Creates an IAM Identity Center instance in THIS account. Unlike the previous command,
+        # this one makes a change.
+
+        ORG_OUT=$(aws organizations describe-organization \
+                    --query 'Organization.MasterAccountId' --output text 2>&1)
+        CALLER=$(aws sts get-caller-identity --query 'Account' --output text 2>/dev/null)
+
+        if [ "$ORG_OUT" = "$CALLER" ] && [ -n "$CALLER" ]; then
+          echo 'This is your AWS Organizations management account.'
+          echo 'AWS rejects CreateInstance here. Enable an organization instance from the console:'
+          echo '  https://console.aws.amazon.com/singlesignon/home'
+          echo 'You will choose a primary region, which CANNOT be changed afterwards.'
+          exit 1
+        fi
+
+        case "$ORG_OUT" in
+          *AWSOrganizationsNotInUse*) ;;
+          *)
+            # Permitted, and usually not what they want. Said plainly rather than blocked: the
+            # administrator knows their organisation and Connapse does not.
+            echo 'NOTE: this account belongs to an AWS Organization.'
+            echo 'What gets created is an ACCOUNT instance: no multi-account permissions, no'
+            echo 'organization-wide application assignment, no multi-region replication. If your'
+            echo 'organization already has an instance, this will be a separate, weaker one and'
+            echo 'your users will not be in it.'
+            echo ''
+            echo 'Press Ctrl-C now to stop, or wait 10 seconds to continue.'
+            sleep 10 ;;
+        esac
+
+        OUT=$(aws sso-admin create-instance --name '{{safe}}' \
+                --query 'InstanceArn' --output text 2>&1)
+
+        if [ $? -ne 0 ]; then
+          echo "Could not create the instance:"
+          printf '%s\n' "$OUT"
+          exit 1
+        fi
+
+        printf 'Created %s\n' "$OUT"
+        echo 'Now run the first command again to read it back into Connapse.'
+        """;
+    }
+
+    /// <summary>
+    /// Coerces an instance name to the character set AWS accepts, so a name with a space in it
+    /// fails validation here rather than inside the administrator's shell.
+    /// </summary>
+    public static string SanitiseInstanceName(string? name)
+    {
+        const string fallback = "Connapse";
+
+        if (string.IsNullOrWhiteSpace(name))
+            return fallback;
+
+        var cleaned = new string(name.Trim()
+            .Select(c => char.IsLetterOrDigit(c) || c is '_' or '+' or '=' or ',' or '.' or '@' or '-'
+                ? c
+                : '-')
+            .ToArray());
+
+        // 255 is the documented maximum. An all-punctuation name collapses to dashes, which is
+        // valid but meaningless, so an empty-after-trim result falls back too.
+        cleaned = cleaned.Trim('-');
+
+        return cleaned.Length == 0 ? fallback : cleaned[..Math.Min(cleaned.Length, 255)];
     }
 
     /// <summary>
@@ -231,6 +395,7 @@ public static class AwsSsoSetup
 
         var instances = new List<AwsSsoInstance>();
         var missing = new List<string>();
+        var posture = AwsAccountPosture.Unknown;
 
         string? region = null, arn = null, store = null, portal = null;
 
@@ -267,11 +432,22 @@ public static class AwsSsoSetup
                 case "identityStoreId": store = value; break;
                 case "portalUrl": portal = value; break;
                 case "missingPermission": missing.Add(value); break;
+                case "accountType":
+                    // An unrecognised value stays Unknown, which is the honest reading: a newer
+                    // script talking to an older Connapse should not have its answer guessed at.
+                    posture = value.ToLowerInvariant() switch
+                    {
+                        "standalone" => AwsAccountPosture.Standalone,
+                        "member" => AwsAccountPosture.Member,
+                        "management" => AwsAccountPosture.Management,
+                        _ => AwsAccountPosture.Unknown
+                    };
+                    break;
             }
         }
 
         Flush();
 
-        return new AwsSsoSetupResult(instances, missing);
+        return new AwsSsoSetupResult(instances, missing, posture);
     }
 }

--- a/src/Connapse.Web/Components/Settings/AwsSsoSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AwsSsoSettingsTab.razor
@@ -1,4 +1,4 @@
-@using Connapse.Core
+﻿@using Connapse.Core
 @using Connapse.Core.Utilities
 @using Connapse.Storage.ConnectionTesters
 
@@ -58,15 +58,25 @@
                         </div>
 
                         <p class="small mb-2">
-                            Open
-                            <a href="https://console.aws.amazon.com/cloudshell/home" target="_blank" rel="noopener">
-                                CloudShell <span class="bi-box-arrow-up-right"></span>
-                            </a>
-                            in the AWS console, signed in as someone who can read your organisation's
-                            Identity Center, and paste this in.
+                            Copy the command, open CloudShell — a terminal that runs inside the AWS
+                            console, already signed in as you — and paste it there. Sign in as someone
+                            who can read your organisation's Identity Center.
                         </p>
 
                         <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height: 18rem; overflow: auto;"><code>@AwsSsoSetup.GenerateScript()</code></pre>
+
+                        @* Copy first, then open: the order the two buttons are used in, so the one
+                           that opens a new tab is not the one the eye lands on first. *@
+                        <div class="d-flex flex-wrap gap-2 mb-2">
+                            <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="CopyFindScript">
+                                <span class="bi-clipboard me-1"></span> Copy command
+                            </button>
+                            <a class="btn btn-sm btn-primary" href="@CloudShellUrl" target="_blank" rel="noopener">
+                                <span class="bi-terminal me-1"></span> Open CloudShell
+                                <span class="bi-box-arrow-up-right ms-1 small"></span>
+                            </a>
+                            <span class="align-self-center small text-muted">Safe to run more than once.</span>
+                        </div>
 
                         <div class="alert alert-secondary py-2 mb-0 small">
                             <span class="bi-shield-check me-1"></span>
@@ -115,13 +125,102 @@
                             }
                             else if (parsed.Instances.Count == 0)
                             {
-                                <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                @* No instance. What to do next depends entirely on where the account
+                                   sits relative to Organizations, so the posture decides the advice
+                                   rather than everyone getting the same dead end. *@
+                                <div class="alert alert-warning py-2 mt-2 mb-2 small">
                                     <span class="bi-exclamation-triangle me-1"></span>
-                                    The command ran but found no Identity Center instance. Either your
-                                    organisation has not enabled one, or it is in a region this scan does not
-                                    cover — GovCloud and the China partitions need different endpoints. You can
-                                    still fill the fields in by hand from the Identity Center console.
+                                    The command ran but found no Identity Center instance.
+                                    @switch (parsed.Posture)
+                                    {
+                                        case AwsAccountPosture.Standalone:
+                                            <text>
+                                                This account isn't part of an AWS Organization, so you can
+                                                create one here and it will be the only instance the account
+                                                has.
+                                            </text>
+                                            break;
+                                        case AwsAccountPosture.Member:
+                                            <text>
+                                                This account belongs to an AWS Organization, so your
+                                                organisation most likely already has one — reachable from the
+                                                management account, not this one.
+                                            </text>
+                                            break;
+                                        case AwsAccountPosture.Management:
+                                            <text>
+                                                This is your Organizations management account. AWS only lets an
+                                                organisation instance be enabled from the console, because
+                                                enabling it fixes a primary region that
+                                                <strong>cannot be changed afterwards</strong>.
+                                            </text>
+                                            break;
+                                        default:
+                                            <text>
+                                                It may also be in a region this scan doesn't cover — GovCloud
+                                                and the China partitions need different endpoints.
+                                            </text>
+                                            break;
+                                    }
                                 </div>
+
+                                @if (parsed.Posture == AwsAccountPosture.Management)
+                                {
+                                    <a class="btn btn-outline-primary btn-sm"
+                                       href="https://console.aws.amazon.com/singlesignon/home"
+                                       target="_blank" rel="noopener">
+                                        <span class="bi-box-arrow-up-right me-1"></span> Enable it in the console
+                                    </a>
+                                }
+                                else if (parsed.CanCreateInstance && !showCreateScript)
+                                {
+                                    <button type="button" class="btn btn-outline-primary btn-sm"
+                                            @onclick="() => showCreateScript = true">
+                                        <span class="bi-plus-lg me-1"></span> Create one instead
+                                    </button>
+                                    @if (parsed.Posture == AwsAccountPosture.Member)
+                                    {
+                                        <div class="form-text">
+                                            You can, but read what it creates first — it won't be the instance
+                                            your organisation signs in through.
+                                        </div>
+                                    }
+                                }
+
+                                @if (showCreateScript && parsed.CanCreateInstance)
+                                {
+                                    <div class="card border-warning mt-2">
+                                        <div class="card-body">
+                                            <h6 class="card-title">
+                                                <span class="bi-exclamation-triangle text-warning me-1"></span>
+                                                This one makes a change
+                                            </h6>
+                                            <p class="small mb-2">
+                                                Unlike the command above, this creates something in your AWS
+                                                account. It checks again where it is running before it does, and
+                                                stops if that turns out to be the management account.
+                                            </p>
+                                            <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height: 18rem; overflow: auto;"><code>@AwsSsoSetup.GenerateCreateScript()</code></pre>
+
+                                            <div class="d-flex flex-wrap gap-2 mb-2">
+                                                <button type="button" class="btn btn-sm btn-outline-secondary"
+                                                        @onclick="CopyCreateScript">
+                                                    <span class="bi-clipboard me-1"></span> Copy command
+                                                </button>
+                                                <a class="btn btn-sm btn-warning" href="@CloudShellUrl"
+                                                   target="_blank" rel="noopener">
+                                                    <span class="bi-terminal me-1"></span> Open CloudShell
+                                                    <span class="bi-box-arrow-up-right ms-1 small"></span>
+                                                </a>
+                                            </div>
+
+                                            <div class="form-text">
+                                                When it finishes, run the first command again and paste the
+                                                result here.
+                                            </div>
+                                        </div>
+                                    </div>
+                                }
                             }
                             else
                             {
@@ -226,8 +325,27 @@
 </EditForm>
 
 @inject AwsSsoConnectionTester ConnectionTester
+@inject IJSRuntime JS
 
 @code {
+    /// <summary>
+    /// CloudShell, opened in a new tab so the wizard stays put behind it.
+    /// </summary>
+    /// <remarks>
+    /// Region-agnostic on purpose. The script scans regardless of where the session lands, and
+    /// pinning a region here would send people to the wrong one more often than the right one.
+    /// </remarks>
+    private const string CloudShellUrl = "https://console.aws.amazon.com/cloudshell/home";
+
+    /// <summary>Revealed only after a scan found nothing, and only on request.</summary>
+    private bool showCreateScript;
+
+    private async Task CopyFindScript() =>
+        await JS.InvokeVoidAsync("navigator.clipboard.writeText", AwsSsoSetup.GenerateScript());
+
+    private async Task CopyCreateScript() =>
+        await JS.InvokeVoidAsync("navigator.clipboard.writeText", AwsSsoSetup.GenerateCreateScript());
+
     [Parameter]
     public AwsSsoSettings Settings { get; set; } = new();
 
@@ -246,6 +364,7 @@
     {
         guidedSetup = true;
         pastedResult = null;
+        showCreateScript = false;
         testMessage = null;
     }
 
@@ -253,6 +372,7 @@
     {
         guidedSetup = false;
         pastedResult = null;
+        showCreateScript = false;
     }
 
     /// <summary>
@@ -281,6 +401,7 @@
 
         guidedSetup = false;
         pastedResult = null;
+        showCreateScript = false;
 
         testSuccess = true;
         testMessage = $"Filled in from {instance.Region}. Test the connection, then save.";

--- a/src/Connapse.Web/Components/Settings/AwsSsoSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AwsSsoSettingsTab.razor
@@ -125,102 +125,74 @@
                             }
                             else if (parsed.Instances.Count == 0)
                             {
-                                @* No instance. What to do next depends entirely on where the account
-                                   sits relative to Organizations, so the posture decides the advice
-                                   rather than everyone getting the same dead end. *@
+                                @* No instance. Connapse needs an ORGANISATION instance, which is
+                                   enabled from the console in the Organizations management account.
+                                   An account instance -- the only kind sso-admin create-instance can
+                                   make -- does not support permission sets, and so does not support
+                                   access to AWS accounts. Connapse scopes search by calling
+                                   ListAccounts, so that kind would sign someone in and then have
+                                   nothing to scope by.
+
+                                   Hence a pointer to the right place rather than a create button:
+                                   the thing that can be scripted is not the thing that works. *@
                                 <div class="alert alert-warning py-2 mt-2 mb-2 small">
                                     <span class="bi-exclamation-triangle me-1"></span>
                                     The command ran but found no Identity Center instance.
                                     @switch (parsed.Posture)
                                     {
-                                        case AwsAccountPosture.Standalone:
+                                        case AwsAccountPosture.Management:
                                             <text>
-                                                This account isn't part of an AWS Organization, so you can
-                                                create one here and it will be the only instance the account
-                                                has.
+                                                This is your Organizations management account, which is
+                                                where one gets enabled — so you can do it yourself.
                                             </text>
                                             break;
                                         case AwsAccountPosture.Member:
                                             <text>
-                                                This account belongs to an AWS Organization, so your
-                                                organisation most likely already has one — reachable from the
-                                                management account, not this one.
+                                                This account belongs to an AWS Organization but isn't the
+                                                management account, and that's the only place an
+                                                organization instance can be enabled. Whoever administers
+                                                your organization needs to turn it on.
                                             </text>
                                             break;
-                                        case AwsAccountPosture.Management:
+                                        case AwsAccountPosture.Standalone:
                                             <text>
-                                                This is your Organizations management account. AWS only lets an
-                                                organisation instance be enabled from the console, because
-                                                enabling it fixes a primary region that
-                                                <strong>cannot be changed afterwards</strong>.
+                                                This account isn't part of an AWS Organization. Identity
+                                                Center needs one, so enabling it starts by creating an
+                                                organization — the console walks you through both.
                                             </text>
                                             break;
                                         default:
                                             <text>
-                                                It may also be in a region this scan doesn't cover — GovCloud
-                                                and the China partitions need different endpoints.
+                                                It may also be in a region this scan doesn't cover —
+                                                GovCloud and the China partitions need different endpoints.
                                             </text>
                                             break;
                                     }
                                 </div>
 
-                                @if (parsed.Posture == AwsAccountPosture.Management)
-                                {
-                                    <a class="btn btn-outline-primary btn-sm"
-                                       href="https://console.aws.amazon.com/singlesignon/home"
-                                       target="_blank" rel="noopener">
-                                        <span class="bi-box-arrow-up-right me-1"></span> Enable it in the console
+                                <div class="d-flex flex-wrap gap-2 align-items-center">
+                                    <a class="btn btn-sm @(parsed.CanEnableItself ? "btn-primary" : "btn-outline-primary")"
+                                       href="@IdentityCenterConsoleUrl" target="_blank" rel="noopener">
+                                        <span class="bi-box-arrow-up-right me-1"></span>
+                                        @(parsed.CanEnableItself ? "Enable Identity Center" : "Open the Identity Center console")
                                     </a>
-                                }
-                                else if (parsed.CanCreateInstance && !showCreateScript)
-                                {
-                                    <button type="button" class="btn btn-outline-primary btn-sm"
-                                            @onclick="() => showCreateScript = true">
-                                        <span class="bi-plus-lg me-1"></span> Create one instead
-                                    </button>
-                                    @if (parsed.Posture == AwsAccountPosture.Member)
-                                    {
-                                        <div class="form-text">
-                                            You can, but read what it creates first — it won't be the instance
-                                            your organisation signs in through.
-                                        </div>
-                                    }
-                                }
+                                    <span class="small text-muted">
+                                        You'll pick a primary region there, which can't be changed later.
+                                        Then run the command above again.
+                                    </span>
+                                </div>
 
-                                @if (showCreateScript && parsed.CanCreateInstance)
-                                {
-                                    <div class="card border-warning mt-2">
-                                        <div class="card-body">
-                                            <h6 class="card-title">
-                                                <span class="bi-exclamation-triangle text-warning me-1"></span>
-                                                This one makes a change
-                                            </h6>
-                                            <p class="small mb-2">
-                                                Unlike the command above, this creates something in your AWS
-                                                account. It checks again where it is running before it does, and
-                                                stops if that turns out to be the management account.
-                                            </p>
-                                            <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height: 18rem; overflow: auto;"><code>@AwsSsoSetup.GenerateCreateScript()</code></pre>
-
-                                            <div class="d-flex flex-wrap gap-2 mb-2">
-                                                <button type="button" class="btn btn-sm btn-outline-secondary"
-                                                        @onclick="CopyCreateScript">
-                                                    <span class="bi-clipboard me-1"></span> Copy command
-                                                </button>
-                                                <a class="btn btn-sm btn-warning" href="@CloudShellUrl"
-                                                   target="_blank" rel="noopener">
-                                                    <span class="bi-terminal me-1"></span> Open CloudShell
-                                                    <span class="bi-box-arrow-up-right ms-1 small"></span>
-                                                </a>
-                                            </div>
-
-                                            <div class="form-text">
-                                                When it finishes, run the first command again and paste the
-                                                result here.
-                                            </div>
-                                        </div>
-                                    </div>
-                                }
+                                @* Said once, plainly, because the obvious next move for someone
+                                   technical is to reach for the CLI -- and that path produces an
+                                   instance Connapse cannot use. *@
+                                <div class="form-text mt-2">
+                                    <span class="bi-info-circle me-1"></span>
+                                    It has to be enabled from the console.
+                                    <code>aws sso-admin create-instance</code> makes an
+                                    <em>account</em> instance, which doesn't support access to AWS
+                                    accounts — Connapse would sign people in and find nothing to scope
+                                    their search by.
+                                </div>
                             }
                             else
                             {
@@ -337,14 +309,11 @@
     /// </remarks>
     private const string CloudShellUrl = "https://console.aws.amazon.com/cloudshell/home";
 
-    /// <summary>Revealed only after a scan found nothing, and only on request.</summary>
-    private bool showCreateScript;
+    /// <summary>Where an organisation instance is actually enabled.</summary>
+    private const string IdentityCenterConsoleUrl = "https://console.aws.amazon.com/singlesignon/home";
 
     private async Task CopyFindScript() =>
         await JS.InvokeVoidAsync("navigator.clipboard.writeText", AwsSsoSetup.GenerateScript());
-
-    private async Task CopyCreateScript() =>
-        await JS.InvokeVoidAsync("navigator.clipboard.writeText", AwsSsoSetup.GenerateCreateScript());
 
     [Parameter]
     public AwsSsoSettings Settings { get; set; } = new();
@@ -364,7 +333,6 @@
     {
         guidedSetup = true;
         pastedResult = null;
-        showCreateScript = false;
         testMessage = null;
     }
 
@@ -372,7 +340,6 @@
     {
         guidedSetup = false;
         pastedResult = null;
-        showCreateScript = false;
     }
 
     /// <summary>
@@ -401,7 +368,6 @@
 
         guidedSetup = false;
         pastedResult = null;
-        showCreateScript = false;
 
         testSuccess = true;
         testMessage = $"Filled in from {instance.Region}. Test the connection, then save.";

--- a/src/Connapse.Web/Components/Settings/AwsSsoSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AwsSsoSettingsTab.razor
@@ -1,4 +1,5 @@
 @using Connapse.Core
+@using Connapse.Core.Utilities
 @using Connapse.Storage.ConnectionTesters
 
 <EditForm Model="@localSettings" OnValidSubmit="HandleSubmit">
@@ -13,6 +14,149 @@
                 on first use.
             </div>
         </div>
+
+        @*
+            Guided setup.
+
+            The region is the field people get wrong, and it cannot be derived: Identity Center
+            lives in one region per organisation, and the legacy portal URL
+            (https://d-1234567890.awsapps.com/start) does not encode it. A wrong region produces
+            InvalidClientMetadataException, which says the URL and region disagree without saying
+            which one is wrong.
+
+            CloudShell rather than a credential field or a CloudFormation callback. It already
+            holds temporary credentials from the administrator's console session, so nothing is
+            created, pasted here, or stored — the copy-paste round trip is the credential
+            boundary. A callback, which is how most services onboard an AWS account, needs a
+            public URL that a self-hosted Connapse usually does not have.
+        *@
+        @if (!guidedSetup)
+        {
+            <div class="col-12">
+                <div class="alert alert-primary d-flex flex-wrap align-items-center gap-2 py-2 mb-0">
+                    <span class="bi-magic"></span>
+                    <span class="flex-grow-1 small">
+                        Don't know your region or portal URL? Connapse will write one read-only command
+                        to run in AWS CloudShell, and read both back from what it prints.
+                    </span>
+                    <button type="button" class="btn btn-primary btn-sm" @onclick="StartGuidedSetup">
+                        <span class="bi-cloud me-1"></span> Find my instance
+                    </button>
+                </div>
+            </div>
+        }
+        else
+        {
+            <div class="col-12">
+                <div class="card border-primary">
+                    <div class="card-body">
+                        <div class="d-flex align-items-start mb-3">
+                            <h6 class="card-title flex-grow-1 mb-0">1 &middot; Run this in AWS CloudShell</h6>
+                            <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="CancelGuidedSetup">
+                                Cancel
+                            </button>
+                        </div>
+
+                        <p class="small mb-2">
+                            Open
+                            <a href="https://console.aws.amazon.com/cloudshell/home" target="_blank" rel="noopener">
+                                CloudShell <span class="bi-box-arrow-up-right"></span>
+                            </a>
+                            in the AWS console, signed in as someone who can read your organisation's
+                            Identity Center, and paste this in.
+                        </p>
+
+                        <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height: 18rem; overflow: auto;"><code>@AwsSsoSetup.GenerateScript()</code></pre>
+
+                        <div class="alert alert-secondary py-2 mb-0 small">
+                            <span class="bi-shield-check me-1"></span>
+                            <strong>Read-only.</strong> It lists your Identity Center instances and prints
+                            what it found — it creates and changes nothing. It needs
+                            <code>@string.Join("</code>, <code>", AwsSsoSetup.RequiredPermissions)</code>,
+                            and says so if you don't have it. No AWS credential is created here or stored
+                            by Connapse; CloudShell uses the session you are already signed into.
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <h6 class="card-title">2 &middot; Paste back what it printed</h6>
+                        <textarea class="form-control font-monospace" rows="5" @bind="pastedResult"
+                                  @bind:event="oninput"
+                                  placeholder="@AwsSsoSetup.BeginMarker&#10;region=…&#10;identityStoreId=…&#10;@AwsSsoSetup.EndMarker"></textarea>
+                        <div class="form-text">
+                            The whole terminal output is fine — Connapse finds the block.
+                        </div>
+
+                        @if (!string.IsNullOrWhiteSpace(pastedResult))
+                        {
+                            var parsed = AwsSsoSetup.ParseResult(pastedResult);
+
+                            @if (parsed is null)
+                            {
+                                <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                    <span class="bi-exclamation-triangle me-1"></span>
+                                    No setup block found yet. Copy everything the command printed, including
+                                    both <code>-----</code> marker lines.
+                                </div>
+                            }
+                            else if (parsed.MissingPermissions.Count > 0)
+                            {
+                                <div class="alert alert-danger py-2 mt-2 mb-0 small">
+                                    <span class="bi-x-circle me-1"></span>
+                                    AWS refused the lookup. The account you ran this as needs
+                                    <code>@string.Join("</code>, <code>", parsed.MissingPermissions)</code>.
+                                    Ask whoever administers your AWS organisation, or run it again as
+                                    someone who has it.
+                                </div>
+                            }
+                            else if (parsed.Instances.Count == 0)
+                            {
+                                <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                    <span class="bi-exclamation-triangle me-1"></span>
+                                    The command ran but found no Identity Center instance. Either your
+                                    organisation has not enabled one, or it is in a region this scan does not
+                                    cover — GovCloud and the China partitions need different endpoints. You can
+                                    still fill the fields in by hand from the Identity Center console.
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="mt-3">
+                                    @if (parsed.Instances.Count > 1)
+                                    {
+                                        @* Multi-region replication gives one portal per region, and only
+                                           the administrator knows which their users sign in through. *@
+                                        <div class="alert alert-info py-2 small">
+                                            <span class="bi-info-circle me-1"></span>
+                                            Found @parsed.Instances.Count instances — pick the one your users
+                                            sign in through.
+                                        </div>
+                                    }
+
+                                    @foreach (var instance in parsed.Instances)
+                                    {
+                                        <div class="border rounded p-2 mb-2 d-flex flex-wrap align-items-center gap-2">
+                                            <div class="flex-grow-1 small">
+                                                <div><strong>@instance.Region</strong> &middot; <code>@instance.IdentityStoreId</code></div>
+                                                <div class="text-muted">@instance.PortalUrl</div>
+                                            </div>
+                                            <button type="button" class="btn btn-primary btn-sm"
+                                                    @onclick="() => ApplyInstance(instance)">
+                                                <span class="bi-check-lg me-1"></span> Use this
+                                            </button>
+                                        </div>
+                                    }
+                                </div>
+                            }
+                        }
+                    </div>
+                </div>
+            </div>
+        }
 
         <div class="col-md-8">
             <label class="form-label">Issuer URL</label>
@@ -94,6 +238,53 @@
     private bool isTestingConnection;
     private string? testMessage;
     private bool testSuccess;
+
+    private bool guidedSetup;
+    private string? pastedResult;
+
+    private void StartGuidedSetup()
+    {
+        guidedSetup = true;
+        pastedResult = null;
+        testMessage = null;
+    }
+
+    private void CancelGuidedSetup()
+    {
+        guidedSetup = false;
+        pastedResult = null;
+    }
+
+    /// <summary>
+    /// Fills the form from the instance the administrator picked.
+    /// </summary>
+    /// <remarks>
+    /// Fills rather than saves. The portal URL is derived from the identity store id, which is
+    /// wrong for an organisation using a custom vanity domain — so the values land in editable
+    /// fields, and Test Connection is the thing that confirms them.
+    /// <para>
+    /// Any previously registered client is cleared. Those credentials belong to the instance they
+    /// were issued by; carrying them across to a different region would leave a client id that
+    /// RegisterClient never issued for it.
+    /// </para>
+    /// </remarks>
+    private void ApplyInstance(AwsSsoInstance instance)
+    {
+        localSettings = new AwsSsoSettings
+        {
+            IssuerUrl = instance.PortalUrl,
+            Region = instance.Region,
+            ClientId = null,
+            ClientSecret = null,
+            ClientSecretExpiresAt = null
+        };
+
+        guidedSetup = false;
+        pastedResult = null;
+
+        testSuccess = true;
+        testMessage = $"Filled in from {instance.Region}. Test the connection, then save.";
+    }
 
     protected override void OnParametersSet()
     {

--- a/src/Connapse.Web/Components/Settings/AwsSsoSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AwsSsoSettingsTab.razor
@@ -75,14 +75,16 @@
                                 <span class="bi-terminal me-1"></span> Open CloudShell
                                 <span class="bi-box-arrow-up-right ms-1 small"></span>
                             </a>
-                            <span class="align-self-center small text-muted">Safe to run more than once.</span>
+                            <span class="align-self-center small @(copyMessage is null ? "text-muted" : copySucceeded ? "text-success" : "text-danger")">
+                                @(copyMessage ?? "Safe to run more than once.")
+                            </span>
                         </div>
 
                         <div class="alert alert-secondary py-2 mb-0 small">
                             <span class="bi-shield-check me-1"></span>
                             <strong>Read-only.</strong> It lists your Identity Center instances and prints
                             what it found — it creates and changes nothing. It needs
-                            <code>@string.Join("</code>, <code>", AwsSsoSetup.RequiredPermissions)</code>,
+                            <code>@string.Join(", ", AwsSsoSetup.RequiredPermissions)</code>,
                             and says so if you don't have it. No AWS credential is created here or stored
                             by Connapse; CloudShell uses the session you are already signed into.
                         </div>
@@ -118,7 +120,7 @@
                                 <div class="alert alert-danger py-2 mt-2 mb-0 small">
                                     <span class="bi-x-circle me-1"></span>
                                     AWS refused the lookup. The account you ran this as needs
-                                    <code>@string.Join("</code>, <code>", parsed.MissingPermissions)</code>.
+                                    <code>@string.Join(", ", parsed.MissingPermissions)</code>.
                                     Ask whoever administers your AWS organisation, or run it again as
                                     someone who has it.
                                 </div>
@@ -309,11 +311,28 @@
     /// </remarks>
     private const string CloudShellUrl = "https://console.aws.amazon.com/cloudshell/home";
 
+    private string? copyMessage;
+    private bool copySucceeded;
+
     /// <summary>Where an organisation instance is actually enabled.</summary>
     private const string IdentityCenterConsoleUrl = "https://console.aws.amazon.com/singlesignon/home";
 
-    private async Task CopyFindScript() =>
-        await JS.InvokeVoidAsync("navigator.clipboard.writeText", AwsSsoSetup.GenerateScript());
+    /// <summary>Copies the command, and says so — including when it could not.</summary>
+    /// <remarks>
+    /// Through the shared helper rather than <c>navigator.clipboard</c> directly: that API is
+    /// undefined outside a secure context, and Connapse is routinely served over plain HTTP on a
+    /// LAN. Called directly, the button would throw and appear to do nothing at all.
+    /// </remarks>
+    private async Task CopyFindScript()
+    {
+        bool copied = await JS.InvokeAsync<bool>(
+            "connapse.copyToClipboard", AwsSsoSetup.GenerateScript());
+
+        copyMessage = copied
+            ? "Copied. Paste it into CloudShell."
+            : "Could not copy — select the command above and copy it manually.";
+        copySucceeded = copied;
+    }
 
     [Parameter]
     public AwsSsoSettings Settings { get; set; } = new();
@@ -333,6 +352,7 @@
     {
         guidedSetup = true;
         pastedResult = null;
+        copyMessage = null;
         testMessage = null;
     }
 

--- a/tests/Connapse.Core.Tests/Utilities/AwsSsoSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AwsSsoSetupTests.cs
@@ -1,0 +1,229 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+/// <summary>
+/// The guided AWS identity provider setup: the script an administrator runs in CloudShell, and
+/// the block it prints back.
+/// </summary>
+/// <remarks>
+/// Two halves worth different kinds of test. The parser is ordinary code and is tested directly.
+/// The script is text this assembly cannot execute, so what is asserted about it is the small set
+/// of shell traps that have actually cost something here before — chiefly <c>printf</c> and its
+/// leading dash.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class AwsSsoSetupTests
+{
+    private static string Block(params string[] lines) =>
+        AwsSsoSetup.BeginMarker + "\n" + string.Join("\n", lines) + "\n" + AwsSsoSetup.EndMarker;
+
+    // ── The script ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GenerateScript_NeverPassesAMarkerAsAPrintfFormatString()
+    {
+        // Both markers start with dashes, and printf reads a leading '-' as an option. In the
+        // SFTP script the end marker as a format string made bash print "invalid option" instead
+        // of the marker, so the block came back unterminated and would not parse. Asserting that
+        // the marker merely *appears* in the script does not catch this: it appeared, as the
+        // thing that failed to print.
+        string script = AwsSsoSetup.GenerateScript();
+
+        foreach (string line in script.Split('\n'))
+        {
+            string trimmed = line.Trim();
+            if (!trimmed.StartsWith("printf ", StringComparison.Ordinal)) continue;
+
+            string format = trimmed["printf ".Length..].TrimStart();
+            format = format.StartsWith('\'') ? format[1..] : format;
+
+            format.Should().NotStartWith("-",
+                $"printf would read this as an option, not text: {trimmed}");
+        }
+    }
+
+    [Fact]
+    public void GenerateScript_EmitsBothMarkersThroughAStringPlaceholder()
+    {
+        // The positive half of the rule above: the markers are arguments, which is what makes
+        // them survive their own leading dashes.
+        string script = AwsSsoSetup.GenerateScript();
+
+        script.Should().Contain($"'{AwsSsoSetup.BeginMarker}'");
+        script.Should().Contain($"'{AwsSsoSetup.EndMarker}'");
+    }
+
+    [Fact]
+    public void GenerateScript_OnlyReads()
+    {
+        // The administrator is asked to paste this into a shell holding their console session's
+        // credentials. Anything that creates or changes an AWS resource does not belong in it,
+        // and the claim that it is read-only is made to them in the UI.
+        string script = AwsSsoSetup.GenerateScript();
+
+        foreach (string verb in new[] { "create-", "delete-", "put-", "update-", "attach-", "tag-" })
+        {
+            script.Should().NotContain($"aws sso-admin {verb}", $"the script must not {verb.TrimEnd('-')}");
+        }
+
+        script.Should().Contain("aws sso-admin list-instances");
+    }
+
+    [Fact]
+    public void GenerateScript_ScansTheSessionRegionBeforeAnyOther()
+    {
+        // For most people the CloudShell session is already in the right region, and a scan that
+        // ignored it would make twenty calls to learn what the first one knew.
+        string script = AwsSsoSetup.GenerateScript();
+
+        int home = script.IndexOf("AWS_REGION", StringComparison.Ordinal);
+        int loop = script.IndexOf("for R in", StringComparison.Ordinal);
+
+        home.Should().BePositive();
+        loop.Should().BeGreaterThan(home);
+    }
+
+    [Fact]
+    public void CandidateRegions_ExcludeThePartitionsThisScriptCannotServe()
+    {
+        // GovCloud and the China partitions need different endpoints and a different ARN
+        // partition. Including them would produce confident-looking failures rather than a
+        // clear "this script is not for you".
+        AwsSsoSetup.CandidateRegions.Should().NotContain(r => r.StartsWith("us-gov", StringComparison.Ordinal));
+        AwsSsoSetup.CandidateRegions.Should().NotContain(r => r.StartsWith("cn-", StringComparison.Ordinal));
+        AwsSsoSetup.CandidateRegions.Should().OnlyHaveUniqueItems();
+    }
+
+    // ── Parsing ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseResult_OneInstance_ReadsEveryField()
+    {
+        var result = AwsSsoSetup.ParseResult(Block(
+            "region=eu-west-1",
+            "instanceArn=arn:aws:sso:::instance/ssoins-6987abc1234def56",
+            "identityStoreId=d-9067890abc",
+            "portalUrl=https://d-9067890abc.awsapps.com/start"));
+
+        result.Should().NotBeNull();
+        result!.Instances.Should().ContainSingle();
+        result.Instances[0].Region.Should().Be("eu-west-1");
+        result.Instances[0].InstanceArn.Should().Be("arn:aws:sso:::instance/ssoins-6987abc1234def56");
+        result.Instances[0].IdentityStoreId.Should().Be("d-9067890abc");
+        result.Instances[0].PortalUrl.Should().Be("https://d-9067890abc.awsapps.com/start");
+        result.MissingPermissions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseResult_SeveralInstances_KeepsThemSeparate()
+    {
+        // Multi-region replication gives one portal per region. Merging them would silently
+        // pick one, and Connapse cannot know which their users sign in through.
+        var result = AwsSsoSetup.ParseResult(Block(
+            "region=us-east-1",
+            "instanceArn=arn:aws:sso:::instance/ssoins-aaa",
+            "identityStoreId=d-aaaaaaaaa1",
+            "portalUrl=https://d-aaaaaaaaa1.awsapps.com/start",
+            "region=eu-west-1",
+            "instanceArn=arn:aws:sso:::instance/ssoins-bbb",
+            "identityStoreId=d-bbbbbbbbb2",
+            "portalUrl=https://d-bbbbbbbbb2.awsapps.com/start"));
+
+        result!.Instances.Should().HaveCount(2);
+        result.Instances.Select(i => i.Region).Should().Equal("us-east-1", "eu-west-1");
+        result.Instances.Select(i => i.IdentityStoreId).Should().Equal("d-aaaaaaaaa1", "d-bbbbbbbbb2");
+    }
+
+    [Fact]
+    public void ParseResult_NoPortalUrl_DerivesItFromTheIdentityStoreId()
+    {
+        // The default access portal is the identity store id as a subdomain, so a block missing
+        // the line is still usable rather than being a dead end.
+        var result = AwsSsoSetup.ParseResult(Block(
+            "region=us-east-1",
+            "instanceArn=arn:aws:sso:::instance/ssoins-aaa",
+            "identityStoreId=d-1234567890"));
+
+        result!.Instances.Should().ContainSingle();
+        result.Instances[0].PortalUrl.Should().Be("https://d-1234567890.awsapps.com/start");
+    }
+
+    [Fact]
+    public void ParseResult_Denied_ReportsThePermissionRatherThanLookingEmpty()
+    {
+        // "Not allowed to look" and "looked, found nothing" are different problems with different
+        // advice, and without this they are the same empty list.
+        var result = AwsSsoSetup.ParseResult(Block("missingPermission=sso:ListInstances"));
+
+        result.Should().NotBeNull();
+        result!.Instances.Should().BeEmpty();
+        result.MissingPermissions.Should().Equal("sso:ListInstances");
+    }
+
+    [Fact]
+    public void ParseResult_FoundNothing_IsAnEmptyResultAndNotAFailureToParse()
+    {
+        // The scan ran and there was no instance. That is an outcome to report, not a malformed
+        // paste — returning null here would tell the administrator they pasted the wrong thing.
+        var result = AwsSsoSetup.ParseResult(Block());
+
+        result.Should().NotBeNull();
+        result!.Instances.Should().BeEmpty();
+        result.MissingPermissions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseResult_WholeTerminalBuffer_FindsTheBlockInsideIt()
+    {
+        // What people actually paste: the prompt, the command echoed back, the progress line,
+        // and the block somewhere in the middle.
+        string pasted = """
+            [cloudshell-user@ip-10-0-0-1 ~]$ bash setup.sh
+            Not in this session default region; checking the others. This takes a moment.
+
+            """ + Block(
+                "region=ap-southeast-2",
+                "instanceArn=arn:aws:sso:::instance/ssoins-xyz",
+                "identityStoreId=d-abcdef1234") + """
+
+            Copy the block above, including both marker lines, back into Connapse.
+            [cloudshell-user@ip-10-0-0-1 ~]$
+            """;
+
+        var result = AwsSsoSetup.ParseResult(pasted);
+
+        result!.Instances.Should().ContainSingle();
+        result.Instances[0].Region.Should().Be("ap-southeast-2");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("region=us-east-1\nidentityStoreId=d-1234567890")]
+    [InlineData("----- BEGIN CONNAPSE AWS SETUP -----\nregion=us-east-1")]
+    public void ParseResult_WithoutBothMarkers_RefusesRatherThanGuessing(string? pasted)
+    {
+        // Loose key=value lines would happily accept a paste from somewhere else entirely, and
+        // the result of that is an identity provider pointed at the wrong account.
+        AwsSsoSetup.ParseResult(pasted).Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseResult_IncompleteRecord_IsDroppedRatherThanHalfBuilt()
+    {
+        // A region with no instance behind it is not an instance. Admitting it would produce an
+        // entry whose ARN and store id are empty strings.
+        var result = AwsSsoSetup.ParseResult(Block(
+            "region=us-east-1",
+            "region=eu-west-1",
+            "instanceArn=arn:aws:sso:::instance/ssoins-bbb",
+            "identityStoreId=d-bbbbbbbbb2"));
+
+        result!.Instances.Should().ContainSingle();
+        result.Instances[0].Region.Should().Be("eu-west-1");
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/AwsSsoSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AwsSsoSetupTests.cs
@@ -1,4 +1,4 @@
-using Connapse.Core.Utilities;
+﻿using Connapse.Core.Utilities;
 using FluentAssertions;
 using Xunit;
 
@@ -225,5 +225,92 @@ public class AwsSsoSetupTests
 
         result!.Instances.Should().ContainSingle();
         result.Instances[0].Region.Should().Be("eu-west-1");
+    }
+
+    // -- Account posture, and the create script ------------------------------------
+
+    [Theory]
+    [InlineData("standalone", AwsAccountPosture.Standalone)]
+    [InlineData("member", AwsAccountPosture.Member)]
+    [InlineData("management", AwsAccountPosture.Management)]
+    [InlineData("unknown", AwsAccountPosture.Unknown)]
+    [InlineData("something-newer", AwsAccountPosture.Unknown)]
+    public void ParseResult_ReadsThePosture(string reported, AwsAccountPosture expected)
+    {
+        var result = AwsSsoSetup.ParseResult(Block($"accountType={reported}"));
+
+        result!.Posture.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(AwsAccountPosture.Standalone, true)]
+    [InlineData(AwsAccountPosture.Member, true)]
+    [InlineData(AwsAccountPosture.Management, false)]
+    [InlineData(AwsAccountPosture.Unknown, false)]
+    public void CanCreateInstance_MatchesWhatAwsWouldAccept(AwsAccountPosture posture, bool expected)
+    {
+        // Management is rejected by the API outright. Unknown means the script could not tell, and
+        // offering a create step on a guess would send them to a refusal.
+        new AwsSsoSetupResult([], null, posture).CanCreateInstance.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GenerateCreateScript_StopsInTheManagementAccountBeforeCreatingAnything()
+    {
+        // AWS rejects CreateInstance there, and an organisation instance fixes a primary region
+        // that cannot be changed afterwards -- not a choice to make inside a pasted script.
+        string script = AwsSsoSetup.GenerateCreateScript();
+
+        int guard = script.IndexOf("management account", StringComparison.OrdinalIgnoreCase);
+        int create = script.IndexOf("create-instance", StringComparison.Ordinal);
+
+        guard.Should().BePositive("the script must recognise the management account");
+        create.Should().BeGreaterThan(guard, "the guard has to run before the create");
+        script.Should().Contain("exit 1", "recognising it is not enough - it has to stop");
+    }
+
+    [Fact]
+    public void GenerateCreateScript_WarnsBeforeCreatingInsideAnOrganisation()
+    {
+        // Permitted, and usually wrong: an account instance is not the one the organisation signs
+        // in through. Said plainly and then allowed, because the administrator knows their
+        // organisation and Connapse does not.
+        string script = AwsSsoSetup.GenerateCreateScript();
+
+        script.Should().Contain("ACCOUNT instance");
+        script.Should().Contain("Ctrl-C");
+    }
+
+    [Fact]
+    public void GenerateScript_StaysReadOnlyEvenThoughACreateScriptExists()
+    {
+        // The two are separate methods precisely so this stays true. The UI calls the find script
+        // read-only; folding a create branch into it would make that claim false for everyone.
+        AwsSsoSetup.GenerateScript().Should().NotContain("create-instance");
+    }
+
+    [Theory]
+    [InlineData(null, "Connapse")]
+    [InlineData("", "Connapse")]
+    [InlineData("   ", "Connapse")]
+    [InlineData("!!!", "Connapse")]
+    [InlineData("My Instance", "My-Instance")]
+    [InlineData("prod/eu", "prod-eu")]
+    [InlineData("Connapse", "Connapse")]
+    [InlineData("a.b_c@d+e=f,g-h", "a.b_c@d+e=f,g-h")]
+    public void SanitiseInstanceName_CoercesToWhatAwsAccepts(string? given, string expected)
+    {
+        // AWS constrains the name to word characters plus + = , . @ and -. A space would break the
+        // quoting in the generated shell line before AWS ever saw it.
+        AwsSsoSetup.SanitiseInstanceName(given).Should().Be(expected);
+    }
+
+    [Fact]
+    public void GenerateCreateScript_EmbedsTheSanitisedNameAndNotTheRawOne()
+    {
+        string script = AwsSsoSetup.GenerateCreateScript("My Prod; rm -rf /");
+
+        script.Should().NotContain("rm -rf /", "the name reaches a shell command line");
+        script.Should().Contain(AwsSsoSetup.SanitiseInstanceName("My Prod; rm -rf /"));
     }
 }

--- a/tests/Connapse.Core.Tests/Utilities/AwsSsoSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AwsSsoSetupTests.cs
@@ -362,4 +362,66 @@ public class AwsSsoSetupTests
         script.Should().NotContain("create-instance");
         script.Should().NotContain("sso-admin create");
     }
+
+    /// <summary>
+    /// The buffer an administrator actually has after pasting the command inline.
+    /// </summary>
+    /// <remarks>
+    /// Built from the real generated script rather than a hand-written excerpt, because the point
+    /// is that the script <i>contains</i> both markers — printing them is its job — so the shell's
+    /// echo of it carries a complete decoy pair above the true output. A fixture written by hand
+    /// would drift the moment the script changed and stop covering the case.
+    /// </remarks>
+    private static string InlinePasteBuffer() =>
+        "~ $ " +
+        string.Join("\n", AwsSsoSetup.GenerateScript().Split('\n').Select(l => "> " + l)) +
+        "\n\n" +
+        AwsSsoSetup.BeginMarker + "\n" +
+        "accountType=management\n" +
+        "region=us-west-1\n" +
+        "instanceArn=arn:aws:sso:::instance/ssoins-8201fe6971208a1a\n" +
+        "identityStoreId=d-91670f356b\n" +
+        "portalUrl=https://d-91670f356b.awsapps.com/start\n" +
+        AwsSsoSetup.EndMarker + "\n\n" +
+        "Copy the block above, including both marker lines, back into Connapse.\n";
+
+    [Fact]
+    public void InlinePasteBuffer_ReallyDoesContainTheMarkersTwice()
+    {
+        // Guards the test above it. If the script ever stopped carrying the markers in its own
+        // text, the regression fixture would quietly become an ordinary one and prove nothing.
+        string buffer = InlinePasteBuffer();
+
+        buffer.Split(AwsSsoSetup.BeginMarker).Should().HaveCount(3, "echoed once, printed once");
+        buffer.Split(AwsSsoSetup.EndMarker).Should().HaveCount(3, "echoed once, printed once");
+    }
+
+    [Fact]
+    public void ParseResult_InlinePasteWithEchoedScript_ReadsThePrintedBlockNotTheEcho()
+    {
+        // The failure this replaces: taking the first marker pair selected the echoed script,
+        // whose body is nothing but printf lines, so an administrator with a working instance was
+        // told there wasn't one.
+        var result = AwsSsoSetup.ParseResult(InlinePasteBuffer());
+
+        result.Should().NotBeNull();
+        result!.Instances.Should().ContainSingle(
+            "the printed block is the last marker pair, and the only one with real fields");
+
+        result.Instances[0].Region.Should().Be("us-west-1");
+        result.Instances[0].IdentityStoreId.Should().Be("d-91670f356b");
+        result.Posture.Should().Be(AwsAccountPosture.Management);
+    }
+
+    [Fact]
+    public void ParseResult_TrailingTextAfterTheBlock_DoesNotHideIt()
+    {
+        // LastIndexOf anchors on the end marker, so anything the shell prints afterwards -- the
+        // "copy the block above" line, a fresh prompt -- must not move the window.
+        var result = AwsSsoSetup.ParseResult(
+            InlinePasteBuffer() + "\n~ $ echo done\ndone\n~ $ ");
+
+        result!.Instances.Should().ContainSingle();
+        result.Instances[0].Region.Should().Be("us-west-1");
+    }
 }

--- a/tests/Connapse.Core.Tests/Utilities/AwsSsoSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AwsSsoSetupTests.cs
@@ -242,76 +242,13 @@ public class AwsSsoSetupTests
         result!.Posture.Should().Be(expected);
     }
 
-    [Theory]
-    [InlineData(AwsAccountPosture.Standalone, true)]
-    [InlineData(AwsAccountPosture.Member, true)]
-    [InlineData(AwsAccountPosture.Management, false)]
-    [InlineData(AwsAccountPosture.Unknown, false)]
-    public void CanCreateInstance_MatchesWhatAwsWouldAccept(AwsAccountPosture posture, bool expected)
-    {
-        // Management is rejected by the API outright. Unknown means the script could not tell, and
-        // offering a create step on a guess would send them to a refusal.
-        new AwsSsoSetupResult([], null, posture).CanCreateInstance.Should().Be(expected);
-    }
-
     [Fact]
-    public void GenerateCreateScript_StopsInTheManagementAccountBeforeCreatingAnything()
+    public void GenerateScript_StaysReadOnly()
     {
-        // AWS rejects CreateInstance there, and an organisation instance fixes a primary region
-        // that cannot be changed afterwards -- not a choice to make inside a pasted script.
-        string script = AwsSsoSetup.GenerateCreateScript();
-
-        int guard = script.IndexOf("management account", StringComparison.OrdinalIgnoreCase);
-        int create = script.IndexOf("create-instance", StringComparison.Ordinal);
-
-        guard.Should().BePositive("the script must recognise the management account");
-        create.Should().BeGreaterThan(guard, "the guard has to run before the create");
-        script.Should().Contain("exit 1", "recognising it is not enough - it has to stop");
-    }
-
-    [Fact]
-    public void GenerateCreateScript_WarnsBeforeCreatingInsideAnOrganisation()
-    {
-        // Permitted, and usually wrong: an account instance is not the one the organisation signs
-        // in through. Said plainly and then allowed, because the administrator knows their
-        // organisation and Connapse does not.
-        string script = AwsSsoSetup.GenerateCreateScript();
-
-        script.Should().Contain("ACCOUNT instance");
-        script.Should().Contain("Ctrl-C");
-    }
-
-    [Fact]
-    public void GenerateScript_StaysReadOnlyEvenThoughACreateScriptExists()
-    {
-        // The two are separate methods precisely so this stays true. The UI calls the find script
-        // read-only; folding a create branch into it would make that claim false for everyone.
+        // The UI calls this script read-only. It must stay true -- and create-instance would be
+        // the wrong tool anyway: it makes an account instance, which does not support access to
+        // AWS accounts, so Connapse would have nothing to scope a signed-in user's search by.
         AwsSsoSetup.GenerateScript().Should().NotContain("create-instance");
-    }
-
-    [Theory]
-    [InlineData(null, "Connapse")]
-    [InlineData("", "Connapse")]
-    [InlineData("   ", "Connapse")]
-    [InlineData("!!!", "Connapse")]
-    [InlineData("My Instance", "My-Instance")]
-    [InlineData("prod/eu", "prod-eu")]
-    [InlineData("Connapse", "Connapse")]
-    [InlineData("a.b_c@d+e=f,g-h", "a.b_c@d+e=f,g-h")]
-    public void SanitiseInstanceName_CoercesToWhatAwsAccepts(string? given, string expected)
-    {
-        // AWS constrains the name to word characters plus + = , . @ and -. A space would break the
-        // quoting in the generated shell line before AWS ever saw it.
-        AwsSsoSetup.SanitiseInstanceName(given).Should().Be(expected);
-    }
-
-    [Fact]
-    public void GenerateCreateScript_EmbedsTheSanitisedNameAndNotTheRawOne()
-    {
-        string script = AwsSsoSetup.GenerateCreateScript("My Prod; rm -rf /");
-
-        script.Should().NotContain("rm -rf /", "the name reaches a shell command line");
-        script.Should().Contain(AwsSsoSetup.SanitiseInstanceName("My Prod; rm -rf /"));
     }
 
     // -- Real CloudShell output -----------------------------------------------------
@@ -398,5 +335,31 @@ public class AwsSsoSetupTests
             .Should().BeGreaterThan(capture);
         script.IndexOf(AwsSsoSetup.EndMarker, StringComparison.Ordinal)
             .Should().BeGreaterThan(capture);
+    }
+
+    [Theory]
+    [InlineData(AwsAccountPosture.Management, true)]
+    [InlineData(AwsAccountPosture.Member, false)]
+    [InlineData(AwsAccountPosture.Standalone, false)]
+    [InlineData(AwsAccountPosture.Unknown, false)]
+    public void CanEnableItself_IsTheManagementAccountAlone(AwsAccountPosture posture, bool expected)
+    {
+        // An organisation instance is the only kind that supports permission sets, and so the only
+        // kind whose users have AWS accounts for ListAccounts to return. It is enabled from the
+        // console, in the management account -- nobody else can fix an empty result alone.
+        new AwsSsoSetupResult([], null, posture).CanEnableItself.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GenerateScript_DoesNotOfferToCreateAnything()
+    {
+        // create-instance produces an ACCOUNT instance. AWS states those do not support permission
+        // sets and therefore do not support access to AWS accounts, so Connapse would sign a user
+        // in through one and then find nothing to scope their search by -- a connection that looks
+        // healthy and returns nothing. The console is the only route to the kind that works.
+        string script = AwsSsoSetup.GenerateScript();
+
+        script.Should().NotContain("create-instance");
+        script.Should().NotContain("sso-admin create");
     }
 }

--- a/tests/Connapse.Core.Tests/Utilities/AwsSsoSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AwsSsoSetupTests.cs
@@ -313,4 +313,90 @@ public class AwsSsoSetupTests
         script.Should().NotContain("rm -rf /", "the name reaches a shell command line");
         script.Should().Contain(AwsSsoSetup.SanitiseInstanceName("My Prod; rm -rf /"));
     }
+
+    // -- Real CloudShell output -----------------------------------------------------
+
+    /// <summary>
+    /// An actual paste from AWS CloudShell, echo and all.
+    /// </summary>
+    /// <remarks>
+    /// Pasting a multi-line script into an interactive shell makes it echo every line back with
+    /// prompts and continuation markers. Before the block was built whole and printed once, that
+    /// echo landed <i>between</i> the markers — so the parser had to read a block containing the
+    /// script's own <c>printf 'region=%s\n'</c> lines without mistaking them for records.
+    /// <para>
+    /// Kept as a test because it is field data: this is what the flow really produced, against a
+    /// real Identity Center instance, not what the script was expected to produce.
+    /// </para>
+    /// </remarks>
+    private const string RealEchoedPaste = """
+        ----- BEGIN CONNAPSE AWS SETUP -----
+        ~ $ printf 'accountType=%s\n' "$POSTURE"
+        accountType=management
+        ~ $
+        ~ $ if [ -n "$FOUND" ]; then
+        >   printf '%s' "$FOUND" | while IFS='|' read -r REGION ARN STORE; do
+        >     [ -z "$REGION" ] && continue
+        >     printf 'region=%s\n' "$REGION"
+        >     printf 'instanceArn=%s\n' "$ARN"
+        >     printf 'identityStoreId=%s\n' "$STORE"
+        >     printf 'portalUrl=https://%s.awsapps.com/start\n' "$STORE"
+        >   done
+        > elif [ -n "$DENIED" ]; then
+        >   printf 'missingPermission=%s\n' 'sso:ListInstances'
+        > fi
+        region=us-west-1
+        instanceArn=arn:aws:sso:::instance/ssoins-8201fe6971208a1a
+        identityStoreId=d-91670f356b
+        portalUrl=https://d-91670f356b.awsapps.com/start
+        ~ $
+        ~ $ printf '%s\n\n' '----- END CONNAPSE AWS SETUP -----'
+        ----- END CONNAPSE AWS SETUP -----
+        """;
+
+    [Fact]
+    public void ParseResult_RealCloudShellPasteWithEcho_ReadsExactlyOneInstance()
+    {
+        var result = AwsSsoSetup.ParseResult(RealEchoedPaste);
+
+        result.Should().NotBeNull();
+        result!.Instances.Should().ContainSingle(
+            "the echoed printf lines are not records, however much they look like them");
+
+        result.Instances[0].Region.Should().Be("us-west-1");
+        result.Instances[0].InstanceArn.Should().Be("arn:aws:sso:::instance/ssoins-8201fe6971208a1a");
+        result.Instances[0].IdentityStoreId.Should().Be("d-91670f356b");
+        result.Instances[0].PortalUrl.Should().Be("https://d-91670f356b.awsapps.com/start");
+    }
+
+    [Fact]
+    public void ParseResult_RealCloudShellPasteWithEcho_DoesNotInventADenial()
+    {
+        // The echo contains the missingPermission line from the elif branch that never ran.
+        // Reading it would tell an administrator with working permissions that they lack them.
+        AwsSsoSetup.ParseResult(RealEchoedPaste)!.MissingPermissions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseResult_RealCloudShellPasteWithEcho_StillReadsThePosture()
+    {
+        AwsSsoSetup.ParseResult(RealEchoedPaste)!.Posture.Should().Be(AwsAccountPosture.Management);
+    }
+
+    [Fact]
+    public void GenerateScript_BuildsTheBlockWholeBeforePrintingIt()
+    {
+        // Both markers are emitted from inside one captured block rather than by statements with
+        // the lookup between them. That is what keeps the shell's echo above the BEGIN marker
+        // instead of interleaved through the result.
+        string script = AwsSsoSetup.GenerateScript();
+
+        int capture = script.IndexOf("BLOCK=$(", StringComparison.Ordinal);
+        capture.Should().BePositive("the block is captured, not printed piecemeal");
+
+        script.IndexOf(AwsSsoSetup.BeginMarker, StringComparison.Ordinal)
+            .Should().BeGreaterThan(capture);
+        script.IndexOf(AwsSsoSetup.EndMarker, StringComparison.Ordinal)
+            .Should().BeGreaterThan(capture);
+    }
 }


### PR DESCRIPTION
## What

A guided setup on the AWS identity provider form. Connapse writes one read-only command, the administrator runs it in **AWS CloudShell**, and pastes the printed block back. Connapse reads the region, instance ARN, identity store ID and portal URL out of it and fills the form.

## Why

The form asked for an issuer URL and a region and helped with neither. The region is the harder half: Identity Center lives in exactly one region per organisation, and the legacy portal URL (`https://d-1234567890.awsapps.com/start`) does not encode it. A wrong region produces `InvalidClientMetadataException`, which surfaces as "verify the issuer URL and region match" — true, but it does not say which one is wrong.

## Why CloudShell, and not the usual onboarding pattern

The standard approach is a CloudFormation quick-create link whose custom resource calls back into the service. **That cannot work here: Connapse is self-hosted and often has no public URL**, so AWS has nowhere to send the callback. Same constraint that made the SFTP setup a copy-paste block.

CloudShell already holds temporary credentials from the administrator's console session — AWS's own guidance is not to put long-term credentials in it, precisely because it inherits the signed-in identity. So no access key is created, nothing is pasted into Connapse, and nothing is stored. **The round trip is the credential boundary, not a workaround for lacking one**, which keeps the no-stored-cloud-credentials rule intact with no exception.

## How

`Connapse.Core.Utilities.AwsSsoSetup`, shaped like `SftpHostSetup`: `GenerateScript()` plus a tolerant `ParseResult()` keyed on begin/end markers.

Two things in the script worth calling out:

- **Session region first.** For most people the CloudShell session is already in the right region, so the scan never runs. Only on a miss does it walk the candidate list.
- **Bails on the first denial.** An `sso:ListInstances` denial is a property of the caller's policy, not of the region, so being refused once means being refused twenty times. This turns the denied path from 20 sequential calls into 1.

`create-instance` is deliberately not used — it only works for standalone accounts outside Organizations, one per account across all regions. For most organisations an instance already exists and the job is finding it.

## Verification

The script is text this assembly cannot execute, so I ran the generated output directly against a stub `aws` CLI in bash. `bash -n` clean, and five scenarios behave correctly:

| Scenario | Result |
|---|---|
| Instance in the session region | Found, scan skipped entirely |
| Instance in another region | Found by scan |
| Access denied | `missingPermission=sso:ListInstances`, **1 aws call, not 20** |
| Nothing found anywhere | Empty block, parses as an empty result rather than an error |
| Two instances in one region | Both reported separately |

Plus 17 unit tests, including the `printf` leading-dash guard that the SFTP script needed — both markers start with `-----`, and as a format string `printf` reads that as options. Asserting the marker merely *appears* in the script does not catch it, because it does appear: as the thing that failed to print.

Build clean, 1,179 unit tests green. Deployed to Docker: route answers, container log clean.

**Not verified:** the flow signed in as an administrator, and the script against a real Identity Center instance. I have neither an AWS account with Identity Center nor admin credentials here. The stub exercises the script's control flow but not the actual shape of `aws sso-admin list-instances` output, so that is the thing worth a real run before trusting it.

## Caveats handled in the UI

- **Custom vanity domain** — the derived `d-….awsapps.com` URL is offered as an editable default, not an answer.
- **Multi-region replication** — several instances are listed and the administrator picks; Connapse cannot know which their users sign in through.
- **Applying an instance clears any registered client**, since those credentials belong to the instance that issued them.

Closes #413


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided AWS SSO setup wizard in Settings.
  * Generate a read-only AWS CloudShell script to discover AWS SSO instances.
  * Paste terminal output to detect account status, permissions, and available instances.
  * Apply a discovered instance to populate the issuer URL and region.
  * Added guided instance creation when no suitable instance exists, with account-specific safeguards and warnings.
  * Copy commands or open AWS CloudShell directly from the wizard.
  * Cancel setup at any time; applying an instance clears previously registered client credentials.

* **Bug Fixes**
  * Improved handling of incomplete, empty, or embedded terminal output during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->