### PR TITLE
feat(search): filter results by what the searcher may reach

### DIFF
--- a/src/Connapse.Core/Interfaces/IVectorStore.cs
+++ b/src/Connapse.Core/Interfaces/IVectorStore.cs
@@ -1,10 +1,15 @@
-namespace Connapse.Core.Interfaces;
+﻿namespace Connapse.Core.Interfaces;
 
 public interface IVectorStore
 {
     Task UpsertAsync(string id, float[] vector, Dictionary<string, string> metadata, CancellationToken ct = default);
     Task UpsertBatchAsync(IReadOnlyList<(string Id, float[] Vector, Dictionary<string, string> Metadata)> items, CancellationToken ct = default);
-    Task<IReadOnlyList<VectorSearchResult>> SearchAsync(float[] queryVector, int topK, Dictionary<string, string>? filters = null, CancellationToken ct = default);
+    /// <param name="scopes">
+    /// What the caller may reach. Null means unrestricted, which is correct for the internal
+    /// callers that are not answering a user's query — clustering and reindex read the whole
+    /// corpus by design. The search path always passes a resolved value.
+    /// </param>
+    Task<IReadOnlyList<VectorSearchResult>> SearchAsync(float[] queryVector, int topK, Dictionary<string, string>? filters = null, SearchScopes? scopes = null, CancellationToken ct = default);
     Task DeleteAsync(string id, CancellationToken ct = default);
     Task DeleteByDocumentIdAsync(string documentId, CancellationToken ct = default);
 

--- a/src/Connapse.Core/Models/SearchScopes.cs
+++ b/src/Connapse.Core/Models/SearchScopes.cs
@@ -1,4 +1,4 @@
-namespace Connapse.Core;
+﻿namespace Connapse.Core;
 
 /// <summary>
 /// What a search is allowed to reach, as resource-URI prefixes.
@@ -51,6 +51,38 @@ public sealed record SearchScopes
 
     /// <summary>True when this permits nothing, so a query need not run at all.</summary>
     public bool IsEmpty => !IsUnrestricted && UriPrefixes.Count == 0;
+
+    /// <summary>The character that turns a wildcard back into a literal.</summary>
+    /// <remarks>
+    /// Not backslash. Postgres accepts it, but it collides with string-literal escaping in enough
+    /// contexts to be worth avoiding when the choice is free.
+    /// </remarks>
+    public const char LikeEscape = '!';
+
+    /// <summary>
+    /// Turns a URI prefix into a <c>LIKE</c> pattern that matches it literally.
+    /// </summary>
+    /// <remarks>
+    /// <c>%</c> and <c>_</c> are wildcards to <c>LIKE</c>, and a grant is not a pattern — it is a
+    /// location. Without this a grant for <c>s3://acme/team_docs/</c> also matches
+    /// <c>s3://acme/teamXdocs/</c>, because <c>_</c> matches any single character. That is a user
+    /// reading a prefix nobody granted them, and underscores in S3 key prefixes are ordinary.
+    /// <para>
+    /// Here rather than in each store, because the escape character chosen in the pattern and the
+    /// one named in the <c>ESCAPE</c> clause have to agree, and they are written in two files.
+    /// </para>
+    /// </remarks>
+    public static string ToLikePattern(string uriPrefix)
+    {
+        ArgumentNullException.ThrowIfNull(uriPrefix);
+
+        // The escape character first, or escaping the wildcards would re-escape its own output.
+        return uriPrefix
+            .Replace("!", "!!", StringComparison.Ordinal)
+            .Replace("%", "!%", StringComparison.Ordinal)
+            .Replace("_", "!_", StringComparison.Ordinal)
+            + "%";
+    }
 }
 
 /// <summary>

