### PR TITLE
docs: stop claiming search is filtered by cloud permissions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,7 +135,7 @@ All swappable implementations are defined as interfaces in `Connapse.Core` or `C
 | `IManagedStorageProvider` | Managed Storage abstraction (routes to active backend) | `MinioManagedStorageProvider` (default); overridable per deployment |
 | `IConnectorFactory` | Create connector from container | `ConnectorFactory` |
 | `IContainerSettingsResolver` | Per-container settings overrides | `ContainerSettingsResolver` |
-| `ICloudScopeService` | IAM-derived access control | `CloudScopeService` |
+| `ICloudScopeService` | IAM-derived access control — **written but not wired to anything; see Scope Enforcement** | `CloudScopeService` |
 | `IConnectionTester` | Service connectivity validation | `MinioConnectionTester`, `OllamaConnectionTester`, `S3ConnectionTester`, `AzureBlobConnectionTester`, `AwsSsoConnectionTester`, `AzureAdConnectionTester`, `OpenAiConnectionTester`, `AzureOpenAiConnectionTester`, `AnthropicConnectionTester` |
 
 **Identity (`Connapse.Identity`)**:
@@ -787,16 +787,31 @@ Users link one cloud identity per provider via their Profile page:
 
 Identity data is encrypted at rest via ASP.NET Core DataProtection (`IDataProtector`).
 
-### Scope Enforcement
+### Scope Enforcement — not implemented
 
-`CloudScopeService` checks cloud identity permissions before allowing access to cloud-backed containers:
+**There is no per-user permission filtering in Connapse today. Every user can search every indexed
+document.** Access is controlled by ASP.NET role authorization (`RequireViewer` and above) and by
+container scoping, both of which are the same for all users of a given role.
 
-1. Retrieve user's linked identity for the container's cloud provider
-2. Call provider-specific `ICloudIdentityProvider.DiscoverScopesAsync()`
-3. Cache result: 15-min allow TTL, 5-min deny TTL (`IConnectorScopeCache`)
-4. Inject allowed prefix filter into search/browse queries
+This section previously described `CloudScopeService` enforcing cloud identity permissions across
+document, search and folder endpoints and the sync trigger. None of that happens. The service is
+registered in `Program.cs` and has no production caller; `CloudScopeResult.IsPathAllowed` is
+invoked only from its own unit tests. `SearchOptions` carries no principal, so there is no channel
+through which a per-user scope could reach a query.
 
-Enforcement applied to: document endpoints, search endpoints, folder endpoints, sync trigger.
+What does exist:
+
+| Piece | State |
+|---|---|
+| `ICloudIdentityService` | Working. Links a user's AWS or Azure identity and stores identity metadata. |
+| `CloudScopeService` | Written, registered, uncalled. Shaped per source rather than per request. |
+| `AwsIdentityProvider` | Returns `FullAccess()` when Connapse's own AWS account appears in the user's SSO account list. Account membership, not RBAC — that is the ceiling of what the SSO device flow reports. |
+| `AzureIdentityProvider` | Probes with the *service's* credential, not the user's, and returns the source's configured prefix. |
+| `ConnectorScopeCache` | Working. Note the TTLs are inverted for a security boundary: allows cached 15 min, denies 5. |
+
+Planned work is tracked in [#421](https://github.com/Destrayon/Connapse/issues/421) and
+[docs/plans/search-permission-filtering.md](plans/search-permission-filtering.md). Until it lands,
+do not describe Connapse as filtering search by cloud permissions.
 
 See [aws-sso-setup.md](aws-sso-setup.md) and [azure-identity-setup.md](azure-identity-setup.md) for setup guides.
 

--- a/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
+++ b/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
@@ -1,4 +1,4 @@
-@page "/profile/integrations"
+﻿@page "/profile/integrations"
 @layout ProfileLayout
 @attribute [Authorize]
 @using Connapse.Core
@@ -34,9 +34,13 @@
         <h2 class="h5 mb-0">Cloud Identities</h2>
     </div>
     <p class="text-muted small mb-4">
-        Link your cloud accounts so search results from an S3 or Azure Blob source are narrowed to
-        what your own cloud permissions allow. Only identity metadata is stored — no access keys or
-        tokens, and linking does not grant Connapse access to your storage.
+        Link your cloud accounts so Connapse knows who you are in AWS or Azure. Only identity
+        metadata is stored — no access keys or tokens, and linking does not grant Connapse access to
+        your storage.
+        <br />
+        <strong>Linking does not yet filter your search results.</strong> Per-user search
+        permissions are not implemented, so every Connapse user can currently search everything
+        indexed, whether or not an account is linked. See issue #421.
     </p>
 
     <div class="row g-3">
@@ -129,8 +133,9 @@
                     else
                     {
                         <p class="text-muted small mb-0">
-                            Sign in with AWS IAM Identity Center so results from S3 sources are limited to the
-                            accounts your SSO identity covers.
+                            Sign in with AWS IAM Identity Center to record which AWS accounts your
+                            SSO identity covers. Connapse stores this for future per-user search
+                            filtering; nothing filters on it today.
                         </p>
                     }
                 </div>

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -18,8 +18,12 @@
     This page shows what each source is *doing*, never what is *inside* it. There is no file
     list, no path, and no document name anywhere on it, and that is the point of the whole
     epic rather than an omission: the file tree exposed every synced object to any Connapse
-    user regardless of what they could see in the source system, which is a far wider surface
-    than search results, and search already passes through CloudScopeService.
+    user regardless of what they could see in the source system.
+
+    An earlier version of this comment justified that by saying search already passes through
+    CloudScopeService. It does not — CloudScopeService has no production caller, and search
+    returns every document to every user (#421). Removing the file tree is still right, but it
+    narrows one surface rather than leaving the other one guarded.
 
     The aggregate document count is the one exception, accepted during design as a weak signal
     in exchange for the page being useful at all.

--- a/tests/Connapse.Web.Tests/Components/CloudIdentityClaimsTests.cs
+++ b/tests/Connapse.Web.Tests/Components/CloudIdentityClaimsTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Web.Tests.Components;
+
+/// <summary>
+/// Pins the product to not claiming a permission filter it does not have.
+/// </summary>
+/// <remarks>
+/// Three places said search was filtered by the user's cloud permissions: the architecture doc, the
+/// comment justifying why Sources has no file tree, and the Integrations page a user reads before
+/// linking an account. None of it happened — <c>CloudScopeService</c> has no production caller and
+/// <c>SearchOptions</c> carries no principal.
+/// <para>
+/// The Integrations one mattered most: it is user-facing, and it is attached to a button that
+/// visibly succeeds. Someone links an account, sees "Connected", and concludes their results are
+/// being narrowed.
+/// </para>
+/// <para>
+/// These assertions are deliberately about wording rather than behaviour, because the defect was
+/// wording. They should be deleted — not adjusted — when filtering actually lands (#421), and the
+/// deletion is the signal that the claim has become true.
+/// </para>
+/// </remarks>
+[Trait("Category", "Unit")]
+public class CloudIdentityClaimsTests
+{
+    private static string Read(params string[] relativePath) =>
+        File.ReadAllText(Path.Combine(
+            new[] { PageTestPaths.RepositoryRoot() }.Concat(relativePath).ToArray()));
+
+    private static string Integrations => Read(
+        "src", "Connapse.Web", "Components", "Pages", "ProfileIntegrations.razor");
+
+    [Fact]
+    public void Integrations_DoesNotPromiseThatLinkingNarrowsSearchResults()
+    {
+        // The exact sentence that was there. Not a fuzzy match: this test exists to fail if
+        // somebody restores the old copy, and a loose pattern would also fire on an honest
+        // rewording that happens to use the same verb.
+        Integrations.Should().NotContain("narrowed to");
+        Integrations.Should().NotContain("what your own cloud permissions allow");
+    }
+
+    [Fact]
+    public void Integrations_SaysPlainlyThatLinkingDoesNotFilterYet()
+    {
+        // A missing false claim is not the same as a true statement. Someone linking an account
+        // deserves to be told what it does and does not do, in the place they are deciding.
+        Integrations.Should().Contain("does not yet filter your search results");
+    }
+
+    [Fact]
+    public void ArchitectureDoc_DoesNotDescribeEnforcementThatDoesNotRun()
+    {
+        string doc = Read("docs", "architecture.md");
+
+        doc.Should().NotContain(
+            "CloudScopeService` checks cloud identity permissions before allowing access");
+
+        // It also listed four enforcement points by name, none of which exist.
+        doc.Should().NotContain(
+            "Enforcement applied to: document endpoints, search endpoints, folder endpoints");
+    }
+
+    [Fact]
+    public void SourcesPage_DoesNotJustifyItsDesignWithACheckThatDoesNotHappen()
+    {
+        // Hiding the file tree is still right. The reasoning just cannot lean on search being
+        // guarded, because it is not.
+        Read("src", "Connapse.Web", "Components", "Pages", "Sources.razor")
+            .Should().NotContain("search already passes through CloudScopeService");
+    }
+}


