### PR TITLE
feat(search): carry the searching user through every surface

### DIFF
--- a/src/Connapse.Core/Models/SearchModels.cs
+++ b/src/Connapse.Core/Models/SearchModels.cs
@@ -1,11 +1,25 @@
-namespace Connapse.Core;
+﻿namespace Connapse.Core;
 
+/// <param name="UserId">
+/// Who is searching. Null when the caller could not be resolved to a person — an unauthenticated
+/// request, or an agent with no user behind it.
+/// </param>
+/// <remarks>
+/// Carried but not yet consumed: per-user permission filtering is #421, and until it lands every
+/// search returns everything regardless of what this holds.
+/// <para>
+/// Nullable with a null default deliberately. A surface that forgets to supply it gets null, and
+/// null is what the filter will deny — so the failure mode of forgetting is too little access
+/// rather than too much.
+/// </para>
+/// </remarks>
 public record SearchOptions(
     int TopK = 10,
     float MinScore = 0.0f,
     string? ContainerId = null,
     SearchMode Mode = SearchMode.Hybrid,
-    Dictionary<string, string>? Filters = null);
+    Dictionary<string, string>? Filters = null,
+    Guid? UserId = null);
 
 public record SearchResult(
     List<SearchHit> Hits,

--- a/src/Connapse.Identity/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/src/Connapse.Identity/Authentication/ApiKeyAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -155,6 +155,13 @@ public class ApiKeyAuthenticationHandler(
             new("agent_id", agentKey.Agent.Id.ToString()),
             new("agent_key_id", agentKey.Id.ToString()),
             new("auth_method", "agent_api_key"),
+
+            // The user an agent acts for. NameIdentifier is the agent's own id, so without this
+            // an agent request carries no person at all — and an agent is meant to reach what its
+            // creator reaches, not more. Emitted here rather than looked up later because the
+            // agent row is already loaded, and a per-search lookup would be a database round trip
+            // for a value that cannot change within a request.
+            new("on_behalf_of", agentKey.Agent.CreatedByUserId.ToString()),
             // Synthetic role claim — satisfies RequireAgent policy without the DB role row existing
             new(ClaimTypes.Role, "Agent"),
         };

--- a/src/Connapse.Web/Components/Pages/Search.razor
+++ b/src/Connapse.Web/Components/Pages/Search.razor
@@ -1,12 +1,14 @@
-@page "/search"
+﻿@page "/search"
 @rendermode InteractiveServer
 @attribute [Authorize]
 @using Connapse.Core
 @using Connapse.Core.Interfaces
 @using Microsoft.Extensions.Options
+@using Connapse.Web.Services
 @inject IContainerStore ContainerStore
 @inject ISourceStore SourceStore
 @inject IKnowledgeSearch SearchService
+@inject AuthenticationStateProvider AuthStateProvider
 @inject IOptionsMonitor<SearchSettings> SearchSettings
 @inject Connapse.Storage.Vectors.VectorModelDiscovery ModelDiscovery
 @inject IOptionsMonitor<EmbeddingSettings> EmbeddingSettingsMonitor
@@ -268,6 +270,15 @@
         }
     }
 
+    /// <summary>Who is searching, from the circuit's authentication state.</summary>
+    /// <remarks>
+    /// The one surface with no HttpContext to read, so it reaches the same resolver by way of the
+    /// circuit's own principal. Same answer as the REST and MCP paths, which is the point of there
+    /// being a single resolver rather than a copy per surface.
+    /// </remarks>
+    private async Task<Guid?> CurrentUserIdAsync() =>
+        SearchPrincipal.Resolve((await AuthStateProvider.GetAuthenticationStateAsync()).User);
+
     private async Task PerformSearch()
     {
         if (string.IsNullOrWhiteSpace(query))
@@ -309,7 +320,8 @@
                 TopK: topK,
                 MinScore: (float)SearchSettings.CurrentValue.MinimumScore,
                 ContainerId: selectedContainerId,
-                Filters: filters.Count > 0 ? filters : null);
+                Filters: filters.Count > 0 ? filters : null,
+                UserId: await CurrentUserIdAsync());
 
             searchResult = await SearchService.SearchAsync(query, options);
         }