--- a/src/Connapse.Core/Models/SearchScopes.cs
+++ b/src/Connapse.Core/Models/SearchScopes.cs
@@ -1,0 +1,74 @@
+namespace Connapse.Core;
+
+/// <summary>
+/// What a search is allowed to reach, as resource-URI prefixes.
+/// </summary>
+/// <remarks>
+/// Prefixes rather than document ids. A user's grants are a handful of locations —
+/// <c>s3://bucket/team/</c> — while the documents inside them are unbounded, so matching prefixes
+/// costs a predicate whose size is the number of grants and an id list costs one whose size is the
+/// corpus.
+/// <para>
+/// <see cref="Unrestricted"/> and an empty <see cref="UriPrefixes"/> are opposites and must never
+/// be confused: the first is "this deployment does not filter", the second is "this user reaches
+/// nothing". A type that represented both as an empty list would turn a misconfiguration into an
+/// open door, which is the failure this distinction exists to prevent.
+/// </para>
+/// </remarks>
+public sealed record SearchScopes
+{
+    private SearchScopes(bool unrestricted, IReadOnlyList<string> uriPrefixes)
+    {
+        IsUnrestricted = unrestricted;
+        UriPrefixes = uriPrefixes;
+    }
+
+    /// <summary>
+    /// No filtering: every document is reachable.
+    /// </summary>
+    /// <remarks>
+    /// The state of a deployment that has not configured per-user permissions, which is every
+    /// deployment until a resolver exists. Filtering is opt-in because denying by default here
+    /// would leave every existing installation unable to search anything after an upgrade.
+    /// </remarks>
+    public static readonly SearchScopes Unrestricted = new(true, []);
+
+    /// <summary>Nothing is reachable. A resolved user with no grants.</summary>
+    public static readonly SearchScopes None = new(false, []);
+
+    /// <summary>Only documents whose resource URI starts with one of these.</summary>
+    public static SearchScopes Of(IReadOnlyList<string> uriPrefixes)
+    {
+        ArgumentNullException.ThrowIfNull(uriPrefixes);
+
+        var usable = uriPrefixes.Where(p => !string.IsNullOrWhiteSpace(p)).ToList();
+        return usable.Count == 0 ? None : new SearchScopes(false, usable);
+    }
+
+    public bool IsUnrestricted { get; }
+
+    public IReadOnlyList<string> UriPrefixes { get; }
+
+    /// <summary>True when this permits nothing, so a query need not run at all.</summary>
+    public bool IsEmpty => !IsUnrestricted && UriPrefixes.Count == 0;
+}
+
+/// <summary>
+/// Works out what a given user may reach.
+/// </summary>
+/// <remarks>
+/// The seam between where permissions come from and how they are enforced. Enforcement is the
+/// expensive, risky half — a predicate in two hand-written SQL queries — and it does not care
+/// whether the answer came from a cloud provider, a table, or a test.
+/// <para>
+/// Implementations must not cache an allow across requests without a way to invalidate it. A stale
+/// allow is a user reading what they no longer may; a stale deny is a support ticket.
+/// </para>
+/// </remarks>
+public interface ISearchScopeResolver
+{
+    /// <param name="userId">
+    /// Who is searching, or null when the caller could not be resolved to a person.
+    /// </param>
+    Task<SearchScopes> ResolveAsync(Guid? userId, CancellationToken ct = default);
+}

--- a/src/Connapse.Search/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Search/Extensions/ServiceCollectionExtensions.cs
@@ -1,9 +1,11 @@
+using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Search.Hybrid;
 using Connapse.Search.Keyword;
 using Connapse.Search.Reranking;
 using Connapse.Search.Vector;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Connapse.Search.Extensions;
 
@@ -21,6 +23,10 @@ public static class ServiceCollectionExtensions
         // Register individual search services
         services.AddScoped<VectorSearchService>();
         services.AddScoped<KeywordSearchService>();
+
+        // The default is no filtering, so registering the enforcement path changes nothing.
+        // A deployment opts in by replacing this with a resolver that resolves something.
+        services.TryAddScoped<ISearchScopeResolver, UnrestrictedScopeResolver>();
 
         // Register rerankers
         services.AddScoped<ISearchReranker, CrossEncoderReranker>();

--- a/src/Connapse.Search/Hybrid/HybridSearchService.cs
+++ b/src/Connapse.Search/Hybrid/HybridSearchService.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Search.Keyword;
@@ -106,19 +106,27 @@ public class HybridSearchService : IKnowledgeSearch
         var vectorSearch = scope.ServiceProvider.GetRequiredService<VectorSearchService>();
         var keywordSearch = scope.ServiceProvider.GetRequiredService<KeywordSearchService>();
 
+        // One resolution per search, taken here because this is where the query fans out. Doing it
+        // inside each leaf would mean two answers for one query, and hybrid would be the mode in
+        // which they could disagree — half a result set from one set of permissions and half from
+        // another, with no way to tell from the outside.
+        var scopes = await scope.ServiceProvider
+            .GetRequiredService<ISearchScopeResolver>()
+            .ResolveAsync(options.UserId, ct);
+
         switch (mode)
         {
             case SearchMode.Semantic:
-                hits = await vectorSearch.SearchAsync(query, options, ct);
+                hits = await vectorSearch.SearchAsync(query, options, scopes, ct);
                 break;
 
             case SearchMode.Keyword:
-                hits = await keywordSearch.SearchAsync(query, options, ct);
+                hits = await keywordSearch.SearchAsync(query, options, scopes, ct);
                 break;
 
             case SearchMode.Hybrid:
             default:
-                hits = await PerformHybridSearchAsync(query, options, ct);
+                hits = await PerformHybridSearchAsync(query, options, scopes, ct);
                 break;
         }
 
@@ -178,6 +186,7 @@ public class HybridSearchService : IKnowledgeSearch
     private async Task<List<SearchHit>> PerformHybridSearchAsync(
         string query,
         SearchOptions options,
+        SearchScopes scopes,
         CancellationToken ct)
     {
         // Run both searches in parallel, each with its own scope (and thus separate DbContext)
@@ -185,7 +194,7 @@ public class HybridSearchService : IKnowledgeSearch
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
             var vectorSearch = scope.ServiceProvider.GetRequiredService<VectorSearchService>();
-            var results = await vectorSearch.SearchAsync(query, options, ct);
+            var results = await vectorSearch.SearchAsync(query, options, scopes, ct);
             return results;
         }, ct);
 
