### PR TITLE
feat(identity): connect an AWS identity through Cognito

### DIFF
--- a/docs/superpowers/plans/2026-08-28-per-user-permissions-5b-connect-aws-identity.md
+++ b/docs/superpowers/plans/2026-08-28-per-user-permissions-5b-connect-aws-identity.md
@@ -699,7 +699,7 @@ Two endpoints mirroring the `/azure/connect` and `/azure/callback` pair that alr
 
 **Interfaces:**
 - Consumes: `CognitoSettings` (Task 1), `AwsIdentityLinkStore` (Task 3).
-- Produces: `GET /api/cloud-identity/cognito/connect` → 302 to the pool's authorize endpoint; `GET /api/cloud-identity/cognito/callback` → exchanges the code and stores the token.
+- Produces: `GET /api/v1/auth/cloud/cognito/connect` → 302 to the pool's authorize endpoint; `GET /api/v1/auth/cloud/cognito/callback` → exchanges the code and stores the token.
 
 - [ ] **Step 1: Read the Azure pair**
 
@@ -739,7 +739,7 @@ public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
             AllowAutoRedirect = false,
         });
 
-        var response = await client.GetAsync("/api/cloud-identity/cognito/connect");
+        var response = await client.GetAsync("/api/v1/auth/cloud/cognito/connect");
 
         response.StatusCode.Should().NotBe(HttpStatusCode.Redirect,
             "there is nowhere valid to redirect to");
@@ -755,7 +755,7 @@ public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
             AllowAutoRedirect = false,
         });
 
-        var response = await client.GetAsync("/api/cloud-identity/cognito/callback?code=abc");
+        var response = await client.GetAsync("/api/v1/auth/cloud/cognito/callback?code=abc");
 
         response.StatusCode.Should().NotBe(HttpStatusCode.OK);
     }
@@ -769,7 +769,7 @@ public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
         });
 
         var response = await client.GetAsync(
-            "/api/cloud-identity/cognito/callback?code=abc&state=not-a-state-we-issued");
+            "/api/v1/auth/cloud/cognito/callback?code=abc&state=not-a-state-we-issued");
 
         response.StatusCode.Should().NotBe(HttpStatusCode.OK);
     }
@@ -992,7 +992,7 @@ Expected: FAIL — the markup contains none of it.
 In the Cloud Identities section of `src/Connapse.Web/Components/Pages/ProfileIntegrations.razor`, add a card beside the existing AWS and Azure ones. It shows one of three states:
 
 - **Not configured** — Cognito settings are absent. Say an administrator sets this up, and do not offer a button that cannot work.
-- **Not connected** — a Connect button that navigates to `/api/cloud-identity/cognito/connect`.
+- **Not connected** — a Connect button that navigates to `/api/v1/auth/cloud/cognito/connect`.
 - **Connected** — the email it is connected as, when, and a Disconnect button.
 
 **Disconnect must revoke, not just forget.** Deleting the local row leaves the refresh token valid at Cognito, so anything that already copied it keeps working — the link is gone from Connapse's point of view and alive from AWS's. Call the pool's `POST {Domain}/oauth2/revoke` with the token and the client credentials **before** deleting the row, and delete the row whether or not revocation succeeded: a user who clicks Disconnect must end up disconnected locally regardless of what AWS says.

--- a/src/Connapse.Core/Models/AuthModels.cs
+++ b/src/Connapse.Core/Models/AuthModels.cs
@@ -119,5 +119,13 @@ public record AwsIdentityLinkDto(string Email, DateTime ConnectedAt, DateTime? L
 /// <see cref="Deleted"/> and <see cref="RevokedSuccessfully"/> are independent: the local row is
 /// removed regardless of whether Cognito could be told, so a caller can report "disconnected here,
 /// but AWS could not be told" instead of a uniformly clean success.
+/// <para>
+/// <see cref="LinkChangedDuringDisconnect"/> is a third, distinct outcome from a plain "nothing to
+/// delete": it means a link existed, its token was revoked, but a reconnect replaced the row
+/// before the delete could run — so the row was deliberately left in place rather than removing a
+/// link that was never revoked. <see cref="Deleted"/> is false in this case too, but the caller
+/// must tell the two apart to say "try again" instead of "nothing was connected".
+/// </para>
 /// </remarks>
-public record AwsIdentityLinkDisconnectResult(bool Deleted, bool RevokedSuccessfully);
+public record AwsIdentityLinkDisconnectResult(
+    bool Deleted, bool RevokedSuccessfully, bool LinkChangedDuringDisconnect = false);

--- a/src/Connapse.Core/Models/AuthModels.cs
+++ b/src/Connapse.Core/Models/AuthModels.cs
@@ -105,3 +105,19 @@ public record AwsDeviceAuthStartResult(
     string DeviceCode,
     int ExpiresInSeconds,
     int IntervalSeconds);
+
+/// <summary>
+/// A user's connected AWS (Cognito) identity link, as the integrations page needs to show it —
+/// never the refresh token itself.
+/// </summary>
+public record AwsIdentityLinkDto(string Email, DateTime ConnectedAt, DateTime? LastUsedAt);
+
+/// <summary>
+/// The outcome of disconnecting an AWS identity link.
+/// </summary>
+/// <remarks>
+/// <see cref="Deleted"/> and <see cref="RevokedSuccessfully"/> are independent: the local row is
+/// removed regardless of whether Cognito could be told, so a caller can report "disconnected here,
+/// but AWS could not be told" instead of a uniformly clean success.
+/// </remarks>
+public record AwsIdentityLinkDisconnectResult(bool Deleted, bool RevokedSuccessfully);

--- a/src/Connapse.Core/Models/CognitoSettings.cs
+++ b/src/Connapse.Core/Models/CognitoSettings.cs
@@ -1,0 +1,67 @@
+namespace Connapse.Core;
+
+/// <summary>
+/// The customer's Amazon Cognito user pool — the identity provider they host inside their own AWS
+/// account so that Connapse can prove which AWS identity a user is.
+/// </summary>
+/// <remarks>
+/// A mutable class with a <c>SectionName</c> rather than a record, matching <see cref="AwsSsoSettings"/>
+/// and every other settings category: they are bound by the options system and edited by an admin
+/// form, both of which want settable properties.
+/// <para>
+/// <see cref="ClientSecret"/> is a secret at rest in the settings table like every other provider
+/// credential here. It is not a per-user secret — one pool, one client, shared by the deployment.
+/// </para>
+/// </remarks>
+public class CognitoSettings
+{
+    public const string SectionName = "Identity:Cognito";
+
+    /// <summary>
+    /// The pool's OIDC issuer, <c>https://cognito-idp.{region}.amazonaws.com/{poolId}</c>.
+    /// </summary>
+    /// <remarks>
+    /// This exact string is what an issued token carries as its <c>iss</c> claim and what the
+    /// Identity Center trusted token issuer is registered against. A mismatch between the two is
+    /// rejected at exchange time with an error that names neither side.
+    /// </remarks>
+    public string IssuerUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The pool's hosted UI domain, which is where <c>/oauth2/authorize</c> lives.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="IssuerUrl"/> and genuinely needed: the token exchange against
+    /// Identity Center works on a pool with no domain, but the browser redirect that starts this
+    /// flow does not exist without one.
+    /// </remarks>
+    public string Domain { get; set; } = string.Empty;
+
+    /// <summary>The app client id. Also the audience the Identity Center grant authorises.</summary>
+    public string ClientId { get; set; } = string.Empty;
+
+    public string ClientSecret { get; set; } = string.Empty;
+
+    public string Region { get; set; } = string.Empty;
+
+    /// <summary>True when every field needed to complete a connection is present and usable.</summary>
+    /// <remarks>
+    /// The URLs must be HTTPS, with <c>http://localhost</c> the only exception. Both carry an
+    /// authorization code or a token, so a plain-HTTP hop puts a credential on the wire in
+    /// cleartext — and a non-empty check alone would happily accept one. Cognito enforces the same
+    /// rule on its side for callback URLs, so anything else was never going to work anyway; failing
+    /// here says why, rather than leaving the operator with a rejection from AWS.
+    /// </remarks>
+    public bool IsConfigured =>
+        IsSecureUrl(IssuerUrl)
+        && IsSecureUrl(Domain)
+        && !string.IsNullOrWhiteSpace(ClientId)
+        && !string.IsNullOrWhiteSpace(ClientSecret)
+        && !string.IsNullOrWhiteSpace(Region);
+
+    /// <summary>HTTPS, or loopback HTTP for a single-machine deployment.</summary>
+    internal static bool IsSecureUrl(string value) =>
+        Uri.TryCreate(value, UriKind.Absolute, out var uri)
+        && (uri.Scheme == Uri.UriSchemeHttps
+            || (uri.Scheme == Uri.UriSchemeHttp && uri.IsLoopback));
+}

--- a/src/Connapse.Core/Models/CognitoSettings.cs
+++ b/src/Connapse.Core/Models/CognitoSettings.cs
@@ -46,11 +46,15 @@ public class CognitoSettings
 
     /// <summary>True when every field needed to complete a connection is present and usable.</summary>
     /// <remarks>
-    /// The URLs must be HTTPS, with <c>http://localhost</c> the only exception. Both carry an
-    /// authorization code or a token, so a plain-HTTP hop puts a credential on the wire in
-    /// cleartext — and a non-empty check alone would happily accept one. Cognito enforces the same
-    /// rule on its side for callback URLs, so anything else was never going to work anyway; failing
-    /// here says why, rather than leaving the operator with a rejection from AWS.
+    /// The URLs must be HTTPS, with no loopback exception. Both carry an authorization code or a
+    /// token, so a plain-HTTP hop puts a credential on the wire in cleartext — and a non-empty
+    /// check alone would happily accept one. Unlike the OAuth redirect URI (Connapse's own
+    /// address, computed from the incoming request rather than stored here), <see cref="IssuerUrl"/>
+    /// and <see cref="Domain"/> are always AWS-hosted: there is no such thing as a localhost
+    /// Cognito pool, so a loopback exception on these two would only widen what is accepted
+    /// without buying anything. Cognito enforces HTTPS on its side too, so anything else was never
+    /// going to work anyway; failing here says why, rather than leaving the operator with a
+    /// rejection from AWS.
     /// </remarks>
     public bool IsConfigured =>
         IsSecureUrl(IssuerUrl)
@@ -59,9 +63,16 @@ public class CognitoSettings
         && !string.IsNullOrWhiteSpace(ClientSecret)
         && !string.IsNullOrWhiteSpace(Region);
 
-    /// <summary>HTTPS, or loopback HTTP for a single-machine deployment.</summary>
+    /// <summary>HTTPS only — these are the provider's own endpoints, not Connapse's.</summary>
+    /// <remarks>
+    /// No loopback exception. That exception belongs to the OAuth redirect URI, which is
+    /// Connapse's own address and is not part of this settings type at all — it is computed from
+    /// the incoming request when the flow starts. <see cref="IssuerUrl"/> and <see cref="Domain"/>
+    /// are always AWS-hosted (<c>https://cognito-idp.{region}.amazonaws.com/{poolId}</c> and
+    /// <c>https://{prefix}.auth.{region}.amazoncognito.com</c>), so there is no equivalent
+    /// single-machine case to allow for.
+    /// </remarks>
     internal static bool IsSecureUrl(string value) =>
         Uri.TryCreate(value, UriKind.Absolute, out var uri)
-        && (uri.Scheme == Uri.UriSchemeHttps
-            || (uri.Scheme == Uri.UriSchemeHttp && uri.IsLoopback));
+        && uri.Scheme == Uri.UriSchemeHttps;
 }