--- a/src/Connapse.Web/Endpoints/SearchEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/SearchEndpoints.cs
@@ -2,6 +2,8 @@
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
 using Connapse.Storage.Vectors;
+using System.Security.Claims;
+using Connapse.Web.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -25,6 +27,7 @@ public static class SearchEndpoints
             [FromServices] IContainerStore containerStore,
             [FromServices] IKnowledgeSearch searchService,
             [FromServices] IOptionsMonitor<SearchSettings> searchSettings,
+            ClaimsPrincipal user,
             CancellationToken ct) =>
         {
             var container = await containerStore.GetAsync(containerId, ct);
@@ -52,7 +55,8 @@ public static class SearchEndpoints
                 TopK: topK ?? 10,
                 MinScore: effectiveMinScore,
                 ContainerId: containerId.ToString(),
-                Filters: filters.Count > 0 ? filters : null);
+                Filters: filters.Count > 0 ? filters : null,
+                UserId: SearchPrincipal.Resolve(user));
 
             var results = await searchService.SearchAsync(q, options, ct);
             return Results.Ok(results);
@@ -67,6 +71,7 @@ public static class SearchEndpoints
             [FromServices] IContainerStore containerStore,
             [FromServices] IKnowledgeSearch searchService,
             [FromServices] IOptionsMonitor<SearchSettings> searchSettings,
+            ClaimsPrincipal user,
             CancellationToken ct) =>
         {
             var container = await containerStore.GetAsync(containerId, ct);
@@ -92,7 +97,8 @@ public static class SearchEndpoints
                 TopK: request.TopK ?? 10,
                 MinScore: effectiveMinScore,
                 ContainerId: containerId.ToString(),
-                Filters: filters.Count > 0 ? filters : null);
+                Filters: filters.Count > 0 ? filters : null,
+                UserId: SearchPrincipal.Resolve(user));
 
             var results = await searchService.SearchAsync(request.Query, options, ct);
             return Results.Ok(results);

--- a/src/Connapse.Web/Mcp/McpTools.cs
+++ b/src/Connapse.Web/Mcp/McpTools.cs
@@ -170,12 +170,19 @@ public class McpTools
         if (!string.IsNullOrWhiteSpace(path))
             filters = new Dictionary<string, string> { ["pathPrefix"] = path };
 
+        // Through IHttpContextAccessor because an MCP tool is handed only an IServiceProvider.
+        // The accessor is registered for this: without it these tools are the one surface that
+        // cannot name its caller, and a permission filter is only as good as its weakest entry
+        // point.
+        var caller = services.GetService<IHttpContextAccessor>()?.HttpContext?.User;
+
         var options = new SearchOptions(
             Mode: parsedMode,
             TopK: effectiveTopK,
             MinScore: effectiveMinScore,
             ContainerId: resolvedId.Value.ToString(),
-            Filters: filters);
+            Filters: filters,
+            UserId: SearchPrincipal.Resolve(caller));
 
         var searchService = services.GetRequiredService<IKnowledgeSearch>();
         var result = await searchService.SearchAsync(query, options, ct);

--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -149,6 +149,11 @@ builder.Services.AddScoped<ICloudScopeService, CloudScopeService>();
 builder.Services.AddScoped<SourceScopePreflight>();
 builder.Services.AddScoped<IProviderSetupReader, ProviderSetupReader>();
 
+// So an MCP tool can name its caller. Tools receive an IServiceProvider and nothing else, so
+// without this the MCP surface cannot resolve a principal at all — and #421 will deny what it
+// cannot identify, which would silently turn every MCP search into no results.
+builder.Services.AddHttpContextAccessor();
+
 // Injected rather than read statically so the provisioning window ProviderSetupReader applies to a
 // freshly created access key can be tested without waiting an hour for it.
 builder.Services.AddSingleton(TimeProvider.System);

