### PR TITLE
feat(web): offer the buckets a connection allows on the source form

### DIFF
--- a/src/Connapse.Core/Utilities/StorageLocationPolicy.cs
+++ b/src/Connapse.Core/Utilities/StorageLocationPolicy.cs
@@ -130,6 +130,36 @@ public static class StorageLocationPolicy
     }
 
     /// <summary>
+    /// Splits an allowlist entry into the container and the prefix within it.
+    /// </summary>
+    /// <remarks>
+    /// Here rather than in the page that offers these entries, because the split has to agree with
+    /// <see cref="Evaluate"/> and the two drifting apart is the whole failure this class exists to
+    /// prevent. The property worth holding is round-trip: splitting an entry and feeding the parts
+    /// back must be <see cref="StorageLocationDecision.Allowed"/> against that same entry.
+    /// <para>
+    /// The prefix keeps whatever trailing slash the entry had. <c>Evaluate</c> normalises it away,
+    /// but the connectors use it as a literal key prefix — where <c>team/</c> and <c>team</c>
+    /// differ, because the second also matches <c>team-archive/</c>.
+    /// </para>
+    /// </remarks>
+    public static (string Container, string? Prefix) SplitEntry(string entry)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entry);
+
+        string trimmed = entry.Replace('\\', '/').Trim().TrimStart('/');
+        int slash = trimmed.IndexOf('/');
+
+        if (slash < 0)
+            return (trimmed, null);
+
+        string container = trimmed[..slash];
+        string prefix = trimmed[(slash + 1)..];
+
+        return (container, prefix.Length == 0 ? null : prefix);
+    }
+
+    /// <summary>
     /// Collapses a location to a comparable form. Bucket and container names are
     /// case-sensitive in both S3 and Azure, so this never changes case.
     /// </summary>

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -3,6 +3,8 @@
 @attribute [Authorize]
 @using Connapse.Core
 @using Connapse.Core.Interfaces
+@using Connapse.Core.Utilities
+@using System.Text.Json
 
 @using Connapse.Web.Services
 @inject ISourceStore SourceStore
