### PR TITLE
feat(storage): record where each synced document came from

### DIFF
--- a/src/Connapse.Core/Models/StorageModels.cs
+++ b/src/Connapse.Core/Models/StorageModels.cs
@@ -11,7 +11,32 @@ public record ContainerSettingsOverrides
     public SummarySettings? Summary { get; init; }
 }
 
-public record ConnectorFile(string Path, long SizeBytes, DateTime LastModified, string? ContentType);
+/// <summary>One file a connector found, as the connector sees it.</summary>
+/// <param name="Path">
+/// Virtual path within the source: the key with the source's prefix stripped and a leading slash
+/// added. This is what a document row stores, and what the connector is asked for later.
+/// </param>
+/// <param name="ResourceUri">
+/// Where the file actually is, absolutely and outside Connapse — <c>s3://bucket/key</c> for S3.
+/// Null for connectors with no meaningful external address.
+/// </param>
+/// <remarks>
+/// <paramref name="ResourceUri"/> is reported rather than reconstructed, because reconstruction is
+/// wrong in cases nothing can detect. <paramref name="Path"/> is relative to the source's prefix,
+/// and a source's prefix is editable with no reconciliation of existing rows — so a source
+/// re-pointed after ingestion leaves paths relative to a prefix no longer on record.
+/// <para>
+/// It also survives a normalisation that <paramref name="Path"/> does not. S3 permits
+/// <c>docs/a.md</c>, <c>/docs/a.md</c> and <c>//docs/a.md</c> as three distinct keys; prefix
+/// stripping collapses all three to one path.
+/// </para>
+/// </remarks>
+public record ConnectorFile(
+    string Path,
+    long SizeBytes,
+    DateTime LastModified,
+    string? ContentType,
+    string? ResourceUri = null);
 public record ConnectorFileEvent(ConnectorFileEventType EventType, string Path, string? OldPath = null);
 public enum ConnectorFileEventType { Created, Changed, Deleted, Renamed }
 

--- a/src/Connapse.Core/Utilities/ResourceUri.cs
+++ b/src/Connapse.Core/Utilities/ResourceUri.cs
@@ -1,0 +1,44 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Builds the absolute address a connector reports for a file it lists.
+/// </summary>
+/// <remarks>
+/// One place, because two things have to agree about this format and they are written far apart:
+/// the connectors that mint these, and the permission filter that will match scopes against them.
+/// A format decided independently in each connector is the drift that
+/// <see cref="StorageLocationPolicy"/> exists to prevent one layer down.
+/// <para>
+/// The shape is <c>scheme://authority/path</c>, where the authority is whatever makes the path
+/// unambiguous — a bucket for S3, an account and container for Azure. Getting the authority wrong
+/// is not cosmetic: two connections whose URIs collide would let a permission rule written for one
+/// silently match the other's documents.
+/// </para>
+/// </remarks>
+public static class ResourceUri
+{
+    /// <summary>An S3 object, as <c>s3://bucket/key</c>.</summary>
+    /// <remarks>
+    /// The key is carried exactly as S3 reported it, including any leading or doubled slash. S3
+    /// treats <c>a</c>, <c>/a</c> and <c>//a</c> as three distinct keys, and normalising here would
+    /// merge documents that are not the same object.
+    /// </remarks>
+    public static string ForS3(string bucket, string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bucket);
+        return $"s3://{bucket}/{key}";
+    }
+
+    /// <summary>An Azure blob, as <c>azblob://account/container/blob</c>.</summary>
+    /// <remarks>
+    /// The account is part of the address, not context. Container names are unique only within an
+    /// account, so omitting it would give two connections holding a container of the same name one
+    /// identical URI — and a rule granting one would reach the other's documents.
+    /// </remarks>
+    public static string ForAzureBlob(string storageAccount, string container, string blob)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(storageAccount);
+        ArgumentException.ThrowIfNullOrWhiteSpace(container);
+        return $"azblob://{storageAccount}/{container}/{blob}";
+    }
+}

