### PR TITLE
feat: guided S3 setup, and tell operators what their credentials are

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ docs/v0.3.0-plan.md
 
 # Subagent-driven-development scratch (ledger, briefs, review packages)
 .superpowers/
+
+# AWS credentials dropped in for S3 sources — never commit these.
+aws/*
+!aws/README.md

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,0 +1,18 @@
+# AWS credentials for S3 sources
+
+Drop your AWS `credentials` and/or `config` file in this folder and restart Connapse:
+
+    docker compose restart web
+
+Connapse mounts this folder read-only at `~/.aws` inside the container and reads whatever it
+finds. It stores no credential of its own — without something here (or an instance role, or
+`CONNAPSE_AWS_DIR` pointing elsewhere in `.env`), every S3 connection fails with
+"No AWS credentials found".
+
+To use the profile you already have instead of copying it, set this in `.env`:
+
+    CONNAPSE_AWS_DIR=C:\Users\you\.aws      # Windows
+    CONNAPSE_AWS_DIR=/home/you/.aws         # Linux and macOS
+
+Anything you put here is git-ignored. On EC2, ECS or EKS, attach an instance role and ignore
+this folder entirely.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,26 @@ services:
     volumes:
       - appdata:/app/appdata
 
+      # ── AWS credentials, for S3 sources ──────────────────────────────────────
+      # Always mounted, and empty until you put something in ./aws. Drop your AWS
+      # credentials file in that folder and restart — no edit to this file needed.
+      # To point at a profile you already keep elsewhere, set CONNAPSE_AWS_DIR in
+      # .env instead. See aws/README.md.
+      #
+      # Read-only, and nothing is copied into Connapse: it stores no credential of
+      # its own and reads whatever this makes visible. The same mount carries
+      # whichever kind of profile you keep there — a static one, an SSO one, or a
+      # credential_process entry pointing at the IAM Roles Anywhere helper, which
+      # gives a workload outside AWS temporary credentials with no static keys.
+      # On EC2, ECS or EKS, attach an instance role and leave ./aws empty.
+      #
+      # A repo-relative default rather than ${HOME}/.aws, for two reasons. HOME is
+      # unset in Windows PowerShell, where Compose warns and substitutes a blank
+      # string, silently mounting /.aws. And some Compose versions refuse to start
+      # at all when a bind source is missing — ./aws ships with the repo, so it is
+      # always there, while a home directory without .aws is the common case.
+      - ${CONNAPSE_AWS_DIR:-./aws}:/home/app/.aws:ro
+
     depends_on:
       postgres:
         condition: service_healthy

--- a/src/Connapse.Core/Interfaces/IS3Discovery.cs
+++ b/src/Connapse.Core/Interfaces/IS3Discovery.cs
@@ -1,0 +1,106 @@
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// How the credentials Connapse resolved were obtained, which is the part that decides whether a
+/// deployment is sound — not whether they work today.
+/// </summary>
+/// <remarks>
+/// The SDK's default provider chain will resolve a static key from 2019 as happily as an instance
+/// role and say nothing about the difference. Reporting the kind is what lets the UI say something.
+/// </remarks>
+public enum AwsCredentialKind
+{
+    /// <summary>Resolved, but the chain link is one this build does not recognise.</summary>
+    Unrecognised = 0,
+
+    /// <summary>An IAM role attached to the compute — EC2, ECS or EKS. Rotates itself, expires,
+    /// belongs to the machine. The strongest option, and the only one needing no arrangement.</summary>
+    InstanceOrTaskRole = 1,
+
+    /// <summary>Assumed through STS, so temporary and scoped.</summary>
+    AssumedRole = 2,
+
+    /// <summary>An IAM Identity Center session. Temporary, but expires and needs a human with a
+    /// browser to renew — so it cannot sustain unattended sync.</summary>
+    SsoSession = 3,
+
+    /// <summary>Produced by an external <c>credential_process</c>, which is how IAM Roles Anywhere
+    /// is wired in: temporary credentials for a workload outside AWS, no static keys.</summary>
+    ExternalProcess = 4,
+
+    /// <summary>A long-lived access key, from the environment or a profile. Works, never expires,
+    /// and is the thing AWS guidance tells people to move away from.</summary>
+    StaticKey = 5
+}
+
+/// <summary>What the container could see and reach.</summary>
+/// <param name="Arn">The identity the credentials resolve to, from <c>sts:GetCallerIdentity</c>.</param>
+/// <param name="AccountId">The AWS account those credentials belong to.</param>
+/// <param name="Kind">Where they came from.</param>
+public record AwsCallerIdentity(string Arn, string AccountId, AwsCredentialKind Kind);
+
+/// <summary>
+/// The outcome of asking AWS something, separating the three cases that need different advice:
+/// it worked, the credentials are absent, or they are present but not allowed.
+/// </summary>
+/// <remarks>
+/// Collapsing "no credentials" into "denied" is the specific failure this exists to prevent. The
+/// first is a deployment problem the operator fixes in their compose file; the second is an IAM
+/// problem they fix in AWS. The messages have nothing in common.
+/// </remarks>
+public record AwsProbe<T>(T? Value, AwsProbeOutcome Outcome, string? Detail = null)
+{
+    public bool Succeeded => Outcome == AwsProbeOutcome.Succeeded;
+
+    public static AwsProbe<T> Ok(T value) => new(value, AwsProbeOutcome.Succeeded);
+
+    public static AwsProbe<T> NoCredentials(string? detail = null) =>
+        new(default, AwsProbeOutcome.NoCredentials, detail);
+
+    public static AwsProbe<T> Denied(string? detail = null) =>
+        new(default, AwsProbeOutcome.Denied, detail);
+
+    public static AwsProbe<T> Failed(string? detail = null) =>
+        new(default, AwsProbeOutcome.Failed, detail);
+}
+
+public enum AwsProbeOutcome
+{
+    Succeeded = 0,
+
+    /// <summary>Nothing in the chain resolved. The container cannot see any credentials.</summary>
+    NoCredentials = 1,
+
+    /// <summary>Credentials resolved, and AWS refused the call.</summary>
+    Denied = 2,
+
+    /// <summary>Something else — a timeout, a network fault, an unexpected error.</summary>
+    Failed = 3
+}
+
+/// <summary>
+/// Reads what the container's own AWS credentials can see, so the connection form can be filled in
+/// rather than typed.
+/// </summary>
+/// <remarks>
+/// Unlike the SFTP and identity-provider wizards, this one needs no script: Connapse's process is
+/// meant to hold these credentials, so it can make the calls itself.
+/// </remarks>
+public interface IS3Discovery
+{
+    /// <summary>Who Connapse is, as far as AWS is concerned.</summary>
+    Task<AwsProbe<AwsCallerIdentity>> WhoAmIAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Every bucket the credentials can enumerate.
+    /// </summary>
+    /// <remarks>
+    /// Needs <c>s3:ListAllMyBuckets</c>, which narrowly scoped credentials very often lack — and
+    /// lacking it is correct, not broken. A denial here must leave the operator typing a bucket
+    /// name, never blocked.
+    /// </remarks>
+    Task<AwsProbe<IReadOnlyList<string>>> ListBucketsAsync(CancellationToken ct = default);
+
+    /// <summary>The region a bucket lives in, so it does not have to be guessed.</summary>
+    Task<AwsProbe<string>> GetBucketRegionAsync(string bucket, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/IS3Discovery.cs
+++ b/src/Connapse.Core/Interfaces/IS3Discovery.cs
@@ -1,4 +1,4 @@
-namespace Connapse.Core.Interfaces;
+﻿namespace Connapse.Core.Interfaces;
 
 /// <summary>
 /// How the credentials Connapse resolved were obtained, which is the part that decides whether a
@@ -36,8 +36,20 @@ public enum AwsCredentialKind
 /// <summary>What the container could see and reach.</summary>
 /// <param name="Arn">The identity the credentials resolve to, from <c>sts:GetCallerIdentity</c>.</param>
 /// <param name="AccountId">The AWS account those credentials belong to.</param>
-/// <param name="Kind">Where they came from.</param>
-public record AwsCallerIdentity(string Arn, string AccountId, AwsCredentialKind Kind);
+/// <param name="Kind">Where the base credentials came from.</param>
+/// <param name="AssumedRoleArn">
+/// The role that was assumed to reach <paramref name="Arn"/>, or null when the base credentials
+/// were used directly.
+/// <para>
+/// Reported because the two can be in different AWS accounts entirely, and the generated policy
+/// has to be attached to the effective principal rather than the base one.
+/// </para>
+/// </param>
+public record AwsCallerIdentity(
+    string Arn,
+    string AccountId,
+    AwsCredentialKind Kind,
+    string? AssumedRoleArn = null);
 
 /// <summary>
 /// The outcome of asking AWS something, separating the three cases that need different advice:
@@ -85,11 +97,17 @@ public enum AwsProbeOutcome
 /// <remarks>
 /// Unlike the SFTP and identity-provider wizards, this one needs no script: Connapse's process is
 /// meant to hold these credentials, so it can make the calls itself.
+/// <para>
+/// Every method takes the connection's <c>roleArn</c>, and must assume it exactly as
+/// <c>S3Connector</c> and <c>S3ConnectionTester</c> do. Probing with the base credentials while
+/// the connection runs as an assumed role means the wizard describes one account and the sync uses
+/// another — and the policy it tells the operator to attach lands on the wrong principal.
+/// </para>
 /// </remarks>
 public interface IS3Discovery
 {
     /// <summary>Who Connapse is, as far as AWS is concerned.</summary>
-    Task<AwsProbe<AwsCallerIdentity>> WhoAmIAsync(CancellationToken ct = default);
+    Task<AwsProbe<AwsCallerIdentity>> WhoAmIAsync(string? roleArn = null, CancellationToken ct = default);
 
     /// <summary>
     /// Every bucket the credentials can enumerate.
@@ -99,8 +117,8 @@ public interface IS3Discovery
     /// lacking it is correct, not broken. A denial here must leave the operator typing a bucket
     /// name, never blocked.
     /// </remarks>
-    Task<AwsProbe<IReadOnlyList<string>>> ListBucketsAsync(CancellationToken ct = default);
+    Task<AwsProbe<IReadOnlyList<string>>> ListBucketsAsync(string? roleArn = null, CancellationToken ct = default);
 
     /// <summary>The region a bucket lives in, so it does not have to be guessed.</summary>
-    Task<AwsProbe<string>> GetBucketRegionAsync(string bucket, CancellationToken ct = default);
+    Task<AwsProbe<string>> GetBucketRegionAsync(string bucket, string? roleArn = null, CancellationToken ct = default);
 }

--- a/src/Connapse.Core/Utilities/S3SetupPolicy.cs
+++ b/src/Connapse.Core/Utilities/S3SetupPolicy.cs
@@ -89,6 +89,80 @@ public static class S3SetupPolicy
     }
 
     /// <summary>
+    /// One policy document covering every allowed location.
+    /// </summary>
+    /// <param name="locations">
+    /// Allowlist entries, each a bucket optionally followed by <c>/</c> and a prefix — the same
+    /// form the connection's allowed-locations field holds.
+    /// </param>
+    /// <remarks>
+    /// A single document, not several concatenated. Generating one per bucket and joining them
+    /// produces two top-level JSON objects, which is not a policy at all: IAM rejects it outright,
+    /// while the UI presented it as something to paste. Anyone allowing two buckets got output
+    /// that could not work.
+    /// <para>
+    /// Sids are suffixed by index because they must be unique within a document, and bucket names
+    /// can contain characters a Sid cannot.
+    /// </para>
+    /// </remarks>
+    public static string ForBuckets(IEnumerable<string> locations)
+    {
+        var statements = new List<object>();
+        int index = 0;
+
+        foreach (string location in locations)
+        {
+            if (string.IsNullOrWhiteSpace(location)) continue;
+
+            string entry = location.Trim();
+            int slash = entry.IndexOf('/');
+            string bucket = (slash < 0 ? entry : entry[..slash]).Trim();
+            if (bucket.Length == 0) continue;
+
+            string prefix = NormalisePrefix(slash < 0 ? null : entry[(slash + 1)..]);
+
+            var list = new Dictionary<string, object>
+            {
+                ["Sid"] = $"ConnapseListBucket{index}",
+                ["Effect"] = "Allow",
+                ["Action"] = new[] { "s3:ListBucket" },
+                ["Resource"] = $"arn:aws:s3:::{bucket}"
+            };
+
+            if (prefix.Length > 0)
+            {
+                list["Condition"] = new Dictionary<string, object>
+                {
+                    ["StringLike"] = new Dictionary<string, object>
+                    {
+                        ["s3:prefix"] = new[] { $"{prefix}*" }
+                    }
+                };
+            }
+
+            statements.Add(list);
+            statements.Add(new Dictionary<string, object>
+            {
+                ["Sid"] = $"ConnapseReadObjects{index}",
+                ["Effect"] = "Allow",
+                ["Action"] = new[] { "s3:GetObject" },
+                ["Resource"] = $"arn:aws:s3:::{bucket}/{prefix}*"
+            });
+
+            index++;
+        }
+
+        if (statements.Count == 0)
+            throw new ArgumentException("No usable bucket in the allowed locations.", nameof(locations));
+
+        return JsonSerializer.Serialize(new Dictionary<string, object>
+        {
+            ["Version"] = "2012-10-17",
+            ["Statement"] = statements
+        }, PolicyJson);
+    }
+
+    /// <summary>
     /// Trims a prefix to the form an ARN wants: no leading slash, one trailing slash, or empty.
     /// </summary>
     /// <remarks>

--- a/src/Connapse.Core/Utilities/S3SetupPolicy.cs
+++ b/src/Connapse.Core/Utilities/S3SetupPolicy.cs
@@ -120,17 +120,41 @@ public static class S3SetupPolicy
     /// home rather than <c>/root</c>.
     /// </para>
     /// </remarks>
-    // $$ so that a lone brace is literal: the snippet contains ${HOME}, which compose expands and
-    // C# must not.
-    public static string ComposeCredentialMount(string containerHome = "/home/app") =>
-        $$"""
-        services:
-          web:
-            volumes:
-              - ${HOME}/.aws:{{containerHome}}/.aws:ro
-            environment:
-              # Only needed if the profile you want is not [default].
-              # - AWS_PROFILE=my-profile
+    /// <summary>The folder, beside docker-compose.yml, that is already mounted at ~/.aws.</summary>
+    public const string CredentialFolder = "aws";
+
+    /// <summary>The .env variable that points the mount somewhere else instead.</summary>
+    public const string CredentialDirVariable = "CONNAPSE_AWS_DIR";
+
+    /// <summary>
+    /// What to do when Connapse can see no credentials.
+    /// </summary>
+    /// <remarks>
+    /// Two steps, neither of which touches YAML. The compose file already mounts
+    /// <c>./aws</c> read-only at the container user's <c>~/.aws</c>, so supplying credentials is
+    /// dropping a file into a folder — which is the whole point: an operator who has to edit
+    /// compose to make a feature work will conclude the feature does not work.
+    /// <para>
+    /// The mount is unconditional and defaults to a repo-relative path deliberately. A
+    /// <c>${HOME}</c>-based default is blank in Windows PowerShell and silently mounts
+    /// <c>/.aws</c>, and some Compose versions refuse to start when a bind source is missing —
+    /// which a home directory without <c>.aws</c> very often is.
+    /// </para>
+    /// </remarks>
+    public static string CredentialInstructions(string containerHome = "/home/app") =>
+        $"""
+        1. Put your AWS credentials file in the "{CredentialFolder}" folder beside
+           docker-compose.yml. It is already mounted read-only at {containerHome}/.aws,
+           and nothing is copied into Connapse.
+
+           Or, to use a profile you already keep elsewhere, add one line to .env:
+
+               {CredentialDirVariable}=C:\Users\you\.aws     (Windows)
+               {CredentialDirVariable}=/home/you/.aws        (Linux, macOS)
+
+        2. Restart, then run this check again:
+
+               docker compose restart web
         """;
 
     private static readonly JsonSerializerOptions PolicyJson = new() { WriteIndented = true };

--- a/src/Connapse.Core/Utilities/S3SetupPolicy.cs
+++ b/src/Connapse.Core/Utilities/S3SetupPolicy.cs
@@ -1,0 +1,137 @@
+﻿using System.Text.Json;
+
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Builds the IAM policy that lets Connapse read one bucket, and the deployment snippet that lets
+/// it see any credentials at all.
+/// </summary>
+/// <remarks>
+/// Both are text an operator copies into their own files — an IAM policy into AWS, a volume into
+/// their compose file. Connapse never applies either, and stores no credential: it reads whatever
+/// <c>DefaultAWSCredentials</c> finds, which is the operator's arrangement to make.
+/// </remarks>
+public static class S3SetupPolicy
+{
+    /// <summary>
+    /// The two actions Connapse actually performs against a source bucket.
+    /// </summary>
+    /// <remarks>
+    /// <c>ListBucket</c> is a bucket-level action and <c>GetObject</c> an object-level one, which
+    /// is why the generated policy has two statements with different resources rather than one
+    /// with both actions. A single statement listing both against either resource silently fails:
+    /// against the bucket ARN alone, every object read is denied.
+    /// </remarks>
+    public static readonly IReadOnlyList<string> ReadActions = ["s3:ListBucket", "s3:GetObject"];
+
+    /// <summary>
+    /// A policy granting read access to <paramref name="bucket"/>, narrowed to
+    /// <paramref name="prefix"/> when one is given.
+    /// </summary>
+    /// <remarks>
+    /// Offered so an operator can tighten credentials that currently allow more, which is the
+    /// usual state of an access key someone made to get started. It is deliberately not the
+    /// policy Connapse needs to <i>discover</i> buckets — that needs
+    /// <c>s3:ListAllMyBuckets</c> across every bucket, and handing out a wide grant to save one
+    /// dropdown is the wrong trade once the bucket is known.
+    /// </remarks>
+    public static string ForBucket(string bucket, string? prefix = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bucket);
+
+        string cleanBucket = bucket.Trim();
+        string cleanPrefix = NormalisePrefix(prefix);
+
+        // The object statement is scoped by key, the bucket statement by a ListBucket condition.
+        // Without the condition the grant still bounds *reading* to the prefix, but lets the
+        // holder enumerate every key in the bucket, which is more than Connapse needs.
+        string objectResource = $"arn:aws:s3:::{cleanBucket}/{cleanPrefix}*";
+
+        var listStatement = new Dictionary<string, object>
+        {
+            ["Sid"] = "ConnapseListBucket",
+            ["Effect"] = "Allow",
+            ["Action"] = new[] { "s3:ListBucket" },
+            ["Resource"] = $"arn:aws:s3:::{cleanBucket}"
+        };
+
+        // Added rather than set to null. A dictionary entry whose value is null still serialises,
+        // and IAM rejects "Condition": null outright — WhenWritingNull governs object properties,
+        // not dictionary entries, so the key has to be absent instead of empty.
+        if (cleanPrefix.Length > 0)
+        {
+            listStatement["Condition"] = new Dictionary<string, object>
+            {
+                ["StringLike"] = new Dictionary<string, object>
+                {
+                    ["s3:prefix"] = new[] { $"{cleanPrefix}*" }
+                }
+            };
+        }
+
+        var policy = new Dictionary<string, object>
+        {
+            ["Version"] = "2012-10-17",
+            ["Statement"] = new object[]
+            {
+                listStatement,
+                new Dictionary<string, object>
+                {
+                    ["Sid"] = "ConnapseReadObjects",
+                    ["Effect"] = "Allow",
+                    ["Action"] = new[] { "s3:GetObject" },
+                    ["Resource"] = objectResource
+                }
+            }
+        };
+
+        return JsonSerializer.Serialize(policy, PolicyJson);
+    }
+
+    /// <summary>
+    /// Trims a prefix to the form an ARN wants: no leading slash, one trailing slash, or empty.
+    /// </summary>
+    /// <remarks>
+    /// A prefix typed as <c>/docs</c> would produce <c>bucket//docs*</c>, which matches nothing —
+    /// S3 keys have no leading slash. One typed as <c>docs</c> without a trailing slash would also
+    /// match <c>docs-archive/</c>, quietly widening the grant past the folder the operator meant.
+    /// </remarks>
+    public static string NormalisePrefix(string? prefix)
+    {
+        string trimmed = (prefix ?? string.Empty).Trim().TrimStart('/');
+
+        if (trimmed.Length == 0)
+            return string.Empty;
+
+        return trimmed.EndsWith('/') ? trimmed : trimmed + "/";
+    }
+
+    /// <summary>
+    /// The compose fragment that lets the container see the operator's AWS credentials.
+    /// </summary>
+    /// <remarks>
+    /// A read-only bind mount rather than environment variables: credentials stay off the
+    /// container filesystem and out of its process listing, and the same mount carries whichever
+    /// posture the operator chose — a static profile, an SSO profile, or a
+    /// <c>credential_process</c> line pointing at the IAM Roles Anywhere helper, which is how a
+    /// workload outside AWS gets temporary credentials with no static keys at all.
+    /// <para>
+    /// Connapse runs as a non-root user in its image, so the container-side path is that user's
+    /// home rather than <c>/root</c>.
+    /// </para>
+    /// </remarks>
+    // $$ so that a lone brace is literal: the snippet contains ${HOME}, which compose expands and
+    // C# must not.
+    public static string ComposeCredentialMount(string containerHome = "/home/app") =>
+        $$"""
+        services:
+          web:
+            volumes:
+              - ${HOME}/.aws:{{containerHome}}/.aws:ro
+            environment:
+              # Only needed if the profile you want is not [default].
+              # - AWS_PROFILE=my-profile
+        """;
+
+    private static readonly JsonSerializerOptions PolicyJson = new() { WriteIndented = true };
+}

--- a/src/Connapse.Storage/CloudScope/S3Discovery.cs
+++ b/src/Connapse.Storage/CloudScope/S3Discovery.cs
@@ -1,4 +1,4 @@
-using Amazon;
+﻿using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
@@ -38,10 +38,10 @@ public class S3Discovery(ILogger<S3Discovery> logger) : IS3Discovery
 
     public async Task<AwsProbe<AwsCallerIdentity>> WhoAmIAsync(CancellationToken ct = default)
     {
-        AWSCredentials? credentials = Resolve();
+        var (credentials, error) = Resolve();
         if (credentials is null)
-            return AwsProbe<AwsCallerIdentity>.NoCredentials(
-                "The AWS SDK found no credentials in its provider chain.");
+            return AwsProbe<AwsCallerIdentity>.NoCredentials(error
+                ?? "The AWS SDK found no credentials in its provider chain.");
 
         try
         {
@@ -70,9 +70,9 @@ public class S3Discovery(ILogger<S3Discovery> logger) : IS3Discovery
 
     public async Task<AwsProbe<IReadOnlyList<string>>> ListBucketsAsync(CancellationToken ct = default)
     {
-        AWSCredentials? credentials = Resolve();
+        var (credentials, error) = Resolve();
         if (credentials is null)
-            return AwsProbe<IReadOnlyList<string>>.NoCredentials();
+            return AwsProbe<IReadOnlyList<string>>.NoCredentials(error);
 
         try
         {
@@ -109,9 +109,9 @@ public class S3Discovery(ILogger<S3Discovery> logger) : IS3Discovery
         if (string.IsNullOrWhiteSpace(bucket))
             return AwsProbe<string>.Failed("No bucket name given.");
 
-        AWSCredentials? credentials = Resolve();
+        var (credentials, error) = Resolve();
         if (credentials is null)
-            return AwsProbe<string>.NoCredentials();
+            return AwsProbe<string>.NoCredentials(error);
 
         try
         {
@@ -159,17 +159,28 @@ public class S3Discovery(ILogger<S3Discovery> logger) : IS3Discovery
     /// exception.
     /// </para>
     /// </remarks>
-    private AWSCredentials? Resolve()
+    private (AWSCredentials? Credentials, string? Error) Resolve()
     {
         try
         {
-            return Amazon.Runtime.Credentials.DefaultAWSCredentialsIdentityResolver
-                .GetCredentials(new AmazonS3Config { RegionEndpoint = DiscoveryRegion });
+            return (Amazon.Runtime.Credentials.DefaultAWSCredentialsIdentityResolver
+                .GetCredentials(new AmazonS3Config { RegionEndpoint = DiscoveryRegion }), null);
         }
-        catch (AmazonServiceException ex)
+        catch (Exception ex)
         {
+            // Every exception, and deliberately not a specific AWS type.
+            //
+            // This caught AmazonServiceException first, which looks like the careful choice. The
+            // resolver throws AmazonClientException when nothing is configured, and those two are
+            // siblings — each derives straight from Exception, neither from the other — so that
+            // catch covered none of it. The most likely state of a fresh deployment took the
+            // Blazor circuit down instead of returning an answer.
+            //
+            // Nothing this method can hit is worth crashing a page over: every caller treats a
+            // null as "tell them how to supply credentials", which is the useful response to any
+            // failure to obtain them.
             logger.LogDebug(ex, "No AWS credentials resolved from the provider chain");
-            return null;
+            return (null, ex.Message);
         }
     }
 

--- a/src/Connapse.Storage/CloudScope/S3Discovery.cs
+++ b/src/Connapse.Storage/CloudScope/S3Discovery.cs
@@ -1,0 +1,230 @@
+using Amazon;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Asks AWS what this container's own credentials can see.
+/// </summary>
+/// <remarks>
+/// Every call goes through the SDK's default provider chain — no credential is passed in, and none
+/// is stored. That chain is what makes the same code pick up an instance role in production and a
+/// mounted profile in development, which is why Connapse uses it rather than holding credentials
+/// of its own.
+/// <para>
+/// What the chain will not tell you is whether the credential it found is a good one: a static key
+/// resolves exactly as smoothly as an instance role. Classifying the result is the point of
+/// <see cref="Classify"/>.
+/// </para>
+/// </remarks>
+public class S3Discovery(ILogger<S3Discovery> logger) : IS3Discovery
+{
+    /// <summary>
+    /// Endpoint for the calls that are not about a particular bucket.
+    /// </summary>
+    /// <remarks>
+    /// STS and ListBuckets answer the same everywhere, so this is only somewhere to send the
+    /// request. It is not a claim about where anything lives.
+    /// </remarks>
+    private static readonly RegionEndpoint DiscoveryRegion = RegionEndpoint.USEast1;
+
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    public async Task<AwsProbe<AwsCallerIdentity>> WhoAmIAsync(CancellationToken ct = default)
+    {
+        AWSCredentials? credentials = Resolve();
+        if (credentials is null)
+            return AwsProbe<AwsCallerIdentity>.NoCredentials(
+                "The AWS SDK found no credentials in its provider chain.");
+
+        try
+        {
+            using var sts = new AmazonSecurityTokenServiceClient(credentials,
+                new AmazonSecurityTokenServiceConfig { RegionEndpoint = DiscoveryRegion, Timeout = Timeout });
+
+            var response = await sts.GetCallerIdentityAsync(new GetCallerIdentityRequest(), ct);
+
+            return AwsProbe<AwsCallerIdentity>.Ok(new AwsCallerIdentity(
+                response.Arn, response.Account, Classify(credentials)));
+        }
+        catch (AmazonServiceException ex) when (IsDenial(ex))
+        {
+            // Rare but real: credentials that exist and are refused sts:GetCallerIdentity, which
+            // almost every policy allows. Worth distinguishing anyway, because "your key is wrong"
+            // and "your key is not allowed to do this" send the operator to different places.
+            logger.LogWarning(ex, "GetCallerIdentity was denied");
+            return AwsProbe<AwsCallerIdentity>.Denied(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "GetCallerIdentity failed");
+            return AwsProbe<AwsCallerIdentity>.Failed(ex.Message);
+        }
+    }
+
+    public async Task<AwsProbe<IReadOnlyList<string>>> ListBucketsAsync(CancellationToken ct = default)
+    {
+        AWSCredentials? credentials = Resolve();
+        if (credentials is null)
+            return AwsProbe<IReadOnlyList<string>>.NoCredentials();
+
+        try
+        {
+            using var s3 = new AmazonS3Client(credentials,
+                new AmazonS3Config { RegionEndpoint = DiscoveryRegion, Timeout = Timeout });
+
+            var response = await s3.ListBucketsAsync(new ListBucketsRequest(), ct);
+
+            IReadOnlyList<string> names = response.Buckets?
+                .Select(b => b.BucketName)
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                .ToList() ?? [];
+
+            return AwsProbe<IReadOnlyList<string>>.Ok(names);
+        }
+        catch (AmazonS3Exception ex) when (IsDenial(ex))
+        {
+            // Expected, and not a fault. s3:ListAllMyBuckets is account-wide, so a credential
+            // scoped to one bucket is *supposed* to be refused here. The caller falls back to
+            // asking for the name.
+            logger.LogDebug("ListBuckets denied — credentials are scoped, which is fine");
+            return AwsProbe<IReadOnlyList<string>>.Denied(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "ListBuckets failed");
+            return AwsProbe<IReadOnlyList<string>>.Failed(ex.Message);
+        }
+    }
+
+    public async Task<AwsProbe<string>> GetBucketRegionAsync(string bucket, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(bucket))
+            return AwsProbe<string>.Failed("No bucket name given.");
+
+        AWSCredentials? credentials = Resolve();
+        if (credentials is null)
+            return AwsProbe<string>.NoCredentials();
+
+        try
+        {
+            using var s3 = new AmazonS3Client(credentials,
+                new AmazonS3Config { RegionEndpoint = DiscoveryRegion, Timeout = Timeout });
+
+            var response = await s3.GetBucketLocationAsync(
+                new GetBucketLocationRequest { BucketName = bucket.Trim() }, ct);
+
+            // The oldest quirk in S3: us-east-1 reports itself as an empty location constraint,
+            // because it predates the constraint existing. Passing that through would put a blank
+            // in the region field for the single most common region.
+            string region = response.Location?.Value is { Length: > 0 } value
+                ? value
+                : "us-east-1";
+
+            // And "EU" is a legacy alias that RegionEndpoint does not accept.
+            if (region.Equals("EU", StringComparison.OrdinalIgnoreCase))
+                region = "eu-west-1";
+
+            return AwsProbe<string>.Ok(region);
+        }
+        catch (AmazonS3Exception ex) when (IsDenial(ex))
+        {
+            logger.LogDebug("GetBucketLocation denied for {Bucket}", bucket);
+            return AwsProbe<string>.Denied(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "GetBucketLocation failed for {Bucket}", bucket);
+            return AwsProbe<string>.Failed(ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Walks the SDK's provider chain, returning null when it comes back empty.
+    /// </summary>
+    /// <remarks>
+    /// Through <c>DefaultAWSCredentialsIdentityResolver</c>, not <c>FallbackCredentialsFactory</c>
+    /// — the SDK deprecated the latter in v4 and says so at compile time. Same chain, current
+    /// entry point.
+    /// <para>
+    /// The chain throws rather than returning null when nothing resolves, and "nothing configured"
+    /// is the single most likely state of a fresh deployment — so it is an answer here, not an
+    /// exception.
+    /// </para>
+    /// </remarks>
+    private AWSCredentials? Resolve()
+    {
+        try
+        {
+            return Amazon.Runtime.Credentials.DefaultAWSCredentialsIdentityResolver
+                .GetCredentials(new AmazonS3Config { RegionEndpoint = DiscoveryRegion });
+        }
+        catch (AmazonServiceException ex)
+        {
+            logger.LogDebug(ex, "No AWS credentials resolved from the provider chain");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Names the chain link the credentials came from.
+    /// </summary>
+    /// <remarks>
+    /// By runtime type, which is the only thing the chain exposes about its own decision. The
+    /// point is not diagnostics but posture: a static key works forever and is what AWS guidance
+    /// steers people away from, and nothing else in the system would ever mention it.
+    /// </remarks>
+    internal static AwsCredentialKind Classify(AWSCredentials credentials) =>
+        ClassifyType(credentials.GetType());
+
+    /// <summary>
+    /// The same decision, made from the type alone.
+    /// </summary>
+    /// <remarks>
+    /// Split out because several of these classes do real work in their constructors and cannot be
+    /// created in a test: <c>EnvironmentVariablesAWSCredentials</c> throws when the variables are
+    /// unset, and <c>InstanceProfileAWSCredentials</c> calls the EC2 metadata service and takes
+    /// most of a second to fail anywhere else. Taking the type keeps the one piece of judgement
+    /// here testable without any of that.
+    /// <para>
+    /// Walks the base chain, so a derived or wrapped credential still classifies as the thing it
+    /// derives from rather than falling through to Unrecognised.
+    /// </para>
+    /// </remarks>
+    internal static AwsCredentialKind ClassifyType(Type? type)
+    {
+        for (Type? t = type; t is not null; t = t.BaseType)
+        {
+            AwsCredentialKind kind = t.Name switch
+            {
+                nameof(InstanceProfileAWSCredentials) => AwsCredentialKind.InstanceOrTaskRole,
+                nameof(GenericContainerCredentials) => AwsCredentialKind.InstanceOrTaskRole,
+                nameof(AssumeRoleWithWebIdentityCredentials) => AwsCredentialKind.AssumedRole,
+                nameof(AssumeRoleAWSCredentials) => AwsCredentialKind.AssumedRole,
+                nameof(SessionAWSCredentials) => AwsCredentialKind.AssumedRole,
+                nameof(SSOAWSCredentials) => AwsCredentialKind.SsoSession,
+                nameof(ProcessAWSCredentials) => AwsCredentialKind.ExternalProcess,
+                nameof(EnvironmentVariablesAWSCredentials) => AwsCredentialKind.StaticKey,
+                nameof(BasicAWSCredentials) => AwsCredentialKind.StaticKey,
+                _ => AwsCredentialKind.Unrecognised
+            };
+
+            if (kind != AwsCredentialKind.Unrecognised)
+                return kind;
+        }
+
+        return AwsCredentialKind.Unrecognised;
+    }
+
+    private static bool IsDenial(AmazonServiceException ex) =>
+        ex.StatusCode is System.Net.HttpStatusCode.Forbidden
+                      or System.Net.HttpStatusCode.Unauthorized
+        || (ex.ErrorCode?.Contains("AccessDenied", StringComparison.OrdinalIgnoreCase) ?? false);
+}

--- a/src/Connapse.Storage/CloudScope/S3Discovery.cs
+++ b/src/Connapse.Storage/CloudScope/S3Discovery.cs
@@ -36,22 +36,29 @@ public class S3Discovery(ILogger<S3Discovery> logger) : IS3Discovery
 
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
 
-    public async Task<AwsProbe<AwsCallerIdentity>> WhoAmIAsync(CancellationToken ct = default)
+    public async Task<AwsProbe<AwsCallerIdentity>> WhoAmIAsync(
+        string? roleArn = null, CancellationToken ct = default)
     {
-        var (credentials, error) = Resolve();
-        if (credentials is null)
+        var (baseCredentials, error) = Resolve();
+        if (baseCredentials is null)
             return AwsProbe<AwsCallerIdentity>.NoCredentials(error
                 ?? "The AWS SDK found no credentials in its provider chain.");
 
         try
         {
+            AWSCredentials credentials = await AssumeIfNeededAsync(baseCredentials, roleArn, ct);
+
             using var sts = new AmazonSecurityTokenServiceClient(credentials,
                 new AmazonSecurityTokenServiceConfig { RegionEndpoint = DiscoveryRegion, Timeout = Timeout });
 
             var response = await sts.GetCallerIdentityAsync(new GetCallerIdentityRequest(), ct);
 
+            // Kind describes the BASE credentials deliberately. The assumed role is temporary by
+            // construction, so classifying the session would report every deployment as healthy
+            // and hide the static key underneath it.
             return AwsProbe<AwsCallerIdentity>.Ok(new AwsCallerIdentity(
-                response.Arn, response.Account, Classify(credentials)));
+                response.Arn, response.Account, Classify(baseCredentials),
+                string.IsNullOrWhiteSpace(roleArn) ? null : roleArn.Trim()));
         }
         catch (AmazonServiceException ex) when (IsDenial(ex))
         {
@@ -68,14 +75,17 @@ public class S3Discovery(ILogger<S3Discovery> logger) : IS3Discovery
         }
     }
 
-    public async Task<AwsProbe<IReadOnlyList<string>>> ListBucketsAsync(CancellationToken ct = default)
+    public async Task<AwsProbe<IReadOnlyList<string>>> ListBucketsAsync(
+        string? roleArn = null, CancellationToken ct = default)
     {
-        var (credentials, error) = Resolve();
-        if (credentials is null)
+        var (baseCredentials, error) = Resolve();
+        if (baseCredentials is null)
             return AwsProbe<IReadOnlyList<string>>.NoCredentials(error);
 
         try
         {
+            AWSCredentials credentials = await AssumeIfNeededAsync(baseCredentials, roleArn, ct);
+
             using var s3 = new AmazonS3Client(credentials,
                 new AmazonS3Config { RegionEndpoint = DiscoveryRegion, Timeout = Timeout });
 
@@ -104,17 +114,20 @@ public class S3Discovery(ILogger<S3Discovery> logger) : IS3Discovery
         }
     }
 
-    public async Task<AwsProbe<string>> GetBucketRegionAsync(string bucket, CancellationToken ct = default)
+    public async Task<AwsProbe<string>> GetBucketRegionAsync(
+        string bucket, string? roleArn = null, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(bucket))
             return AwsProbe<string>.Failed("No bucket name given.");
 
-        var (credentials, error) = Resolve();
-        if (credentials is null)
+        var (baseCredentials, error) = Resolve();
+        if (baseCredentials is null)
             return AwsProbe<string>.NoCredentials(error);
 
         try
         {
+            AWSCredentials credentials = await AssumeIfNeededAsync(baseCredentials, roleArn, ct);
+
             using var s3 = new AmazonS3Client(credentials,
                 new AmazonS3Config { RegionEndpoint = DiscoveryRegion, Timeout = Timeout });
 
@@ -144,6 +157,43 @@ public class S3Discovery(ILogger<S3Discovery> logger) : IS3Discovery
             logger.LogWarning(ex, "GetBucketLocation failed for {Bucket}", bucket);
             return AwsProbe<string>.Failed(ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Assumes <paramref name="roleArn"/> when the connection names one, so every probe runs as
+    /// the principal the sync will actually run as.
+    /// </summary>
+    /// <remarks>
+    /// <c>S3Connector</c> and <c>S3ConnectionTester</c> both assume the role when it is set.
+    /// Discovery did not, so a connection configured for cross-account access reported the base
+    /// identity, listed the base account's buckets, and read regions from the wrong place — then
+    /// told the operator to attach the generated policy to that identity. The grant would land on
+    /// a principal the sync never uses, and the setup would look correct and fail later.
+    /// <para>
+    /// The 900-second session matches the tester's. Discovery is a handful of calls made while
+    /// somebody watches, so nothing here outlives it.
+    /// </para>
+    /// </remarks>
+    private static async Task<AWSCredentials> AssumeIfNeededAsync(
+        AWSCredentials baseCredentials, string? roleArn, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(roleArn))
+            return baseCredentials;
+
+        using var sts = new AmazonSecurityTokenServiceClient(baseCredentials,
+            new AmazonSecurityTokenServiceConfig { RegionEndpoint = DiscoveryRegion, Timeout = Timeout });
+
+        var assumed = await sts.AssumeRoleAsync(new AssumeRoleRequest
+        {
+            RoleArn = roleArn.Trim(),
+            RoleSessionName = "connapse-discovery",
+            DurationSeconds = 900
+        }, ct);
+
+        return new SessionAWSCredentials(
+            assumed.Credentials.AccessKeyId,
+            assumed.Credentials.SecretAccessKey,
+            assumed.Credentials.SessionToken);
     }
 
     /// <summary>

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.CloudScope;
 using Connapse.Storage.ConnectionTesters;
@@ -184,6 +184,10 @@ public static class ServiceCollectionExtensions
         services.AddScoped<OllamaConnectionTester>();
         services.AddScoped<MinioConnectionTester>();
         services.AddScoped<S3ConnectionTester>();
+
+        // Singleton: it holds no per-request state, and the SDK caches and refreshes the resolved
+        // credential itself, so a new instance per scope would discard that cache each time.
+        services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
         services.AddScoped<SftpConnectionTester>();
         services.AddScoped<AzureBlobConnectionTester>();
         services.AddScoped<AwsSsoConnectionTester>();

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -15,6 +15,7 @@
 @inject IOptionsMonitor<SourceSecuritySettings> SourceSecurity
 @inject IContainerHostResolver HostResolver
 @inject S3ConnectionTester S3Tester
+@inject IS3Discovery S3Discovery
 @inject AzureBlobConnectionTester AzureTester
 @inject SftpConnectionTester SftpTester
 
@@ -478,9 +479,185 @@
 
         @if (form.Provider == ConnectionProvider.S3)
         {
+            @*
+                Guided setup.
+
+                No script here, unlike SFTP and the identity provider. Connapse's own process is
+                meant to hold these credentials — that is what the default provider chain is for —
+                so it can call STS and S3 itself and fill the form in.
+
+                What the chain will not say is whether the credential it found is a *good* one: a
+                static key from years ago resolves exactly as smoothly as an instance role. So the
+                preflight reports the kind, not only the identity.
+            *@
+            <div class="col-12">
+                @if (s3Identity is null && s3Probe is null)
+                {
+                    <div class="alert alert-primary d-flex flex-wrap align-items-center gap-2 py-2 mb-0">
+                        <span class="bi-magic"></span>
+                        <span class="flex-grow-1 small">
+                            Connapse can check which AWS identity it is running as, list the buckets it
+                            can reach, and fill in the region for you.
+                        </span>
+                        <button type="button" class="btn btn-primary btn-sm"
+                                @onclick="RunS3Preflight" disabled="@s3Busy">
+                            @if (s3Busy)
+                            {
+                                <span class="spinner-border spinner-border-sm me-1"></span>
+                                <span>Checking…</span>
+                            }
+                            else
+                            {
+                                <span class="bi-search me-1"></span>
+                                <span>Check my AWS access</span>
+                            }
+                        </button>
+                    </div>
+                }
+                else if (s3Identity is { } who)
+                {
+                    <div class="card border-success mb-0">
+                        <div class="card-body py-2">
+                            <div class="d-flex flex-wrap align-items-center gap-2">
+                                <span class="bi-check-circle-fill text-success"></span>
+                                <div class="flex-grow-1 small">
+                                    Connapse is running as
+                                    <code>@who.Arn</code>
+                                    in account <code>@who.AccountId</code>.
+                                </div>
+                                <button type="button" class="btn btn-sm btn-outline-secondary"
+                                        @onclick="ResetS3Preflight">Recheck</button>
+                            </div>
+
+                            @* Posture, not connectivity. Everything below works either way; this is
+                               the only place anything tells an operator their production deployment
+                               is resting on a key that never expires. *@
+                            <div class="mt-2 small">
+                                @switch (who.Kind)
+                                {
+                                    case AwsCredentialKind.StaticKey:
+                                        <span class="badge text-bg-warning">Static access key</span>
+                                        <span class="text-muted ms-1">
+                                            Works, and never expires — which is why AWS steers deployments
+                                            towards roles instead. On EC2, ECS or EKS an instance role needs
+                                            no configuration at all; elsewhere, IAM Roles Anywhere gives
+                                            temporary credentials with no static keys.
+                                        </span>
+                                        break;
+                                    case AwsCredentialKind.SsoSession:
+                                        <span class="badge text-bg-warning">SSO session</span>
+                                        <span class="text-muted ms-1">
+                                            Temporary, which is good — but it expires and needs a browser
+                                            sign-in to renew, so unattended syncing stops when it does.
+                                        </span>
+                                        break;
+                                    case AwsCredentialKind.InstanceOrTaskRole:
+                                        <span class="badge text-bg-success">Instance role</span>
+                                        <span class="text-muted ms-1">Rotates itself. Nothing to maintain.</span>
+                                        break;
+                                    case AwsCredentialKind.ExternalProcess:
+                                        <span class="badge text-bg-success">External credential process</span>
+                                        <span class="text-muted ms-1">
+                                            Temporary credentials, no static keys — how IAM Roles Anywhere
+                                            is wired in.
+                                        </span>
+                                        break;
+                                    case AwsCredentialKind.AssumedRole:
+                                        <span class="badge text-bg-success">Assumed role</span>
+                                        <span class="text-muted ms-1">Temporary and scoped.</span>
+                                        break;
+                                    default:
+                                        <span class="badge text-bg-secondary">Unrecognised source</span>
+                                        break;
+                                }
+                            </div>
+
+                            @if (s3Buckets is { Count: > 0 })
+                            {
+                                <div class="mt-3">
+                                    <label class="form-label small mb-1">Buckets Connapse can see</label>
+                                    <div class="d-flex flex-wrap gap-1">
+                                        @foreach (string bucket in s3Buckets)
+                                        {
+                                            <button type="button"
+                                                    class="btn btn-sm @(IsAllowed(bucket) ? "btn-success" : "btn-outline-secondary")"
+                                                    @onclick="() => ToggleBucket(bucket)">
+                                                @bucket
+                                            </button>
+                                        }
+                                    </div>
+                                    <div class="form-text">
+                                        Selecting a bucket adds it to <strong>Allowed locations</strong> below
+                                        and fills in the region from the first one chosen.
+                                    </div>
+                                </div>
+                            }
+                            else if (s3BucketsDenied)
+                            {
+                                @* Correct, not broken: s3:ListAllMyBuckets is account-wide, so a
+                                   credential scoped to one bucket is supposed to be refused. *@
+                                <div class="alert alert-secondary py-2 mt-3 mb-0 small">
+                                    <span class="bi-info-circle me-1"></span>
+                                    These credentials can't list buckets, which is normal for a scoped
+                                    key — <code>s3:ListAllMyBuckets</code> is account-wide. Type the
+                                    bucket name below and Connapse will still look up its region.
+                                </div>
+                            }
+                        </div>
+                    </div>
+                }
+                else if (s3Probe is { } probe)
+                {
+                    <div class="card border-warning mb-0">
+                        <div class="card-body py-2">
+                            <h6 class="card-title">
+                                <span class="bi-exclamation-triangle text-warning me-1"></span>
+                                @(probe.Outcome == AwsProbeOutcome.NoCredentials
+                                    ? "Connapse can't see any AWS credentials"
+                                    : "AWS refused the check")
+                            </h6>
+
+                            @if (probe.Outcome == AwsProbeOutcome.NoCredentials)
+                            {
+                                <p class="small mb-2">
+                                    Connapse reads whatever credentials its own environment provides and
+                                    stores none of its own. Inside a container that means nothing is
+                                    visible until you pass something in — most simply, by mounting the
+                                    AWS profile you already use:
+                                </p>
+                                <pre class="bg-body-tertiary border rounded p-2 small mb-2"><code>@S3SetupPolicy.ComposeCredentialMount()</code></pre>
+                                <div class="form-text mb-0">
+                                    Read-only, and nothing is copied into Connapse. The same mount carries
+                                    whichever kind of profile you keep there — a static one, an SSO one, or
+                                    a <code>credential_process</code> entry pointing at the IAM Roles
+                                    Anywhere helper, which gives a workload outside AWS temporary
+                                    credentials with no static keys. On EC2, ECS or EKS, attach an instance
+                                    role instead and no mount is needed.
+                                </div>
+                            }
+                            else
+                            {
+                                <p class="small mb-0">@probe.Detail</p>
+                            }
+
+                            <button type="button" class="btn btn-sm btn-outline-secondary mt-2"
+                                    @onclick="RunS3Preflight" disabled="@s3Busy">
+                                Try again
+                            </button>
+                        </div>
+                    </div>
+                }
+            </div>
+
             <div class="col-md-6">
                 <label class="form-label">Region</label>
                 <input class="form-control" @bind="form.Region" placeholder="us-east-1" />
+                @if (s3RegionNote is not null)
+                {
+                    <div class="form-text text-success">
+                        <span class="bi-check-lg me-1"></span>@s3RegionNote
+                    </div>
+                }
             </div>
             <div class="col-md-6">
                 <label class="form-label">Role ARN <span class="text-muted">(optional)</span></label>
@@ -683,6 +860,24 @@
                     permits any prefix within it. Leave empty to allow any — currently permitted, with
                     a warning logged.
                 </div>
+
+                @* Offered once something is allowed, because until then there is nothing to scope
+                   a policy to. Aimed at operators whose credential currently allows more than this
+                   connection needs, which is the usual state of a key made to get started. *@
+                @if (form.Provider == ConnectionProvider.S3 && S3PolicyForAllowed() is { } policy)
+                {
+                    <details class="mt-2">
+                        <summary class="small text-muted" style="cursor:pointer">
+                            IAM policy granting exactly this access
+                        </summary>
+                        <pre class="bg-body-tertiary border rounded p-2 small mt-2 mb-1" style="max-height:20rem;overflow:auto"><code>@policy</code></pre>
+                        <div class="form-text">
+                            Only <code>s3:ListBucket</code> and <code>s3:GetObject</code> — Connapse
+                            never writes to a source. Attach this to the identity above to narrow a
+                            credential that currently allows more.
+                        </div>
+                    </details>
+                }
             </div>
         }
 
@@ -781,6 +976,134 @@
     private SshKeyPair? localKeyPair;
     private string setupScript = "";
     private string? pastedResult;
+
+    // ── S3 guided setup ───────────────────────────────────────────────────────────
+
+    private AwsCallerIdentity? s3Identity;
+
+    /// <summary>The failed preflight, kept so its reason can be shown rather than just "no".</summary>
+    private AwsProbe<AwsCallerIdentity>? s3Probe;
+
+    private IReadOnlyList<string>? s3Buckets;
+    private bool s3BucketsDenied;
+    private bool s3Busy;
+    private string? s3RegionNote;
+
+    /// <summary>
+    /// Asks AWS who Connapse is, then what it can see.
+    /// </summary>
+    /// <remarks>
+    /// The bucket listing is attempted only once the identity is known, and its failure is not
+    /// the preflight's failure: a credential scoped to a single bucket is refused
+    /// <c>s3:ListAllMyBuckets</c> by design, and that operator still has a working setup.
+    /// </remarks>
+    private async Task RunS3Preflight()
+    {
+        s3Busy = true;
+        s3Probe = null;
+        s3Identity = null;
+        s3Buckets = null;
+        s3BucketsDenied = false;
+
+        try
+        {
+            var identity = await S3Discovery.WhoAmIAsync();
+            if (!identity.Succeeded)
+            {
+                s3Probe = identity;
+                return;
+            }
+
+            s3Identity = identity.Value;
+
+            var buckets = await S3Discovery.ListBucketsAsync();
+            if (buckets.Succeeded)
+                s3Buckets = buckets.Value;
+            else
+                s3BucketsDenied = buckets.Outcome == AwsProbeOutcome.Denied;
+        }
+        finally
+        {
+            s3Busy = false;
+        }
+    }
+
+    private void ResetS3Preflight()
+    {
+        s3Identity = null;
+        s3Probe = null;
+        s3Buckets = null;
+        s3BucketsDenied = false;
+        s3RegionNote = null;
+    }
+
+    private List<string> AllowedList() =>
+        (form.AllowedLocations ?? "")
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToList();
+
+    private bool IsAllowed(string bucket) =>
+        AllowedList().Any(l => l == bucket || l.StartsWith(bucket + "/", StringComparison.Ordinal));
+
+    /// <summary>
+    /// Adds or removes a bucket from the allowlist, and fills the region from the first one added.
+    /// </summary>
+    /// <remarks>
+    /// The region comes from the bucket rather than being typed, because a wrong one fails in a way
+    /// that reads like a permissions problem. Only the first selection sets it: a connection has one
+    /// region, and quietly rewriting it on each click would leave the last bucket clicked deciding
+    /// where the whole connection points.
+    /// </remarks>
+    private async Task ToggleBucket(string bucket)
+    {
+        var list = AllowedList();
+
+        if (IsAllowed(bucket))
+        {
+            list.RemoveAll(l => l == bucket || l.StartsWith(bucket + "/", StringComparison.Ordinal));
+        }
+        else
+        {
+            list.Add(bucket);
+
+            if (string.IsNullOrWhiteSpace(form.Region))
+            {
+                var region = await S3Discovery.GetBucketRegionAsync(bucket);
+                if (region.Succeeded && !string.IsNullOrWhiteSpace(region.Value))
+                {
+                    form.Region = region.Value;
+                    s3RegionNote = $"Read from {bucket}.";
+                }
+            }
+
+            // Testing needs a bucket and the connection stores none, so the first one chosen is a
+            // better default than an empty field.
+            if (string.IsNullOrWhiteSpace(probeTarget))
+                probeTarget = bucket;
+        }
+
+        form.AllowedLocations = string.Join("\n", list);
+    }
+
+    /// <summary>The least-privilege policy for whatever is currently allowed.</summary>
+    private string? S3PolicyForAllowed()
+    {
+        var list = AllowedList();
+        if (list.Count == 0) return null;
+
+        // One bucket per entry, and an entry may carry a prefix. Generated per bucket rather than
+        // merged, so an operator granting access to two buckets can see two independent grants.
+        var policies = list.Select(entry =>
+        {
+            int slash = entry.IndexOf('/');
+            string bucket = slash < 0 ? entry : entry[..slash];
+            string? prefix = slash < 0 ? null : entry[(slash + 1)..];
+            return S3SetupPolicy.ForBucket(bucket, prefix);
+        });
+
+        return string.Join("\n\n", policies);
+    }
+
     private string localRoot = "";
     private string localHost = "host.docker.internal";
 

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -521,9 +521,24 @@
                             <div class="d-flex flex-wrap align-items-center gap-2">
                                 <span class="bi-check-circle-fill text-success"></span>
                                 <div class="flex-grow-1 small">
-                                    Connapse is running as
-                                    <code>@who.Arn</code>
-                                    in account <code>@who.AccountId</code>.
+                                    @if (who.AssumedRoleArn is not null)
+                                    {
+                                        @* Named explicitly: the assumed role can live in a different
+                                           AWS account from the base credentials, and the policy below
+                                           has to be attached to this principal, not the other one. *@
+                                        <text>
+                                            This connection runs as <code>@who.Arn</code> in account
+                                            <code>@who.AccountId</code>, assumed from
+                                            <code>@who.AssumedRoleArn</code>.
+                                        </text>
+                                    }
+                                    else
+                                    {
+                                        <text>
+                                            Connapse is running as <code>@who.Arn</code> in account
+                                            <code>@who.AccountId</code>.
+                                        </text>
+                                    }
                                 </div>
                                 <button type="button" class="btn btn-sm btn-outline-secondary"
                                         @onclick="ResetS3Preflight">Recheck</button>
@@ -1018,7 +1033,12 @@
 
         try
         {
-            var identity = await S3Discovery.WhoAmIAsync();
+            // The connection's role, not the ambient identity. S3Connector and S3ConnectionTester
+            // both assume it, so probing without it would describe a different account entirely
+            // from the one that ends up syncing.
+            string? role = form.RoleArn;
+
+            var identity = await S3Discovery.WhoAmIAsync(role);
             if (!identity.Succeeded)
             {
                 s3Probe = identity;
@@ -1027,7 +1047,7 @@
 
             s3Identity = identity.Value;
 
-            var buckets = await S3Discovery.ListBucketsAsync();
+            var buckets = await S3Discovery.ListBucketsAsync(role);
             if (buckets.Succeeded)
                 s3Buckets = buckets.Value;
             else
@@ -1079,7 +1099,7 @@
 
             if (string.IsNullOrWhiteSpace(form.Region))
             {
-                var region = await S3Discovery.GetBucketRegionAsync(bucket);
+                var region = await S3Discovery.GetBucketRegionAsync(bucket, form.RoleArn);
                 if (region.Succeeded && !string.IsNullOrWhiteSpace(region.Value))
                 {
                     form.Region = region.Value;
@@ -1097,22 +1117,26 @@
     }
 
     /// <summary>The least-privilege policy for whatever is currently allowed.</summary>
+    /// <remarks>
+    /// One document covering every entry. This used to generate a policy per bucket and join them
+    /// with blank lines, which produces two top-level JSON objects — not a policy at all, and IAM
+    /// rejects it. Anyone allowing two buckets was handed output that could not be pasted.
+    /// </remarks>
     private string? S3PolicyForAllowed()
     {
         var list = AllowedList();
         if (list.Count == 0) return null;
 
-        // One bucket per entry, and an entry may carry a prefix. Generated per bucket rather than
-        // merged, so an operator granting access to two buckets can see two independent grants.
-        var policies = list.Select(entry =>
+        try
         {
-            int slash = entry.IndexOf('/');
-            string bucket = slash < 0 ? entry : entry[..slash];
-            string? prefix = slash < 0 ? null : entry[(slash + 1)..];
-            return S3SetupPolicy.ForBucket(bucket, prefix);
-        });
-
-        return string.Join("\n\n", policies);
+            return S3SetupPolicy.ForBuckets(list);
+        }
+        catch (ArgumentException)
+        {
+            // Entries are typed freehand, so "/" or whitespace alone reaches here. Nothing to
+            // offer, and a half-written allowlist is not an error worth interrupting for.
+            return null;
+        }
     }
 
     private string localRoot = "";

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -621,19 +621,30 @@
                             {
                                 <p class="small mb-2">
                                     Connapse reads whatever credentials its own environment provides and
-                                    stores none of its own. Inside a container that means nothing is
-                                    visible until you pass something in — most simply, by mounting the
-                                    AWS profile you already use:
+                                    stores none of its own — so nothing is visible until you supply
+                                    something. No config file needs editing:
                                 </p>
-                                <pre class="bg-body-tertiary border rounded p-2 small mb-2"><code>@S3SetupPolicy.ComposeCredentialMount()</code></pre>
+                                <pre class="bg-body-tertiary border rounded p-2 small mb-2"><code>@S3SetupPolicy.CredentialInstructions()</code></pre>
                                 <div class="form-text mb-0">
-                                    Read-only, and nothing is copied into Connapse. The same mount carries
-                                    whichever kind of profile you keep there — a static one, an SSO one, or
-                                    a <code>credential_process</code> entry pointing at the IAM Roles
-                                    Anywhere helper, which gives a workload outside AWS temporary
-                                    credentials with no static keys. On EC2, ECS or EKS, attach an instance
-                                    role instead and no mount is needed.
+                                    That folder is already mounted read-only, and nothing is copied into
+                                    Connapse. It carries whichever kind of profile you put there — a static
+                                    one, an SSO one, or a <code>credential_process</code> entry pointing at
+                                    the IAM Roles Anywhere helper, which gives a workload outside AWS
+                                    temporary credentials with no static keys. On EC2, ECS or EKS, attach an
+                                    instance role and leave the folder empty.
                                 </div>
+
+                                @* The SDK lists every provider it tried, which is more use than anything
+                                   written here: it names the one the operator meant to configure. *@
+                                @if (!string.IsNullOrWhiteSpace(probe.Detail))
+                                {
+                                    <details class="mt-2">
+                                        <summary class="small text-muted" style="cursor:pointer">
+                                            What Connapse looked for
+                                        </summary>
+                                        <pre class="bg-body-tertiary border rounded p-2 small mt-2 mb-0" style="max-height:14rem;overflow:auto"><code>@probe.Detail</code></pre>
+                                    </details>
+                                }
                             }
                             else
                             {

--- a/tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
@@ -169,4 +169,91 @@ public class S3SetupPolicyTests
         text.Should().NotContain("AWS_SECRET_ACCESS_KEY");
         text.Should().NotContain("AWS_ACCESS_KEY_ID");
     }
+
+    // -- Several buckets at once ----------------------------------------------------
+
+    [Fact]
+    public void ForBuckets_TwoBuckets_ParseAsOneDocument()
+    {
+        // The bug this replaces: a policy was generated per bucket and the results joined with
+        // blank lines. Two top-level JSON objects are not a policy, IAM rejects the paste, and the
+        // UI presented it as a single thing to attach. Parsing is the assertion that matters --
+        // string checks would have passed on the broken version.
+        string policy = S3SetupPolicy.ForBuckets(["docs-bucket", "shared-bucket/team"]);
+
+        var root = Parse(policy);
+        root.GetProperty("Version").GetString().Should().Be("2012-10-17");
+        root.GetProperty("Statement").GetArrayLength().Should().Be(4, "two statements per bucket");
+    }
+
+    [Fact]
+    public void ForBuckets_GivesEveryStatementItsOwnSid()
+    {
+        // Sids must be unique within a document. Reusing ConnapseListBucket across buckets makes a
+        // document IAM refuses, which is the same failure in a subtler form.
+        var sids = Parse(S3SetupPolicy.ForBuckets(["a-bucket", "b-bucket", "c-bucket"]))
+            .GetProperty("Statement").EnumerateArray()
+            .Select(x => x.GetProperty("Sid").GetString())
+            .ToList();
+
+        sids.Should().OnlyHaveUniqueItems();
+        sids.Should().HaveCount(6);
+    }
+
+    [Fact]
+    public void ForBuckets_CarriesThePrefixFromEachEntry()
+    {
+        // An allowlist entry may name a bucket alone or a bucket and a prefix, and the two must not
+        // be flattened together: one grants the whole bucket, the other one folder.
+        var resources = Parse(S3SetupPolicy.ForBuckets(["wide-bucket", "narrow-bucket/team"]))
+            .GetProperty("Statement").EnumerateArray()
+            .Where(x => x.GetProperty("Sid").GetString()!.StartsWith("ConnapseReadObjects"))
+            .Select(x => x.GetProperty("Resource").GetString())
+            .ToList();
+
+        resources.Should().Equal(
+            "arn:aws:s3:::wide-bucket/*",
+            "arn:aws:s3:::narrow-bucket/team/*");
+    }
+
+    [Fact]
+    public void ForBuckets_ScopesListingOnlyWhereAPrefixWasGiven()
+    {
+        var statements = Parse(S3SetupPolicy.ForBuckets(["wide-bucket", "narrow-bucket/team"]))
+            .GetProperty("Statement").EnumerateArray()
+            .Where(x => x.GetProperty("Sid").GetString()!.StartsWith("ConnapseListBucket"))
+            .ToList();
+
+        statements[0].TryGetProperty("Condition", out _).Should().BeFalse("no prefix was given");
+        statements[1].GetProperty("Condition").GetProperty("StringLike")
+            .GetProperty("s3:prefix").EnumerateArray().Single().GetString().Should().Be("team/*");
+    }
+
+    public static TheoryData<string[]> NothingUsable()
+    {
+        var data = new TheoryData<string[]>();
+        data.Add([]);
+        data.Add([""]);
+        data.Add(["   ", "/"]);
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(NothingUsable))]
+    public void ForBuckets_WithNothingUsable_Throws(string[] locations)
+    {
+        // Entries are typed freehand, so a half-written allowlist reaches here. Throwing lets the
+        // caller show nothing rather than emit a policy granting access to "arn:aws:s3:::/*".
+        FluentActions.Invoking(() => S3SetupPolicy.ForBuckets(locations))
+            .Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void ForBuckets_SkipsBlankEntriesBetweenRealOnes()
+    {
+        // Splitting a textarea on newlines leaves blanks behind whenever somebody hits enter twice.
+        string policy = S3SetupPolicy.ForBuckets(["docs-bucket", "  ", "shared-bucket"]);
+
+        Parse(policy).GetProperty("Statement").GetArrayLength().Should().Be(4);
+    }
 }

--- a/tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
@@ -1,0 +1,151 @@
+using System.Text.Json;
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+/// <summary>
+/// The IAM policy Connapse offers so an operator can narrow a credential to exactly what a source
+/// needs, and the compose fragment that lets the container see any credential at all.
+/// </summary>
+/// <remarks>
+/// Text destined for other systems, neither of which Connapse applies. Both fail in ways a compiler
+/// cannot see — IAM rejects a malformed document, and a bad ARN silently matches nothing — so the
+/// assertions are about the shape AWS requires rather than about the string.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class S3SetupPolicyTests
+{
+    private static JsonElement Parse(string policy) =>
+        JsonDocument.Parse(policy).RootElement;
+
+    private static JsonElement Statement(string policy, string sid) =>
+        Parse(policy).GetProperty("Statement").EnumerateArray()
+            .Single(s => s.GetProperty("Sid").GetString() == sid);
+
+    [Fact]
+    public void ForBucket_IsValidJsonWithAPolicyVersion()
+    {
+        var root = Parse(S3SetupPolicy.ForBucket("my-bucket"));
+
+        root.GetProperty("Version").GetString().Should().Be("2012-10-17");
+        root.GetProperty("Statement").GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public void ForBucket_NoPrefix_OmitsTheConditionRatherThanNullingIt()
+    {
+        // Caught by generating one and reading it: the entry serialised as "Condition": null,
+        // which IAM rejects outright. WhenWritingNull governs object properties, not dictionary
+        // entries, so the key has to be absent rather than empty.
+        string policy = S3SetupPolicy.ForBucket("my-bucket");
+
+        policy.Should().NotContain("null");
+        Statement(policy, "ConnapseListBucket").TryGetProperty("Condition", out _)
+            .Should().BeFalse("an unscoped grant has no prefix to condition on");
+    }
+
+    [Fact]
+    public void ForBucket_SplitsBucketAndObjectActionsAcrossTwoStatements()
+    {
+        // s3:ListBucket is a bucket-level action and s3:GetObject an object-level one. Granting
+        // both against a single resource is the classic mistake: against the bucket ARN alone,
+        // every object read is denied, and the policy looks correct while nothing can be read.
+        string policy = S3SetupPolicy.ForBucket("my-bucket", "docs");
+
+        Statement(policy, "ConnapseListBucket").GetProperty("Resource").GetString()
+            .Should().Be("arn:aws:s3:::my-bucket");
+
+        Statement(policy, "ConnapseReadObjects").GetProperty("Resource").GetString()
+            .Should().Be("arn:aws:s3:::my-bucket/docs/*");
+    }
+
+    [Fact]
+    public void ForBucket_GrantsNothingBeyondReading()
+    {
+        // Connapse has no write surface against a source at all — IConnector does not expose one —
+        // so a policy suggesting otherwise would ask for authority the product cannot use.
+        string policy = S3SetupPolicy.ForBucket("my-bucket");
+
+        var actions = Parse(policy).GetProperty("Statement").EnumerateArray()
+            .SelectMany(s => s.GetProperty("Action").EnumerateArray())
+            .Select(a => a.GetString())
+            .ToList();
+
+        actions.Should().BeEquivalentTo(S3SetupPolicy.ReadActions);
+        actions.Should().NotContain(a => a!.Contains("Put") || a.Contains("Delete") || a.Contains("*"));
+    }
+
+    [Fact]
+    public void ForBucket_WithPrefix_BoundsListingAsWellAsReading()
+    {
+        // Without the condition the grant still bounds *reading* to the prefix, but lets the holder
+        // enumerate every key in the bucket — more than the source needs, and more than the
+        // operator agreed to by typing a prefix.
+        var condition = Statement(S3SetupPolicy.ForBucket("my-bucket", "docs"), "ConnapseListBucket")
+            .GetProperty("Condition").GetProperty("StringLike").GetProperty("s3:prefix");
+
+        condition.EnumerateArray().Single().GetString().Should().Be("docs/*");
+    }
+
+    [Theory]
+    [InlineData("docs", "docs/")]
+    [InlineData("/docs", "docs/")]
+    [InlineData("docs/", "docs/")]
+    [InlineData("  /docs/sub  ", "docs/sub/")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void NormalisePrefix_ProducesWhatAnArnWants(string? given, string expected)
+    {
+        // A leading slash yields bucket//docs*, which matches nothing: S3 keys have no leading
+        // slash. A missing trailing slash makes "docs" also match "docs-archive/", quietly
+        // widening the grant past the folder that was meant.
+        S3SetupPolicy.NormalisePrefix(given).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ForBucket_PrefixWithoutTrailingSlash_DoesNotLeakIntoASiblingFolder()
+    {
+        string policy = S3SetupPolicy.ForBucket("my-bucket", "docs");
+
+        Statement(policy, "ConnapseReadObjects").GetProperty("Resource").GetString()
+            .Should().NotBe("arn:aws:s3:::my-bucket/docs*",
+                "that also matches docs-archive/, which the operator did not grant");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ForBucket_WithoutABucket_Throws(string? bucket)
+    {
+        // A policy naming arn:aws:s3::: with no bucket is not a narrower grant, it is a malformed
+        // one — better to fail here than to hand someone a document IAM will reject.
+        FluentActions.Invoking(() => S3SetupPolicy.ForBucket(bucket!))
+            .Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void ComposeCredentialMount_MountsReadOnlyIntoTheContainerUsersHome()
+    {
+        // The image runs as the non-root user "app" with HOME=/home/app, verified against the
+        // running container. Mounting to /root would put the profile somewhere the process cannot
+        // read, and the SDK would report no credentials with nothing to explain why.
+        string snippet = S3SetupPolicy.ComposeCredentialMount();
+
+        snippet.Should().Contain("/home/app/.aws:ro");
+        snippet.Should().Contain("${HOME}/.aws", "compose expands this, and C# must not");
+    }
+
+    [Fact]
+    public void ComposeCredentialMount_DoesNotSuggestPastingKeys()
+    {
+        // The whole point of the mount is that no credential is copied anywhere. A snippet with
+        // AWS_SECRET_ACCESS_KEY in it would undo that in the one place people copy from.
+        string snippet = S3SetupPolicy.ComposeCredentialMount();
+
+        snippet.Should().NotContain("AWS_SECRET_ACCESS_KEY");
+        snippet.Should().NotContain("AWS_ACCESS_KEY_ID");
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using Connapse.Core.Utilities;
 using FluentAssertions;
 using Xunit;
@@ -127,25 +127,46 @@ public class S3SetupPolicyTests
     }
 
     [Fact]
-    public void ComposeCredentialMount_MountsReadOnlyIntoTheContainerUsersHome()
+    public void CredentialInstructions_AskForAFileInAFolder_NotAComposeEdit()
+    {
+        // The point of the whole arrangement. An operator who has to edit docker-compose.yml to
+        // make a feature work concludes the feature does not work, so the compose file mounts
+        // ./aws unconditionally and this only has to say where to put the file.
+        string text = S3SetupPolicy.CredentialInstructions();
+
+        text.Should().Contain(S3SetupPolicy.CredentialFolder);
+        text.Should().NotContain("volumes:", "editing compose is what this exists to avoid");
+        text.Should().NotContain("services:");
+    }
+
+    [Fact]
+    public void CredentialInstructions_OfferTheEnvVariableAsTheAlternative()
+    {
+        // For anyone who would rather point at the profile they already keep than copy it. One
+        // line, in a file that already exists for exactly this purpose.
+        string text = S3SetupPolicy.CredentialInstructions();
+
+        text.Should().Contain(S3SetupPolicy.CredentialDirVariable);
+        text.Should().Contain(".env");
+    }
+
+    [Fact]
+    public void CredentialInstructions_NameTheContainerUsersHome()
     {
         // The image runs as the non-root user "app" with HOME=/home/app, verified against the
         // running container. Mounting to /root would put the profile somewhere the process cannot
         // read, and the SDK would report no credentials with nothing to explain why.
-        string snippet = S3SetupPolicy.ComposeCredentialMount();
-
-        snippet.Should().Contain("/home/app/.aws:ro");
-        snippet.Should().Contain("${HOME}/.aws", "compose expands this, and C# must not");
+        S3SetupPolicy.CredentialInstructions().Should().Contain("/home/app/.aws");
     }
 
     [Fact]
-    public void ComposeCredentialMount_DoesNotSuggestPastingKeys()
+    public void CredentialInstructions_DoNotSuggestPastingKeys()
     {
-        // The whole point of the mount is that no credential is copied anywhere. A snippet with
-        // AWS_SECRET_ACCESS_KEY in it would undo that in the one place people copy from.
-        string snippet = S3SetupPolicy.ComposeCredentialMount();
+        // Nothing is copied into Connapse, and the one place people copy from must not imply
+        // otherwise.
+        string text = S3SetupPolicy.CredentialInstructions();
 
-        snippet.Should().NotContain("AWS_SECRET_ACCESS_KEY");
-        snippet.Should().NotContain("AWS_ACCESS_KEY_ID");
+        text.Should().NotContain("AWS_SECRET_ACCESS_KEY");
+        text.Should().NotContain("AWS_ACCESS_KEY_ID");
     }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/S3DiscoveryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/S3DiscoveryTests.cs
@@ -71,6 +71,35 @@ public class S3DiscoveryTests
     private sealed class DerivedBasicCredentials(string a, string b) : BasicAWSCredentials(a, b);
 
     /// <summary>
+    /// The exception hierarchy the credential resolver's catch depends on.
+    /// </summary>
+    /// <remarks>
+    /// Guards a bug that shipped and took the Blazor circuit down with "An unhandled error has
+    /// occurred". The resolve was wrapped in <c>catch (AmazonServiceException)</c>, which reads as
+    /// the careful, specific choice. The resolver throws <c>AmazonClientException</c> when nothing
+    /// is configured — and these two are <b>siblings</b>, each deriving straight from
+    /// <c>Exception</c> rather than one from the other. So catching either one catches nothing
+    /// whatsoever of the other, and the most likely state of a fresh deployment escaped.
+    /// <para>
+    /// Asserted rather than commented, because the instinct when tidying is to replace a broad
+    /// catch with a specific one, and here no single AWS exception type covers the case.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void TheTwoAwsExceptionRoots_AreSiblings_SoNeitherCatchCoversTheOther()
+    {
+        typeof(AmazonServiceException).IsSubclassOf(typeof(AmazonClientException))
+            .Should().BeFalse("catching the service exception does not catch the client one");
+
+        typeof(AmazonClientException).IsSubclassOf(typeof(AmazonServiceException))
+            .Should().BeFalse("nor the other way round");
+
+        typeof(AmazonClientException).BaseType.Should().Be<Exception>();
+        typeof(AmazonServiceException).BaseType.Should().Be<Exception>();
+    }
+
+    /// <summary>
     /// The three outcomes the UI branches on.
     /// </summary>
     /// <remarks>

--- a/tests/Connapse.Storage.Tests/CloudScope/S3DiscoveryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/S3DiscoveryTests.cs
@@ -1,0 +1,105 @@
+﻿using Amazon.Runtime;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+/// <summary>
+/// Naming the chain link a credential came from.
+/// </summary>
+/// <remarks>
+/// The AWS calls themselves are not tested here — they need AWS. What is tested is the one piece of
+/// judgement in the class: the default provider chain resolves a static key from years ago exactly
+/// as smoothly as an instance role and reports no difference, and this mapping is the only thing
+/// standing between that and an operator never being told.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class S3DiscoveryTests
+{
+    /// <remarks>
+    /// By type rather than by instance. Several of these classes do real work in their
+    /// constructors: <c>EnvironmentVariablesAWSCredentials</c> throws when the variables are
+    /// unset, and <c>InstanceProfileAWSCredentials</c> calls the EC2 metadata service and takes
+    /// the better part of a second to fail off-EC2. Constructing them here made the suite depend
+    /// on the machine it ran on.
+    /// </remarks>
+    [Theory]
+    // The most common way a container ends up with credentials, and the weakest: it never expires.
+    [InlineData(typeof(EnvironmentVariablesAWSCredentials), AwsCredentialKind.StaticKey)]
+    [InlineData(typeof(BasicAWSCredentials), AwsCredentialKind.StaticKey)]
+    // Temporary by construction -- they carry a session token and expire.
+    [InlineData(typeof(SessionAWSCredentials), AwsCredentialKind.AssumedRole)]
+    [InlineData(typeof(AssumeRoleAWSCredentials), AwsCredentialKind.AssumedRole)]
+    // The one posture needing no arrangement at all, and it rotates itself.
+    [InlineData(typeof(InstanceProfileAWSCredentials), AwsCredentialKind.InstanceOrTaskRole)]
+    [InlineData(typeof(GenericContainerCredentials), AwsCredentialKind.InstanceOrTaskRole)]
+    // Expires, and needs a browser sign-in to renew, so it cannot sustain unattended sync.
+    [InlineData(typeof(SSOAWSCredentials), AwsCredentialKind.SsoSession)]
+    // How IAM Roles Anywhere arrives: temporary credentials, no static keys.
+    [InlineData(typeof(ProcessAWSCredentials), AwsCredentialKind.ExternalProcess)]
+    public void ClassifyType_NamesTheChainLink(Type type, AwsCredentialKind expected)
+    {
+        S3Discovery.ClassifyType(type).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ClassifyType_UnknownType_IsUnrecognisedRatherThanStrong()
+    {
+        // A newer SDK adding a chain link must not be reported as an instance role by default.
+        // Unrecognised is honest; anything else is a claim the code cannot support.
+        S3Discovery.ClassifyType(typeof(AnonymousAWSCredentials))
+            .Should().Be(AwsCredentialKind.Unrecognised);
+    }
+
+    [Fact]
+    public void ClassifyType_Null_IsUnrecognised()
+    {
+        S3Discovery.ClassifyType(null).Should().Be(AwsCredentialKind.Unrecognised);
+    }
+
+    [Fact]
+    public void ClassifyType_DerivedCredential_ClassifiesAsWhatItDerivesFrom()
+    {
+        // The SDK wraps and subclasses these internally, and a wrapper reported as Unrecognised
+        // would quietly stop warning about a static key.
+        S3Discovery.ClassifyType(typeof(DerivedBasicCredentials))
+            .Should().Be(AwsCredentialKind.StaticKey);
+    }
+
+    private sealed class DerivedBasicCredentials(string a, string b) : BasicAWSCredentials(a, b);
+
+    /// <summary>
+    /// The three outcomes the UI branches on.
+    /// </summary>
+    /// <remarks>
+    /// Collapsing "no credentials" into "denied" is the specific failure the type exists to
+    /// prevent: the first is fixed in a compose file and the second in AWS, and the advice for one
+    /// is useless for the other.
+    /// </remarks>
+    public class ProbeTests
+    {
+        [Fact]
+        [Trait("Category", "Unit")]
+        public void NoCredentials_AndDenied_AreNotTheSameOutcome()
+        {
+            var missing = AwsProbe<string>.NoCredentials();
+            var denied = AwsProbe<string>.Denied();
+
+            missing.Outcome.Should().NotBe(denied.Outcome);
+            missing.Succeeded.Should().BeFalse();
+            denied.Succeeded.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        public void Ok_CarriesTheValueAndSucceeds()
+        {
+            var probe = AwsProbe<string>.Ok("us-west-1");
+
+            probe.Succeeded.Should().BeTrue();
+            probe.Value.Should().Be("us-west-1");
+        }
+    }
+}


### PR DESCRIPTION
## What

A guided setup on the S3 connection form: Connapse checks which AWS identity it is running as, lists the buckets it can see, fills in the region, and offers a least-privilege IAM policy.

## Why

**The S3 connector could not work in the default deployment at all.** `docker-compose.yml` passes no AWS environment variables and mounts no profile, so the SDK's provider chain finds nothing inside the container. Every S3 connection created today fails with "No AWS credentials found", and nothing in the UI says why or what to do about it.

That is a bigger problem than the form having three fields — though the form also asked for a bucket and region that are each one API call away.

## No script this time

The SFTP and AWS SSO wizards hand out a command because Connapse cannot act in those places. Here it can: Connapse's own process is *meant* to hold these credentials — that is what the default provider chain is for — so it calls STS and S3 directly. No copy-paste.

This is distinct from the identity provider, which authenticates a *person*. `CloudScopeService.GetScopesAsync(userId, source, connection)` runs at **search** time and uses a signed-in user's AWS identity to filter what they may see. Ingestion happened hours earlier in `SourceSyncService`, a `BackgroundService` on a timer with no user present. Two moments, two identities.

## The part I would most like reviewed

**The preflight reports the credential's *kind*, not just that it worked.**

The provider chain resolves a static key from 2019 exactly as smoothly as an instance role and reports no difference. So someone can run Connapse in production on a key that never expires and never be told. The preflight classifies the source — instance/task role, assumed role, SSO session, external credential process, or static key — and says plainly that the last is what AWS guidance steers deployments away from.

Nothing else in the system would ever surface that.

## How credentials should reach the container

Researched rather than assumed. A **read-only bind mount of `~/.aws`** is the documented container practice, preferred over environment variables because credentials stay off the container filesystem and out of process listings.

It is also how the best option is delivered: IAM Roles Anywhere — AWS's mechanism for workloads outside AWS to exchange an X.509 certificate for temporary credentials, no static keys — plugs in through a `credential_process` line the .NET SDK reads and refreshes. So one mount covers every posture:

| In `~/.aws` | Static keys | Survives unattended sync |
|---|---|---|
| Static profile | yes | yes |
| SSO profile | no | no, the session expires |
| `credential_process` to Roles Anywhere | **no** | **yes** |

The no-credentials screen shows the compose snippet and explains all three. Connapse still stores nothing.

## Details worth knowing

- **`DefaultAWSCredentialsIdentityResolver`, not `FallbackCredentialsFactory`** — the SDK deprecated the latter in v4 and warns at compile time. Same chain, current entry point.
- **`ListBuckets` needs `s3:ListAllMyBuckets`**, which a credential scoped to one bucket is *supposed* to be refused. That path falls back to typing the name and says why, rather than looking broken.
- **Selecting a bucket fills `AllowedLocations`**, which is free text today and permissive when empty, and reads the region off the bucket — a wrong region fails in a way that reads like a permissions problem.
- **The generated policy grants `s3:ListBucket` and `s3:GetObject` only.** `IConnector` has no write surface, so anything more would be authority the product cannot use.

## Verification

Two bugs found by running the code rather than trusting it:

- The IAM policy emitted `"Condition": null` with no prefix, which IAM rejects. `WhenWritingNull` governs object properties, not dictionary entries, so the key has to be absent.
- Two of my own tests failed first: the SDK credential classes do real work in their constructors — `InstanceProfileAWSCredentials` calls the EC2 metadata service and took 829ms to fail off-EC2. `Classify` was split into a type-based `ClassifyType` so the one piece of judgement here is testable without depending on the machine the suite runs on.

The container's home directory was verified as `/home/app` by exec, not assumed.

Build clean, **1,227 unit tests green**. Deployed to Docker: `/connections` answers, log clean, and the container confirmed to have no AWS credentials — which is exactly the case the new screen explains.

**Not verified:** the flow against a real AWS account with working credentials. I have none here, so the identity, bucket-listing and region paths are covered by unit tests and the SDK's own contract rather than by a live call. Worth one real run before merging.

Closes #415


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided AWS S3 setup to the Connections page, including credential checks, identity details, bucket discovery, region selection, and retry/reset controls.
  * Added least-privilege S3 policy generation for selected buckets and optional prefixes.
  * Added read-only AWS credential mounting support for container deployments.

* **Bug Fixes**
  * Improved handling of missing credentials, denied access, failed requests, and regional aliases.

* **Tests**
  * Added coverage for policy generation, credential classification, discovery outcomes, and secure credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->