@@ -193,7 +202,7 @@ public class HybridSearchService : IKnowledgeSearch
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
             var keywordSearch = scope.ServiceProvider.GetRequiredService<KeywordSearchService>();
-            var results = await keywordSearch.SearchAsync(query, options, ct);
+            var results = await keywordSearch.SearchAsync(query, options, scopes, ct);
             return results;
         }, ct);
 

--- a/src/Connapse.Search/Keyword/KeywordSearchService.cs
+++ b/src/Connapse.Search/Keyword/KeywordSearchService.cs
@@ -1,4 +1,4 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using Connapse.Storage.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -19,9 +19,14 @@ public class KeywordSearchService
         _logger = logger;
     }
 
+    /// <param name="scopes">
+    /// What the caller may reach. Required rather than optional: a default would make forgetting
+    /// it compile, and forgetting it here returns everything to everyone.
+    /// </param>
     public async Task<List<SearchHit>> SearchAsync(
         string query,
         SearchOptions options,
+        SearchScopes scopes,
         CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(query))
@@ -63,6 +68,28 @@ public class KeywordSearchService
 
         var topKIdx = parameters.Count;
         parameters.Add(options.TopK);
+
+        // The same rule as the vector side, and it has to be: a hit reachable through one
+        // mode and not the other is a leak through whichever the caller happens to choose.
+        if (scopes is { IsUnrestricted: false })
+        {
+            if (scopes.IsEmpty)
+            {
+                whereClauses.Add("1=0");
+            }
+            else
+            {
+                var ors = new List<string>();
+                foreach (string prefix in scopes.UriPrefixes)
+                {
+                    int scopeIdx = parameters.Count;
+                    ors.Add($"d.resource_uri LIKE {{{scopeIdx}}}");
+                    parameters.Add(prefix + "%");
+                }
+
+                whereClauses.Add($"(d.resource_uri IS NOT NULL AND ({string.Join(" OR ", ors)}))");
+            }
+        }
 
         var whereClause = string.Join(" AND ", whereClauses);
 

--- a/src/Connapse.Search/Keyword/KeywordSearchService.cs
+++ b/src/Connapse.Search/Keyword/KeywordSearchService.cs
@@ -83,8 +83,8 @@ public class KeywordSearchService
                 foreach (string prefix in scopes.UriPrefixes)
                 {
                     int scopeIdx = parameters.Count;
-                    ors.Add($"d.resource_uri LIKE {{{scopeIdx}}}");
-                    parameters.Add(prefix + "%");
+                    ors.Add($"d.resource_uri LIKE {{{scopeIdx}}} ESCAPE '{SearchScopes.LikeEscape}'");
+                    parameters.Add(SearchScopes.ToLikePattern(prefix));
                 }
 
                 whereClauses.Add($"(d.resource_uri IS NOT NULL AND ({string.Join(" OR ", ors)}))");

--- a/src/Connapse.Search/UnrestrictedScopeResolver.cs
+++ b/src/Connapse.Search/UnrestrictedScopeResolver.cs
@@ -1,0 +1,27 @@
+using Connapse.Core;
+
+namespace Connapse.Search;
+
+/// <summary>
+/// The resolver a deployment gets when it has configured no per-user permissions.
+/// </summary>
+/// <remarks>
+/// Every search reaches every document, which is what Connapse has always done. Registered as the
+/// default so that adding the enforcement path changes no behaviour: a deployment opts in to
+/// filtering by registering a resolver that resolves something.
+/// <para>
+/// Denying by default here would be safer in the abstract and wrong in practice — it would leave
+/// every existing installation unable to search anything the moment it upgraded, for a feature
+/// nobody had switched on.
+/// </para>
+/// <para>
+/// This is deliberately not a place to put logic. A resolver that sometimes restricts belongs in
+/// its own implementation, so that reading this one tells you the whole truth about what a
+/// default deployment enforces: nothing.
+/// </para>
+/// </remarks>
+public sealed class UnrestrictedScopeResolver : ISearchScopeResolver
+{
+    public Task<SearchScopes> ResolveAsync(Guid? userId, CancellationToken ct = default) =>
+        Task.FromResult(SearchScopes.Unrestricted);
+}

--- a/src/Connapse.Search/Vector/VectorSearchService.cs
+++ b/src/Connapse.Search/Vector/VectorSearchService.cs
@@ -32,9 +32,14 @@ public class VectorSearchService
     /// <summary>
     /// Performs semantic search by embedding the query and searching the vector store.
     /// </summary>
+    /// <param name="scopes">
+    /// What the caller may reach. Required rather than optional: a default would make forgetting
+    /// it compile, and forgetting it here returns everything to everyone.
+    /// </param>
     public async Task<List<SearchHit>> SearchAsync(
         string query,
         SearchOptions options,
+        SearchScopes scopes,
         CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(query))