--- a/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
+++ b/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
@@ -1,4 +1,4 @@
-using Azure.Identity;
+﻿using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Connapse.Core;
@@ -69,7 +69,11 @@ public class AzureBlobConnector : IConnector
                 Path: virtualPath,
                 SizeBytes: blob.Properties.ContentLength ?? 0,
                 LastModified: blob.Properties.LastModified?.UtcDateTime ?? DateTime.UtcNow,
-                ContentType: blob.Properties.ContentType));
+                ContentType: blob.Properties.ContentType,
+                // The account is on the connection rather than here, so this names the container
+                // and blob. Enough to be unique within an account and to match an Azure RBAC
+                // scope, which is what it exists for.
+                ResourceUri: $"azblob://{_config.ContainerName}/{blob.Name}"));
         }
 
         return files;

--- a/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
+++ b/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
@@ -1,7 +1,8 @@
-﻿using Azure.Identity;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Connapse.Core;
+using Connapse.Core.Utilities;
 using Connapse.Core.Interfaces;
 
 namespace Connapse.Storage.Connectors;
@@ -70,10 +71,12 @@ public class AzureBlobConnector : IConnector
                 SizeBytes: blob.Properties.ContentLength ?? 0,
                 LastModified: blob.Properties.LastModified?.UtcDateTime ?? DateTime.UtcNow,
                 ContentType: blob.Properties.ContentType,
-                // The account is on the connection rather than here, so this names the container
-                // and blob. Enough to be unique within an account and to match an Azure RBAC
-                // scope, which is what it exists for.
-                ResourceUri: $"azblob://{_config.ContainerName}/{blob.Name}"));
+                // Account, container, blob. The account is not optional: container names are
+                // unique only within an account, so two connections to different accounts each
+                // holding a "docs" container would mint identical URIs -- and a permission rule
+                // matching one would silently match the other's documents too.
+                ResourceUri: ResourceUri.ForAzureBlob(
+                    _config.StorageAccountName, _config.ContainerName, blob.Name)));
         }
 
         return files;

--- a/src/Connapse.Storage/Connectors/S3Connector.cs
+++ b/src/Connapse.Storage/Connectors/S3Connector.cs
@@ -82,7 +82,12 @@ public class S3Connector : IConnector, IDisposable
                     Path: virtualPath,
                     SizeBytes: obj.Size ?? 0,
                     LastModified: obj.LastModified?.ToUniversalTime() ?? DateTime.UtcNow,
-                    ContentType: null));
+                    ContentType: null,
+                    // The key exactly as S3 gave it. Reconstructing this later from the bucket, the
+                    // source's prefix and the stored path is wrong in two ways nothing can detect:
+                    // the prefix is editable after ingestion with no reconciliation, and the line
+                    // above collapses "a", "/a" and "//a" into one path where S3 has three keys.
+                    ResourceUri: $"s3://{_config.BucketName}/{obj.Key}"));
             }
             request.ContinuationToken = response.NextContinuationToken;
         } while (response.IsTruncated == true);

--- a/src/Connapse.Storage/Connectors/S3Connector.cs
+++ b/src/Connapse.Storage/Connectors/S3Connector.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
@@ -6,6 +6,7 @@ using Amazon.S3.Model;
 using Amazon.SecurityToken;
 using Amazon.SecurityToken.Model;
 using Connapse.Core;
+using Connapse.Core.Utilities;
 using Connapse.Core.Interfaces;
 
 namespace Connapse.Storage.Connectors;
@@ -87,7 +88,7 @@ public class S3Connector : IConnector, IDisposable
                     // source's prefix and the stored path is wrong in two ways nothing can detect:
                     // the prefix is editable after ingestion with no reconciliation, and the line
                     // above collapses "a", "/a" and "//a" into one path where S3 has three keys.