--- a/src/Connapse.Web/Services/SearchPrincipal.cs
+++ b/src/Connapse.Web/Services/SearchPrincipal.cs
@@ -1,0 +1,50 @@
+using System.Security.Claims;
+
+namespace Connapse.Web.Services;
+
+/// <summary>
+/// Works out which person a search is running for.
+/// </summary>
+/// <remarks>
+/// One place, because four surfaces ask the question — the REST endpoints, the Blazor page, the MCP
+/// tools, and agent-authenticated requests — and a surface that answers it differently is a hole in
+/// the filter rather than an inconsistency. There are already four private copies of a
+/// <c>GetUserId</c> in the endpoint classes; this deliberately does not become a fifth.
+/// <para>
+/// It answers <b>who</b>, never <b>whether</b>. Authorisation stays where it is; this only reports
+/// the identity that a permission filter will later resolve scopes for (#421).
+/// </para>
+/// </remarks>
+public static class SearchPrincipal
+{
+    /// <summary>The claim naming the user an agent acts for.</summary>
+    public const string OnBehalfOfClaim = "on_behalf_of";
+
+    /// <summary>The claim distinguishing an agent's key from a person's.</summary>
+    public const string ActorTypeClaim = "actor_type";
+
+    /// <summary>
+    /// The user this request is for, or null when there is not one.
+    /// </summary>
+    /// <remarks>
+    /// An agent authenticates as itself: <see cref="ClaimTypes.NameIdentifier"/> holds the agent's
+    /// id, not a person's. Reading it as a user id would hand the filter a Guid that matches no
+    /// user and resolve to no scopes — denial by accident rather than by decision, and impossible
+    /// to tell from a real denial. So an agent is resolved through the user it was created by.
+    /// <para>
+    /// Null is a real answer, not a failure: an unauthenticated request has no user, and so will a
+    /// standalone agent once agents can exist without one.
+    /// </para>
+    /// </remarks>
+    public static Guid? Resolve(ClaimsPrincipal? principal)
+    {
+        if (principal?.Identity?.IsAuthenticated != true)
+            return null;
+
+        string? claim = principal.FindFirstValue(ActorTypeClaim) == "agent"
+            ? principal.FindFirstValue(OnBehalfOfClaim)
+            : principal.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        return Guid.TryParse(claim, out var id) ? id : null;
+    }
+}