@@ -74,6 +79,7 @@ public class VectorSearchService
             queryVector,
             options.TopK,
             filters.Count > 0 ? filters : null,
+            scopes,
             ct);
 
         // Convert VectorSearchResult to SearchHit (MinScore applied later by HybridSearchService)

--- a/src/Connapse.Storage/Vectors/PgVectorStore.cs
+++ b/src/Connapse.Storage/Vectors/PgVectorStore.cs
@@ -255,10 +255,10 @@ public class PgVectorStore : IVectorStore
                 var ors = new List<string>();
                 for (int i = 0; i < scopes.UriPrefixes.Count; i++)
                 {
-                    ors.Add($"d.resource_uri LIKE @scope{i}");
+                    ors.Add($"d.resource_uri LIKE @scope{i} ESCAPE '{SearchScopes.LikeEscape}'");
                     parameters.Add(new NpgsqlParameter($"@scope{i}", NpgsqlDbType.Text)
                     {
-                        Value = scopes.UriPrefixes[i] + "%"
+                        Value = SearchScopes.ToLikePattern(scopes.UriPrefixes[i])
                     });
                 }
 

--- a/src/Connapse.Storage/Vectors/PgVectorStore.cs
+++ b/src/Connapse.Storage/Vectors/PgVectorStore.cs
@@ -1,4 +1,4 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.Data;
 using Connapse.Storage.Data.Entities;
@@ -190,6 +190,7 @@ public class PgVectorStore : IVectorStore
         float[] queryVector,
         int topK,
         Dictionary<string, string>? filters = null,
+        SearchScopes? scopes = null,
         CancellationToken ct = default)
     {
         if (queryVector == null || queryVector.Length == 0)
@@ -231,6 +232,37 @@ public class PgVectorStore : IVectorStore
             {
                 whereClauses.Add("cv.model_id = @modelId");
                 parameters.Add(new NpgsqlParameter("@modelId", NpgsqlDbType.Text) { Value = modelId });
+            }
+        }
+
+        // Permission filtering. Pushed into the query rather than applied to its results: a
+        // post-filter would take the top K and then remove most of them, so a user with narrow
+        // access would get a handful of hits for a query that had plenty — worse answers for
+        // being less privileged, with nothing on screen to say so.
+        if (scopes is { IsUnrestricted: false })
+        {
+            if (scopes.IsEmpty)
+            {
+                // Nothing is reachable. Say so in SQL rather than returning early, so this reads
+                // the same as any other empty result to everything downstream.
+                whereClauses.Add("1=0");
+            }
+            else
+            {
+                // A document with no resource URI is denied, never allowed. It is one nothing can
+                // locate, so no permission rule can be checked against it — an upload, or a row
+                // not synced since the column existed.
+                var ors = new List<string>();
+                for (int i = 0; i < scopes.UriPrefixes.Count; i++)
+                {
+                    ors.Add($"d.resource_uri LIKE @scope{i}");
+                    parameters.Add(new NpgsqlParameter($"@scope{i}", NpgsqlDbType.Text)
+                    {
+                        Value = scopes.UriPrefixes[i] + "%"
+                    });
+                }
+
+                whereClauses.Add($"(d.resource_uri IS NOT NULL AND ({string.Join(" OR ", ors)}))");
             }
         }
 

--- a/tests/Connapse.Core.Tests/Search/KeywordSearchQueryTests.cs
+++ b/tests/Connapse.Core.Tests/Search/KeywordSearchQueryTests.cs
@@ -30,7 +30,7 @@ public class KeywordSearchServiceTests
     {
         var options = new Connapse.Core.SearchOptions { TopK = 10, ContainerId = Guid.NewGuid().ToString() };
 
-        var results = await _service.SearchAsync(query!, options);
+        var results = await _service.SearchAsync(query!, options, SearchScopes.Unrestricted);
 
         results.Should().BeEmpty();
     }

--- a/tests/Connapse.Core.Tests/Search/SearchScopesTests.cs
+++ b/tests/Connapse.Core.Tests/Search/SearchScopesTests.cs
@@ -1,4 +1,4 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using FluentAssertions;
 using Xunit;
 