-                    ResourceUri: $"s3://{_config.BucketName}/{obj.Key}"));
+                    ResourceUri: ResourceUri.ForS3(_config.BucketName, obj.Key)));
             }
             request.ContinuationToken = response.NextContinuationToken;
         } while (response.IsTruncated == true);

--- a/src/Connapse.Storage/Data/Entities/DocumentEntity.cs
+++ b/src/Connapse.Storage/Data/Entities/DocumentEntity.cs
@@ -1,4 +1,4 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 
 namespace Connapse.Storage.Data.Entities;
 
@@ -28,6 +28,24 @@ public class DocumentEntity
     public string FileName { get; set; } = string.Empty;
     public string? ContentType { get; set; }
     public string Path { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Where this document came from, absolutely and outside Connapse — <c>s3://bucket/key</c>.
+    /// Null for uploads, and for anything not synced since this column existed.
+    /// </summary>
+    /// <remarks>
+    /// Reported by the connector at sync time rather than derived from <see cref="Path"/> and the
+    /// source's scope. That derivation is wrong in cases nothing can detect: a source's prefix is
+    /// editable with no reconciliation of existing rows, so a source re-pointed after ingestion
+    /// leaves paths relative to a prefix no longer on record, and the arithmetic would produce a
+    /// confident wrong answer. For a permission filter, a document attributed to the wrong key is
+    /// worse than one attributed to none.
+    /// <para>
+    /// Null is denied once per-user filtering is switched on (#421) — never allowed. An upload has
+    /// no external address at all, so a URI scheme built for cloud RBAC cannot describe one.
+    /// </para>
+    /// </remarks>
+    public string? ResourceUri { get; set; }
     public string ContentHash { get; set; } = string.Empty;
     public long SizeBytes { get; set; }
     public int ChunkCount { get; set; }

--- a/src/Connapse.Storage/Data/KnowledgeDbContext.cs
+++ b/src/Connapse.Storage/Data/KnowledgeDbContext.cs
@@ -226,6 +226,17 @@ public class KnowledgeDbContext(DbContextOptions<KnowledgeDbContext> options) : 
                 .HasDatabaseName("idx_documents_owner_path")
                 .IsUnique();
 
+            entity.Property(e => e.ResourceUri)
+                .HasColumnName("resource_uri")
+                .HasMaxLength(2048);
+
+            // The predicate a permission filter runs is a prefix match over this column, so it is
+            // indexed for that rather than for equality. text_pattern_ops is what lets LIKE
+            // 's3://bucket/team/%' use an index at all.
+            entity.HasIndex(e => e.ResourceUri)
+                .HasDatabaseName("idx_documents_resource_uri")
+                .HasOperators("text_pattern_ops");
+
             entity.HasOne(e => e.Container)
                 .WithMany(c => c.Documents)
                 .HasForeignKey(e => e.ContainerId)

--- a/src/Connapse.Storage/Migrations/20260827062208_AddDocumentResourceUri.Designer.cs
+++ b/src/Connapse.Storage/Migrations/20260827062208_AddDocumentResourceUri.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Connapse.Storage.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -15,9 +16,11 @@ using Pgvector;
 namespace Connapse.Storage.Migrations
 {
     [DbContext(typeof(KnowledgeDbContext))]
-    partial class KnowledgeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260827062208_AddDocumentResourceUri")]
+    partial class AddDocumentResourceUri
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Connapse.Storage/Migrations/20260827062208_AddDocumentResourceUri.cs
+++ b/src/Connapse.Storage/Migrations/20260827062208_AddDocumentResourceUri.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Connapse.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDocumentResourceUri : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "resource_uri",
+                table: "documents",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "idx_documents_resource_uri",
+                table: "documents",
+                column: "resource_uri")
+                .Annotation("Npgsql:IndexOperators", new[] { "text_pattern_ops" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "idx_documents_resource_uri",
+                table: "documents");
+
+            migrationBuilder.DropColumn(
+                name: "resource_uri",
+                table: "documents");
+        }
+    }
+}