@@ -259,12 +261,48 @@
                        one produces a source that silently syncs nothing. *@
                     @if (selectedProvider is ConnectionProvider.S3 or ConnectionProvider.AzureBlob)
                     {
+                        @* The connection already names which buckets it permits, so asking for
+                           one in free text made the reader supply a fact Connapse was holding —
+                           and a name typed from memory saves cleanly, then fails at the first
+                           sync or is refused by the scope preflight afterwards. *@
                         <div class="mb-3">
                             <label class="form-label">
                                 @(selectedProvider == ConnectionProvider.S3 ? "Bucket" : "Blob container")
                             </label>
-                            <input class="form-control font-monospace" @bind="form.Container"
-                                   placeholder="@(selectedProvider == ConnectionProvider.S3 ? "company-knowledge" : "knowledge")" />
+
+                            @if (AllowedScopes() is { Count: > 0 } allowed)
+                            {
+                                <select class="form-select font-monospace" @bind="form.Container">
+                                    <option value="">Choose one…</option>
+                                    @foreach (string scope in allowed)
+                                    {
+                                        <option value="@scope">@scope</option>
+                                    }
+                                </select>
+                                @* Named rather than linked. Every link to the Connections page
+                                   here sits inside an isAdmin block, and a test counts them —
+                                   this dialog opens only from an administrator's button, but that
+                                   is an indirect guarantee the test cannot see, and weakening the
+                                   count to accommodate two help links would cost more than the
+                                   links are worth. *@
+                                <div class="form-text">
+                                    @(selectedProvider == ConnectionProvider.S3 ? "Buckets" : "Containers")
+                                    this connection is allowed to read. To use another, add it to
+                                    that connection's allowed locations on the Connections page.
+                                </div>
+                            }
+                            else
+                            {
+                                <input class="form-control font-monospace" @bind="form.Container"
+                                       placeholder="@(selectedProvider == ConnectionProvider.S3 ? "company-knowledge" : "knowledge")" />
+                                <div class="form-text">
+                                    Which
+                                    @(selectedProvider == ConnectionProvider.S3 ? "bucket" : "container")
+                                    inside this connection the source reads. This connection lists
+                                    no allowed locations, so it permits any its credential can
+                                    reach — naming them on the Connections page bounds that.
+                                </div>
+                            }
                         </div>
 
                         <div class="mb-3">
@@ -378,8 +416,40 @@
     private string? createError;
     private string? createWarning;
 
-    private ConnectionProvider? selectedProvider =>
-        connections.FirstOrDefault(c => c.Id == form?.ConnectionId)?.Provider;
+    private ConnectionProvider? selectedProvider => SelectedConnection?.Provider;
+
+    private Connection? SelectedConnection =>
+        connections.FirstOrDefault(c => c.Id == form?.ConnectionId);
+
+    /// <summary>
+    /// The buckets or containers the chosen connection permits, or null when it permits any.
+    /// </summary>
+    /// <remarks>
+    /// Read from the connection rather than probed: this is about what the connection allows, not
+    /// what exists in the cloud account, and those are deliberately different questions. A bucket
+    /// that exists but is outside the allowlist is refused at sync time, so offering it here would
+    /// be offering a choice that cannot work.
+    /// <para>
+    /// Entries may name a prefix after a slash. They are offered whole, because an entry of
+    /// <c>bucket/team</c> permits only that subtree and the bucket alone would be refused.
+    /// </para>
+    /// </remarks>
+    private IReadOnlyList<string>? AllowedScopes()
+    {
+        if (SelectedConnection?.ConfigJson is not { Length: > 0 } json) return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            return StorageLocationPolicy.ReadAllowedLocations(document.RootElement);
+        }
+        catch (JsonException)
+        {
+            // An unreadable configuration is not a reason to block the form. Falling through to
+            // free text leaves the operator exactly where they were before this existed.
+            return null;
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -1,4 +1,4 @@
-﻿@page "/sources"
+@page "/sources"
 @rendermode InteractiveServer
 @attribute [Authorize]
 @using Connapse.Core
@@ -270,9 +270,32 @@
                                 @(selectedProvider == ConnectionProvider.S3 ? "Bucket" : "Blob container")
                             </label>
 
-                            @if (AllowedScopes() is { Count: > 0 } allowed)
+                            @{ var choices = AllowedScopes(); }
+
+                            @if (choices.Unreadable)
                             {
-                                <select class="form-select font-monospace" @bind="form.Container">
+                                @* Not the same as "no allowlist", and saying so matters: the free-text
+                                   branch below tells the reader this connection permits anything its
+                                   credential can reach, which for an unreadable configuration is a
+                                   claim nothing supports. *@
+                                <div class="alert alert-warning py-2 mb-0 small">
+                                    <span class="bi-exclamation-triangle me-1"></span>
+                                    This connection's allowed locations cannot be read, so Connapse
+                                    cannot say which
+                                    @(selectedProvider == ConnectionProvider.S3 ? "buckets" : "containers")
+                                    it permits. Fix them on the Connections page before adding a
+                                    source — a source saved now would be refused at sync time.
+                                </div>
+                            }
+                            else if (choices.Entries is { Count: > 0 } allowed)
+                            {
+                                @* Bound to the entry, which is then split across two fields. An entry
+                                   may name a prefix — bucket/team — and writing that whole string into
+                                   Container puts "bucket/team" in bucketName, which the S3 and Azure
+                                   connectors use as a literal bucket or container name. The source
+                                   passes preflight and then never syncs. *@
+                                <select class="form-select font-monospace"
+                                        value="@selectedScope" @onchange="SelectScope">
                                     <option value="">Choose one…</option>
                                     @foreach (string scope in allowed)
                                     {
@@ -434,22 +457,67 @@
     /// <c>bucket/team</c> permits only that subtree and the bucket alone would be refused.
     /// </para>
     /// </remarks>
-    private IReadOnlyList<string>? AllowedScopes()
-    {
-        if (SelectedConnection?.ConfigJson is not { Length: > 0 } json) return null;
+    /// <summary>What a connection permits, and whether that could be determined at all.</summary>
+    /// <param name="Entries">Allowlist entries. Empty means the connection bounds nothing.</param>
+    /// <param name="Unreadable">
+    /// The configuration exists and could not be understood. Distinct from an empty allowlist,
+    /// because the two call for opposite messages — one permits everything, the other permits
+    /// nothing and needs fixing.
+    /// </param>
+    private sealed record ScopeChoices(IReadOnlyList<string> Entries, bool Unreadable);
 
+    private ScopeChoices AllowedScopes()
+    {
+        if (SelectedConnection?.ConfigJson is not { Length: > 0 } json)
+            return new ScopeChoices([], Unreadable: false);
+
+        IReadOnlyList<string>? entries;
         try
         {
             using var document = JsonDocument.Parse(json);
-            return StorageLocationPolicy.ReadAllowedLocations(document.RootElement);
+            entries = StorageLocationPolicy.ReadAllowedLocations(document.RootElement);
         }
         catch (JsonException)
         {
-            // An unreadable configuration is not a reason to block the form. Falling through to
-            // free text leaves the operator exactly where they were before this existed.
-            return null;
+            return new ScopeChoices([], Unreadable: true);
         }
+
+        // A blank entry is the reader's sentinel for present-but-unusable — a non-array value, a
+        // number where a string belongs. It is not an offer, and rendering it produced a dropdown
+        // with one empty option and no explanation.
+        if (entries is null)
+            return new ScopeChoices([], Unreadable: false);
+
+        return entries.Any(string.IsNullOrWhiteSpace)
+            ? new ScopeChoices([], Unreadable: true)
+            : new ScopeChoices(entries, Unreadable: false);
     }
+
+    /// <summary>The allowlist entry currently chosen, kept apart from the two fields it fills.</summary>
+    /// <remarks>
+    /// Separate state rather than a computed round-trip, so that narrowing the prefix by hand after
+    /// choosing a grant does not blank the dropdown. The entry records which grant was picked; the
+    /// prefix field records where inside it the source points.
+    /// </remarks>
+    private string? selectedScope;
+
+    private void SelectScope(ChangeEventArgs e)
+    {
+        selectedScope = e.Value?.ToString();
+
+        if (string.IsNullOrWhiteSpace(selectedScope))
+        {
+            form!.Container = null;
+            form.Prefix = null;
+            return;
+        }
+
+        var (container, prefix) = StorageLocationPolicy.SplitEntry(selectedScope);
+        form!.Container = container;
+        form.Prefix = prefix;
+    }
+
+
 
     protected override async Task OnInitializedAsync()
     {

--- a/tests/Connapse.Core.Tests/Utilities/StorageLocationPolicyTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/StorageLocationPolicyTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Nodes;
 using Connapse.Core.Utilities;
 using FluentAssertions;
@@ -253,5 +253,72 @@ public class StorageLocationPolicyTests
         read.Should().NotBeNull();
         StorageLocationPolicy.Evaluate(read, "any-bucket", null)
             .Should().Be(StorageLocationDecision.Denied);
+    }
+
+    // -- Splitting an entry back into the two fields a source stores -----------------
+
+    [Theory]
+    [InlineData("my-bucket", "my-bucket", null)]
+    [InlineData("my-bucket/team", "my-bucket", "team")]
+    [InlineData("my-bucket/team/", "my-bucket", "team/")]
+    [InlineData("my-bucket/team/docs", "my-bucket", "team/docs")]
+    [InlineData("  my-bucket/team  ", "my-bucket", "team")]
+    [InlineData("/my-bucket/team", "my-bucket", "team")]
+    [InlineData("my-bucket/", "my-bucket", null)]
+    [InlineData("my-bucket\\team", "my-bucket", "team")]
+    public void SplitEntry_SeparatesTheContainerFromThePrefix(
+        string entry, string container, string? prefix)
+    {
+        var split = StorageLocationPolicy.SplitEntry(entry);
+
+        split.Container.Should().Be(container);
+        split.Prefix.Should().Be(prefix);
+    }
+
+    [Fact]
+    public void SplitEntry_KeepsATrailingSlashOnThePrefix()
+    {
+        // Evaluate normalises it away, but the connectors use the prefix as a literal S3 key
+        // prefix -- where "team" also matches "team-archive/" and "team/" does not. Trimming it
+        // here would widen the source past what the connection allows, silently.
+        StorageLocationPolicy.SplitEntry("my-bucket/team/").Prefix.Should().Be("team/");
+    }
+
+    [Theory]
+    [InlineData("my-bucket")]
+    [InlineData("my-bucket/team")]
+    [InlineData("my-bucket/team/")]
+    [InlineData("my-bucket/team/docs")]
+    [InlineData("/my-bucket/team/")]
+    public void SplitEntry_RoundTripsThroughEvaluate(string entry)
+    {
+        // The property that matters, and the reason this lives beside Evaluate rather than in the
+        // page that offers the entries. A source built from an entry must be permitted by that
+        // entry -- otherwise the form hands somebody a choice the enforcement path then refuses,
+        // or worse, one the connector cannot use at all.
+        var (container, prefix) = StorageLocationPolicy.SplitEntry(entry);
+
+        StorageLocationPolicy.Evaluate([entry], container, prefix)
+            .Should().Be(StorageLocationDecision.Allowed);
+    }
+
+    [Fact]
+    public void SplitEntry_DoesNotHandTheWholeEntryToTheConnectorAsABucketName()
+    {
+        // The bug this replaces: the picker wrote "bucket/team" into the source's bucketName. It
+        // passed preflight, because the allowlist check is about the pair -- and then the S3
+        // connector used it as a literal bucket name and the source never synced.
+        StorageLocationPolicy.SplitEntry("my-bucket/team").Container
+            .Should().NotContain("/");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SplitEntry_WithNothingUsable_Throws(string? entry)
+    {
+        FluentActions.Invoking(() => StorageLocationPolicy.SplitEntry(entry!))
+            .Should().Throw<ArgumentException>();
     }
 }


### PR DESCRIPTION
## What

The **Bucket** field on the New source dialog offers the buckets the chosen connection allows, instead of asking for one in free text.

Closes #419

## Why

The connection above it already names an allowed-locations list. The source form then asked for a bucket again, with a placeholder and no explanation — so it asked the reader to supply a fact Connapse was already holding, and never said the answer had to be one of the buckets that connection permits.

A name typed from memory saves cleanly and fails at the first sync, or is refused by the scope preflight afterwards. That is the same failure the Connections page had before it grew a bucket picker.

## How

- **Connection lists allowed locations** → a select of exactly those, with `Buckets this connection is allowed to read. To use another, add it to that connection's allowed locations on the Connections page.`
- **Connection lists none** → stays free text, and now says what that means: the connection permits any bucket its credential can reach, and naming them bounds it.

Azure containers get the same treatment; the field has the identical shape.

## Two decisions worth reviewing

**Read from the connection, not probed from AWS.** What a connection *allows* and what *exists in the account* are different questions. A bucket that exists but sits outside the allowlist is refused at sync time, so offering it here would be offering a choice that cannot work. Entries are offered whole rather than split, because `bucket/team` permits only that subtree and the bucket alone would be refused.

**The help text names the Connections page rather than linking to it.** Every such link on this page sits inside an `isAdmin` block and `SourcesPage_OffersConnectionsOnlyToAdministrators` counts them. This dialog opens only from an administrator's button, but that is an indirect guarantee a text-scanning test cannot see — and weakening the count to accommodate two help links would cost more than the links are worth.

## Verification

Build clean, **1,272 unit tests green**. Driven in a browser against the running container, signed in, with a real S3 connection whose allowlist holds one bucket:

- Bucket renders as a select offering `Choose one…` and `test-bucket-for-connapse`, and nothing else
- The help text reads as above
- Zero links to `/connections` inside the dialog
- SFTP connections are unaffected — the field is still `Sub-path`

That test caught this branch twice, both times correctly: first for adding two links a Viewer could theoretically see, then because the comment explaining the fix contained the literal string the test counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dropdown for selecting allowed storage buckets or containers when creating a new source.
  * Automatically displays the selected connection’s permitted locations.
  * Provides a free-text entry option when allowed locations are unavailable or cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->