@@ -55,6 +55,50 @@ public class SearchScopesTests
     public void Of_WithNull_Throws()
     {
         FluentActions.Invoking(() => SearchScopes.Of(null!))
+            .Should().Throw<ArgumentNullException>();
+    }
+
+    // -- LIKE escaping -------------------------------------------------------------
+
+    [Fact]
+    public void ToLikePattern_EscapesUnderscore_SoAGrantIsNotAWildcard()
+    {
+        // The bypass this closes. "_" matches any single character, so a grant for
+        // s3://acme/team_docs/ also matched s3://acme/teamXdocs/ -- a prefix nobody granted, and
+        // underscores in S3 key prefixes are ordinary rather than exotic.
+        SearchScopes.ToLikePattern("s3://acme/team_docs/")
+            .Should().Be("s3://acme/team!_docs/%");
+    }
+
+    [Fact]
+    public void ToLikePattern_EscapesPercent()
+    {
+        // Worse than the underscore: "%" matches any sequence, so one in a prefix widens the grant
+        // to everything sharing whatever came before it.
+        SearchScopes.ToLikePattern("s3://acme/50%off/")
+            .Should().Be("s3://acme/50!%off/%");
+    }
+
+    [Fact]
+    public void ToLikePattern_EscapesTheEscapeCharacterItself()
+    {
+        // And does it first. Escaping the wildcards before the escape character would re-escape
+        // this method's own output, turning a literal "!" into an escape and shifting everything
+        // after it by one.
+        SearchScopes.ToLikePattern("s3://acme/hey!/")
+            .Should().Be("s3://acme/hey!!/%");
+    }
+
+    [Fact]
+    public void ToLikePattern_LeavesAnOrdinaryPrefixAlone()
+    {
+        SearchScopes.ToLikePattern("s3://acme/team/").Should().Be("s3://acme/team/%");
+    }
+
+    [Fact]
+    public void ToLikePattern_WithNull_Throws()
+    {
+        FluentActions.Invoking(() => SearchScopes.ToLikePattern(null!))
             .Should().Throw<ArgumentNullException>();
     }
 }