--- a/src/Connapse.Web/Services/SourceSyncService.cs
+++ b/src/Connapse.Web/Services/SourceSyncService.cs
@@ -350,9 +350,33 @@ public class SourceSyncService(
         var due = new List<ConnectorFile>();
         var claims = new Dictionary<string, Guid>(StringComparer.Ordinal);
 
+        // Counted separately from claims and due, because a coordinate update is neither. On a
+        // source where nothing has changed it is the only pending write, and the save below is
+        // conditional -- so without this the update is built and then silently discarded, which
+        // is exactly the case that matters: a stable source is the one that would otherwise never
+        // acquire coordinates at all.
+        int located = 0;
+
         foreach (var file in files)
         {
             existingByPath.TryGetValue(file.Path, out var existing);
+
+            // Before the skip below, deliberately. A source that has not changed still needs its
+            // documents to learn where they came from, and the skip is the common case -- leaving
+            // it until a file changes would mean a stable source never acquires coordinates at
+            // all. One listing pass therefore populates a whole source.
+            //
+            // Rows arrive AsNoTracking, so a stub carries the single changed column rather than
+            // the whole entity, and rides the SaveChangesAsync already at the end of this method.
+            if (existing is not null &&
+                file.ResourceUri is not null &&
+                !string.Equals(existing.ResourceUri, file.ResourceUri, StringComparison.Ordinal))
+            {
+                var stub = new DocumentEntity { Id = existing.Id };
+                context.Documents.Attach(stub);
+                stub.ResourceUri = file.ResourceUri;
+                located++;
+            }
 
             // Without this the fallback path re-ingests the entire remote on every cycle:
             // the content hash is computed after the download and parse, so it dedupes
@@ -406,6 +430,7 @@ public class SourceSyncService(
                     FileName = Path.GetFileName(file.Path),
                     ContentType = file.ContentType,
                     Path = file.Path,
+                    ResourceUri = file.ResourceUri,
                     ContentHash = string.Empty,
                     SizeBytes = file.SizeBytes,
                     Status = "Pending",
@@ -423,7 +448,7 @@ public class SourceSyncService(
 
         // One round trip, and before any enqueue: a claim that did not persist must not have a
         // job pointing at it, and a retry that was not counted would not be bounded.
-        if (claims.Count > 0 || due.Count > 0)
+        if (claims.Count > 0 || due.Count > 0 || located > 0)
             await context.SaveChangesAsync(ct);
 
         foreach (var file in due)

--- a/tests/Connapse.Core.Tests/Connectors/ConnectorFileResourceUriTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/ConnectorFileResourceUriTests.cs
@@ -1,0 +1,68 @@
+using Connapse.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Connectors;
+
+/// <summary>
+/// The absolute location a connector reports for each file it lists.
+/// </summary>
+/// <remarks>
+/// This exists because the alternative — reconstructing the location later from the source's bucket
+/// and prefix plus the document's stored path — is wrong in two ways, and both are silent.
+/// <para>
+/// A source's scope is editable and <c>PostgresSourceStore.UpdateAsync</c> reconciles no existing
+/// rows, so a source re-pointed from <c>old/</c> to <c>new/</c> leaves documents whose path is
+/// relative to a prefix nothing records any more. And prefix stripping normalises away a
+/// distinction S3 keeps.
+/// </para>
+/// <para>
+/// These assert the shape of the contract rather than a connector's behaviour, which needs a live
+/// bucket. The connector-side tests live in the integration suite.
+/// </para>
+/// </remarks>
+[Trait("Category", "Unit")]
+public class ConnectorFileResourceUriTests
+{
+    [Fact]
+    public void ConnectorFile_ReportsAnAbsoluteLocationAlongsideTheVirtualPath()
+    {
+        // The pair is the point: Path is what a document row stores and what the connector is
+        // asked for later; ResourceUri is what an external permission system names.
+        var file = new ConnectorFile(
+            Path: "/q3/report.pdf",
+            SizeBytes: 12,
+            LastModified: DateTime.UnixEpoch,
+            ContentType: null,
+            ResourceUri: "s3://acme/team/docs/q3/report.pdf");
+
+        file.Path.Should().Be("/q3/report.pdf");
+        file.ResourceUri.Should().Be("s3://acme/team/docs/q3/report.pdf");
+    }
+
+    [Fact]
+    public void ConnectorFile_ResourceUriIsOptional()
+    {
+        // Filesystem, SFTP and managed storage have no meaningful external address. They are not
+        // broken for lacking one; they are simply not describable by a cloud RBAC scope, and a
+        // null here is what makes that explicit rather than inventing a scheme for them.
+        var file = new ConnectorFile("/a.md", 1, DateTime.UnixEpoch, null);
+
+        file.ResourceUri.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("docs/a.md")]
+    [InlineData("/docs/a.md")]
+    [InlineData("//docs/a.md")]
+    public void ResourceUri_DistinguishesKeysThatPrefixStrippingCollapses(string key)
+    {
+        // S3 permits all three as distinct keys. StripConfigPrefix returns "/" + TrimStart('/'),
+        // so all three become the same stored path -- and any reconstruction from that path can
+        // only ever produce one of the three. Carrying the key verbatim is what keeps them apart.
+        string uri = $"s3://acme/{key}";
+
+        uri.Should().EndWith(key);
+        uri.Should().Be($"s3://acme/{key}", "the key is carried verbatim, not normalised");
+    }
+}

--- a/tests/Connapse.Core.Tests/Connectors/ConnectorFileResourceUriTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/ConnectorFileResourceUriTests.cs
@@ -1,4 +1,4 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using FluentAssertions;
 using Xunit;
 
@@ -25,7 +25,7 @@ namespace Connapse.Core.Tests.Connectors;
 public class ConnectorFileResourceUriTests
 {
     [Fact]
-    public void ConnectorFile_ReportsAnAbsoluteLocationAlongsideTheVirtualPath()
+    public void ConnectorFile_WithResourceUri_KeepsItAlongsideTheVirtualPath()
     {
         // The pair is the point: Path is what a document row stores and what the connector is
         // asked for later; ResourceUri is what an external permission system names.
@@ -41,7 +41,7 @@ public class ConnectorFileResourceUriTests
     }
 
     [Fact]
-    public void ConnectorFile_ResourceUriIsOptional()
+    public void ConnectorFile_WithoutResourceUri_LeavesItNull()
     {
         // Filesystem, SFTP and managed storage have no meaningful external address. They are not
         // broken for lacking one; they are simply not describable by a cloud RBAC scope, and a
@@ -55,7 +55,7 @@ public class ConnectorFileResourceUriTests
     [InlineData("docs/a.md")]
     [InlineData("/docs/a.md")]
     [InlineData("//docs/a.md")]
-    public void ResourceUri_DistinguishesKeysThatPrefixStrippingCollapses(string key)
+    public void ResourceUri_ForKeysPrefixStrippingCollapses_KeepsThemDistinct(string key)
     {
         // S3 permits all three as distinct keys. StripConfigPrefix returns "/" + TrimStart('/'),
         // so all three become the same stored path -- and any reconstruction from that path can

--- a/tests/Connapse.Core.Tests/Utilities/ResourceUriTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/ResourceUriTests.cs
@@ -1,0 +1,85 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+/// <summary>
+/// The absolute address a connector reports for each file, which a permission filter will match
+/// scopes against.
+/// </summary>
+/// <remarks>
+/// The authority carries the weight here. Two connections whose URIs collide would let a rule
+/// written for one silently reach the other's documents, and that is a grant nobody wrote.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class ResourceUriTests
+{
+    [Fact]
+    public void ForS3_WithBucketAndKey_NamesBoth()
+    {
+        ResourceUri.ForS3("acme", "team/docs/q3.pdf")
+            .Should().Be("s3://acme/team/docs/q3.pdf");
+    }
+
+    [Theory]
+    [InlineData("docs/a.md", "s3://acme/docs/a.md")]
+    [InlineData("/docs/a.md", "s3://acme//docs/a.md")]
+    [InlineData("//docs/a.md", "s3://acme///docs/a.md")]
+    public void ForS3_WithSlashesInTheKey_CarriesThemVerbatim(string key, string expected)
+    {
+        // S3 treats these as three distinct keys. Normalising here would merge documents that are
+        // not the same object, which is the exact loss that made reconstructing the URI from the
+        // stored path unusable in the first place.
+        ResourceUri.ForS3("acme", key).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ForAzureBlob_NamesTheStorageAccount()
+    {
+        // The finding this pins: the first version was azblob://container/blob. Container names
+        // are unique only within an account, so two connections to different accounts each with a
+        // "docs" container produced one identical URI.
+        ResourceUri.ForAzureBlob("contoso", "docs", "team/q3.pdf")
+            .Should().Be("azblob://contoso/docs/team/q3.pdf");
+    }
+
+    [Fact]
+    public void ForAzureBlob_ForSameContainerInDifferentAccounts_DoesNotCollide()
+    {
+        ResourceUri.ForAzureBlob("contoso", "docs", "a.md")
+            .Should().NotBe(ResourceUri.ForAzureBlob("fabrikam", "docs", "a.md"));
+    }
+
+    [Fact]
+    public void Schemes_AreDistinctPerProvider()
+    {
+        // A resolver reads these back. A shared scheme would make an S3 rule and an Azure rule
+        // indistinguishable by prefix, which is how the filter will compare them.
+        ResourceUri.ForS3("a", "k").Should().StartWith("s3://");
+        ResourceUri.ForAzureBlob("a", "c", "k").Should().StartWith("azblob://");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ForS3_WithoutABucket_Throws(string? bucket)
+    {
+        // A URI with an empty authority is worse than none: "s3:///key" would prefix-match every
+        // rule written against that scheme.
+        FluentActions.Invoking(() => ResourceUri.ForS3(bucket!, "k"))
+            .Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(null, "docs")]
+    [InlineData("contoso", null)]
+    [InlineData("", "docs")]
+    [InlineData("contoso", "")]
+    public void ForAzureBlob_WithoutBothAuthorityParts_Throws(string? account, string? container)
+    {
+        FluentActions.Invoking(() => ResourceUri.ForAzureBlob(account!, container!, "k"))
+            .Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
@@ -755,7 +755,7 @@ public class SourceSyncIntegrationTests(SharedWebAppFixture fixture)
     // -- Document coordinates (#421) ------------------------------------------------
 
     [Fact]
-    public async Task SyncSourceAsync_RecordsWhereEachDocumentCameFrom()
+    public async Task SyncSourceAsync_NewDocument_RecordsWhereItCameFrom()
     {
         await using var scope = fixture.Factory.Services.CreateAsyncScope();
         var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
@@ -780,7 +780,7 @@ public class SourceSyncIntegrationTests(SharedWebAppFixture fixture)
     }
 
     [Fact]
-    public async Task SyncSourceAsync_GivesCoordinatesToDocumentsThatDidNotChange()
+    public async Task SyncSourceAsync_UnchangedDocument_StillRecordsWhereItCameFrom()
     {
         // The case that decides whether this works at all. A stable source skips every file on
         // every cycle -- that skip is what stops a five-minute poll re-embedding everything -- so
@@ -815,7 +815,7 @@ public class SourceSyncIntegrationTests(SharedWebAppFixture fixture)
     }
 
     [Fact]
-    public async Task SyncSourceAsync_LeavesCoordinatesNullWhenTheConnectorReportsNone()
+    public async Task SyncSourceAsync_ConnectorReportsNoLocation_LeavesItNull()
     {
         // Filesystem and SFTP have no external address. Null is the honest answer, and once
         // filtering is on it means denied -- never allowed, because a document nothing can locate

--- a/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SourceSyncIntegrationTests.cs
@@ -158,6 +158,9 @@ public class SourceSyncIntegrationTests(SharedWebAppFixture fixture)
     private static ConnectorFile File(string path, long size = 10) =>
         new(path, size, DateTime.UtcNow, "text/markdown");
 
+    private static ConnectorFile Located(string path, string uri, long size = 10) =>
+        new(path, size, DateTime.UtcNow, "text/markdown", uri);
+
     private async Task<(Source Source, Connection Connection)> SeedSourceAsync(IServiceProvider sp)
     {
         var connections = sp.GetRequiredService<IConnectionStore>();
@@ -747,5 +750,87 @@ public class SourceSyncIntegrationTests(SharedWebAppFixture fixture)
             .SyncSourceAsync(source, connection, CancellationToken.None);
 
         result.Upserted.Should().Be(0, "enqueueing again would race the in-flight job");
+    }
+
+    // -- Document coordinates (#421) ------------------------------------------------
+
+    [Fact]
+    public async Task SyncSourceAsync_RecordsWhereEachDocumentCameFrom()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+
+        var connector = new FakeListConnector(
+            Located("/q3/report.pdf", "s3://b/team/q3/report.pdf"));
+
+        await BuildService(scope.ServiceProvider, connector)
+            .SyncSourceAsync(source, connection, CancellationToken.None);
+
+        var factory = scope.ServiceProvider
+            .GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var db = await factory.CreateDbContextAsync();
+
+        var document = await db.Documents.AsNoTracking()
+            .SingleAsync(d => d.SourceId == source.Id);
+
+        // The connector's answer, stored verbatim. Not rebuilt from bucket + prefix + path, which
+        // is the derivation this column exists to avoid.
+        document.ResourceUri.Should().Be("s3://b/team/q3/report.pdf");
+        document.Path.Should().Be("/q3/report.pdf", "the virtual path is unchanged by this");
+    }
+
+    [Fact]
+    public async Task SyncSourceAsync_GivesCoordinatesToDocumentsThatDidNotChange()
+    {
+        // The case that decides whether this works at all. A stable source skips every file on
+        // every cycle -- that skip is what stops a five-minute poll re-embedding everything -- so
+        // populating only on ingest would leave a source that never changes without coordinates
+        // for ever, and its documents permanently denied once filtering is on.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+
+        var factory = scope.ServiceProvider
+            .GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+
+        // First cycle: the connector reports no location, as one built before this column did.
+        await BuildService(scope.ServiceProvider, new FakeListConnector(File("/a.md")))
+            .SyncSourceAsync(source, connection, CancellationToken.None);
+
+        await using (var before = await factory.CreateDbContextAsync())
+        {
+            (await before.Documents.AsNoTracking().SingleAsync(d => d.SourceId == source.Id))
+                .ResourceUri.Should().BeNull();
+        }
+
+        // Second cycle: same file, same size and timestamp, so the sync skips it entirely.
+        var located = new FakeListConnector(Located("/a.md", "s3://b/a.md"));
+        var result = await BuildService(scope.ServiceProvider, located)
+            .SyncSourceAsync(source, connection, CancellationToken.None);
+
+        result.Upserted.Should().Be(0, "nothing changed, so nothing was re-ingested");
+
+        await using var after = await factory.CreateDbContextAsync();
+        (await after.Documents.AsNoTracking().SingleAsync(d => d.SourceId == source.Id))
+            .ResourceUri.Should().Be("s3://b/a.md", "a skipped file still learns where it is");
+    }
+
+    [Fact]
+    public async Task SyncSourceAsync_LeavesCoordinatesNullWhenTheConnectorReportsNone()
+    {
+        // Filesystem and SFTP have no external address. Null is the honest answer, and once
+        // filtering is on it means denied -- never allowed, because a document nothing can locate
+        // is a document no permission rule can be checked against.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var (source, connection) = await SeedSourceAsync(scope.ServiceProvider);
+
+        await BuildService(scope.ServiceProvider, new FakeListConnector(File("/a.md")))
+            .SyncSourceAsync(source, connection, CancellationToken.None);
+
+        var factory = scope.ServiceProvider
+            .GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var db = await factory.CreateDbContextAsync();
+
+        (await db.Documents.AsNoTracking().SingleAsync(d => d.SourceId == source.Id))
+            .ResourceUri.Should().BeNull();
     }
 }


### PR DESCRIPTION
## What

Adds `documents.resource_uri` — where each synced document actually came from, as `s3://bucket/key`. Reported by the connector at sync time.

Phase 2 of [#421](https://github.com/Destrayon/Connapse/issues/421). Nothing consumes the column yet; this is the coordinate a permission filter will match against.

## Why it is reported, not derived

The plan originally said to backfill this from each source's bucket and prefix plus the document's stored path. **I dropped the backfill.** That derivation is wrong in two ways, and neither leaves a trace.

**A source's scope is editable and nothing reconciles existing rows.** `PostgresSourceStore.UpdateAsync` writes the new `ScopeJson` and stops. A source re-pointed from `old/` to `new/` leaves documents whose `Path` is relative to a prefix no longer on record — so the arithmetic produces a *confident wrong answer*. For a permission filter, a document attributed to the wrong key is worse than one attributed to none.

**`StripConfigPrefix` normalises away a distinction S3 keeps.** It returns `"/" + key.TrimStart('/')`, collapsing `a`, `/a` and `//a` into one stored path where S3 has three distinct keys. No reconstruction from that path can recover which one it was.

Carrying the key verbatim from the listing avoids both.

## Written for every file, not just changed ones

The listing pass sees every remote file each cycle, but only *changed* files are ingested — that skip is what stops a five-minute poll re-embedding everything a source holds.

So the URI is written **before** the skip. Populating on ingest alone would leave a source that never changes without coordinates for ever, and its documents permanently denied once filtering is on. One listing cycle now populates a whole source, and there is no migration-time backfill at all.

Rows arrive `AsNoTracking`, so a stub carries the single changed column rather than the whole entity.

## A bug this found

`EnqueueAllAsync` ends with:

```csharp
if (claims.Count > 0 || due.Count > 0)
    await context.SaveChangesAsync(ct);
```

A coordinate update is neither a claim nor due work. So on the exact source that needs it most — one where nothing has changed — the update was built and silently discarded. Caught by the integration test below; it is counted now.

## Null

Means no external address: uploads, filesystem and SFTP sources, and anything not synced since this column existed. **Null is denied once filtering is on, never allowed** — a document nothing can locate is one no permission rule can be checked against.

## Verification

Build clean. 1,299 unit tests green.

Three integration tests, the middle one being the one that matters:

- a synced document records the connector's URI verbatim
- **a file that did not change still acquires its URI** — first cycle with no URI, second cycle same size and timestamp so `Upserted == 0`, and the URI lands anyway
- a connector reporting no location leaves null

Migration applied to a live database and the column confirmed present.

**Pre-existing failures, not from this branch:** `SourceIngestionOwnershipTests.Ingest_ForSourceOwner_WritesChunksWithSourceOwnerNotEmpty` and `ForcedReindex_WhenTheEnqueueFails_LeavesTheDocumentSearchable` fail on clean `main` too — verified by stashing this work and re-running. Worth a separate issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added external resource locations to synced files and documents.
  * Azure Blob and S3 files now retain their original resource addresses, including exact object keys.
  * Resource locations remain available when file paths are normalized or documents are unchanged during later syncs.
  * Files without a meaningful external address continue to show no resource location.

* **Bug Fixes**
  * Corrected tracking of remote file locations when existing documents are updated during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->