--- a/src/Connapse.Identity/Data/ConnapseIdentityDbContext.cs
+++ b/src/Connapse.Identity/Data/ConnapseIdentityDbContext.cs
@@ -20,6 +20,7 @@ public class ConnapseIdentityDbContext(DbContextOptions<ConnapseIdentityDbContex
     public DbSet<OAuthClientEntity> OAuthClients => Set<OAuthClientEntity>();
     public DbSet<OAuthAuthCodeEntity> OAuthAuthCodes => Set<OAuthAuthCodeEntity>();
     public DbSet<UserCloudIdentityEntity> UserCloudIdentities => Set<UserCloudIdentityEntity>();
+    public DbSet<UserAwsIdentityLinkEntity> UserAwsIdentityLinks => Set<UserAwsIdentityLinkEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -35,6 +36,7 @@ public class ConnapseIdentityDbContext(DbContextOptions<ConnapseIdentityDbContex
         ConfigureOAuthClients(modelBuilder);
         ConfigureOAuthAuthCodes(modelBuilder);
         ConfigureUserCloudIdentities(modelBuilder);
+        ConfigureUserAwsIdentityLinks(modelBuilder);
     }
 
     private static void ConfigureIdentityTables(ModelBuilder modelBuilder)
@@ -624,6 +626,50 @@ public class ConnapseIdentityDbContext(DbContextOptions<ConnapseIdentityDbContex
 
             entity.HasOne(e => e.User)
                 .WithMany(u => u.CloudIdentities)
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+
+    private static void ConfigureUserAwsIdentityLinks(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<UserAwsIdentityLinkEntity>(entity =>
+        {
+            entity.ToTable("user_aws_identity_links");
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.Id)
+                .HasColumnName("id")
+                .HasDefaultValueSql("gen_random_uuid()");
+
+            entity.Property(e => e.UserId)
+                .HasColumnName("user_id")
+                .IsRequired();
+
+            entity.Property(e => e.Email)
+                .HasColumnName("email")
+                .HasMaxLength(320)
+                .IsRequired();
+
+            entity.Property(e => e.ProtectedRefreshToken)
+                .HasColumnName("protected_refresh_token")
+                .IsRequired();
+
+            entity.Property(e => e.ConnectedAt)
+                .HasColumnName("connected_at")
+                .HasDefaultValueSql("now()");
+
+            entity.Property(e => e.LastUsedAt)
+                .HasColumnName("last_used_at");
+
+            // One link per user: connecting again replaces it, so nothing has to decide which of
+            // two stored tokens is the live one.
+            entity.HasIndex(e => e.UserId)
+                .HasDatabaseName("ix_user_aws_identity_links_user_id")
+                .IsUnique();
+
+            entity.HasOne(e => e.User)
+                .WithMany()
                 .HasForeignKey(e => e.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
         });

--- a/src/Connapse.Identity/Data/Entities/UserAwsIdentityLinkEntity.cs
+++ b/src/Connapse.Identity/Data/Entities/UserAwsIdentityLinkEntity.cs
@@ -1,0 +1,49 @@
+namespace Connapse.Identity.Data.Entities;
+
+/// <summary>
+/// A Connapse user's connected AWS identity, and the token that lets Connapse prove it again later
+/// without them present.
+/// </summary>
+/// <remarks>
+/// Separate from <see cref="UserCloudIdentityEntity"/> on purpose. That entity records which cloud
+/// account a user signed into, as plaintext metadata in a JSON column, and it predates this feature.
+/// A refresh token is a per-user secret; putting one in a column built for display metadata would
+/// be a mistake nothing in the type system would catch.
+/// <para>
+/// One row per user, enforced by a unique index. Connecting again replaces the row rather than
+/// adding a second, so there is never a question of which token is current.
+/// </para>
+/// </remarks>
+public class UserAwsIdentityLinkEntity
+{
+    public Guid Id { get; set; }
+
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// The verified email the token was issued for, and the join key into IAM Identity Center.
+    /// </summary>
+    /// <remarks>
+    /// Stored rather than re-read from the token because it is what a later exchange is matched on,
+    /// and because it lets the integrations page say which identity is connected without decrypting
+    /// anything. AWS accepts only user name, email or external ID as the claim mapped to a directory
+    /// user, so the opaque OIDC subject cannot serve here.
+    /// </remarks>
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The Cognito refresh token, already through ASP.NET Core Data Protection.
+    /// </summary>
+    /// <remarks>
+    /// Named for its state so that assigning a plaintext token reads as wrong at the call site.
+    /// Only <c>AwsIdentityLinkStore</c> protects and unprotects it; nothing else should hold the
+    /// plaintext for longer than one exchange.
+    /// </remarks>
+    public string ProtectedRefreshToken { get; set; } = string.Empty;
+
+    public DateTime ConnectedAt { get; set; }
+
+    public DateTime? LastUsedAt { get; set; }
+
+    public ConnapseUser User { get; set; } = null!;
+}

--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -79,6 +79,7 @@ public static class IdentityServiceExtensions
         services.Configure<JwtSettings>(configuration.GetSection(JwtSettings.SectionName));
         services.Configure<AzureAdSettings>(configuration.GetSection(AzureAdSettings.SectionName));
         services.Configure<AwsSsoSettings>(configuration.GetSection(AwsSsoSettings.SectionName));
+        services.Configure<CognitoSettings>(configuration.GetSection(CognitoSettings.SectionName));
 
         // Ensure JWT secret is available
         EnsureJwtSecret(configuration);

--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -73,6 +73,7 @@ public static class IdentityServiceExtensions
         services.AddScoped<ICloudIdentityStore, Stores.PostgresCloudIdentityStore>();
         services.AddScoped<ICloudIdentityService, CloudIdentityService>();
         services.AddScoped<AwsIdentityLinkStore>();
+        services.AddScoped<IAwsIdentityLinkService, AwsIdentityLinkService>();
         services.AddHttpContextAccessor();
 
         // Configure JWT settings

--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -38,6 +38,12 @@ public static class IdentityServiceExtensions
             options.UseNpgsql(connectionString, npgsql =>
                 npgsql.MigrationsHistoryTable("__EFMigrationsHistory_Identity")));
 
+        // Factory for short-lived per-operation contexts (required for Blazor Server and background
+        // services to avoid concurrent DbContext access on the same scoped instance).
+        services.AddDbContextFactory<ConnapseIdentityDbContext>(options =>
+            options.UseNpgsql(connectionString, npgsql =>
+                npgsql.MigrationsHistoryTable("__EFMigrationsHistory_Identity")), ServiceLifetime.Scoped);
+
         // Register ASP.NET Core Identity with API endpoint support
         services.AddIdentity<ConnapseUser, ConnapseRole>(options =>
             {
@@ -66,6 +72,7 @@ public static class IdentityServiceExtensions
         services.AddHttpClient<OAuthClientService>();
         services.AddScoped<ICloudIdentityStore, Stores.PostgresCloudIdentityStore>();
         services.AddScoped<ICloudIdentityService, CloudIdentityService>();
+        services.AddScoped<AwsIdentityLinkStore>();
         services.AddHttpContextAccessor();
 
         // Configure JWT settings

--- a/src/Connapse.Identity/Migrations/20260828022243_AddUserAwsIdentityLinks.Designer.cs
+++ b/src/Connapse.Identity/Migrations/20260828022243_AddUserAwsIdentityLinks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Connapse.Identity.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Connapse.Identity.Migrations
 {
     [DbContext(typeof(ConnapseIdentityDbContext))]
-    partial class ConnapseIdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260828022243_AddUserAwsIdentityLinks")]
+    partial class AddUserAwsIdentityLinks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Connapse.Identity/Migrations/20260828022243_AddUserAwsIdentityLinks.cs
+++ b/src/Connapse.Identity/Migrations/20260828022243_AddUserAwsIdentityLinks.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Connapse.Identity.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserAwsIdentityLinks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "user_aws_identity_links",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    email = table.Column<string>(type: "character varying(320)", maxLength: 320, nullable: false),
+                    protected_refresh_token = table.Column<string>(type: "text", nullable: false),
+                    connected_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    last_used_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_aws_identity_links", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_user_aws_identity_links_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_aws_identity_links_user_id",
+                table: "user_aws_identity_links",
+                column: "user_id",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "user_aws_identity_links");
+        }
+    }
+}

--- a/src/Connapse.Identity/Services/AwsIdentityLinkService.cs
+++ b/src/Connapse.Identity/Services/AwsIdentityLinkService.cs
@@ -29,11 +29,25 @@ public sealed class AwsIdentityLinkService(
 
     public async Task<AwsIdentityLinkDisconnectResult> DisconnectAsync(Guid userId, CancellationToken ct = default)
     {
-        var refreshToken = await linkStore.GetRefreshTokenAsync(userId, ct);
+        // One fetch serves both questions this needs answered — whether a row exists at all, and
+        // whether its token can be read — so a caller that must tell those two apart (this one)
+        // does not pay for a second round trip to do it. GetRefreshTokenAsync collapses both into
+        // a single null and is right to for its own simpler callers, but "no link" and "link
+        // present, token unreadable" are not the same case here: only the first has nothing to
+        // revoke. The second is a real link Connapse simply lost the ability to speak for, and
+        // that is a revocation failure, not a no-op.
+        var link = await linkStore.GetAsync(userId, ct);
 
-        // Nothing to revoke either because there was never a link, or because the stored token
-        // could no longer be decrypted — either way there is no live token this call can affect.
-        var revoked = refreshToken is null || await TryRevokeAsync(refreshToken, ct);
+        bool revoked;
+        if (link is null)
+        {
+            revoked = true; // Nothing to revoke — there was never a link.
+        }
+        else
+        {
+            var refreshToken = linkStore.TryUnprotectToken(link);
+            revoked = refreshToken is not null && await TryRevokeAsync(refreshToken, ct);
+        }
 
         // Delete unconditionally: a user who clicks Disconnect must end up disconnected locally
         // regardless of what AWS reports.

--- a/src/Connapse.Identity/Services/AwsIdentityLinkService.cs
+++ b/src/Connapse.Identity/Services/AwsIdentityLinkService.cs
@@ -11,9 +11,11 @@ namespace Connapse.Identity.Services;
 /// <remarks>
 /// Deleting the local row without revoking would leave the refresh token valid at Cognito — anything
 /// that already holds a copy keeps working while Connapse reports the link gone. So the order here is
-/// fixed: try to revoke first, then delete the row unconditionally. A revocation failure is reported
-/// back to the caller rather than swallowed, so the UI can say the token may still be live instead of
-/// claiming a clean disconnect.
+/// fixed: try to revoke first, then delete only the row just revoked (discriminated by its protected
+/// token value, not its Id — see <see cref="AwsIdentityLinkStore.DeleteAsync(Guid, string, CancellationToken)"/>),
+/// so a reconnect racing the disconnect can never lose a link it never revoked. A revocation failure
+/// is reported back to the caller rather than swallowed, so the UI can say the token may still be live
+/// instead of claiming a clean disconnect.
 /// </remarks>
 public sealed class AwsIdentityLinkService(
     AwsIdentityLinkStore linkStore,
@@ -38,22 +40,29 @@ public sealed class AwsIdentityLinkService(
         // that is a revocation failure, not a no-op.
         var link = await linkStore.GetAsync(userId, ct);
 
-        bool revoked;
         if (link is null)
+            return new AwsIdentityLinkDisconnectResult(Deleted: false, RevokedSuccessfully: true);
+
+        var refreshToken = linkStore.TryUnprotectToken(link);
+        var revoked = refreshToken is not null && await TryRevokeAsync(refreshToken, ct);
+
+        // Delete only the row just revoked, not "whatever is there for this user now": a
+        // reconnect that raced this call runs SaveAsync between the fetch above and this delete,
+        // which updates the existing row in place and keeps its Id — so an Id-based delete would
+        // remove the new link while its refresh token stays live at Cognito, precisely what
+        // disconnect exists to prevent. The protected token value is the discriminator, since it
+        // changes on every SaveAsync; a mismatch means the row changed underneath this call, and
+        // the row is left alone for the caller to report and the user to retry.
+        var deleted = await linkStore.DeleteAsync(userId, link.ProtectedRefreshToken, ct);
+        var linkChanged = !deleted;
+
+        if (linkChanged)
         {
-            revoked = true; // Nothing to revoke — there was never a link.
-        }
-        else
-        {
-            var refreshToken = linkStore.TryUnprotectToken(link);
-            revoked = refreshToken is not null && await TryRevokeAsync(refreshToken, ct);
+            logger.LogWarning(
+                "AWS identity link changed for a user during disconnect; the row was left in place");
         }
 
-        // Delete unconditionally: a user who clicks Disconnect must end up disconnected locally
-        // regardless of what AWS reports.
-        var deleted = await linkStore.DeleteAsync(userId, ct);
-
-        return new AwsIdentityLinkDisconnectResult(deleted, revoked);
+        return new AwsIdentityLinkDisconnectResult(deleted, revoked, linkChanged);
     }
 
     private async Task<bool> TryRevokeAsync(string refreshToken, CancellationToken ct)

--- a/src/Connapse.Identity/Services/AwsIdentityLinkService.cs
+++ b/src/Connapse.Identity/Services/AwsIdentityLinkService.cs
@@ -1,0 +1,89 @@
+using Connapse.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>
+/// Wraps <see cref="AwsIdentityLinkStore"/> with the one piece of logic a store should not own: the
+/// live call to Cognito's <c>/oauth2/revoke</c> endpoint that a disconnect requires.
+/// </summary>
+/// <remarks>
+/// Deleting the local row without revoking would leave the refresh token valid at Cognito — anything
+/// that already holds a copy keeps working while Connapse reports the link gone. So the order here is
+/// fixed: try to revoke first, then delete the row unconditionally. A revocation failure is reported
+/// back to the caller rather than swallowed, so the UI can say the token may still be live instead of
+/// claiming a clean disconnect.
+/// </remarks>
+public sealed class AwsIdentityLinkService(
+    AwsIdentityLinkStore linkStore,
+    IOptionsMonitor<CognitoSettings> cognitoOptions,
+    IHttpClientFactory httpClientFactory,
+    ILogger<AwsIdentityLinkService> logger) : IAwsIdentityLinkService
+{
+    public async Task<AwsIdentityLinkDto?> GetAsync(Guid userId, CancellationToken ct = default)
+    {
+        var link = await linkStore.GetAsync(userId, ct);
+        return link is null ? null : new AwsIdentityLinkDto(link.Email, link.ConnectedAt, link.LastUsedAt);
+    }
+
+    public async Task<AwsIdentityLinkDisconnectResult> DisconnectAsync(Guid userId, CancellationToken ct = default)
+    {
+        var refreshToken = await linkStore.GetRefreshTokenAsync(userId, ct);
+
+        // Nothing to revoke either because there was never a link, or because the stored token
+        // could no longer be decrypted — either way there is no live token this call can affect.
+        var revoked = refreshToken is null || await TryRevokeAsync(refreshToken, ct);
+
+        // Delete unconditionally: a user who clicks Disconnect must end up disconnected locally
+        // regardless of what AWS reports.
+        var deleted = await linkStore.DeleteAsync(userId, ct);
+
+        return new AwsIdentityLinkDisconnectResult(deleted, revoked);
+    }
+
+    private async Task<bool> TryRevokeAsync(string refreshToken, CancellationToken ct)
+    {
+        var cognito = cognitoOptions.CurrentValue;
+        if (!cognito.IsConfigured)
+        {
+            // Settings can be cleared by an admin after a link was already established. There is
+            // no pool to call, so this cannot be treated as a successful revocation.
+            logger.LogWarning("Cannot revoke an AWS identity link because Cognito is not configured");
+            return false;
+        }
+
+        var httpClient = httpClientFactory.CreateClient();
+        // A browser is waiting on this. Don't rely on HttpClient's 100-second default.
+        httpClient.Timeout = TimeSpan.FromSeconds(10);
+
+        var revokeParams = new Dictionary<string, string>
+        {
+            ["token"] = refreshToken,
+            ["client_id"] = cognito.ClientId,
+            ["client_secret"] = cognito.ClientSecret,
+        };
+
+        try
+        {
+            // Never log revokeParams — it carries the refresh token and the client secret.
+            var response = await httpClient.PostAsync(
+                $"{cognito.Domain.TrimEnd('/')}/oauth2/revoke",
+                new FormUrlEncodedContent(revokeParams), ct);
+
+            if (response.IsSuccessStatusCode)
+                return true;
+
+            logger.LogWarning("Cognito token revocation failed with status {StatusCode}", response.StatusCode);
+            return false;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            // TaskCanceledException is what HttpClient throws on its own timeout above (and what a
+            // client-disconnect cancellation looks like) — neither carries the token or secret, so
+            // nothing more than the exception type is worth knowing here.
+            logger.LogWarning(ex, "Cognito token revocation could not reach the pool in time");
+            return false;
+        }
+    }
+}

--- a/src/Connapse.Identity/Services/AwsIdentityLinkStore.cs
+++ b/src/Connapse.Identity/Services/AwsIdentityLinkStore.cs
@@ -1,0 +1,114 @@
+using Connapse.Identity.Data;
+using Connapse.Identity.Data.Entities;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>
+/// Reads and writes a user's connected AWS identity, and is the only code that sees the refresh
+/// token in plaintext.
+/// </summary>
+/// <remarks>
+/// Encryption uses the Data Protection key ring already configured in <c>Program.cs</c>, which is
+/// persisted to the <c>appdata</c> volume — so a stored token survives a container restart. It is
+/// worth knowing what that does and does not buy: the ring is not itself encrypted at rest, so this
+/// protects a token against someone reading the database, not against someone with the volume.
+/// <para>
+/// The purpose string is deliberately specific. Data Protection derives a distinct key from it, so
+/// a payload protected here cannot be unprotected by any other part of the application even though
+/// they share a key ring.
+/// </para>
+/// </remarks>
+public sealed class AwsIdentityLinkStore(
+    IDbContextFactory<ConnapseIdentityDbContext> factory,
+    IDataProtectionProvider protectionProvider,
+    TimeProvider timeProvider)
+{
+    private const string Purpose = "Connapse.AwsIdentityLink.RefreshToken.v1";
+
+    private IDataProtector Protector => protectionProvider.CreateProtector(Purpose);
+
+    /// <summary>Stores a user's link, replacing any existing one.</summary>
+    public async Task SaveAsync(
+        Guid userId, string email, string refreshToken, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+        ArgumentException.ThrowIfNullOrWhiteSpace(refreshToken);
+
+        await using var db = await factory.CreateDbContextAsync(ct);
+
+        var existing = await db.UserAwsIdentityLinks
+            .SingleOrDefaultAsync(x => x.UserId == userId, ct);
+
+        // Replace rather than add: the unique index would reject a second row anyway, and an
+        // upsert keeps ConnectedAt meaning "when this link was established".
+        if (existing is null)
+        {
+            db.UserAwsIdentityLinks.Add(new UserAwsIdentityLinkEntity
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Email = email,
+                ProtectedRefreshToken = Protector.Protect(refreshToken),
+                ConnectedAt = timeProvider.GetUtcNow().UtcDateTime,
+            });
+        }
+        else
+        {
+            existing.Email = email;
+            existing.ProtectedRefreshToken = Protector.Protect(refreshToken);
+            existing.ConnectedAt = timeProvider.GetUtcNow().UtcDateTime;
+            existing.LastUsedAt = null;
+        }
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>The link's metadata, or null when the user has not connected one.</summary>
+    public async Task<UserAwsIdentityLinkEntity?> GetAsync(Guid userId, CancellationToken ct = default)
+    {
+        await using var db = await factory.CreateDbContextAsync(ct);
+        return await db.UserAwsIdentityLinks
+            .AsNoTracking()
+            .SingleOrDefaultAsync(x => x.UserId == userId, ct);
+    }
+
+    /// <summary>The plaintext refresh token, or null when there is no usable link.</summary>
+    /// <remarks>
+    /// Returns null rather than throwing when the stored payload cannot be unprotected. That
+    /// happens for one real reason — the key ring was lost or rotated beyond its retention — and a
+    /// caller cannot do anything about it except treat the link as absent and ask the user to
+    /// reconnect, which is exactly what null already means here.
+    /// </remarks>
+    public async Task<string?> GetRefreshTokenAsync(Guid userId, CancellationToken ct = default)
+    {
+        var link = await GetAsync(userId, ct);
+        if (link is null)
+            return null;
+
+        try
+        {
+            return Protector.Unprotect(link.ProtectedRefreshToken);
+        }
+        catch (System.Security.Cryptography.CryptographicException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Removes a user's link. False when there was nothing to remove.</summary>
+    public async Task<bool> DeleteAsync(Guid userId, CancellationToken ct = default)
+    {
+        await using var db = await factory.CreateDbContextAsync(ct);
+
+        var existing = await db.UserAwsIdentityLinks
+            .SingleOrDefaultAsync(x => x.UserId == userId, ct);
+        if (existing is null)
+            return false;
+
+        db.UserAwsIdentityLinks.Remove(existing);
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+}

--- a/src/Connapse.Identity/Services/AwsIdentityLinkStore.cs
+++ b/src/Connapse.Identity/Services/AwsIdentityLinkStore.cs
@@ -2,6 +2,7 @@ using Connapse.Identity.Data;
 using Connapse.Identity.Data.Entities;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace Connapse.Identity.Services;
 
@@ -30,6 +31,14 @@ public sealed class AwsIdentityLinkStore(
     private IDataProtector Protector => protectionProvider.CreateProtector(Purpose);
 
     /// <summary>Stores a user's link, replacing any existing one.</summary>
+    /// <remarks>
+    /// The read-then-write below is not itself atomic — two concurrent connects for the same user
+    /// can both read "no row" and both try to insert. Without the catch below, the unique index on
+    /// <c>user_id</c> would reject whichever insert loses that race with an unhandled
+    /// <see cref="DbUpdateException"/> instead of one link simply winning. Catching the violation
+    /// and falling back to an update keeps this correct without a raw-SQL <c>ON CONFLICT</c>
+    /// upsert, which the EF Core InMemory provider (used by this store's unit tests) cannot run.
+    /// </remarks>
     public async Task SaveAsync(
         Guid userId, string email, string refreshToken, CancellationToken ct = default)
     {
@@ -45,25 +54,43 @@ public sealed class AwsIdentityLinkStore(
         // upsert keeps ConnectedAt meaning "when this link was established".
         if (existing is null)
         {
-            db.UserAwsIdentityLinks.Add(new UserAwsIdentityLinkEntity
+            var candidate = new UserAwsIdentityLinkEntity
             {
                 Id = Guid.NewGuid(),
                 UserId = userId,
                 Email = email,
                 ProtectedRefreshToken = Protector.Protect(refreshToken),
                 ConnectedAt = timeProvider.GetUtcNow().UtcDateTime,
-            });
+            };
+            db.UserAwsIdentityLinks.Add(candidate);
+
+            try
+            {
+                await db.SaveChangesAsync(ct);
+                return;
+            }
+            catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+            {
+                // Lost a race with a concurrent connect for the same user: the row now exists
+                // because someone else's insert landed first between our read above and this
+                // write. Detach the insert the unique index rejected — otherwise the next
+                // SaveChangesAsync below would try to re-insert it alongside the update — and
+                // fall through to update the row that won instead of surfacing the violation.
+                db.Entry(candidate).State = EntityState.Detached;
+                existing = await db.UserAwsIdentityLinks.SingleAsync(x => x.UserId == userId, ct);
+            }
         }
-        else
-        {
-            existing.Email = email;
-            existing.ProtectedRefreshToken = Protector.Protect(refreshToken);
-            existing.ConnectedAt = timeProvider.GetUtcNow().UtcDateTime;
-            existing.LastUsedAt = null;
-        }
+
+        existing.Email = email;
+        existing.ProtectedRefreshToken = Protector.Protect(refreshToken);
+        existing.ConnectedAt = timeProvider.GetUtcNow().UtcDateTime;
+        existing.LastUsedAt = null;
 
         await db.SaveChangesAsync(ct);
     }
+
+    private static bool IsUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation };
 
     /// <summary>The link's metadata, or null when the user has not connected one.</summary>
     public async Task<UserAwsIdentityLinkEntity?> GetAsync(Guid userId, CancellationToken ct = default)
@@ -121,6 +148,36 @@ public sealed class AwsIdentityLinkStore(
         var existing = await db.UserAwsIdentityLinks
             .SingleOrDefaultAsync(x => x.UserId == userId, ct);
         if (existing is null)
+            return false;
+
+        db.UserAwsIdentityLinks.Remove(existing);
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+
+    /// <summary>
+    /// Removes a user's link only if its <see cref="UserAwsIdentityLinkEntity.ProtectedRefreshToken"/>
+    /// still matches <paramref name="expectedProtectedRefreshToken"/>. False, and the row left
+    /// untouched, when there is no row or when the token no longer matches.
+    /// </summary>
+    /// <remarks>
+    /// For a caller (a disconnect) that read the link, revoked its token elsewhere, and must now
+    /// delete exactly that row and no other. An <c>Id</c> comparison would not be enough: a
+    /// reconnect that raced the disconnect runs <see cref="SaveAsync"/>, which updates the
+    /// existing row in place and keeps its <c>Id</c> — so a plain <c>DeleteAsync(userId)</c>
+    /// between the read and this call would remove the new link while its refresh token stays live
+    /// at the provider, which is exactly the outcome a disconnect exists to prevent. The protected
+    /// token value changes on every <see cref="SaveAsync"/>, so a match here proves the row is
+    /// still the one the caller revoked.
+    /// </remarks>
+    public async Task<bool> DeleteAsync(
+        Guid userId, string expectedProtectedRefreshToken, CancellationToken ct = default)
+    {
+        await using var db = await factory.CreateDbContextAsync(ct);
+
+        var existing = await db.UserAwsIdentityLinks
+            .SingleOrDefaultAsync(x => x.UserId == userId, ct);
+        if (existing is null || existing.ProtectedRefreshToken != expectedProtectedRefreshToken)
             return false;
 
         db.UserAwsIdentityLinks.Remove(existing);

--- a/src/Connapse.Identity/Services/AwsIdentityLinkStore.cs
+++ b/src/Connapse.Identity/Services/AwsIdentityLinkStore.cs
@@ -80,12 +80,28 @@ public sealed class AwsIdentityLinkStore(
     /// happens for one real reason — the key ring was lost or rotated beyond its retention — and a
     /// caller cannot do anything about it except treat the link as absent and ask the user to
     /// reconnect, which is exactly what null already means here.
+    /// <para>
+    /// Collapsing "no link" and "link present but unreadable" into the same null is fine for a
+    /// caller that only wants a usable token. A caller that must tell those two apart — a revoke
+    /// path needs to know whether it is skipping a real live token — should call <see cref="GetAsync"/>
+    /// once and pass the result to <see cref="TryUnprotectToken"/> instead, so the distinction is not
+    /// lost and no second round trip is needed to make it.
+    /// </para>
     /// </remarks>
     public async Task<string?> GetRefreshTokenAsync(Guid userId, CancellationToken ct = default)
     {
         var link = await GetAsync(userId, ct);
-        if (link is null)
-            return null;
+        return link is null ? null : TryUnprotectToken(link);
+    }
+
+    /// <summary>
+    /// Unprotects the token on an already-fetched link (from <see cref="GetAsync"/>), with no DB
+    /// access of its own. Null means the row exists but its token could not be decrypted — the
+    /// key-ring-lost-or-rotated case described on <see cref="GetRefreshTokenAsync"/>.
+    /// </summary>
+    public string? TryUnprotectToken(UserAwsIdentityLinkEntity link)
+    {
+        ArgumentNullException.ThrowIfNull(link);
 
         try
         {

--- a/src/Connapse.Identity/Services/CognitoIdTokenValidator.cs
+++ b/src/Connapse.Identity/Services/CognitoIdTokenValidator.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using Connapse.Core;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Connapse.Identity.Services;
@@ -22,6 +23,32 @@ namespace Connapse.Identity.Services;
 /// </remarks>
 public static class CognitoIdTokenValidator
 {
+    /// <summary>
+    /// Builds the <see cref="TokenValidationParameters"/> the callback endpoint validates a Cognito
+    /// ID token against: the pool's own issuer and client id from <paramref name="settings"/>, and
+    /// <paramref name="signingKeys"/> fetched by the caller from the pool's discovery document.
+    /// </summary>
+    /// <remarks>
+    /// Pulled out from the endpoint so the five validation flags are pinned by a named unit test
+    /// each — a single flag flipped back to <see langword="false"/> (or the endpoint forgetting to
+    /// call this at all) fails one specific test rather than silently weakening validation for
+    /// every token this deployment ever accepts.
+    /// </remarks>
+    public static TokenValidationParameters BuildValidationParameters(
+        CognitoSettings settings, IEnumerable<SecurityKey> signingKeys) =>
+        new()
+        {
+            ValidIssuer = settings.IssuerUrl,
+            ValidAudience = settings.ClientId,
+            IssuerSigningKeys = signingKeys,
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            RequireSignedTokens = true,
+            ClockSkew = TimeSpan.FromMinutes(2),
+        };
+
     /// <summary>
     /// Validates <paramref name="idToken"/> against <paramref name="validationParameters"/> (the
     /// pool's signing keys, issuer and audience — built by the caller from live discovery, or from

--- a/src/Connapse.Identity/Services/CognitoIdTokenValidator.cs
+++ b/src/Connapse.Identity/Services/CognitoIdTokenValidator.cs
@@ -1,0 +1,83 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>
+/// Validates a Cognito ID token's signature, issuer, audience and lifetime, then checks the nonce
+/// this deployment issued and that the pool has proven the email it carries.
+/// </summary>
+/// <remarks>
+/// Split out from the callback endpoint specifically so each rejection path — bad signature, wrong
+/// nonce, unverified email — can be exercised against a token forged locally with a throwaway
+/// signing key, without needing a live Cognito pool to mint a genuine one.
+/// <para>
+/// Worth knowing why signature validation is belt-and-braces rather than the only line of defence:
+/// the token arrives on a direct server-to-server call to the token endpoint, over TLS,
+/// authenticated with the client secret, and OIDC Core §3.1.3.7 permits skipping signature
+/// validation in exactly that case. It is done anyway because the claim being read here is the
+/// join key into an authorization decision.
+/// </para>
+/// </remarks>
+public static class CognitoIdTokenValidator
+{
+    /// <summary>
+    /// Validates <paramref name="idToken"/> against <paramref name="validationParameters"/> (the
+    /// pool's signing keys, issuer and audience — built by the caller from live discovery, or from
+    /// a throwaway key in a test), then checks its <c>nonce</c> claim against
+    /// <paramref name="expectedNonce"/> and that <c>email_verified</c> is true.
+    /// </summary>
+    public static CognitoIdTokenResult Validate(
+        string idToken,
+        TokenValidationParameters validationParameters,
+        string? expectedNonce)
+    {
+        // Cognito issues bare claim names ("email", "sub", ...). JwtSecurityTokenHandler's default
+        // inbound claim map rewrites well-known names like "email"/"sub" to legacy XML-schema
+        // claim URIs, which would make every lookup below fail silently. Disabling it on this
+        // instance only keeps the claims exactly as the token carries them.
+        JwtSecurityTokenHandler handler = new() { InboundClaimTypeMap = new Dictionary<string, string>() };
+        ClaimsPrincipal principal;
+        try
+        {
+            principal = handler.ValidateToken(idToken, validationParameters, out _);
+        }
+        catch (SecurityTokenException)
+        {
+            return CognitoIdTokenResult.Rejected("token_invalid");
+        }
+        catch (ArgumentException)
+        {
+            return CognitoIdTokenResult.Rejected("token_invalid");
+        }
+
+        // Rule: bind the nonce this deployment issued. Stops a token minted for a different
+        // authorization request being replayed into this one.
+        string? tokenNonce = principal.FindFirst("nonce")?.Value;
+        if (string.IsNullOrEmpty(expectedNonce) || string.IsNullOrEmpty(tokenNonce) ||
+            !string.Equals(tokenNonce, expectedNonce, StringComparison.Ordinal))
+        {
+            return CognitoIdTokenResult.Rejected("nonce_mismatch");
+        }
+
+        // Rule: refuse an unverified email. The pool has not proven the address, and the address
+        // is the join key into Identity Center.
+        string? emailVerified = principal.FindFirst("email_verified")?.Value;
+        string? email = principal.FindFirst("email")?.Value;
+        if (!string.Equals(emailVerified, "true", StringComparison.OrdinalIgnoreCase) ||
+            string.IsNullOrWhiteSpace(email))
+        {
+            return CognitoIdTokenResult.Rejected("email_not_verified");
+        }
+
+        return CognitoIdTokenResult.Accepted(email);
+    }
+}
+
+/// <summary>The outcome of validating a Cognito ID token: either the verified email, or why not.</summary>
+public sealed record CognitoIdTokenResult(bool Success, string? Email, string? FailureReason)
+{
+    public static CognitoIdTokenResult Accepted(string email) => new(true, email, null);
+    public static CognitoIdTokenResult Rejected(string reason) => new(false, null, reason);
+}

--- a/src/Connapse.Identity/Services/IAwsIdentityLinkService.cs
+++ b/src/Connapse.Identity/Services/IAwsIdentityLinkService.cs
@@ -1,0 +1,20 @@
+using Connapse.Core;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>
+/// The read/disconnect side of a user's Cognito-based AWS identity link, for the integrations page
+/// and any other caller that needs the link's state without touching <see cref="AwsIdentityLinkStore"/>
+/// directly.
+/// </summary>
+public interface IAwsIdentityLinkService
+{
+    /// <summary>The link's display state, or null when the user has not connected one.</summary>
+    Task<AwsIdentityLinkDto?> GetAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Revokes the refresh token at Cognito, then deletes the local row regardless of whether
+    /// revocation succeeded — see <see cref="AwsIdentityLinkDisconnectResult"/>.
+    /// </summary>
+    Task<AwsIdentityLinkDisconnectResult> DisconnectAsync(Guid userId, CancellationToken ct = default);
+}

--- a/src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs
+++ b/src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs
@@ -22,6 +22,7 @@ public class DatabaseSettingsProvider : ConfigurationProvider
         ["security"] = "Identity:Jwt",
         ["awssso"] = "Identity:AwsSso",
         ["azuread"] = "Identity:AzureAd",
+        ["cognito"] = "Identity:Cognito",
     };
 
     public DatabaseSettingsProvider(Action<DbContextOptionsBuilder> optionsAction)

--- a/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
+++ b/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
@@ -38,9 +38,11 @@
         <h2 class="h5 mb-0">Cloud Identities</h2>
     </div>
     <p class="text-muted small mb-4">
-        Link your cloud accounts so Connapse knows who you are in AWS or Azure. Only identity
-        metadata is stored — no access keys or tokens, and linking does not grant Connapse access to
-        your storage.
+        Link your cloud accounts so Connapse knows who you are in AWS or Azure. The AWS and Azure
+        sign-in cards below store identity metadata only — no access keys or tokens — and linking
+        does not grant Connapse access to your storage. The AWS Permissions card is different:
+        connecting it stores an encrypted refresh token so Connapse can check your AWS permissions
+        on your behalf.
         <br />
         <strong>Linking does not yet filter your search results.</strong> Per-user search
         permissions are not implemented, so every Connapse user can currently search everything
@@ -347,35 +349,40 @@
                         </p>
                     }
                 </div>
-                @if (cognitoConfigured)
+                @if (cognitoIdentity is not null)
                 {
+                    <!-- Always reachable, even if an admin cleared the pool settings after this user
+                         connected: disconnecting must never depend on cognitoConfigured, or a
+                         connected user's row (and its live refresh token) becomes unremovable
+                         through any surface. AwsIdentityLinkService.DisconnectAsync already
+                         handles the not-configured case — it deletes the local row and reports
+                         that AWS could not be told, rather than failing outright. -->
                     <div class="card-footer border-top-0 px-4 pb-4 pt-0">
-                        @if (cognitoIdentity is not null)
+                        @if (confirmDisconnectCognito)
                         {
-                            @if (confirmDisconnectCognito)
-                            {
-                                <div class="d-flex gap-2">
-                                    <button class="btn btn-sm btn-danger" @onclick="DisconnectCognitoAsync" disabled="@isProcessing">
-                                        Confirm Disconnect
-                                    </button>
-                                    <button class="btn btn-sm btn-outline-secondary" @onclick="() => confirmDisconnectCognito = false">
-                                        Cancel
-                                    </button>
-                                </div>
-                            }
-                            else
-                            {
-                                <button class="btn btn-sm btn-outline-danger" @onclick="() => confirmDisconnectCognito = true" disabled="@isProcessing">
-                                    <span class="bi-x-circle me-1"></span>Disconnect
+                            <div class="d-flex gap-2">
+                                <button class="btn btn-sm btn-danger" @onclick="DisconnectCognitoAsync" disabled="@isProcessing">
+                                    Confirm Disconnect
                                 </button>
-                            }
+                                <button class="btn btn-sm btn-outline-secondary" @onclick="() => confirmDisconnectCognito = false">
+                                    Cancel
+                                </button>
+                            </div>
                         }
                         else
                         {
-                            <button class="btn btn-sm btn-primary" @onclick="ConnectCognitoAsync" disabled="@isProcessing">
-                                <span class="bi-link-45deg me-1"></span>Connect AWS Permissions
+                            <button class="btn btn-sm btn-outline-danger" @onclick="() => confirmDisconnectCognito = true" disabled="@isProcessing">
+                                <span class="bi-x-circle me-1"></span>Disconnect
                             </button>
                         }
+                    </div>
+                }
+                else if (cognitoConfigured)
+                {
+                    <div class="card-footer border-top-0 px-4 pb-4 pt-0">
+                        <button class="btn btn-sm btn-primary" @onclick="ConnectCognitoAsync" disabled="@isProcessing">
+                            <span class="bi-link-45deg me-1"></span>Connect AWS Permissions
+                        </button>
                     </div>
                 }
             </div>
@@ -449,6 +456,7 @@
             "exchange_failed" => "Could not connect your AWS identity: the token exchange with Cognito failed.",
             "token_invalid" => "Could not connect your AWS identity: Cognito returned a token that could not be verified.",
             "nonce_mismatch" => "Could not connect your AWS identity: the response did not match the request that started it. Please try again.",
+            "user_mismatch" => "Could not connect your AWS identity: you were signed in as a different user by the time AWS responded. Please try again.",
             "email_not_verified" => "Could not connect your AWS identity: AWS reports your email address is not verified.",
             _ => "Could not connect your AWS identity. Please try again.",
         };
@@ -462,7 +470,7 @@
 
     private void ConnectCognitoAsync()
     {
-        Navigation.NavigateTo("/api/cloud-identity/cognito/connect", forceLoad: true);
+        Navigation.NavigateTo("/api/v1/auth/cloud/cognito/connect", forceLoad: true);
     }
 
     private async Task DisconnectCognitoAsync()

--- a/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
+++ b/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
@@ -458,6 +458,8 @@
             "nonce_mismatch" => "Could not connect your AWS identity: the response did not match the request that started it. Please try again.",
             "user_mismatch" => "Could not connect your AWS identity: you were signed in as a different user by the time AWS responded. Please try again.",
             "email_not_verified" => "Could not connect your AWS identity: AWS reports your email address is not verified.",
+            "user_cancelled" => "AWS sign-in was cancelled.",
+            "provider_error" => "Could not connect your AWS identity: Cognito reported a problem with the request.",
             _ => "Could not connect your AWS identity. Please try again.",
         };
         statusSuccess = false;
@@ -481,7 +483,16 @@
         try
         {
             var result = await AwsIdentityLinkService.DisconnectAsync(currentUserId);
-            if (result.Deleted)
+            if (result.LinkChangedDuringDisconnect)
+            {
+                // A reconnect raced this disconnect: the token was revoked, but the row was left
+                // in place because it had already been replaced by the time the delete ran.
+                // Reload so the card reflects whatever is actually connected now.
+                statusMessage = "Your AWS identity changed while disconnecting. Please try again.";
+                statusSuccess = false;
+                await LoadIdentitiesAsync();
+            }
+            else if (result.Deleted)
             {
                 if (result.RevokedSuccessfully)
                 {

--- a/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
+++ b/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
@@ -4,7 +4,11 @@
 @using Connapse.Core
 @using Connapse.Identity.Services
 @using Connapse.Web.Components.Layout
+@using Microsoft.AspNetCore.WebUtilities
+@using Microsoft.Extensions.Options
 @inject ICloudIdentityService CloudIdentityService
+@inject IAwsIdentityLinkService AwsIdentityLinkService
+@inject IOptionsMonitor<CognitoSettings> CognitoOptions
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject NavigationManager Navigation
 @inject ILogger<ProfileIntegrations> Logger
@@ -55,7 +59,7 @@
                             <span class="bi-cloud" style="font-size: 1.1rem; color: #f59e0b;"></span>
                         </div>
                         <div class="ms-3 flex-grow-1">
-                            <strong>Amazon Web Services</strong>
+                            <strong>Amazon Web Services (Sign-In)</strong>
                         </div>
                         @if (awsIdentity is not null)
                         {
@@ -280,6 +284,102 @@
                 </div>
             </div>
         </div>
+
+        <!-- AWS Permissions Identity Card (Cognito) -->
+        <div class="col-md-6">
+            <div class="card h-100 provider-card @(cognitoIdentity is not null ? "provider-connected" : "")"
+                 style="--provider-color: #f59e0b;">
+                <div class="card-body p-4">
+                    <div class="d-flex align-items-center mb-3">
+                        <div class="rounded d-flex align-items-center justify-content-center flex-shrink-0"
+                             style="width: 40px; height: 40px; background: rgba(245, 158, 11, 0.1); border: 1px solid rgba(245, 158, 11, 0.25);">
+                            <span class="bi-shield-lock" style="font-size: 1.1rem; color: #f59e0b;"></span>
+                        </div>
+                        <div class="ms-3 flex-grow-1">
+                            <strong>Amazon Web Services (Permissions)</strong>
+                        </div>
+                        @if (cognitoIdentity is not null)
+                        {
+                            <span class="badge rounded-pill" style="background: color-mix(in srgb, var(--color-success) 15%, transparent); color: color-mix(in srgb, var(--color-success) 70%, white); border: 1px solid color-mix(in srgb, var(--color-success) 30%, transparent);">
+                                <span class="bi-check-circle-fill me-1"></span>Connected
+                            </span>
+                        }
+                    </div>
+
+                    @if (!cognitoConfigured)
+                    {
+                        <div class="rounded-3 p-3" style="background: rgba(245, 158, 11, 0.08); border: 1px solid rgba(245, 158, 11, 0.2);">
+                            <small class="d-flex align-items-start" style="color: #fbbf24;">
+                                <span class="bi-info-circle-fill me-2 mt-1 flex-shrink-0"></span>
+                                <span>Amazon Cognito is not configured. An administrator must set up the pool under Settings before anyone can connect.</span>
+                            </small>
+                        </div>
+                    }
+                    else if (cognitoIdentity is not null)
+                    {
+                        <div class="d-flex flex-column gap-2 mb-3">
+                            <div>
+                                <small class="text-muted d-block">Connected as</small>
+                                <span class="small">@cognitoIdentity.Email</span>
+                            </div>
+                            <div class="d-flex gap-4">
+                                <div>
+                                    <small class="text-muted d-block">Connected</small>
+                                    <small>@cognitoIdentity.ConnectedAt.ToString("MMM dd, yyyy")</small>
+                                </div>
+                                @if (cognitoIdentity.LastUsedAt is not null)
+                                {
+                                    <div>
+                                        <small class="text-muted d-block">Last used</small>
+                                        <small>@cognitoIdentity.LastUsedAt.Value.ToString("MMM dd, yyyy")</small>
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="text-muted small mb-0">
+                            Separate from the AWS sign-in card above, which carries no permission
+                            information. Connecting here lets Connapse check your AWS permissions
+                            once per-user search filtering is switched on — it does not filter your
+                            search results today.
+                        </p>
+                    }
+                </div>
+                @if (cognitoConfigured)
+                {
+                    <div class="card-footer border-top-0 px-4 pb-4 pt-0">
+                        @if (cognitoIdentity is not null)
+                        {
+                            @if (confirmDisconnectCognito)
+                            {
+                                <div class="d-flex gap-2">
+                                    <button class="btn btn-sm btn-danger" @onclick="DisconnectCognitoAsync" disabled="@isProcessing">
+                                        Confirm Disconnect
+                                    </button>
+                                    <button class="btn btn-sm btn-outline-secondary" @onclick="() => confirmDisconnectCognito = false">
+                                        Cancel
+                                    </button>
+                                </div>
+                            }
+                            else
+                            {
+                                <button class="btn btn-sm btn-outline-danger" @onclick="() => confirmDisconnectCognito = true" disabled="@isProcessing">
+                                    <span class="bi-x-circle me-1"></span>Disconnect
+                                </button>
+                            }
+                        }
+                        else
+                        {
+                            <button class="btn btn-sm btn-primary" @onclick="ConnectCognitoAsync" disabled="@isProcessing">
+                                <span class="bi-link-45deg me-1"></span>Connect AWS Permissions
+                            </button>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
     </div>
 </div>
 
@@ -294,6 +394,11 @@
     private CloudIdentityDto? azureIdentity;
     private bool awsSsoConfigured;
     private bool azureAdConfigured;
+
+    // AWS permissions identity (Cognito) — a separate link from awsIdentity above.
+    private AwsIdentityLinkDto? cognitoIdentity;
+    private bool cognitoConfigured;
+    private bool confirmDisconnectCognito;
 
     // Device auth flow state
     private AwsDeviceAuthStartResult? awsDeviceAuth;
@@ -310,6 +415,9 @@
 
         awsSsoConfigured = CloudIdentityService.IsAwsSsoConfigured();
         azureAdConfigured = CloudIdentityService.IsAzureAdConfigured();
+        cognitoConfigured = CognitoOptions.CurrentValue.IsConfigured;
+
+        ApplyCognitoErrorFromQuery();
 
         await LoadIdentitiesAsync();
     }
@@ -319,11 +427,84 @@
         var identities = await CloudIdentityService.ListAsync(currentUserId);
         awsIdentity = identities.FirstOrDefault(i => i.Provider == CloudProvider.AWS);
         azureIdentity = identities.FirstOrDefault(i => i.Provider == CloudProvider.Azure);
+        cognitoIdentity = await AwsIdentityLinkService.GetAsync(currentUserId);
+    }
+
+    // The Cognito callback redirects here with ?error=cognito_<reason> when a connection attempt
+    // failed. A silent, unchanged page would leave the user guessing whether anything happened.
+    private void ApplyCognitoErrorFromQuery()
+    {
+        var uri = new Uri(Navigation.Uri);
+        var query = QueryHelpers.ParseQuery(uri.Query);
+        if (!query.TryGetValue("error", out var errorValues))
+            return;
+
+        var error = errorValues.ToString();
+        if (!error.StartsWith("cognito_", StringComparison.Ordinal))
+            return;
+
+        var reason = error["cognito_".Length..];
+        statusMessage = reason switch
+        {
+            "exchange_failed" => "Could not connect your AWS identity: the token exchange with Cognito failed.",
+            "token_invalid" => "Could not connect your AWS identity: Cognito returned a token that could not be verified.",
+            "nonce_mismatch" => "Could not connect your AWS identity: the response did not match the request that started it. Please try again.",
+            "email_not_verified" => "Could not connect your AWS identity: AWS reports your email address is not verified.",
+            _ => "Could not connect your AWS identity. Please try again.",
+        };
+        statusSuccess = false;
     }
 
     private void ConnectAzureAsync()
     {
         Navigation.NavigateTo("/api/v1/auth/cloud/azure/connect", forceLoad: true);
+    }
+
+    private void ConnectCognitoAsync()
+    {
+        Navigation.NavigateTo("/api/cloud-identity/cognito/connect", forceLoad: true);
+    }
+
+    private async Task DisconnectCognitoAsync()
+    {
+        isProcessing = true;
+        statusMessage = null;
+        confirmDisconnectCognito = false;
+        try
+        {
+            var result = await AwsIdentityLinkService.DisconnectAsync(currentUserId);
+            if (result.Deleted)
+            {
+                if (result.RevokedSuccessfully)
+                {
+                    statusMessage = "AWS identity disconnected.";
+                    statusSuccess = true;
+                }
+                else
+                {
+                    // Never claim a clean success here: the row is gone locally, but the refresh
+                    // token may still be valid at AWS until it expires on its own.
+                    statusMessage = "Disconnected here, but AWS could not be told; the token stays valid until it expires.";
+                    statusSuccess = false;
+                }
+                await LoadIdentitiesAsync();
+            }
+            else
+            {
+                statusMessage = "No AWS identity link found.";
+                statusSuccess = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to disconnect AWS identity link for user {UserId}", currentUserId);
+            statusMessage = "Failed to disconnect. Please try again.";
+            statusSuccess = false;
+        }
+        finally
+        {
+            isProcessing = false;
+        }
     }
 
     private async Task StartAwsDeviceAuthAsync()

--- a/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
 using Connapse.Identity.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -179,8 +180,9 @@ public static class CloudIdentityEndpoints
         // GET /api/v1/auth/cloud/cognito/callback — Cognito OAuth2 callback.
         group.MapGet("/cognito/callback", async (
             HttpContext http,
-            [FromQuery] string code,
-            [FromQuery] string state,
+            [FromQuery] string? code,
+            [FromQuery] string? state,
+            [FromQuery] string? error,
             [FromServices] IOptionsMonitor<CognitoSettings> settings,
             [FromServices] AwsIdentityLinkStore linkStore,
             [FromServices] IHttpClientFactory httpClientFactory,
@@ -200,13 +202,39 @@ public static class CloudIdentityEndpoints
             http.Response.Cookies.Delete(CognitoPkceCookieName, deleteCookieOptions);
             http.Response.Cookies.Delete(CognitoNonceCookieName, deleteCookieOptions);
 
+            // Rule: a provider-side error (the user declined consent, or Cognito rejected the
+            // request before ever issuing a code) arrives with `error` set and no `code` at all.
+            // code/state used to be non-nullable [FromQuery] parameters, so minimal API's model
+            // binding rejected this shape before the handler ever ran, leaving the user with a
+            // raw 400 and the three cookies just cleared above stuck in the browser until they
+            // expired on their own. Handle it the same way every other failure path here does:
+            // cookies are already gone, so just redirect with a fixed reason. The provider's raw
+            // error string is never echoed into the redirect — only ever one of our own values.
+            if (!string.IsNullOrEmpty(error))
+            {
+                logger.LogWarning(
+                    "Cognito callback reported a provider-side error: {Error}", LogSanitizer.Sanitize(error));
+                var reason = error == "access_denied" ? "cognito_user_cancelled" : "cognito_provider_error";
+                return Results.Redirect($"/profile/integrations?error={reason}");
+            }
+
             // Rule: validate state before anything else. A callback whose state does not match is
             // not a connection.
-            if (string.IsNullOrEmpty(expectedState) || expectedState != state)
+            if (string.IsNullOrEmpty(expectedState) || string.IsNullOrEmpty(state) || expectedState != state)
                 return Results.BadRequest(new { error = "invalid_state", message = "Invalid or expired state parameter." });
 
             if (string.IsNullOrEmpty(codeVerifier))
                 return Results.BadRequest(new { error = "invalid_pkce", message = "Missing PKCE code verifier." });
+
+            if (string.IsNullOrEmpty(code))
+            {
+                // No provider error was reported, yet there is still no code to exchange. Not a
+                // shape Cognito is documented to produce, but code below assumes a non-empty code,
+                // so this is handled the same way as the explicit-error branch above rather than
+                // let a null reach the token exchange.
+                logger.LogWarning("Cognito callback carried no error but was also missing an authorization code");
+                return Results.Redirect("/profile/integrations?error=cognito_provider_error");
+            }
 
             var userId = GetUserId(http);
             if (userId is null) return Results.Unauthorized();

--- a/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Connapse.Web.Endpoints;
 
@@ -207,6 +206,9 @@ public static class CloudIdentityEndpoints
 
             var redirectUri = CognitoCallbackUri(http);
             var httpClient = httpClientFactory.CreateClient();
+            // A browser is waiting on this request. Don't rely on HttpClient's 100-second default —
+            // an unreachable or slow pool should redirect with an error well before the user gives up.
+            httpClient.Timeout = TimeSpan.FromSeconds(10);
 
             var tokenParams = new Dictionary<string, string>
             {
@@ -227,9 +229,12 @@ public static class CloudIdentityEndpoints
                     $"{cognito.Domain.TrimEnd('/')}/oauth2/token",
                     new FormUrlEncodedContent(tokenParams), ct);
             }
-            catch (HttpRequestException)
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
             {
-                logger.LogError("Cognito token exchange could not reach the pool");
+                // TaskCanceledException is what HttpClient throws on its own timeout above (and
+                // what a client-disconnect cancellation looks like) — neither carries a token or
+                // secret, so nothing more than the exception type is worth knowing here.
+                logger.LogError("Cognito token exchange could not reach the pool in time");
                 return Results.Redirect("/profile/integrations?error=cognito_exchange_failed");
             }
 
@@ -248,8 +253,11 @@ public static class CloudIdentityEndpoints
                 idToken = tokenJson.TryGetProperty("id_token", out var idTokenProp) ? idTokenProp.GetString() : null;
                 refreshToken = tokenJson.TryGetProperty("refresh_token", out var refreshTokenProp) ? refreshTokenProp.GetString() : null;
             }
-            catch (JsonException)
+            catch (Exception ex) when (ex is JsonException or InvalidOperationException)
             {
+                // InvalidOperationException is what JsonElement.GetString() throws when a property
+                // is present but not a string (e.g. the pool returned id_token as a number/object) —
+                // a malformed response, not a parse failure, but the same "give up cleanly" outcome.
                 logger.LogError("Cognito token response was not valid JSON");
                 return Results.Redirect("/profile/integrations?error=cognito_exchange_failed");
             }
@@ -274,18 +282,7 @@ public static class CloudIdentityEndpoints
                 return Results.Redirect("/profile/integrations?error=cognito_token_invalid");
             }
 
-            var validationParameters = new TokenValidationParameters
-            {
-                ValidIssuer = cognito.IssuerUrl,
-                ValidAudience = cognito.ClientId,
-                IssuerSigningKeys = openIdConfig.SigningKeys,
-                ValidateIssuer = true,
-                ValidateAudience = true,
-                ValidateLifetime = true,
-                ValidateIssuerSigningKey = true,
-                RequireSignedTokens = true,
-                ClockSkew = TimeSpan.FromMinutes(2),
-            };
+            var validationParameters = CognitoIdTokenValidator.BuildValidationParameters(cognito, openIdConfig.SigningKeys);
 
             var result = CognitoIdTokenValidator.Validate(idToken, validationParameters, expectedNonce);
             if (!result.Success)
@@ -295,7 +292,11 @@ public static class CloudIdentityEndpoints
                 return Results.Redirect($"/profile/integrations?error=cognito_{result.FailureReason}");
             }
 
-            await linkStore.SaveAsync(userId.Value, result.Email!, refreshToken, ct);
+            // Normalized because this is the join key into an IAM Identity Center lookup — a case
+            // difference between what Cognito emits and what the directory holds would fail the
+            // match at resolution time, long after this connection looked like it succeeded.
+            var normalizedEmail = result.Email!.ToLowerInvariant();
+            await linkStore.SaveAsync(userId.Value, normalizedEmail, refreshToken, ct);
 
             return Results.Redirect("/profile/integrations");
         }).RequireAuthorization();

--- a/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
@@ -1,9 +1,17 @@
+using System.Collections.Concurrent;
 using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Identity.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Connapse.Web.Endpoints;
 
@@ -11,6 +19,16 @@ public static class CloudIdentityEndpoints
 {
     private const string AzureStateCookieName = "__connapse_az_state";
     private const string AzurePkceCookieName = "__connapse_az_pkce";
+
+    private const string CognitoStateCookieName = "__connapse_cog_state";
+    private const string CognitoPkceCookieName = "__connapse_cog_pkce";
+    private const string CognitoNonceCookieName = "__connapse_cog_nonce";
+    private const string CognitoCookiePath = "/api/cloud-identity/cognito";
+
+    // Cached per issuer so signing keys are fetched from the pool's discovery document once and
+    // reused, rather than refetched on every callback.
+    private static readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>>
+        CognitoConfigManagers = new();
 
     public static IEndpointRouteBuilder MapCloudIdentityEndpoints(this IEndpointRouteBuilder app)
     {
@@ -97,6 +115,189 @@ public static class CloudIdentityEndpoints
             {
                 return Results.BadRequest(new { error = "azure_callback_failed", message = ex.Message });
             }
+        }).RequireAuthorization();
+
+        // --- Cognito (per-user AWS identity link) ---
+        //
+        // A separate route group and a separate table (AwsIdentityLinkStore /
+        // UserAwsIdentityLinkEntity) from the Azure/AWS-SSO pair above, which write to
+        // UserCloudIdentityEntity via ICloudIdentityService. This link exists so per-user AWS
+        // permissions can later be resolved for search — it is not a connector credential.
+        var cognitoGroup = app.MapGroup("/api/cloud-identity").WithTags("Cloud Identity");
+
+        // GET /api/cloud-identity/cognito/connect — redirect to the pool's authorize endpoint.
+        // Mirrors /azure/connect deliberately. A second convention for the same job in the same
+        // file costs more than reusing an imperfect one.
+        cognitoGroup.MapGet("/cognito/connect", (
+            HttpContext http,
+            IOptionsMonitor<CognitoSettings> settings) =>
+        {
+            var cognito = settings.CurrentValue;
+            if (!cognito.IsConfigured)
+                return Results.Problem(
+                    "Cognito is not configured. An administrator sets it up under Settings.",
+                    statusCode: StatusCodes.Status409Conflict);
+
+            // PKCE: the verifier never leaves this deployment, and the challenge is what Cognito
+            // holds until the callback proves possession of the verifier that produced it.
+            string verifier = GenerateCodeVerifier();
+            string challenge = ComputeCodeChallenge(verifier);
+            string state = GenerateOpaqueToken();
+            // Bound in the authorize request; checked against the ID token's `nonce` claim in the
+            // callback. Cheap, and stops a token minted for a different request being replayed
+            // into this one.
+            string nonce = GenerateOpaqueToken();
+
+            StashCognitoState(http, state, verifier, nonce);
+
+            string authorize =
+                $"{cognito.Domain.TrimEnd('/')}/oauth2/authorize" +
+                $"?response_type=code" +
+                $"&client_id={Uri.EscapeDataString(cognito.ClientId)}" +
+                $"&redirect_uri={Uri.EscapeDataString(CognitoCallbackUri(http))}" +
+                $"&scope={Uri.EscapeDataString("openid email offline_access")}" +
+                $"&state={Uri.EscapeDataString(state)}" +
+                $"&nonce={Uri.EscapeDataString(nonce)}" +
+                $"&code_challenge={Uri.EscapeDataString(challenge)}" +
+                $"&code_challenge_method=S256";
+
+            return Results.Redirect(authorize);
+        }).RequireAuthorization();
+
+        // GET /api/cloud-identity/cognito/callback — Cognito OAuth2 callback.
+        cognitoGroup.MapGet("/cognito/callback", async (
+            HttpContext http,
+            [FromQuery] string code,
+            [FromQuery] string state,
+            [FromServices] IOptionsMonitor<CognitoSettings> settings,
+            [FromServices] AwsIdentityLinkStore linkStore,
+            [FromServices] IHttpClientFactory httpClientFactory,
+            [FromServices] ILoggerFactory loggerFactory,
+            CancellationToken ct) =>
+        {
+            var logger = loggerFactory.CreateLogger("CloudIdentityEndpoints.Cognito");
+
+            var expectedState = http.Request.Cookies[CognitoStateCookieName];
+            var codeVerifier = http.Request.Cookies[CognitoPkceCookieName];
+            var expectedNonce = http.Request.Cookies[CognitoNonceCookieName];
+
+            // Rule: clear the stashed state either way — a callback is one-shot regardless of
+            // whether it succeeds.
+            var deleteCookieOptions = new CookieOptions { Path = CognitoCookiePath };
+            http.Response.Cookies.Delete(CognitoStateCookieName, deleteCookieOptions);
+            http.Response.Cookies.Delete(CognitoPkceCookieName, deleteCookieOptions);
+            http.Response.Cookies.Delete(CognitoNonceCookieName, deleteCookieOptions);
+
+            // Rule: validate state before anything else. A callback whose state does not match is
+            // not a connection.
+            if (string.IsNullOrEmpty(expectedState) || expectedState != state)
+                return Results.BadRequest(new { error = "invalid_state", message = "Invalid or expired state parameter." });
+
+            if (string.IsNullOrEmpty(codeVerifier))
+                return Results.BadRequest(new { error = "invalid_pkce", message = "Missing PKCE code verifier." });
+
+            var userId = GetUserId(http);
+            if (userId is null) return Results.Unauthorized();
+
+            var cognito = settings.CurrentValue;
+            if (!cognito.IsConfigured)
+                return Results.Problem(
+                    "Cognito is not configured. An administrator sets it up under Settings.",
+                    statusCode: StatusCodes.Status409Conflict);
+
+            var redirectUri = CognitoCallbackUri(http);
+            var httpClient = httpClientFactory.CreateClient();
+
+            var tokenParams = new Dictionary<string, string>
+            {
+                ["grant_type"] = "authorization_code",
+                ["client_id"] = cognito.ClientId,
+                ["client_secret"] = cognito.ClientSecret,
+                ["code"] = code,
+                ["redirect_uri"] = redirectUri,
+                ["code_verifier"] = codeVerifier,
+            };
+
+            HttpResponseMessage tokenResponse;
+            try
+            {
+                // Never log tokenParams above — it carries the authorization code, the PKCE
+                // verifier and the client secret.
+                tokenResponse = await httpClient.PostAsync(
+                    $"{cognito.Domain.TrimEnd('/')}/oauth2/token",
+                    new FormUrlEncodedContent(tokenParams), ct);
+            }
+            catch (HttpRequestException)
+            {
+                logger.LogError("Cognito token exchange could not reach the pool");
+                return Results.Redirect("/profile/integrations?error=cognito_exchange_failed");
+            }
+
+            if (!tokenResponse.IsSuccessStatusCode)
+            {
+                logger.LogError("Cognito token exchange failed with status {StatusCode}", tokenResponse.StatusCode);
+                return Results.Redirect("/profile/integrations?error=cognito_exchange_failed");
+            }
+
+            string? idToken;
+            string? refreshToken;
+            try
+            {
+                var responseBody = await tokenResponse.Content.ReadAsStringAsync(ct);
+                var tokenJson = JsonSerializer.Deserialize<JsonElement>(responseBody);
+                idToken = tokenJson.TryGetProperty("id_token", out var idTokenProp) ? idTokenProp.GetString() : null;
+                refreshToken = tokenJson.TryGetProperty("refresh_token", out var refreshTokenProp) ? refreshTokenProp.GetString() : null;
+            }
+            catch (JsonException)
+            {
+                logger.LogError("Cognito token response was not valid JSON");
+                return Results.Redirect("/profile/integrations?error=cognito_exchange_failed");
+            }
+
+            if (string.IsNullOrEmpty(idToken) || string.IsNullOrEmpty(refreshToken))
+            {
+                logger.LogError("Cognito token response was missing id_token or refresh_token");
+                return Results.Redirect("/profile/integrations?error=cognito_exchange_failed");
+            }
+
+            // Rule: validate the ID token — signature against the pool's JWKS, issuer, audience
+            // and lifetime — before reading any claim from it.
+            OpenIdConnectConfiguration openIdConfig;
+            try
+            {
+                var configManager = GetCognitoConfigManager(cognito.IssuerUrl);
+                openIdConfig = await configManager.GetConfigurationAsync(ct);
+            }
+            catch (Exception ex) when (ex is IOException or InvalidOperationException)
+            {
+                logger.LogError(ex, "Could not fetch the Cognito pool's discovery document");
+                return Results.Redirect("/profile/integrations?error=cognito_token_invalid");
+            }
+
+            var validationParameters = new TokenValidationParameters
+            {
+                ValidIssuer = cognito.IssuerUrl,
+                ValidAudience = cognito.ClientId,
+                IssuerSigningKeys = openIdConfig.SigningKeys,
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                RequireSignedTokens = true,
+                ClockSkew = TimeSpan.FromMinutes(2),
+            };
+
+            var result = CognitoIdTokenValidator.Validate(idToken, validationParameters, expectedNonce);
+            if (!result.Success)
+            {
+                // result.FailureReason is a fixed code, never token or claim content.
+                logger.LogWarning("Cognito ID token rejected: {Reason}", result.FailureReason);
+                return Results.Redirect($"/profile/integrations?error=cognito_{result.FailureReason}");
+            }
+
+            await linkStore.SaveAsync(userId.Value, result.Email!, refreshToken, ct);
+
+            return Results.Redirect("/profile/integrations");
         }).RequireAuthorization();
 
         // --- AWS SSO (Device Authorization Flow) ---
@@ -208,6 +409,48 @@ public static class CloudIdentityEndpoints
         var idClaim = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
         return Guid.TryParse(idClaim, out var id) ? id : null;
     }
+
+    // --- Cognito helpers ---
+
+    private static ConfigurationManager<OpenIdConnectConfiguration> GetCognitoConfigManager(string issuerUrl) =>
+        CognitoConfigManagers.GetOrAdd(issuerUrl, iss =>
+            new ConfigurationManager<OpenIdConnectConfiguration>(
+                $"{iss.TrimEnd('/')}/.well-known/openid-configuration",
+                new OpenIdConnectConfigurationRetriever()));
+
+    private static void StashCognitoState(HttpContext http, string state, string verifier, string nonce)
+    {
+        var cookieOptions = new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = http.Request.IsHttps,
+            SameSite = SameSiteMode.Lax,
+            MaxAge = TimeSpan.FromMinutes(10),
+            Path = CognitoCookiePath
+        };
+
+        http.Response.Cookies.Append(CognitoStateCookieName, state, cookieOptions);
+        http.Response.Cookies.Append(CognitoPkceCookieName, verifier, cookieOptions);
+        http.Response.Cookies.Append(CognitoNonceCookieName, nonce, cookieOptions);
+    }
+
+    private static string CognitoCallbackUri(HttpContext http) =>
+        $"{http.Request.Scheme}://{http.Request.Host}/api/cloud-identity/cognito/callback";
+
+    private static string GenerateOpaqueToken() =>
+        Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+    private static string GenerateCodeVerifier() =>
+        Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
+
+    private static string ComputeCodeChallenge(string codeVerifier) =>
+        Base64UrlEncode(SHA256.HashData(Encoding.ASCII.GetBytes(codeVerifier)));
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
 }
 
 public record AwsDevicePollRequest(string DeviceCode);

--- a/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
@@ -22,7 +22,7 @@ public static class CloudIdentityEndpoints
     private const string CognitoStateCookieName = "__connapse_cog_state";
     private const string CognitoPkceCookieName = "__connapse_cog_pkce";
     private const string CognitoNonceCookieName = "__connapse_cog_nonce";
-    private const string CognitoCookiePath = "/api/cloud-identity/cognito";
+    private const string CognitoCookiePath = "/api/v1/auth/cloud/cognito";
 
     // Cached per issuer so signing keys are fetched from the pool's discovery document once and
     // reused, rather than refetched on every callback.
@@ -118,19 +118,23 @@ public static class CloudIdentityEndpoints
 
         // --- Cognito (per-user AWS identity link) ---
         //
-        // A separate route group and a separate table (AwsIdentityLinkStore /
-        // UserAwsIdentityLinkEntity) from the Azure/AWS-SSO pair above, which write to
-        // UserCloudIdentityEntity via ICloudIdentityService. This link exists so per-user AWS
-        // permissions can later be resolved for search — it is not a connector credential.
-        var cognitoGroup = app.MapGroup("/api/cloud-identity").WithTags("Cloud Identity");
+        // A separate table (AwsIdentityLinkStore / UserAwsIdentityLinkEntity) from the
+        // Azure/AWS-SSO pair above, which write to UserCloudIdentityEntity via
+        // ICloudIdentityService. This link exists so per-user AWS permissions can later be
+        // resolved for search — it is not a connector credential. It shares the same versioned
+        // route group as the pair above: this callback URL is registered in the customer's
+        // Cognito app client, so it must not need to change again after ship.
 
-        // GET /api/cloud-identity/cognito/connect — redirect to the pool's authorize endpoint.
+        // GET /api/v1/auth/cloud/cognito/connect — redirect to the pool's authorize endpoint.
         // Mirrors /azure/connect deliberately. A second convention for the same job in the same
         // file costs more than reusing an imperfect one.
-        cognitoGroup.MapGet("/cognito/connect", (
+        group.MapGet("/cognito/connect", (
             HttpContext http,
             IOptionsMonitor<CognitoSettings> settings) =>
         {
+            var userId = GetUserId(http);
+            if (userId is null) return Results.Unauthorized();
+
             var cognito = settings.CurrentValue;
             if (!cognito.IsConfigured)
                 return Results.Problem(
@@ -141,7 +145,16 @@ public static class CloudIdentityEndpoints
             // holds until the callback proves possession of the verifier that produced it.
             string verifier = GenerateCodeVerifier();
             string challenge = ComputeCodeChallenge(verifier);
-            string state = GenerateOpaqueToken();
+            // State, verifier and nonce are stashed as browser-scoped cookies, not
+            // session-scoped ones: they carry no user identity of their own. Without more, the
+            // callback would decide whose account to link by trusting whichever principal
+            // happens to be signed in when it runs — which can be a different person than the
+            // one who clicked Connect, if their session ends and someone else signs in on the
+            // same browser inside the cookie's lifetime. Prefixing the initiating user's id onto
+            // the opaque state lets the callback catch that without a fourth cookie. The id is
+            // not a secret, so it must not be treated as contributing entropy — the random half
+            // is generated exactly as it was before this was added.
+            string state = $"{userId.Value}:{GenerateOpaqueToken()}";
             // Bound in the authorize request; checked against the ID token's `nonce` claim in the
             // callback. Cheap, and stops a token minted for a different request being replayed
             // into this one.
@@ -163,8 +176,8 @@ public static class CloudIdentityEndpoints
             return Results.Redirect(authorize);
         }).RequireAuthorization();
 
-        // GET /api/cloud-identity/cognito/callback — Cognito OAuth2 callback.
-        cognitoGroup.MapGet("/cognito/callback", async (
+        // GET /api/v1/auth/cloud/cognito/callback — Cognito OAuth2 callback.
+        group.MapGet("/cognito/callback", async (
             HttpContext http,
             [FromQuery] string code,
             [FromQuery] string state,
@@ -197,6 +210,18 @@ public static class CloudIdentityEndpoints
 
             var userId = GetUserId(http);
             if (userId is null) return Results.Unauthorized();
+
+            // Rule: the flow is bound to whoever started it, not whoever happens to be signed in
+            // when Cognito redirects back. State, verifier and nonce are browser-scoped cookies
+            // with no session identity of their own, so without this check a session that ended
+            // (or was switched) mid-flow on the same browser would silently link the verified AWS
+            // email to whoever is signed in now instead of who clicked Connect.
+            var initiatingUserId = ParseInitiatingUserId(expectedState);
+            if (initiatingUserId is null || initiatingUserId != userId.Value)
+            {
+                logger.LogWarning("Cognito callback rejected: the signed-in user did not match who started the flow");
+                return Results.Redirect("/profile/integrations?error=cognito_user_mismatch");
+            }
 
             var cognito = settings.CurrentValue;
             if (!cognito.IsConfigured)
@@ -436,7 +461,20 @@ public static class CloudIdentityEndpoints
     }
 
     private static string CognitoCallbackUri(HttpContext http) =>
-        $"{http.Request.Scheme}://{http.Request.Host}/api/cloud-identity/cognito/callback";
+        $"{http.Request.Scheme}://{http.Request.Host}/api/v1/auth/cloud/cognito/callback";
+
+    /// <summary>
+    /// Splits the initiating user's id off the front of a stashed Cognito state value (format
+    /// <c>"{userId}:{random}"</c>), or null when the state does not have that shape at all — e.g.
+    /// an old-format state left over from before this existed, which must not be trusted as
+    /// belonging to anyone.
+    /// </summary>
+    private static Guid? ParseInitiatingUserId(string state)
+    {
+        var separatorIndex = state.IndexOf(':');
+        if (separatorIndex <= 0) return null;
+        return Guid.TryParse(state[..separatorIndex], out var id) ? id : null;
+    }
 
     private static string GenerateOpaqueToken() =>
         Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));

--- a/src/Connapse.Web/Endpoints/SettingsEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/SettingsEndpoints.cs
@@ -52,6 +52,7 @@ public static class SettingsEndpoints
                 "upload" => Results.Ok(await GetSettingsAsync<UploadSettings>(categoryLower, settingsStore, serviceProvider, ct)),
                 "awssso" => Results.Ok(await GetSettingsAsync<AwsSsoSettings>(categoryLower, settingsStore, serviceProvider, ct)),
                 "azuread" => Results.Ok(await GetSettingsAsync<AzureAdSettings>(categoryLower, settingsStore, serviceProvider, ct)),
+                "cognito" => Results.Ok(await GetSettingsAsync<CognitoSettings>(categoryLower, settingsStore, serviceProvider, ct)),
                 _ => Results.NotFound(new { error = $"Unknown settings category: {category}" })
             };
         })
@@ -104,6 +105,10 @@ public static class SettingsEndpoints
                     case "azuread":
                         var azureAd = JsonSerializer.Deserialize<AzureAdSettings>(rawJson, JsonOptions);
                         if (azureAd != null) await settingsStore.SaveAsync(categoryLower, azureAd, ct);
+                        break;
+                    case "cognito":
+                        var cognito = JsonSerializer.Deserialize<CognitoSettings>(rawJson, JsonOptions);
+                        if (cognito != null) await settingsStore.SaveAsync(categoryLower, cognito, ct);
                         break;
                     default:
                         return Results.NotFound(new { error = $"Unknown settings category: {category}" });

--- a/tests/Connapse.Core.Tests/Models/CognitoSettingsTests.cs
+++ b/tests/Connapse.Core.Tests/Models/CognitoSettingsTests.cs
@@ -1,0 +1,80 @@
+using Connapse.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Models;
+
+/// <summary>
+/// Whether a deployment has enough to talk to a Cognito user pool.
+/// </summary>
+[Trait("Category", "Unit")]
+public class CognitoSettingsTests
+{
+    private static CognitoSettings Complete() => new()
+    {
+        IssuerUrl = "https://cognito-idp.us-west-1.amazonaws.com/us-west-1_abc123",
+        Domain = "https://connapse.auth.us-west-1.amazoncognito.com",
+        ClientId = "3ia37m5mg4rtioih2slv8etmed",
+        ClientSecret = "shh",
+        Region = "us-west-1",
+    };
+
+    [Fact]
+    public void IsConfigured_WithEveryField_IsTrue()
+    {
+        Complete().IsConfigured.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("http://cognito-idp.us-west-1.amazonaws.com/us-west-1_abc123")]
+    [InlineData("http://connapse.auth.us-west-1.amazoncognito.com")]
+    public void IsConfigured_WithAPlainHttpUrl_IsFalse(string insecure)
+    {
+        // Both URLs carry a credential — an authorization code on one, a token on the other — so
+        // a plain-HTTP hop puts it on the wire in cleartext. Cognito refuses these too, so the
+        // only thing accepting them buys is a rejection from AWS instead of an explanation here.
+        var settings = Complete();
+        settings.Domain = insecure;
+
+        settings.IsConfigured.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsConfigured_WithLoopbackHttp_IsTrue()
+    {
+        // The one exception, and Cognito makes it too: a single-machine deployment has no TLS to
+        // terminate and nothing on the wire to intercept.
+        var settings = Complete();
+        settings.Domain = "http://localhost:5001";
+
+        settings.IsConfigured.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("IssuerUrl")]
+    [InlineData("Domain")]
+    [InlineData("ClientId")]
+    [InlineData("ClientSecret")]
+    [InlineData("Region")]
+    public void IsConfigured_WithAnyFieldMissing_IsFalse(string missing)
+    {
+        // Every field is load-bearing, and a half-configured pool fails at a different step
+        // depending on which half is missing — the redirect 404s, or the token exchange 401s,
+        // or the issuer does not match what Identity Center trusts. One check up front is
+        // cheaper to explain than five failures spread across the flow.
+        var settings = Complete();
+        typeof(CognitoSettings).GetProperty(missing)!.SetValue(settings, "");
+
+        settings.IsConfigured.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsConfigured_WithWhitespaceOnly_IsFalse()
+    {
+        // A settings row saved from a form with a stray space is not configuration.
+        var settings = Complete();
+        settings.ClientId = "   ";
+
+        settings.IsConfigured.Should().BeFalse();
+    }
+}

--- a/tests/Connapse.Core.Tests/Models/CognitoSettingsTests.cs
+++ b/tests/Connapse.Core.Tests/Models/CognitoSettingsTests.cs
@@ -40,14 +40,17 @@ public class CognitoSettingsTests
     }
 
     [Fact]
-    public void IsConfigured_WithLoopbackHttp_IsTrue()
+    public void IsConfigured_WithLoopbackHttp_IsFalse()
     {
-        // The one exception, and Cognito makes it too: a single-machine deployment has no TLS to
-        // terminate and nothing on the wire to intercept.
+        // No loopback exception here: IssuerUrl and Domain are always AWS-hosted endpoints
+        // (there is no such thing as a localhost Cognito pool), unlike the OAuth redirect URI,
+        // which is Connapse's own address and is computed from the incoming request rather than
+        // read from these settings. A loopback allowance on these two would only widen what is
+        // accepted without buying anything.
         var settings = Complete();
         settings.Domain = "http://localhost:5001";
 
-        settings.IsConfigured.Should().BeTrue();
+        settings.IsConfigured.Should().BeFalse();
     }
 
     [Theory]

--- a/tests/Connapse.Identity.Tests/AwsIdentityLinkServiceTests.cs
+++ b/tests/Connapse.Identity.Tests/AwsIdentityLinkServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Connapse.Core;
 using Connapse.Identity.Data;
+using Connapse.Identity.Data.Entities;
 using Connapse.Identity.Services;
 using FluentAssertions;
 using Microsoft.AspNetCore.DataProtection;
@@ -41,6 +42,25 @@ public class AwsIdentityLinkServiceTests
                     .UseInMemoryDatabase(dbName)
                     .Options)));
         return factory;
+    }
+
+    // Bypasses AwsIdentityLinkStore.SaveAsync (which always writes a properly protected token) to
+    // put a row in place whose ProtectedRefreshToken is not valid Data Protection payload at all —
+    // the shape a corrupted column or a rotated-beyond-retention key ring would leave behind.
+    private static async Task SeedUnreadableLinkAsync(string dbName, Guid userId, string email)
+    {
+        await using var db = new ConnapseIdentityDbContext(
+            new DbContextOptionsBuilder<ConnapseIdentityDbContext>().UseInMemoryDatabase(dbName).Options);
+
+        db.UserAwsIdentityLinks.Add(new UserAwsIdentityLinkEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Email = email,
+            ProtectedRefreshToken = "not-valid-protected-data",
+            ConnectedAt = DateTime.UtcNow,
+        });
+        await db.SaveChangesAsync();
     }
 
     private static IOptionsMonitor<CognitoSettings> Options(CognitoSettings settings)
@@ -140,6 +160,30 @@ public class AwsIdentityLinkServiceTests
 
         result.Deleted.Should().BeFalse();
         handler.LastRequest.Should().BeNull("there is no token to revoke when nothing was connected");
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_UnreadableToken_ReportsRevocationFailed_NeverCallsCognito_ButStillDeletesTheRow()
+    {
+        // A row exists — unlike DisconnectAsync_NoLinkExists — but its token cannot be decrypted.
+        // This must not be treated as "nothing to revoke": the row being present means the token
+        // may still be live at Cognito, and Connapse has simply lost the ability to speak for it.
+        var dbName = Guid.NewGuid().ToString();
+        var userId = Guid.NewGuid();
+        await SeedUnreadableLinkAsync(dbName, userId, "user@example.com");
+        var store = CreateStore(dbName);
+
+        var handler = new RecordingHandler(HttpStatusCode.OK);
+        var sut = new AwsIdentityLinkService(
+            store, Options(ConfiguredSettings), HttpFactory(handler), NullLogger<AwsIdentityLinkService>.Instance);
+
+        var result = await sut.DisconnectAsync(userId);
+
+        result.RevokedSuccessfully.Should().BeFalse(
+            "an unreadable token means Connapse never told Cognito, not that there was nothing to tell it");
+        handler.LastRequest.Should().BeNull("there is no plaintext token to send in a revoke request");
+        result.Deleted.Should().BeTrue("the local row must still go regardless of the revoke outcome");
+        (await store.GetAsync(userId)).Should().BeNull();
     }
 
     [Fact]

--- a/tests/Connapse.Identity.Tests/AwsIdentityLinkServiceTests.cs
+++ b/tests/Connapse.Identity.Tests/AwsIdentityLinkServiceTests.cs
@@ -1,0 +1,205 @@
+using System.Net;
+using Connapse.Core;
+using Connapse.Identity.Data;
+using Connapse.Identity.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Connapse.Identity.Tests;
+
+/// <summary>
+/// Disconnecting an AWS identity link must revoke the refresh token at Cognito before removing the
+/// local row, and must remove the row regardless of whether revocation succeeded — see
+/// <see cref="AwsIdentityLinkService"/>.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AwsIdentityLinkServiceTests
+{
+    private static readonly CognitoSettings ConfiguredSettings = new()
+    {
+        IssuerUrl = "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_test",
+        Domain = "https://my-pool.auth.us-east-1.amazoncognito.com",
+        ClientId = "test-client-id",
+        ClientSecret = "test-client-secret",
+        Region = "us-east-1",
+    };
+
+    private AwsIdentityLinkStore CreateStore(string dbName) =>
+        new(CreateFactory(dbName), new EphemeralDataProtectionProvider(), TimeProvider.System);
+
+    private static IDbContextFactory<ConnapseIdentityDbContext> CreateFactory(string dbName)
+    {
+        var factory = Substitute.For<IDbContextFactory<ConnapseIdentityDbContext>>();
+        factory.CreateDbContextAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(new ConnapseIdentityDbContext(
+                new DbContextOptionsBuilder<ConnapseIdentityDbContext>()
+                    .UseInMemoryDatabase(dbName)
+                    .Options)));
+        return factory;
+    }
+
+    private static IOptionsMonitor<CognitoSettings> Options(CognitoSettings settings)
+    {
+        var options = Substitute.For<IOptionsMonitor<CognitoSettings>>();
+        options.CurrentValue.Returns(settings);
+        return options;
+    }
+
+    private static IHttpClientFactory HttpFactory(HttpMessageHandler handler)
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(handler));
+        return factory;
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_ExistingLink_RevokesAtCognitoWhileTheRowStillExists_ThenDeletesIt()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+        var userId = Guid.NewGuid();
+        await store.SaveAsync(userId, "user@example.com", "refresh-token-abc");
+
+        bool? linkPresentDuringRevoke = null;
+        var handler = new RecordingHandler(HttpStatusCode.OK,
+            onSend: async () => linkPresentDuringRevoke = await store.GetAsync(userId) is not null);
+
+        var sut = new AwsIdentityLinkService(
+            store, Options(ConfiguredSettings), HttpFactory(handler), NullLogger<AwsIdentityLinkService>.Instance);
+
+        var result = await sut.DisconnectAsync(userId);
+
+        result.Deleted.Should().BeTrue();
+        result.RevokedSuccessfully.Should().BeTrue();
+        linkPresentDuringRevoke.Should().BeTrue("the token must be revoked before the local row disappears");
+        (await store.GetAsync(userId)).Should().BeNull("the row must be gone once Disconnect returns");
+
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString().Should().Be("https://my-pool.auth.us-east-1.amazoncognito.com/oauth2/revoke");
+        handler.LastRequestBody.Should().Contain("token=refresh-token-abc");
+        handler.LastRequestBody.Should().Contain("client_id=test-client-id");
+        handler.LastRequestBody.Should().Contain("client_secret=test-client-secret");
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_RevocationFails_StillDeletesTheRow_AndReportsRevocationFailed()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+        var userId = Guid.NewGuid();
+        await store.SaveAsync(userId, "user@example.com", "refresh-token-abc");
+
+        var handler = new RecordingHandler(HttpStatusCode.BadRequest);
+        var sut = new AwsIdentityLinkService(
+            store, Options(ConfiguredSettings), HttpFactory(handler), NullLogger<AwsIdentityLinkService>.Instance);
+
+        var result = await sut.DisconnectAsync(userId);
+
+        // A user who clicks Disconnect must end up disconnected locally regardless of what AWS
+        // reports — but a failed revocation must not be reported as a clean success.
+        result.Deleted.Should().BeTrue();
+        result.RevokedSuccessfully.Should().BeFalse();
+        (await store.GetAsync(userId)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_UnreachablePool_StillDeletesTheRow_AndReportsRevocationFailed()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+        var userId = Guid.NewGuid();
+        await store.SaveAsync(userId, "user@example.com", "refresh-token-abc");
+
+        var handler = new ThrowingHandler(new HttpRequestException("connection refused"));
+        var sut = new AwsIdentityLinkService(
+            store, Options(ConfiguredSettings), HttpFactory(handler), NullLogger<AwsIdentityLinkService>.Instance);
+
+        var result = await sut.DisconnectAsync(userId);
+
+        result.Deleted.Should().BeTrue();
+        result.RevokedSuccessfully.Should().BeFalse();
+        (await store.GetAsync(userId)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_NoLinkExists_ReturnsDeletedFalse_AndNeverCallsCognito()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+
+        var handler = new RecordingHandler(HttpStatusCode.OK);
+        var sut = new AwsIdentityLinkService(
+            store, Options(ConfiguredSettings), HttpFactory(handler), NullLogger<AwsIdentityLinkService>.Instance);
+
+        var result = await sut.DisconnectAsync(Guid.NewGuid());
+
+        result.Deleted.Should().BeFalse();
+        handler.LastRequest.Should().BeNull("there is no token to revoke when nothing was connected");
+    }
+
+    [Fact]
+    public async Task GetAsync_ExistingLink_ReturnsEmailAndTimestamps()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+        var userId = Guid.NewGuid();
+        await store.SaveAsync(userId, "user@example.com", "refresh-token-abc");
+
+        var handler = new RecordingHandler(HttpStatusCode.OK);
+        var sut = new AwsIdentityLinkService(
+            store, Options(ConfiguredSettings), HttpFactory(handler), NullLogger<AwsIdentityLinkService>.Instance);
+
+        var dto = await sut.GetAsync(userId);
+
+        dto.Should().NotBeNull();
+        dto!.Email.Should().Be("user@example.com");
+        dto.LastUsedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAsync_NoLink_ReturnsNull()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+
+        var handler = new RecordingHandler(HttpStatusCode.OK);
+        var sut = new AwsIdentityLinkService(
+            store, Options(ConfiguredSettings), HttpFactory(handler), NullLogger<AwsIdentityLinkService>.Instance);
+
+        var dto = await sut.GetAsync(Guid.NewGuid());
+
+        dto.Should().BeNull();
+    }
+
+    private sealed class RecordingHandler(HttpStatusCode statusCode, Func<Task>? onSend = null) : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public string? LastRequestBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            LastRequestBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            if (onSend is not null)
+                await onSend();
+
+            return new HttpResponseMessage(statusCode);
+        }
+    }
+
+    private sealed class ThrowingHandler(Exception exception) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw exception;
+    }
+}