--- a/tests/Connapse.Core.Tests/Search/SearchScopesTests.cs
+++ b/tests/Connapse.Core.Tests/Search/SearchScopesTests.cs
@@ -1,0 +1,60 @@
+using Connapse.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Search;
+
+/// <summary>
+/// What a search may reach, and the one distinction the whole filter rests on.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SearchScopesTests
+{
+    [Fact]
+    public void Unrestricted_AndNone_AreOpposites()
+    {
+        // The distinction that must never collapse. "This deployment does not filter" and "this
+        // user reaches nothing" would both be an empty list in a naive model, and confusing them
+        // turns a misconfiguration into an open door rather than a closed one.
+        SearchScopes.Unrestricted.IsUnrestricted.Should().BeTrue();
+        SearchScopes.Unrestricted.IsEmpty.Should().BeFalse();
+
+        SearchScopes.None.IsUnrestricted.Should().BeFalse();
+        SearchScopes.None.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Of_WithPrefixes_RestrictsToThem()
+    {
+        var scopes = SearchScopes.Of(["s3://acme/team/", "s3://acme/shared/"]);
+
+        scopes.IsUnrestricted.Should().BeFalse();
+        scopes.IsEmpty.Should().BeFalse();
+        scopes.UriPrefixes.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Of_WithNothingUsable_IsNoneRatherThanUnrestricted()
+    {
+        // A resolver that returns an empty or blank-filled list means the user has no grants. The
+        // dangerous reading is "no restrictions", and this is where that reading is refused.
+        SearchScopes.Of([]).Should().BeSameAs(SearchScopes.None);
+        SearchScopes.Of(["", "   "]).Should().BeSameAs(SearchScopes.None);
+    }
+
+    [Fact]
+    public void Of_DropsBlankEntriesBetweenRealOnes()
+    {
+        // A blank prefix would match every URI, so one stray empty string in a resolver's output
+        // would silently grant everything to a user who should see one bucket.
+        SearchScopes.Of(["s3://acme/team/", "", "s3://acme/shared/"])
+            .UriPrefixes.Should().BeEquivalentTo(["s3://acme/team/", "s3://acme/shared/"]);
+    }
+
+    [Fact]
+    public void Of_WithNull_Throws()
+    {
+        FluentActions.Invoking(() => SearchScopes.Of(null!))
+            .Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/Connapse.Integration.Tests/SearchScopeEnforcementTests.cs
+++ b/tests/Connapse.Integration.Tests/SearchScopeEnforcementTests.cs
@@ -1,4 +1,4 @@
-using Connapse.Core;
+﻿using Connapse.Core;
 using Connapse.Search.Keyword;
 using Connapse.Storage.Data;
 using Connapse.Storage.Data.Entities;
@@ -31,9 +31,17 @@ public class SearchScopeEnforcementTests(SharedWebAppFixture fixture)
 {
     private const string Term = "zarquon";
 
-    private static KeywordSearchService Build(IServiceProvider sp) =>
-        new(sp.GetRequiredService<KnowledgeDbContext>(),
-            NullLogger<KeywordSearchService>.Instance);
+    private static KeywordSearchService Build(KnowledgeDbContext db) =>
+        new(db, NullLogger<KeywordSearchService>.Instance);
+
+    /// <summary>A context of this test's own, per the DbContextFactory convention.</summary>
+    /// <remarks>
+    /// Resolving the scoped <c>KnowledgeDbContext</c> directly works here and is the habit worth
+    /// not forming: this application registers the factory precisely because a scoped context
+    /// shared across threads is the Blazor Server failure it exists to avoid.
+    /// </remarks>
+    private static Task<KnowledgeDbContext> NewContextAsync(IServiceProvider sp) =>
+        sp.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>().CreateDbContextAsync();
 
     /// <summary>Two documents in one container, in different buckets.</summary>
     private static async Task<Guid> SeedAsync(KnowledgeDbContext db)
@@ -84,10 +92,10 @@ public class SearchScopeEnforcementTests(SharedWebAppFixture fixture)
     {
         // The assertion this whole phase exists for.
         await using var scope = fixture.Factory.Services.CreateAsyncScope();
-        var db = scope.ServiceProvider.GetRequiredService<KnowledgeDbContext>();
+        await using var db = await NewContextAsync(scope.ServiceProvider);
         var containerId = await SeedAsync(db);
 
-        var hits = await Build(scope.ServiceProvider).SearchAsync(
+        var hits = await Build(db).SearchAsync(
             Term, For(containerId), SearchScopes.Of(["s3://acme/team/"]));
 
         hits.Should().ContainSingle();
@@ -100,10 +108,10 @@ public class SearchScopeEnforcementTests(SharedWebAppFixture fixture)
         // The control. Without it the test above passes just as well when the seed is broken, the
         // term never matches, or the query returns nothing for an unrelated reason.
         await using var scope = fixture.Factory.Services.CreateAsyncScope();
-        var db = scope.ServiceProvider.GetRequiredService<KnowledgeDbContext>();
+        await using var db = await NewContextAsync(scope.ServiceProvider);
         var containerId = await SeedAsync(db);
 
-        var hits = await Build(scope.ServiceProvider).SearchAsync(
+        var hits = await Build(db).SearchAsync(
             Term, For(containerId), SearchScopes.Unrestricted);
 
         hits.Should().HaveCount(2);
@@ -115,10 +123,10 @@ public class SearchScopeEnforcementTests(SharedWebAppFixture fixture)
         // A resolved user with no grants. Distinct from unrestricted, and the distinction is the
         // difference between a closed door and an open one.
         await using var scope = fixture.Factory.Services.CreateAsyncScope();
-        var db = scope.ServiceProvider.GetRequiredService<KnowledgeDbContext>();
+        await using var db = await NewContextAsync(scope.ServiceProvider);
         var containerId = await SeedAsync(db);
 
-        var hits = await Build(scope.ServiceProvider).SearchAsync(
+        var hits = await Build(db).SearchAsync(
             Term, For(containerId), SearchScopes.None);
 
         hits.Should().BeEmpty();
@@ -132,7 +140,7 @@ public class SearchScopeEnforcementTests(SharedWebAppFixture fixture)
         // any restriction", would make every upload visible to everyone the moment filtering is
         // switched on.
         await using var scope = fixture.Factory.Services.CreateAsyncScope();
-        var db = scope.ServiceProvider.GetRequiredService<KnowledgeDbContext>();
+        await using var db = await NewContextAsync(scope.ServiceProvider);
 
         var container = new ContainerEntity { Id = Guid.NewGuid(), Name = $"c-{Guid.NewGuid():N}" };
         db.Containers.Add(container);
@@ -161,12 +169,63 @@ public class SearchScopeEnforcementTests(SharedWebAppFixture fixture)
         });
         await db.SaveChangesAsync();
 
-        var service = Build(scope.ServiceProvider);
+        var service = Build(db);
 
         (await service.SearchAsync(Term, For(container.Id), SearchScopes.Unrestricted))
             .Should().ContainSingle("the document is findable when nothing is filtering");
 
         (await service.SearchAsync(Term, For(container.Id), SearchScopes.Of(["s3://acme/"])))
             .Should().BeEmpty("a document with no location cannot be inside any scope");
+    }
+
+    [Fact]
+    public async Task Search_WithAnUnderscoreInTheGrant_DoesNotMatchAnyOtherCharacter()
+    {
+        // Against the real SQL, because the escaping and the ESCAPE clause have to agree and only
+        // Postgres can say whether they do. A unit test of the pattern string cannot catch a
+        // missing ESCAPE clause, which is exactly the half that would leave this open.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        await using var db = await NewContextAsync(scope.ServiceProvider);
+
+        var container = new ContainerEntity { Id = Guid.NewGuid(), Name = $"c-{Guid.NewGuid():N}" };
+        db.Containers.Add(container);
+
+        foreach (var (name, uri) in new[]
+                 {
+                     ("granted.md", "s3://acme/team_docs/granted.md"),
+                     ("sneaky.md", "s3://acme/teamXdocs/sneaky.md"),
+                 })
+        {
+            var document = new DocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                ContainerId = container.Id,
+                FileName = name,
+                Path = "/" + name,
+                ResourceUri = uri,
+                ContentHash = Guid.NewGuid().ToString("N"),
+                Status = "Ready",
+                CreatedAt = DateTime.UtcNow,
+                Metadata = [],
+            };
+            db.Documents.Add(document);
+            db.Chunks.Add(new ChunkEntity
+            {
+                Id = Guid.NewGuid(),
+                DocumentId = document.Id,
+                OwnerId = container.Id,
+                Content = $"the {Term} appears here",
+                ChunkIndex = 0,
+                Metadata = [],
+            });
+        }
+
+        await db.SaveChangesAsync();
+
+        var hits = await Build(db).SearchAsync(
+            Term, For(container.Id), SearchScopes.Of(["s3://acme/team_docs/"]));
+
+        hits.Should().ContainSingle("only the granted prefix is reachable");
+        hits[0].Metadata.GetValueOrDefault("fileName").Should().Be("granted.md");
     }
 }

--- a/tests/Connapse.Integration.Tests/SearchScopeEnforcementTests.cs
+++ b/tests/Connapse.Integration.Tests/SearchScopeEnforcementTests.cs
@@ -1,0 +1,172 @@
+using Connapse.Core;
+using Connapse.Search.Keyword;
+using Connapse.Storage.Data;
+using Connapse.Storage.Data.Entities;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// That the permission predicate actually narrows a search, against the real SQL.
+/// </summary>
+/// <remarks>
+/// The predicate is hand-written SQL in two places, and the failure that matters is silent: a
+/// filter that does not filter returns exactly what an unfiltered search returns, and every
+/// assertion about hit counts and ordering still passes. So these assert the negative — that a
+/// document outside the scope is <i>absent</i> — which is the only shape of test that can fail
+/// when the filter is missing.
+/// <para>
+/// Keyword rather than vector, because it needs no embedding provider and exercises the same
+/// predicate against the same join. The vector side shares its construction; a test needing Ollama
+/// would be one more reason for this to be skipped when it matters most.
+/// </para>
+/// </remarks>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class SearchScopeEnforcementTests(SharedWebAppFixture fixture)
+{
+    private const string Term = "zarquon";
+
+    private static KeywordSearchService Build(IServiceProvider sp) =>
+        new(sp.GetRequiredService<KnowledgeDbContext>(),
+            NullLogger<KeywordSearchService>.Instance);
+
+    /// <summary>Two documents in one container, in different buckets.</summary>
+    private static async Task<Guid> SeedAsync(KnowledgeDbContext db)
+    {
+        var container = new ContainerEntity { Id = Guid.NewGuid(), Name = $"c-{Guid.NewGuid():N}" };
+        db.Containers.Add(container);
+
+        foreach (var (name, uri) in new[]
+                 {
+                     ("mine.md", "s3://acme/team/mine.md"),
+                     ("theirs.md", "s3://acme/other/theirs.md"),
+                 })
+        {
+            var document = new DocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                ContainerId = container.Id,
+                FileName = name,
+                Path = "/" + name,
+                ResourceUri = uri,
+                ContentHash = Guid.NewGuid().ToString("N"),
+                Status = "Ready",
+                CreatedAt = DateTime.UtcNow,
+                Metadata = [],
+            };
+            db.Documents.Add(document);
+
+            db.Chunks.Add(new ChunkEntity
+            {
+                Id = Guid.NewGuid(),
+                DocumentId = document.Id,
+                OwnerId = container.Id,
+                Content = $"the {Term} appears here",
+                ChunkIndex = 0,
+                Metadata = [],
+            });
+        }
+
+        await db.SaveChangesAsync();
+        return container.Id;
+    }
+
+    private static SearchOptions For(Guid containerId) =>
+        new(TopK: 20, ContainerId: containerId.ToString(), Mode: SearchMode.Keyword);
+
+    [Fact]
+    public async Task Search_WithScopesCoveringOneBucket_ExcludesTheOther()
+    {
+        // The assertion this whole phase exists for.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<KnowledgeDbContext>();
+        var containerId = await SeedAsync(db);
+
+        var hits = await Build(scope.ServiceProvider).SearchAsync(
+            Term, For(containerId), SearchScopes.Of(["s3://acme/team/"]));
+
+        hits.Should().ContainSingle();
+        hits[0].Metadata.GetValueOrDefault("fileName").Should().Be("mine.md");
+    }
+
+    [Fact]
+    public async Task Search_WithoutScopes_ReturnsBoth()
+    {
+        // The control. Without it the test above passes just as well when the seed is broken, the
+        // term never matches, or the query returns nothing for an unrelated reason.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<KnowledgeDbContext>();
+        var containerId = await SeedAsync(db);
+
+        var hits = await Build(scope.ServiceProvider).SearchAsync(
+            Term, For(containerId), SearchScopes.Unrestricted);
+
+        hits.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Search_WithNoScopesAtAll_ReturnsNothing()
+    {
+        // A resolved user with no grants. Distinct from unrestricted, and the distinction is the
+        // difference between a closed door and an open one.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<KnowledgeDbContext>();
+        var containerId = await SeedAsync(db);
+
+        var hits = await Build(scope.ServiceProvider).SearchAsync(
+            Term, For(containerId), SearchScopes.None);
+
+        hits.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Search_ForADocumentWithNoResourceUri_ExcludesItWhenScoped()
+    {
+        // Null is denied, never allowed. An upload has no external address, so no permission rule
+        // can be checked against it — and the tempting default, treating null as "not covered by
+        // any restriction", would make every upload visible to everyone the moment filtering is
+        // switched on.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<KnowledgeDbContext>();
+
+        var container = new ContainerEntity { Id = Guid.NewGuid(), Name = $"c-{Guid.NewGuid():N}" };
+        db.Containers.Add(container);
+
+        var document = new DocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            ContainerId = container.Id,
+            FileName = "upload.md",
+            Path = "/upload.md",
+            ResourceUri = null,
+            ContentHash = Guid.NewGuid().ToString("N"),
+            Status = "Ready",
+            CreatedAt = DateTime.UtcNow,
+            Metadata = [],
+        };
+        db.Documents.Add(document);
+        db.Chunks.Add(new ChunkEntity
+        {
+            Id = Guid.NewGuid(),
+            DocumentId = document.Id,
+            OwnerId = container.Id,
+            Content = $"the {Term} appears here",
+            ChunkIndex = 0,
+            Metadata = [],
+        });
+        await db.SaveChangesAsync();
+
+        var service = Build(scope.ServiceProvider);
+
+        (await service.SearchAsync(Term, For(container.Id), SearchScopes.Unrestricted))
+            .Should().ContainSingle("the document is findable when nothing is filtering");
+
+        (await service.SearchAsync(Term, For(container.Id), SearchScopes.Of(["s3://acme/"])))
+            .Should().BeEmpty("a document with no location cannot be inside any scope");
+    }
+}


### PR DESCRIPTION
## What

The enforcement half of per-user search permissions: a resolver seam, a scope type, and a predicate in both search stores.

Phase 4 of [#421](https://github.com/Destrayon/Connapse/issues/421). **Behaviour is unchanged** — the resolver registered by default returns `Unrestricted`, so a deployment opts in to filtering by registering one that resolves something. There is no such resolver yet; that is phase 6.

## Pre-filter, not post-filter

The predicate goes into the query. A post-filter takes the top K and then removes most of it, so a user with narrow access gets a handful of hits for a query that had plenty — **worse answers for being less privileged**, with nothing on screen to say why. It also uses the `text_pattern_ops` index added in #423, which exists for exactly this `LIKE 'prefix%'` shape.

## The distinction the whole thing rests on

`SearchScopes` keeps **`Unrestricted`** and **`None`** as separate states rather than both being an empty list:

- `Unrestricted` — this deployment does not filter
- `None` — this user reaches nothing

A type that conflated them would turn a misconfiguration into an open door. `Of()` with nothing usable resolves to `None`, and blank prefixes are dropped — one stray empty string would match every URI and grant everything to a user who should see one bucket.

## A null resource URI is denied, never allowed

A document nothing can locate is one no permission rule can be checked against. The tempting reading — "not covered by any restriction" — would make **every upload visible to everyone** the moment filtering was switched on. There is an integration test for exactly this, including a control proving the document is findable when nothing is filtering.

## Two smaller calls

**Scopes resolve once, where the query fans out**, not inside each leaf. Two resolutions for one query would make hybrid the mode in which they could disagree — half a result set from one set of permissions and half from another, indistinguishable from outside.

**The leaf services take scopes as a required parameter with no default**, so forgetting it does not compile. Forgetting it would return everything to everyone, which is the one mistake here that looks exactly like success. The compiler found all four call sites when I changed the signature.

## Verification

**1,325 unit tests and 390 integration tests green.**

The four enforcement tests assert the *negative* — that a document outside the scope is **absent** — because a filter that does not filter passes every positive assertion about hit counts and ordering. One is a control proving the excluded document is findable without scopes, so the others cannot pass by finding nothing for an unrelated reason.

Keyword rather than vector, deliberately: it needs no embedding provider, and exercises the same predicate against the same join. A test requiring Ollama would be one more reason for this to be skipped in the environment where it matters most — which [#424](https://github.com/Destrayon/Connapse/issues/424) showed is not hypothetical.

## Still missing

Nothing resolves real scopes yet, so this is machinery with one production implementation that permits everything. Phases 5 and 6 — OIDC sign-in and the S3 Access Grants resolver — are what make it do anything. The claims corrected in #422 stay corrected until then.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added search scopes to restrict results to permitted resource paths.
  * Searches now support unrestricted, restricted, and no-access scopes.
  * User-specific scopes are resolved before hybrid, keyword, and vector searches.
  * Restricted searches exclude inaccessible resources and documents without resource paths.
  * Resource-path matching safely handles literal underscores, percent signs, and escape characters.

* **Bug Fixes**
  * Prevented empty-permission searches from returning results.
  * Applied permission filtering consistently across search methods.

* **Tests**
  * Added coverage for scope creation, filtering, access scenarios, and pattern escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->