--- a/tests/Connapse.Web.Tests/Services/SearchPrincipalTests.cs
+++ b/tests/Connapse.Web.Tests/Services/SearchPrincipalTests.cs
@@ -1,0 +1,91 @@
+using System.Security.Claims;
+using Connapse.Web.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Web.Tests.Services;
+
+/// <summary>
+/// Which person a search runs for, across the four surfaces that ask.
+/// </summary>
+/// <remarks>
+/// The answer is currently carried and not consumed — per-user filtering is #421. These tests exist
+/// now because the resolution rules are where the mistakes are, and they are much easier to get
+/// right before something depends on them than after.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class SearchPrincipalTests
+{
+    private static ClaimsPrincipal Authenticated(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims, authenticationType: "Test"));
+
+    private static readonly Guid User = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Agent = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void Resolve_ForASignedInUser_ReturnsTheirId()
+    {
+        SearchPrincipal.Resolve(Authenticated(
+            new Claim(ClaimTypes.NameIdentifier, User.ToString()),
+            new Claim(SearchPrincipal.ActorTypeClaim, "user")))
+            .Should().Be(User);
+    }
+
+    [Fact]
+    public void Resolve_ForAnAgent_ReturnsTheUserItActsFor()
+    {
+        // The one that would be wrong by default. An agent authenticates as itself, so
+        // NameIdentifier holds the agent's id -- reading that as a user id yields a Guid matching
+        // no user, which resolves to no scopes: a denial by accident, indistinguishable from a
+        // real one.
+        SearchPrincipal.Resolve(Authenticated(
+            new Claim(ClaimTypes.NameIdentifier, Agent.ToString()),
+            new Claim(SearchPrincipal.ActorTypeClaim, "agent"),
+            new Claim(SearchPrincipal.OnBehalfOfClaim, User.ToString())))
+            .Should().Be(User);
+    }
+
+    [Fact]
+    public void Resolve_ForAnAgent_NeverReturnsTheAgentsOwnId()
+    {
+        SearchPrincipal.Resolve(Authenticated(
+            new Claim(ClaimTypes.NameIdentifier, Agent.ToString()),
+            new Claim(SearchPrincipal.ActorTypeClaim, "agent"),
+            new Claim(SearchPrincipal.OnBehalfOfClaim, User.ToString())))
+            .Should().NotBe(Agent);
+    }
+
+    [Fact]
+    public void Resolve_ForAnAgentWithNoUserBehindIt_ReturnsNull()
+    {
+        // The shape a standalone agent will have once agents can exist without a creator. Null
+        // rather than a fallback to the agent's own id, because that fallback would quietly grant
+        // whatever a user with that Guid happened to have.
+        SearchPrincipal.Resolve(Authenticated(
+            new Claim(ClaimTypes.NameIdentifier, Agent.ToString()),
+            new Claim(SearchPrincipal.ActorTypeClaim, "agent")))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_ForAnAnonymousRequest_ReturnsNull()
+    {
+        SearchPrincipal.Resolve(new ClaimsPrincipal(new ClaimsIdentity())).Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_ForNoPrincipalAtAll_ReturnsNull()
+    {
+        SearchPrincipal.Resolve(null).Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_ForAnUnparseableIdentifier_ReturnsNull()
+    {
+        // Null, not an exception. A malformed claim is something an attacker can arrange, and a
+        // search surface that throws on one is a denial-of-service rather than a refusal.
+        SearchPrincipal.Resolve(Authenticated(
+            new Claim(ClaimTypes.NameIdentifier, "not-a-guid")))
+            .Should().BeNull();
+    }
+}


### PR DESCRIPTION
## What

`SearchOptions` gains `UserId`, and the four surfaces that build one now supply it: both REST handlers, the Blazor page, and the MCP tool.

Phase 3 of [#421](https://github.com/Destrayon/Connapse/issues/421). **Nothing consumes it yet**, so this changes no behaviour.

## Why separate

The resolution rules are where the mistakes live, and they are far easier to get right before something depends on them than after. Two of the four surfaces turned out to need real work rather than plumbing — see below.

`UserId` is nullable with a null default deliberately: a surface that forgets gets null, and null is what the filter will deny. Forgetting fails toward *too little* access.

## One resolver, not a copy per surface

There are already four private `GetUserId` helpers among the endpoint classes. A fifth answering slightly differently would be a hole in the filter rather than an inconsistency, so `SearchPrincipal.Resolve` is the single answer all four surfaces reach. It answers *who*, never *whether* — authorisation stays where it is.

## The agent case would have been wrong by default

An agent authenticates **as itself**. `ApiKeyAuthenticationHandler:152` puts the *agent's* id in `NameIdentifier`, with `actor_type = "agent"`. Reading that as a user id yields a Guid matching no user, which resolves to no scopes — a denial by accident, indistinguishable from a real one, and one that would look like the filter working.

Agents resolve through the user that **created** them, carried in a new `on_behalf_of` claim emitted where the agent row is already loaded rather than looked up per search. That matches the intent that an agent reaches what its creator reaches.

A standalone agent with no user behind it resolves to **null**, not to its own id — that fallback would quietly grant whatever a user with that Guid happened to have. This is the shape agents-without-users will arrive in later.

## MCP had no route to its caller at all

MCP tools receive only an `IServiceProvider`, and `IHttpContextAccessor` was not registered. So the MCP surface could not name a principal by any means. It is registered now — without it, a filter that denies what it cannot identify would have silently returned nothing for every MCP search.

## Verification

Build clean. **1,320 unit tests green**, including 7 covering resolution: signed-in user, agent-acting-for-user, agent-with-no-user, anonymous, no principal at all, and an unparseable claim (which returns null rather than throwing — a malformed claim is something an attacker can arrange).

`AuthEndpointTests` (40) green, which is the container-graph check that matters after a DI registration.

## Pre-existing failures, not from this branch

`SearchValidationTests` has **5 failures on clean `main`** — `500` where `200` is expected on valid boundary inputs. Verified by stashing this work and re-running. Reported on [#424](https://github.com/Destrayon/Connapse/issues/424) along with `SourceIngestionOwnershipTests` (2) and a `SourceSyncS3IntegrationTests` failure.

Worth resolving before phase 4: those are the suites that would have to be trusted when a permission predicate goes into the same queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search requests now carry the authenticated user’s identity.
  * Searches performed by agents are associated with the user they act on behalf of.
  * User identity is consistently recognized across web, API, and integrated search experiences.

* **Bug Fixes**
  * Anonymous or invalid identities no longer cause search identity resolution errors.

* **Tests**
  * Added coverage for signed-in users, agents, anonymous requests, missing identities, and invalid identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->