--- a/tests/Connapse.Identity.Tests/AwsIdentityLinkServiceTests.cs
+++ b/tests/Connapse.Identity.Tests/AwsIdentityLinkServiceTests.cs
@@ -187,6 +187,36 @@ public class AwsIdentityLinkServiceTests
     }
 
     [Fact]
+    public async Task DisconnectAsync_LinkReplacedDuringRevoke_LeavesTheNewRowInPlace_AndReportsLinkChanged()
+    {
+        // A reconnect races this disconnect: SaveAsync updates the existing row in place, keeping
+        // its Id, while the HTTP revoke call for the *old* token is still in flight. An Id-based
+        // delete would not be able to tell the new row apart from the old one and would remove the
+        // reconnect's link along with it — the row must survive, and the caller must be told the
+        // link changed so it can try again, rather than being told it cleanly disconnected.
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+        var userId = Guid.NewGuid();
+        await store.SaveAsync(userId, "user@example.com", "refresh-token-abc");
+
+        var handler = new RecordingHandler(HttpStatusCode.OK,
+            onSend: () => store.SaveAsync(userId, "reconnected@example.com", "refresh-token-xyz"));
+
+        var sut = new AwsIdentityLinkService(
+            store, Options(ConfiguredSettings), HttpFactory(handler), NullLogger<AwsIdentityLinkService>.Instance);
+
+        var result = await sut.DisconnectAsync(userId);
+
+        result.RevokedSuccessfully.Should().BeTrue("the original token was successfully revoked at Cognito");
+        result.Deleted.Should().BeFalse("the row that exists now is not the one this call revoked");
+        result.LinkChangedDuringDisconnect.Should().BeTrue();
+
+        var survivingLink = await store.GetAsync(userId);
+        survivingLink.Should().NotBeNull("the reconnect's link must survive an unrelated disconnect");
+        survivingLink!.Email.Should().Be("reconnected@example.com");
+    }
+
+    [Fact]
     public async Task GetAsync_ExistingLink_ReturnsEmailAndTimestamps()
     {
         var dbName = Guid.NewGuid().ToString();

--- a/tests/Connapse.Identity.Tests/CognitoIdTokenValidatorTests.cs
+++ b/tests/Connapse.Identity.Tests/CognitoIdTokenValidatorTests.cs
@@ -1,0 +1,176 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using Connapse.Identity.Services;
+using FluentAssertions;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Connapse.Identity.Tests;
+
+/// <summary>
+/// The Cognito ID token checks that stand between a forged or misdirected token and a stored
+/// identity link. Every token here is signed locally with a throwaway RSA key — no live Cognito
+/// pool involved — because the point is to prove each rejection path actually fires, not to
+/// exercise Cognito itself. <see cref="CognitoIdTokenValidator.Validate"/> is the only gate before
+/// <c>AwsIdentityLinkStore.SaveAsync</c> is called in the callback endpoint, so a rejection here is
+/// exactly the case where that save is never reached.
+/// </summary>
+[Trait("Category", "Unit")]
+public class CognitoIdTokenValidatorTests
+{
+    private const string Issuer = "https://cognito-idp.us-west-1.amazonaws.com/us-west-1_test";
+    private const string Audience = "test-client-id";
+    private const string Nonce = "expected-nonce-value";
+
+    private static readonly RsaSecurityKey SigningKey = new(RSA.Create(2048)) { KeyId = "test-key" };
+    private static readonly RsaSecurityKey OtherKey = new(RSA.Create(2048)) { KeyId = "other-key" };
+
+    private static TokenValidationParameters ValidationParameters(SecurityKey? trustedKey = null) => new()
+    {
+        ValidIssuer = Issuer,
+        ValidAudience = Audience,
+        IssuerSigningKey = trustedKey ?? SigningKey,
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        RequireSignedTokens = true,
+        ClockSkew = TimeSpan.FromMinutes(2),
+    };
+
+    private static string ForgeToken(
+        string issuer = Issuer,
+        string audience = Audience,
+        SecurityKey? signWith = null,
+        DateTime? expires = null,
+        string? nonce = Nonce,
+        string email = "person@example.com",
+        bool? emailVerified = true)
+    {
+        var credentials = new SigningCredentials(signWith ?? SigningKey, SecurityAlgorithms.RsaSha256);
+
+        var claims = new List<Claim>
+        {
+            new("sub", Guid.NewGuid().ToString()),
+            new("email", email),
+        };
+        if (emailVerified.HasValue)
+            claims.Add(new Claim("email_verified", emailVerified.Value ? "true" : "false"));
+        if (nonce is not null)
+            claims.Add(new Claim("nonce", nonce));
+
+        var token = new JwtSecurityToken(
+            issuer: issuer,
+            audience: audience,
+            claims: claims,
+            notBefore: DateTime.UtcNow.AddMinutes(-15),
+            expires: expires ?? DateTime.UtcNow.AddMinutes(10),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    [Fact]
+    public void Validate_WellFormedToken_IsAccepted()
+    {
+        var token = ForgeToken();
+
+        var result = CognitoIdTokenValidator.Validate(token, ValidationParameters(), Nonce);
+
+        result.Success.Should().BeTrue();
+        result.Email.Should().Be("person@example.com");
+        result.FailureReason.Should().BeNull();
+    }
+
+    [Fact]
+    public void Validate_SignedWithAKeyTheValidatorDoesNotTrust_IsRejected()
+    {
+        // A token that did not come from the pool it claims to — the exact shape of a forgery.
+        var token = ForgeToken(signWith: OtherKey);
+
+        var result = CognitoIdTokenValidator.Validate(token, ValidationParameters(), Nonce);
+
+        result.Success.Should().BeFalse();
+        result.FailureReason.Should().Be("token_invalid");
+        result.Email.Should().BeNull();
+    }
+
+    [Fact]
+    public void Validate_WrongIssuer_IsRejected()
+    {
+        var token = ForgeToken(issuer: "https://cognito-idp.us-west-1.amazonaws.com/us-west-1_someone_else");
+
+        var result = CognitoIdTokenValidator.Validate(token, ValidationParameters(), Nonce);
+
+        result.Success.Should().BeFalse();
+        result.FailureReason.Should().Be("token_invalid");
+    }
+
+    [Fact]
+    public void Validate_WrongAudience_IsRejected()
+    {
+        var token = ForgeToken(audience: "some-other-client-id");
+
+        var result = CognitoIdTokenValidator.Validate(token, ValidationParameters(), Nonce);
+
+        result.Success.Should().BeFalse();
+        result.FailureReason.Should().Be("token_invalid");
+    }
+
+    [Fact]
+    public void Validate_ExpiredToken_IsRejected()
+    {
+        var token = ForgeToken(expires: DateTime.UtcNow.AddMinutes(-10));
+
+        var result = CognitoIdTokenValidator.Validate(token, ValidationParameters(), Nonce);
+
+        result.Success.Should().BeFalse();
+        result.FailureReason.Should().Be("token_invalid");
+    }
+
+    [Fact]
+    public void Validate_NonceDoesNotMatchWhatThisDeploymentIssued_IsRejected()
+    {
+        var token = ForgeToken(nonce: "a-nonce-the-token-carries");
+
+        var result = CognitoIdTokenValidator.Validate(
+            token, ValidationParameters(), "a-different-nonce-this-deployment-issued");
+
+        result.Success.Should().BeFalse();
+        result.FailureReason.Should().Be("nonce_mismatch");
+    }
+
+    [Fact]
+    public void Validate_TokenCarriesNoNonce_IsRejected()
+    {
+        var token = ForgeToken(nonce: null);
+
+        var result = CognitoIdTokenValidator.Validate(token, ValidationParameters(), Nonce);
+
+        result.Success.Should().BeFalse();
+        result.FailureReason.Should().Be("nonce_mismatch");
+    }
+
+    [Fact]
+    public void Validate_EmailNotVerified_IsRejected()
+    {
+        var token = ForgeToken(emailVerified: false);
+
+        var result = CognitoIdTokenValidator.Validate(token, ValidationParameters(), Nonce);
+
+        result.Success.Should().BeFalse();
+        result.FailureReason.Should().Be("email_not_verified");
+        result.Email.Should().BeNull("nothing should be readable out of a rejected result");
+    }
+
+    [Fact]
+    public void Validate_EmailVerifiedClaimMissing_IsRejected()
+    {
+        var token = ForgeToken(emailVerified: null);
+
+        var result = CognitoIdTokenValidator.Validate(token, ValidationParameters(), Nonce);
+
+        result.Success.Should().BeFalse();
+        result.FailureReason.Should().Be("email_not_verified");
+    }
+}

--- a/tests/Connapse.Identity.Tests/CognitoIdTokenValidatorTests.cs
+++ b/tests/Connapse.Identity.Tests/CognitoIdTokenValidatorTests.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
+using Connapse.Core;
 using Connapse.Identity.Services;
 using FluentAssertions;
 using Microsoft.IdentityModel.Tokens;
@@ -172,5 +173,100 @@ public class CognitoIdTokenValidatorTests
 
         result.Success.Should().BeFalse();
         result.FailureReason.Should().Be("email_not_verified");
+    }
+
+    // --- BuildValidationParameters ---
+    //
+    // These exist because CognitoIdTokenValidatorTests above builds its own
+    // TokenValidationParameters by hand, which proves Validate() honours whatever it is handed —
+    // nothing proved the endpoint hands it the right thing. Each flag gets its own test so a single
+    // flag flipped back to false (or the endpoint forgetting to call this factory at all) fails a
+    // named test rather than a shared one.
+
+    private static CognitoSettings BuildSettings() => new()
+    {
+        IssuerUrl = Issuer,
+        Domain = "https://example.auth.us-west-1.amazoncognito.com",
+        ClientId = Audience,
+        ClientSecret = "secret",
+        Region = "us-west-1",
+    };
+
+    [Fact]
+    public void BuildValidationParameters_ValidatesIssuer()
+    {
+        var parameters = CognitoIdTokenValidator.BuildValidationParameters(BuildSettings(), [SigningKey]);
+
+        parameters.ValidateIssuer.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildValidationParameters_ValidatesAudience()
+    {
+        var parameters = CognitoIdTokenValidator.BuildValidationParameters(BuildSettings(), [SigningKey]);
+
+        parameters.ValidateAudience.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildValidationParameters_ValidatesLifetime()
+    {
+        var parameters = CognitoIdTokenValidator.BuildValidationParameters(BuildSettings(), [SigningKey]);
+
+        parameters.ValidateLifetime.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildValidationParameters_ValidatesIssuerSigningKey()
+    {
+        var parameters = CognitoIdTokenValidator.BuildValidationParameters(BuildSettings(), [SigningKey]);
+
+        parameters.ValidateIssuerSigningKey.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildValidationParameters_RequiresSignedTokens()
+    {
+        var parameters = CognitoIdTokenValidator.BuildValidationParameters(BuildSettings(), [SigningKey]);
+
+        parameters.RequireSignedTokens.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildValidationParameters_UsesIssuerFromSettings()
+    {
+        var parameters = CognitoIdTokenValidator.BuildValidationParameters(BuildSettings(), [SigningKey]);
+
+        parameters.ValidIssuer.Should().Be(Issuer);
+    }
+
+    [Fact]
+    public void BuildValidationParameters_UsesAudienceFromSettings()
+    {
+        var parameters = CognitoIdTokenValidator.BuildValidationParameters(BuildSettings(), [SigningKey]);
+
+        parameters.ValidAudience.Should().Be(Audience);
+    }
+
+    [Fact]
+    public void BuildValidationParameters_PassesThroughTheSigningKeysItWasGiven()
+    {
+        var parameters = CognitoIdTokenValidator.BuildValidationParameters(BuildSettings(), [SigningKey]);
+
+        parameters.IssuerSigningKeys.Should().ContainSingle().Which.Should().BeSameAs(SigningKey);
+    }
+
+    [Fact]
+    public void BuildValidationParameters_ThenValidate_AcceptsATokenSignedWithThePassedThroughKey()
+    {
+        // The end-to-end proof: parameters built by the factory, handed to Validate(), against a
+        // token forged with the same key the factory was given — exactly the endpoint's own path,
+        // minus the live network calls that fetch settings and signing keys.
+        var token = ForgeToken();
+
+        var parameters = CognitoIdTokenValidator.BuildValidationParameters(BuildSettings(), [SigningKey]);
+        var result = CognitoIdTokenValidator.Validate(token, parameters, Nonce);
+
+        result.Success.Should().BeTrue();
     }
 }

--- a/tests/Connapse.Identity.Tests/UserAwsIdentityLinkEntityTests.cs
+++ b/tests/Connapse.Identity.Tests/UserAwsIdentityLinkEntityTests.cs
@@ -1,0 +1,33 @@
+using Connapse.Identity.Data.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Identity.Tests;
+
+/// <summary>
+/// The shape of a stored AWS identity link.
+/// </summary>
+[Trait("Category", "Unit")]
+public class UserAwsIdentityLinkEntityTests
+{
+    [Fact]
+    public void ProtectedRefreshToken_IsNamedForWhatItHolds()
+    {
+        // The name is the guard rail. A property called RefreshToken invites someone to assign a
+        // plaintext one; "Protected" says the value has already been through Data Protection and
+        // that assigning a raw token here is the bug.
+        typeof(UserAwsIdentityLinkEntity).GetProperty("ProtectedRefreshToken")
+            .Should().NotBeNull();
+        typeof(UserAwsIdentityLinkEntity).GetProperty("RefreshToken")
+            .Should().BeNull("a plaintext token must have nowhere to go");
+    }
+
+    [Fact]
+    public void NewLink_DefaultsToEmptyRatherThanNull()
+    {
+        var link = new UserAwsIdentityLinkEntity();
+
+        link.Email.Should().BeEmpty();
+        link.ProtectedRefreshToken.Should().BeEmpty();
+    }
+}

--- a/tests/Connapse.Integration.Tests/AwsIdentityLinkStoreTests.cs
+++ b/tests/Connapse.Integration.Tests/AwsIdentityLinkStoreTests.cs
@@ -1,0 +1,111 @@
+using Connapse.Identity.Data;
+using Connapse.Identity.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Storing a per-user refresh token so that only this deployment can read it back.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AwsIdentityLinkStoreTests(SharedWebAppFixture fixture)
+{
+    private static AwsIdentityLinkStore Build(IServiceProvider sp) =>
+        sp.GetRequiredService<AwsIdentityLinkStore>();
+
+    private async Task<Guid> SeedUserAsync(IServiceProvider sp)
+    {
+        // A real user row, because the link table has a cascading foreign key to it. Create the
+        // user the way the neighbouring identity integration tests do.
+        var factory = sp.GetRequiredService<IDbContextFactory<ConnapseIdentityDbContext>>();
+        await using var db = await factory.CreateDbContextAsync();
+        var user = new Connapse.Identity.Data.Entities.ConnapseUser
+        {
+            Id = Guid.NewGuid(),
+            UserName = $"u-{Guid.NewGuid():N}@example.com",
+            Email = $"u-{Guid.NewGuid():N}@example.com",
+        };
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+        return user.Id;
+    }
+
+    [Fact]
+    public async Task SaveAsync_ThenGetRefreshTokenAsync_RoundTripsThePlaintext()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        Guid userId = await SeedUserAsync(scope.ServiceProvider);
+        var store = Build(scope.ServiceProvider);
+
+        await store.SaveAsync(userId, "person@example.com", "the-refresh-token");
+
+        (await store.GetRefreshTokenAsync(userId)).Should().Be("the-refresh-token");
+    }
+
+    [Fact]
+    public async Task SaveAsync_DoesNotStoreThePlaintext()
+    {
+        // The point of the whole class. Asserting the round trip alone would pass just as happily
+        // against an implementation that wrote the token straight to the column.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        Guid userId = await SeedUserAsync(scope.ServiceProvider);
+        var store = Build(scope.ServiceProvider);
+
+        await store.SaveAsync(userId, "person@example.com", "the-refresh-token");
+
+        var factory = scope.ServiceProvider
+            .GetRequiredService<IDbContextFactory<ConnapseIdentityDbContext>>();
+        await using var db = await factory.CreateDbContextAsync();
+        var row = await db.UserAwsIdentityLinks.SingleAsync(x => x.UserId == userId);
+
+        row.ProtectedRefreshToken.Should().NotBe("the-refresh-token");
+        row.ProtectedRefreshToken.Should().NotContain("the-refresh-token");
+        row.Email.Should().Be("person@example.com");
+    }
+
+    [Fact]
+    public async Task SaveAsync_CalledTwice_ReplacesRatherThanAdds()
+    {
+        // Connecting again must not leave two rows, or something later has to decide which token
+        // is live and there is no correct way to choose.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        Guid userId = await SeedUserAsync(scope.ServiceProvider);
+        var store = Build(scope.ServiceProvider);
+
+        await store.SaveAsync(userId, "first@example.com", "first-token");
+        await store.SaveAsync(userId, "second@example.com", "second-token");
+
+        var factory = scope.ServiceProvider
+            .GetRequiredService<IDbContextFactory<ConnapseIdentityDbContext>>();
+        await using var db = await factory.CreateDbContextAsync();
+        (await db.UserAwsIdentityLinks.CountAsync(x => x.UserId == userId)).Should().Be(1);
+        (await store.GetRefreshTokenAsync(userId)).Should().Be("second-token");
+        (await store.GetAsync(userId))!.Email.Should().Be("second@example.com");
+    }
+
+    [Fact]
+    public async Task GetRefreshTokenAsync_ForAnUnconnectedUser_IsNull()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        Guid userId = await SeedUserAsync(scope.ServiceProvider);
+
+        (await Build(scope.ServiceProvider).GetRefreshTokenAsync(userId)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesTheRow_AndIsSafeToRepeat()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        Guid userId = await SeedUserAsync(scope.ServiceProvider);
+        var store = Build(scope.ServiceProvider);
+        await store.SaveAsync(userId, "person@example.com", "the-refresh-token");
+
+        (await store.DeleteAsync(userId)).Should().BeTrue();
+        (await store.DeleteAsync(userId)).Should().BeFalse("nothing was left to delete");
+        (await store.GetRefreshTokenAsync(userId)).Should().BeNull();
+    }
+}

--- a/tests/Connapse.Integration.Tests/AwsIdentityLinkStoreTests.cs
+++ b/tests/Connapse.Integration.Tests/AwsIdentityLinkStoreTests.cs
@@ -88,6 +88,39 @@ public class AwsIdentityLinkStoreTests(SharedWebAppFixture fixture)
     }
 
     [Fact]
+    public async Task SaveAsync_ManyConcurrentCallsForOneUser_LeaveExactlyOneRow_AndNoneThrow()
+    {
+        // Every call reads "no row for this user" before deciding whether to insert or update, so
+        // without an atomic upsert, two calls landing close enough together both take the insert
+        // path and the unique index on user_id rejects whichever commits second with an unhandled
+        // exception instead of one link simply winning. A shared gate releases every call at (as
+        // close to) the same instant, and enough callers race at once, so that overlap is all but
+        // guaranteed rather than left to incidental timing between two calls.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        Guid userId = await SeedUserAsync(scope.ServiceProvider);
+        var store = Build(scope.ServiceProvider);
+
+        const int concurrency = 16;
+        using var gate = new ManualResetEventSlim(initialState: false);
+
+        var tasks = Enumerable.Range(0, concurrency)
+            .Select(i => Task.Run(async () =>
+            {
+                gate.Wait();
+                await store.SaveAsync(userId, $"user{i}@example.com", $"token-{i}");
+            }))
+            .ToArray();
+
+        gate.Set();
+        await Task.WhenAll(tasks); // Throws if any SaveAsync call threw.
+
+        var factory = scope.ServiceProvider
+            .GetRequiredService<IDbContextFactory<ConnapseIdentityDbContext>>();
+        await using var db = await factory.CreateDbContextAsync();
+        (await db.UserAwsIdentityLinks.CountAsync(x => x.UserId == userId)).Should().Be(1);
+    }
+
+    [Fact]
     public async Task GetRefreshTokenAsync_ForAnUnconnectedUser_IsNull()
     {
         await using var scope = fixture.Factory.Services.CreateAsyncScope();

--- a/tests/Connapse.Integration.Tests/CognitoConnectEndpointTests.cs
+++ b/tests/Connapse.Integration.Tests/CognitoConnectEndpointTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Starting and finishing a Cognito connection.
+/// </summary>
+/// <remarks>
+/// The happy-path callback cannot be tested here: completing it needs an authorization code that
+/// only a real Cognito pool issues, and a real ID token signed by that pool's key. What is testable,
+/// and what these cover, is everything the endpoint decides on its own — whether it redirects at
+/// all, what it redirects to, what it refuses, and that a saved setting actually reaches
+/// <see cref="IOptionsMonitor{TOptions}"/>. The rejection paths inside ID token validation itself
+/// (bad signature, wrong nonce, unverified email) are covered separately in
+/// <c>CognitoIdTokenValidatorTests</c> against tokens forged with a throwaway key, since that logic
+/// needs no live pool and no HTTP round trip to exercise.
+/// </remarks>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public async Task Connect_WhenCognitoIsNotConfigured_Returns409()
+    {
+        // A deployment with no Cognito settings must fail in a way that says so. Redirecting to a
+        // half-built URL sends the user to a 404 on a domain they have never heard of.
+        var response = await fixture.AdminClient.GetAsync("/api/cloud-identity/cognito/connect");
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict, "there is nowhere valid to redirect to");
+    }
+
+    [Fact]
+    public async Task Connect_Unauthenticated_Returns401()
+    {
+        using var anonClient = fixture.Factory.CreateClient(new()
+        {
+            AllowAutoRedirect = false,
+        });
+
+        var response = await anonClient.GetAsync("/api/cloud-identity/cognito/connect");
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Callback_WithNoState_IsRejected()
+    {
+        // An unsolicited callback is either a bug or an attempt to plant a token against someone
+        // else's account. Either way it is not a connection.
+        var response = await fixture.AdminClient.GetAsync("/api/cloud-identity/cognito/callback?code=abc");
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "a required query parameter is missing, matching how the Azure callback rejects the same shape of request");
+    }
+
+    [Fact]
+    public async Task Callback_WithMismatchedState_IsRejected()
+    {
+        // Start a real connection first so a valid state exists to mismatch against — comparing
+        // against a state nobody issued would test a different, easier branch.
+        var connectResponse = await fixture.AdminClient.GetAsync("/api/cloud-identity/cognito/connect");
+        connectResponse.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
+
+        var response = await fixture.AdminClient.GetAsync(
+            "/api/cloud-identity/cognito/callback?code=abc&state=not-a-state-we-issued");
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SavedSettings_ReachTheOptionsMonitor()
+    {
+        // The three-place registration (options binding, category-to-section map, settings
+        // endpoint arms) is invisible until it is wrong, and when it is wrong the failure looks
+        // like a broken endpoint rather than a missing dictionary entry. This is the only test
+        // that would catch the category prefix and the section name disagreeing: reading back
+        // through GET /api/settings/cognito wouldn't, because that endpoint returns whatever is
+        // stored directly, regardless of whether IOptionsMonitor ever picked it up.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<ISettingsStore>();
+
+        await store.SaveAsync("cognito", new CognitoSettings
+        {
+            IssuerUrl = "https://cognito-idp.us-west-1.amazonaws.com/us-west-1_test",
+            Domain = "https://example.auth.us-west-1.amazoncognito.com",
+            ClientId = "client-id",
+            ClientSecret = "secret",
+            Region = "us-west-1",
+        });
+
+        var monitor = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<CognitoSettings>>();
+        monitor.CurrentValue.IsConfigured.Should().BeTrue();
+        monitor.CurrentValue.ClientId.Should().Be("client-id");
+
+        // Restore, so a later test in the shared fixture doesn't see Cognito as configured.
+        await store.SaveAsync("cognito", new CognitoSettings());
+    }
+}

--- a/tests/Connapse.Integration.Tests/CognitoConnectEndpointTests.cs
+++ b/tests/Connapse.Integration.Tests/CognitoConnectEndpointTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using FluentAssertions;
@@ -16,14 +17,35 @@ namespace Connapse.Integration.Tests;
 /// and what these cover, is everything the endpoint decides on its own — whether it redirects at
 /// all, what it redirects to, what it refuses, and that a saved setting actually reaches
 /// <see cref="IOptionsMonitor{TOptions}"/>. The rejection paths inside ID token validation itself
-/// (bad signature, wrong nonce, unverified email) are covered separately in
-/// <c>CognitoIdTokenValidatorTests</c> against tokens forged with a throwaway key, since that logic
-/// needs no live pool and no HTTP round trip to exercise.
+/// (bad signature, wrong nonce, unverified email) and the validation parameters the endpoint builds
+/// are covered separately in <c>CognitoIdTokenValidatorTests</c> against tokens forged with a
+/// throwaway key, since none of that needs a live pool or an HTTP round trip.
 /// </remarks>
 [Trait("Category", "Integration")]
 [Collection("Integration Tests")]
 public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
 {
+    private static CognitoSettings ConfiguredSettings() => new()
+    {
+        IssuerUrl = "https://cognito-idp.us-west-1.amazonaws.com/us-west-1_test",
+        Domain = "https://example.auth.us-west-1.amazoncognito.com",
+        ClientId = "client-id",
+        ClientSecret = "secret",
+        Region = "us-west-1",
+    };
+
+    // A fresh, authenticated client per test that needs one — never the shared fixture.AdminClient
+    // — for two reasons: AllowAutoRedirect must be false (the shared client defaults to true, which
+    // would try to actually follow the redirect out to the fake configured Cognito domain), and each
+    // test needs its own cookie jar so a stashed state/PKCE/nonce cookie from one test's /connect
+    // call can never leak into another test's /callback call.
+    private HttpClient CreateAuthenticatedClient()
+    {
+        var client = fixture.Factory.CreateClient(new() { AllowAutoRedirect = false });
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", fixture.AdminToken);
+        return client;
+    }
+
     [Fact]
     public async Task Connect_WhenCognitoIsNotConfigured_Returns409()
     {
@@ -64,16 +86,39 @@ public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
     [Fact]
     public async Task Callback_WithMismatchedState_IsRejected()
     {
-        // Start a real connection first so a valid state exists to mismatch against — comparing
-        // against a state nobody issued would test a different, easier branch.
-        var connectResponse = await fixture.AdminClient.GetAsync("/api/cloud-identity/cognito/connect");
-        connectResponse.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
+        // This must actually reach the `expectedState != state` branch, not the
+        // `expectedState is missing` branch Callback_WithNoState_IsRejected already covers — which
+        // means a real /connect call has to have set a real state cookie first. Cognito has to be
+        // configured for /connect to do anything but 409.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<ISettingsStore>();
+        await store.SaveAsync("cognito", ConfiguredSettings());
+        try
+        {
+            // One client for both calls: WebApplicationFactoryClientOptions.HandleCookies defaults
+            // to true, so the state/PKCE/nonce cookies /connect sets are carried automatically into
+            // the /callback request below — no live Cognito pool involved, since /connect only
+            // builds a redirect URL and never dials out.
+            using var client = CreateAuthenticatedClient();
 
-        var response = await fixture.AdminClient.GetAsync(
-            "/api/cloud-identity/cognito/callback?code=abc&state=not-a-state-we-issued");
+            var connectResponse = await client.GetAsync("/api/cloud-identity/cognito/connect");
+            connectResponse.StatusCode.Should().Be(HttpStatusCode.Redirect,
+                "Cognito is configured now, so this must actually start a connection and stash a state cookie");
 
-        response.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            // A state nobody issued, sent alongside the *real* stashed cookie from the call above.
+            var response = await client.GetAsync(
+                "/api/cloud-identity/cognito/callback?code=abc&state=not-a-state-we-issued");
+
+            response.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+        finally
+        {
+            // Always restore, even if an assertion above threw — otherwise this leaves Cognito
+            // configured for whichever test in this shared fixture happens to run next, turning one
+            // real failure into a second, unrelated one.
+            await store.SaveAsync("cognito", new CognitoSettings());
+        }
     }
 
     [Fact]
@@ -88,20 +133,18 @@ public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
         await using var scope = fixture.Factory.Services.CreateAsyncScope();
         var store = scope.ServiceProvider.GetRequiredService<ISettingsStore>();
 
-        await store.SaveAsync("cognito", new CognitoSettings
+        await store.SaveAsync("cognito", ConfiguredSettings());
+        try
         {
-            IssuerUrl = "https://cognito-idp.us-west-1.amazonaws.com/us-west-1_test",
-            Domain = "https://example.auth.us-west-1.amazoncognito.com",
-            ClientId = "client-id",
-            ClientSecret = "secret",
-            Region = "us-west-1",
-        });
-
-        var monitor = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<CognitoSettings>>();
-        monitor.CurrentValue.IsConfigured.Should().BeTrue();
-        monitor.CurrentValue.ClientId.Should().Be("client-id");
-
-        // Restore, so a later test in the shared fixture doesn't see Cognito as configured.
-        await store.SaveAsync("cognito", new CognitoSettings());
+            var monitor = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<CognitoSettings>>();
+            monitor.CurrentValue.IsConfigured.Should().BeTrue();
+            monitor.CurrentValue.ClientId.Should().Be("client-id");
+        }
+        finally
+        {
+            // Always restore, even if an assertion above threw — otherwise Connect_WhenCognitoIsNotConfigured_Returns409
+            // fails as collateral, pointing at the wrong place.
+            await store.SaveAsync("cognito", new CognitoSettings());
+        }
     }
 }

--- a/tests/Connapse.Integration.Tests/CognitoConnectEndpointTests.cs
+++ b/tests/Connapse.Integration.Tests/CognitoConnectEndpointTests.cs
@@ -1,8 +1,13 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Identity.Data.Entities;
+using Connapse.Identity.Services;
 using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -25,6 +30,15 @@ namespace Connapse.Integration.Tests;
 [Collection("Integration Tests")]
 public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
 {
+    private const string OtherUserEmail = "other-cognito-user@integration-tests.connapse.io";
+    private const string OtherUserPassword = "OtherCognitoUserTest1!";
+
+    // Must match the private cookie-name consts in CloudIdentityEndpoints — there is no public
+    // surface to read them from, and the user-mismatch test needs the raw stashed state value.
+    private const string CognitoStateCookieName = "__connapse_cog_state";
+    private const string CognitoPkceCookieName = "__connapse_cog_pkce";
+    private const string CognitoNonceCookieName = "__connapse_cog_nonce";
+
     private static CognitoSettings ConfiguredSettings() => new()
     {
         IssuerUrl = "https://cognito-idp.us-west-1.amazonaws.com/us-west-1_test",
@@ -46,12 +60,73 @@ public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
         return client;
     }
 
+    /// <summary>Creates a second Connapse user distinct from the admin, and returns its id.</summary>
+    private static async Task<Guid> SeedOtherUserAsync(IServiceProvider services)
+    {
+        var userManager = services.GetRequiredService<UserManager<ConnapseUser>>();
+
+        var existing = await userManager.FindByEmailAsync(OtherUserEmail);
+        if (existing is not null)
+            return existing.Id;
+
+        var user = new ConnapseUser
+        {
+            UserName = OtherUserEmail,
+            Email = OtherUserEmail,
+            EmailConfirmed = true,
+            DisplayName = OtherUserEmail,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        var createResult = await userManager.CreateAsync(user, OtherUserPassword);
+        createResult.Succeeded.Should().BeTrue(
+            because: string.Join(", ", createResult.Errors.Select(e => e.Description)));
+
+        await userManager.AddToRoleAsync(user, "Viewer");
+        return user.Id;
+    }
+
+    private async Task<string> LoginAsAsync(string email, string password)
+    {
+        using var anonClient = fixture.Factory.CreateClient();
+        var response = await anonClient.PostAsJsonAsync("/api/v1/auth/token", new LoginRequest(email, password));
+        response.StatusCode.Should().Be(HttpStatusCode.OK, because: $"login as {email} should succeed");
+
+        var token = await response.Content.ReadFromJsonAsync<TokenResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        token.Should().NotBeNull();
+        return token!.AccessToken;
+    }
+
+    /// <summary>Pulls the three stashed Cognito cookies' raw name=value pairs off a /connect response.</summary>
+    private static Dictionary<string, string> ExtractCognitoCookies(HttpResponseMessage response)
+    {
+        var names = new[] { CognitoStateCookieName, CognitoPkceCookieName, CognitoNonceCookieName };
+        var result = new Dictionary<string, string>();
+
+        if (!response.Headers.TryGetValues("Set-Cookie", out var setCookieHeaders))
+            return result;
+
+        foreach (var header in setCookieHeaders)
+        {
+            var nameValue = header.Split(';', 2)[0];
+            var parts = nameValue.Split('=', 2);
+            if (parts.Length == 2 && names.Contains(parts[0]))
+                result[parts[0]] = parts[1];
+        }
+
+        return result;
+    }
+
+    private static string BuildCookieHeader(Dictionary<string, string> cookies) =>
+        string.Join("; ", cookies.Select(kv => $"{kv.Key}={kv.Value}"));
+
     [Fact]
     public async Task Connect_WhenCognitoIsNotConfigured_Returns409()
     {
         // A deployment with no Cognito settings must fail in a way that says so. Redirecting to a
         // half-built URL sends the user to a 404 on a domain they have never heard of.
-        var response = await fixture.AdminClient.GetAsync("/api/cloud-identity/cognito/connect");
+        var response = await fixture.AdminClient.GetAsync("/api/v1/auth/cloud/cognito/connect");
 
         response.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
         response.StatusCode.Should().Be(HttpStatusCode.Conflict, "there is nowhere valid to redirect to");
@@ -65,7 +140,7 @@ public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
             AllowAutoRedirect = false,
         });
 
-        var response = await anonClient.GetAsync("/api/cloud-identity/cognito/connect");
+        var response = await anonClient.GetAsync("/api/v1/auth/cloud/cognito/connect");
 
         response.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -76,7 +151,7 @@ public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
     {
         // An unsolicited callback is either a bug or an attempt to plant a token against someone
         // else's account. Either way it is not a connection.
-        var response = await fixture.AdminClient.GetAsync("/api/cloud-identity/cognito/callback?code=abc");
+        var response = await fixture.AdminClient.GetAsync("/api/v1/auth/cloud/cognito/callback?code=abc");
 
         response.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
@@ -101,13 +176,13 @@ public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
             // builds a redirect URL and never dials out.
             using var client = CreateAuthenticatedClient();
 
-            var connectResponse = await client.GetAsync("/api/cloud-identity/cognito/connect");
+            var connectResponse = await client.GetAsync("/api/v1/auth/cloud/cognito/connect");
             connectResponse.StatusCode.Should().Be(HttpStatusCode.Redirect,
                 "Cognito is configured now, so this must actually start a connection and stash a state cookie");
 
             // A state nobody issued, sent alongside the *real* stashed cookie from the call above.
             var response = await client.GetAsync(
-                "/api/cloud-identity/cognito/callback?code=abc&state=not-a-state-we-issued");
+                "/api/v1/auth/cloud/cognito/callback?code=abc&state=not-a-state-we-issued");
 
             response.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -117,6 +192,82 @@ public class CognitoConnectEndpointTests(SharedWebAppFixture fixture)
             // Always restore, even if an assertion above threw — otherwise this leaves Cognito
             // configured for whichever test in this shared fixture happens to run next, turning one
             // real failure into a second, unrelated one.
+            await store.SaveAsync("cognito", new CognitoSettings());
+        }
+    }
+
+    [Fact]
+    public async Task Callback_WhenSignedInUserDiffersFromWhoStartedTheFlow_IsRejectedAndStoresNothing()
+    {
+        // The failure this guards against needs no attacker: user A clicks Connect, goes to the
+        // Cognito hosted UI, and while they are there their Connapse session ends and user B signs
+        // in on the same browser. The redirect lands inside the cookie window. State, PKCE verifier
+        // and nonce are all still valid — they are browser-scoped cookies, not session-scoped — so
+        // without the fix the callback would decide whose account to link by reading whichever
+        // principal happens to be signed in right now (B), storing A's verified AWS identity
+        // against B's account.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<ISettingsStore>();
+        await store.SaveAsync("cognito", ConfiguredSettings());
+        try
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ConnapseUser>>();
+            var initiatingUser = await userManager.FindByEmailAsync(SharedWebAppFixture.AdminEmail);
+            initiatingUser.Should().NotBeNull("the shared admin account is the one used to start the flow below");
+
+            var switchedInUserId = await SeedOtherUserAsync(scope.ServiceProvider);
+            var switchedInUserToken = await LoginAsAsync(OtherUserEmail, OtherUserPassword);
+
+            // Start the flow as the admin (user A) — this is the request whose cookies carry A's id.
+            using var initiatingClient = CreateAuthenticatedClient();
+            var connectResponse = await initiatingClient.GetAsync("/api/v1/auth/cloud/cognito/connect");
+            connectResponse.StatusCode.Should().Be(HttpStatusCode.Redirect,
+                "Cognito is configured, so /connect must stash state and redirect");
+
+            var cognitoCookies = ExtractCognitoCookies(connectResponse);
+            cognitoCookies.Should().ContainKey(CognitoStateCookieName,
+                "the state cookie has to exist for the mismatch check downstream to have anything to parse");
+
+            // The callback arrives with the same browser's cookies, but a different signed-in user
+            // (B) — simulated here by sending them explicitly on a client authenticated as B rather
+            // than A, since the two are otherwise indistinguishable to the server. HandleCookies
+            // must be off: WebApplicationFactory's cookie handler manages the Cookie header from
+            // its own (empty, for this brand-new client) container and discards a manually set one
+            // otherwise, which would defeat the whole point of forwarding A's cookies here.
+            using var switchedInClient = fixture.Factory.CreateClient(new() { AllowAutoRedirect = false, HandleCookies = false });
+            switchedInClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", switchedInUserToken);
+
+            // Set-Cookie values are percent-encoded by ASP.NET Core (Response.Cookies.Append
+            // escapes them; Request.Cookies[name] decodes them back on the way in). The raw
+            // extracted cookie value is already in that encoded form, so it goes on the Cookie
+            // header unchanged — but the query string's `state` needs the *decoded* value
+            // re-escaped exactly once, or the endpoint reads two different strings for
+            // "the state the cookie carries" vs. "the state the query string carries" and
+            // rejects the callback as a state mismatch before ever reaching the check this test
+            // is for.
+            var decodedState = Uri.UnescapeDataString(cognitoCookies[CognitoStateCookieName]);
+            var callbackUrl =
+                $"/api/v1/auth/cloud/cognito/callback?code=abc&state={Uri.EscapeDataString(decodedState)}";
+            using var callbackRequest = new HttpRequestMessage(HttpMethod.Get, callbackUrl);
+            callbackRequest.Headers.TryAddWithoutValidation("Cookie", BuildCookieHeader(cognitoCookies));
+
+            var callbackResponse = await switchedInClient.SendAsync(callbackRequest);
+
+            callbackResponse.StatusCode.Should().NotBe(HttpStatusCode.NotFound, "the route must actually be registered");
+            callbackResponse.StatusCode.Should().Be(HttpStatusCode.Redirect,
+                "a user mismatch is reported the same way the other rejection reasons are: a redirect back with ?error=");
+            callbackResponse.Headers.Location.Should().NotBeNull();
+            callbackResponse.Headers.Location!.ToString().Should().Contain("error=cognito_user_mismatch");
+
+            var linkStore = scope.ServiceProvider.GetRequiredService<AwsIdentityLinkStore>();
+            (await linkStore.GetAsync(initiatingUser!.Id)).Should().BeNull(
+                "the user who started the flow must not gain a link from a callback that ran under someone else's session");
+            (await linkStore.GetAsync(switchedInUserId)).Should().BeNull(
+                "the user signed in at callback time must not gain a link either — the callback stores nothing on a mismatch");
+        }
+        finally
+        {
             await store.SaveAsync("cognito", new CognitoSettings());
         }
     }

--- a/tests/Connapse.Web.Tests/Components/AwsIdentityLinkCopyTests.cs
+++ b/tests/Connapse.Web.Tests/Components/AwsIdentityLinkCopyTests.cs
@@ -44,6 +44,20 @@ public class AwsIdentityLinkCopyTests
     }
 
     [Fact]
+    public void Page_DoesNotClaimNoTokensAreStoredForEveryCard()
+    {
+        // The intro paragraph above all three cards used to say "Only identity metadata is
+        // stored — no access keys or tokens" as a single blanket claim covering all of them. This
+        // card broke that the moment it started storing an encrypted Cognito refresh token: the
+        // card's own copy is careful, but the page-level sentence framing it was left
+        // contradicting it (#433 review finding). The intro must instead scope the "no tokens"
+        // claim to the sign-in cards and admit this card is the exception.
+        Markup.Should().NotContain("Only identity metadata is stored");
+        Markup.Should().Contain("encrypted refresh token",
+            "the intro must admit this card is the one that stores a token, not claim none are stored");
+    }
+
+    [Fact]
     public void Page_CanBeRead()
     {
         // A source-pinning test that passes when it cannot find its subject is worse than none.

--- a/tests/Connapse.Web.Tests/Components/AwsIdentityLinkCopyTests.cs
+++ b/tests/Connapse.Web.Tests/Components/AwsIdentityLinkCopyTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Web.Tests.Components;
+
+/// <summary>
+/// What the integrations page promises about a connected AWS identity.
+/// </summary>
+/// <remarks>
+/// Wording, not markup. This page already carries a test pinning it to *not* claiming that linking
+/// an identity filters search results, because it once did and that was false. The same care
+/// applies to the new card: connecting stores a token so Connapse can check permissions later, and
+/// saying more than that would be the same defect again.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class AwsIdentityLinkCopyTests
+{
+    private static readonly string Markup =
+        File.ReadAllText(Path.Combine(
+            PageTestPaths.RepositoryRoot(),
+            "src", "Connapse.Web", "Components", "Pages", "ProfileIntegrations.razor"));
+
+    [Fact]
+    public void Page_OffersToConnectAnAwsIdentity()
+    {
+        Markup.Should().Contain("cognito/connect",
+            "the card has to actually start the flow");
+    }
+
+    [Fact]
+    public void Page_SaysWhyConnectingMatters()
+    {
+        Markup.Should().Contain("permission",
+            "a user asked to connect an account deserves to know what it buys");
+    }
+
+    [Fact]
+    public void Page_DoesNotClaimSearchIsAlreadyFiltered()
+    {
+        // Nothing filters until 5d registers a resolver. Promising it here would repeat exactly
+        // the defect #422 removed from this same page.
+        Markup.Should().NotContain("results are narrowed");
+        Markup.Should().NotContain("only the documents you can");
+    }
+
+    [Fact]
+    public void Page_CanBeRead()
+    {
+        // A source-pinning test that passes when it cannot find its subject is worse than none.
+        Markup.Should().NotBeNullOrWhiteSpace();
+    }
+}


### PR DESCRIPTION
## What

Sub-phase 5b-i of [#421](https://github.com/Destrayon/Connapse/issues/421): a signed-in user can connect their AWS identity from the integrations page, and Connapse ends up holding an encrypted Cognito refresh token against them. **Nothing filters yet** — no resolver is registered, so search behaves exactly as it does today.

## Why

Closes #433

## How

**Connapse sign-in is untouched.** This is an integration, not an authentication method — Cognito is what an already-signed-in user *connects*, the same shape as the existing AWS device-flow link. No fourth auth scheme, no change to the scheme router. The flow is a plain authorization-code exchange with PKCE that Connapse drives, mirroring the `/azure/connect` + `/azure/callback` pair already in the same file.

Five pieces: `CognitoSettings`; a `user_aws_identity_links` table; `AwsIdentityLinkStore`, the only code that sees the plaintext token; the connect/callback endpoints with `CognitoIdTokenValidator`; and the card on the integrations page.

## The callback is bound to the user who started the flow

The whole-branch review found this and it is the most important thing here. State, PKCE verifier and nonce all lived in browser cookies carrying no user identity, while the account to link was read from whoever was signed in *at callback time*. No attacker was needed: user A clicks Connect, goes to Cognito, their session ends while they are there, user B signs in on the same browser, and the redirect lands inside the cookie window. State, verifier and nonce all match — they are browser-scoped, not session-scoped — so **A's verified AWS email would be stored against B's account**, and since that email is the join key into the Identity Center lookup, B would later resolve with A's AWS permissions.

The state now carries the initiating user id, compared against the live principal, rejecting with `?error=cognito_user_mismatch`. The id is not a trust anchor by itself — the real authorization still flows from the session — so tampering can only produce self-denial.

## Two more things testing found

**A `JwtSecurityTokenHandler` quirk would have silently broken the join key.** Its default inbound claim mapping rewrites `email` to a legacy XML-schema URI, so reading the claim by its bare name returns nothing. Fixed by scoping `InboundClaimTypeMap` to the one handler instance, so it cannot leak into any other JWT path.

**An undecryptable token reported a clean success.** `GetRefreshTokenAsync` returns null both when there is no link and when the Data Protection key ring has been lost, and disconnect collapsed the two — showing "disconnected" while the token stayed live at AWS. Those are now distinguished.

## The ID token is validated before any claim is read

Signature against the pool's JWKS, `iss`, `aud`, lifetime, and a bound nonce — with `email_verified` required true, and a missing claim failing rather than passing by default. The token arrives server-to-server over TLS with client authentication, which is the case OIDC Core §3.1.3.7 permits skipping this in; it is done anyway because the claim being read decides an authorization outcome. The parameter construction is an extracted factory with one named test per flag, so flipping `ValidateAudience` to false breaks a test rather than nothing.

## Disconnect revokes before it deletes

Deleting the local row alone leaves the token valid at Cognito — link gone from Connapse's view, alive from AWS's. `/oauth2/revoke` is called first, the row is deleted either way so a user who clicks Disconnect ends up disconnected regardless, and a failed revocation says so rather than reporting success. The button is reachable even when an admin has cleared the pool settings, which previously stranded a connected user with a live token and no way to remove it.

## Settings registration is three places, not one

`DatabaseSettingsProvider` maps categories to config sections explicitly and defaults unlisted ones to `Knowledge:{category}`. Without the `["cognito"] = "Identity:Cognito"` entry, saved settings would never reach `IOptionsMonitor.CurrentValue` and `/connect` would return 409 forever with every symptom pointing at the endpoint. A test saves through the admin path and asserts the value arrives.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test update or addition

## Testing

- [x] Unit tests pass (`dotnet test --filter "Category=Unit"`) — **1396 passed**
- [x] Integration tests pass (`dotnet test --filter "Category=Integration"`) — **408 passed**
- [ ] Manual testing performed where applicable — **not yet, see below**

The two riskiest tests were verified by mutation rather than trusted: inverting the state comparison and flipping `ValidateAudience` each made the covering test fail.

**Manual verification still required**, because completing a real connection needs a live Cognito pool issuing an authorization code and no automated test can do it. The plan carries the steps; the one worth not skipping is restarting the container and confirming a stored token still decrypts — that proves the Data Protection key ring is genuinely persisted, and its absence would otherwise surface weeks later as every link breaking at once.

## Still missing

- **Refresh, the weekly touch job, and broken-link handling are 5b-ii.** "Permanent" is a property this feature acquires there, not here.
- **No REST endpoint for disconnect**, so `connapse-cli` cannot do it — only the Blazor page can.
- **No `RequestRefresh()` on a signature failure**, so a Cognito signing-key rotation would fail every callback for up to 12 hours. Rare and operator-initiated; worth an issue.
- **`AwsIdentityLinkStore` is injected concretely into an endpoint** where every other endpoint takes an interface, because `IAwsIdentityLinkService` covers Get and Disconnect but not Save. Worth closing when 5b-ii touches this surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added AWS permissions linking through Amazon Cognito from Profile Integrations.
  - Added connection status, email, timestamps, and disconnect controls.
  - Added Cognito configuration support through settings.
  - Added secure token handling and validation for identity connections.

- **Bug Fixes**
  - Updated Cognito connection and callback documentation and test routes to use the correct API paths.

- **Tests**
  - Added coverage for connection flows, token validation, storage, revocation, configuration, and interface copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->