### PR DESCRIPTION
## What

Removes three claims that Connapse filters search results by the user's cloud permissions. It does not.

Phase 1 of [#421](https://github.com/Destrayon/Connapse/issues/421). No behaviour change — this PR only makes the product describe itself accurately.

## Why

`CloudScopeService` is registered in `Program.cs:144` and has **no production caller**. `CloudScopeResult.IsPathAllowed` — the only method that could filter anything — runs only in its own unit tests. `SearchOptions` carries no principal, so there is no channel through which a per-user scope could reach a query.

Every Connapse user can search every indexed document.

## The three

**The Integrations page** told a user that linking narrows their search results to what their cloud permissions allow. This is the one that mattered: it is user-facing, and it is attached to a button that visibly succeeds. Someone links an account, sees **Connected**, and reasonably concludes filtering is on. It now describes what linking does, and states plainly that it does not filter yet.

**`architecture.md`** described `CloudScopeService` checking permissions, then listed four enforcement points by name — document endpoints, search endpoints, folder endpoints, sync trigger. None exist. Replaced with a table of what is actually there, including that `AwsIdentityProvider` returns `FullAccess()` on AWS account membership. That is not a shortcut someone took: account IDs are the ceiling of what the SSO device authorization flow reports.

**`Sources.razor`** justified having no file tree partly because "search already passes through CloudScopeService". Hiding the file tree is still right — it narrows one surface — but the reasoning cannot lean on a check that does not run.

## The tests

`CloudIdentityClaimsTests` asserts **wording, not behaviour**, because the defect was wording. It fails if the old copy comes back.

They are written to be **deleted** when filtering actually lands, not adjusted — the deletion is the signal that the claim has become true. That is called out in the class remarks so the next person does not "fix" them by relaxing the assertions.

## Verification

Build clean, 1,276 unit tests green. Deployed to Docker.

Not verified in a browser: the Integrations page is per-user and behind sign-in. The copy change is static text with a wording test over it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that linking cloud accounts currently records identity information but does not filter search results by cloud permissions.
  - Updated AWS integration messaging to explain that per-user search filtering is not yet available.
  - Revised architecture and Sources documentation to accurately describe current search behavior and planned permission filtering.

- **Tests**
  - Added coverage to ensure product messaging remains aligned with the current cloud search permissions experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->