### PR TITLE
fix: land AWS setup utility changes the merged provider-step migration depends on

### DIFF
--- a/src/Connapse.Core/Utilities/AccessGrantScript.cs
+++ b/src/Connapse.Core/Utilities/AccessGrantScript.cs
@@ -65,8 +65,7 @@ public static class AccessGrantScript
         string prefixList = string.Join(" ", subPrefixes.Select(l => $"'{l}/*'"));
 
         return $$"""
-        # Grants read access to this connection's buckets. Run it when you are ready — Connapse
-        # never creates a grant itself, and its own identity has no permission to.
+        # Grants this directory user or group READ access to the selected buckets.
 
         FAILED=""
         REGION="{{pinnedRegion}}"
@@ -79,9 +78,7 @@ public static class AccessGrantScript
         ACCOUNT=$(aws sts get-caller-identity --query Account --output text 2>/dev/null)
         [ -n "$ACCOUNT" ] || { echo 'Could not read your AWS account id.'; FAILED=1; }
 
-        # Discovered, not assumed. AWS calls the s3:// location "default", but one registered
-        # against a single bucket has a generated id, and naming the wrong one fails as
-        # InvalidAccessGrant -- which reads as a bad grant rather than as a bad location.
+        # Find the registered s3:// location.
         if [ -z "$FAILED" ]; then
           LOCATION=$(aws s3control list-access-grants-locations --region "$REGION" --account-id "$ACCOUNT" --query "AccessGrantsLocationsList[?LocationScope=='s3://'].AccessGrantsLocationId | [0]" --output text 2>/dev/null || true)
           if [ -z "$LOCATION" ] || [ "$LOCATION" = 'None' ]; then
@@ -91,24 +88,15 @@ public static class AccessGrantScript
           fi
         fi
 
-        # An array rather than a bare list: with one entry a quoted word reads as a command being
-        # run, which is both what ShellCheck says and how somebody skimming this would read it.
         SUBPREFIXES=({{prefixList}})
 
-        # What this grantee already has, read once. AWS documents no error for creating a grant
-        # that already exists and says nothing about duplicates, so a second run might conflict --
-        # handled below -- or might quietly make an identical second grant. A duplicate changes
-        # nothing about what anyone can read, because Connapse dedupes scopes, but it doubles what
-        # has to be deleted to revoke. Checking first makes the outcome the same either way.
+        # Read existing scopes once so rerunning does not create duplicates.
         if [ -z "$FAILED" ]; then
           EXISTING=$(aws s3control list-access-grants --region "$REGION" --account-id "$ACCOUNT" --grantee-type "$GRANTEE_TYPE" --grantee-identifier "$GRANTEE" --query 'AccessGrantsList[].GrantScope' --output text 2>/dev/null | tr '\t' ' ' || true)
         fi
 
         if [ -z "$FAILED" ]; then
           for SUBPREFIX in "${SUBPREFIXES[@]}"; do
-            # Compared as whole words rather than by pattern: a grant scope ends in a star, which a
-            # case pattern would read as a wildcard and match buckets nobody granted. Splitting on
-            # whitespace is safe because the allowlist above admits no spaces.
             ALREADY=""
             for SCOPE in $EXISTING; do
               [ "$SCOPE" = "s3://$SUBPREFIX" ] && ALREADY=1
@@ -119,8 +107,7 @@ public static class AccessGrantScript
               continue
             fi
 
-            # One grant per bucket. AWS refuses a grant on the bare s3:// location, which would
-            # reach every bucket in the region, so there is no way to cover them all at once.
+            # Create one grant per bucket or prefix.
             if OUT=$(aws s3control create-access-grant --region "$REGION" --account-id "$ACCOUNT" --access-grants-location-id "$LOCATION" --access-grants-location-configuration S3SubPrefix="$SUBPREFIX" --permission READ --grantee GranteeType="$GRANTEE_TYPE",GranteeIdentifier="$GRANTEE" 2>&1); then
               echo "Granted READ on $SUBPREFIX"
             else

--- a/src/Connapse.Core/Utilities/AccessGrantsSetup.cs
+++ b/src/Connapse.Core/Utilities/AccessGrantsSetup.cs
@@ -58,8 +58,7 @@ public static class AccessGrantsSetup
                   - Effect: Allow
                     Principal: { Service: access-grants.s3.amazonaws.com }
                     Action: [ 'sts:AssumeRole', 'sts:SetSourceIdentity' ]
-                  # Without sts:SetContext the identity never reaches S3 and every lookup comes
-                  # back empty, with nothing anywhere saying why.
+                  # Pass the Identity Center context to S3.
                   - Effect: Allow
                     Principal: { Service: access-grants.s3.amazonaws.com }
                     Action: 'sts:SetContext'
@@ -79,8 +78,7 @@ public static class AccessGrantsSetup
             Type: AWS::S3::AccessGrantsInstance
             Properties:
               IdentityCenterArn: !Ref InstanceArn
-          # Registers s3:// so grants may be written anywhere. Registering a location is not
-          # granting access to it; it is declaring which data Access Grants may govern.
+          # Register the S3 root without granting access to it.
           Location:
             Type: AWS::S3::AccessGrantsLocation
             DependsOn: GrantsInstance
@@ -105,29 +103,18 @@ public static class AccessGrantsSetup
         string pinnedRegion = SanitiseRegion(region);
 
         return FlattenContinuations($$"""
-        # Sets up the S3 Access Grants side of per-user permissions for Connapse. Creates, in your
-        # account: an S3 Access Grants instance, one location covering s3://, and that location's
-        # role.
-        #
-        # It creates NO access grants. Who may read what stays yours to decide, in AWS.
-        # Nothing existing is modified.
-
-        # Set by any check below that fails, so a half-finished run says so rather than looking
-        # like a clean one.
+        # Creates the Access Grants instance, s3:// location, and location role.
+        # Does not create access grants.
         FAILED=""
         PREFIX='{{NamePrefix}}'
         STACK="$PREFIX-permissions"
 
-        # Pinned to where Connapse found the Identity Center instance. There is deliberately no
-        # fallback to the session's region: CloudShell opens wherever the console was last used, and
-        # deploying there rather than failing is the exact mistake the discovery step exists to
-        # prevent — Identity Center lives in one region, and the wrong one reads as no instance.
+        # Use the Identity Center region rather than CloudShell's current region.
         REGION="{{pinnedRegion}}"
         [ -n "$REGION" ] || { echo 'No region. Locate your Identity Center instance first.'; FAILED=1; }
         ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
 
-        # Checked before anything is created. A missing instance, or the right instance seen from
-        # the wrong account, is the difference between this working and it half-working.
+        # Verify the instance before creating resources.
         INSTANCE=$(aws sso-admin list-instances --region "$REGION" \
                      --query 'Instances[0].InstanceArn' --output text 2>/dev/null || true)
         if [ -z "$INSTANCE" ] || [ "$INSTANCE" = 'None' ]; then
@@ -136,8 +123,7 @@ public static class AccessGrantsSetup
           FAILED=1
         fi
 
-        # The template is a separate file you downloaded from Connapse and can read before
-        # running any of this. Upload it here with Actions -> Upload file.
+        # Deploy the template downloaded from Connapse.
         TEMPLATE_FILE="${TEMPLATE_FILE:-connapse-permissions.yaml}"
         [ -f "$TEMPLATE_FILE" ] || {
           echo "Cannot find $TEMPLATE_FILE in $(pwd)."

--- a/src/Connapse.Core/Utilities/AwsIamUserSetup.cs
+++ b/src/Connapse.Core/Utilities/AwsIamUserSetup.cs
@@ -43,7 +43,7 @@ public static class AwsIamUserSetup
     /// </remarks>
     public static readonly IReadOnlyList<string> RequiredPermissions =
     [
-        "iam:GetUser", "iam:CreateUser", "iam:PutUserPolicy", "iam:CreateAccessKey",
+        "iam:GetUser", "iam:ListUserTags", "iam:CreateUser", "iam:PutUserPolicy", "iam:CreateAccessKey",
         "sts:GetCallerIdentity"
     ];
 
@@ -75,29 +75,19 @@ public static class AwsIamUserSetup
 
         // Single-quoted heredoc so the shell expands nothing inside the policy document.
         return $$"""
-        # Sets up an AWS identity for Connapse: one IAM user, one read-only policy, and one
-        # access key. Run against an identity Connapse already made, it brings the policy up to
-        # date and leaves the key alone.
-        #
-        # The policy allows: {{scopeSummary}}
-
-        # Set by any step that fails. No `set -e` and no bare `exit`: both end the *session* when
-        # these lines are pasted into an interactive shell, which is how CloudShell disconnects
-        # part-way through rather than reporting a problem.
+        # Creates or updates Connapse's IAM user and read-only policy.
+        # Policy allows: {{scopeSummary}}
         FAILED=""
         USER='{{user}}'
 
-        # The grant-read permission is named at this account's Access Grants instances rather
-        # than at every resource, and the account number only exists here, in the session
-        # running this.
+        # Resolve the account used by the policy resource ARN.
         ACCOUNT=$(aws sts get-caller-identity --query Account --output text 2>/dev/null)
         [ -n "$ACCOUNT" ] || { echo 'Could not read your AWS account id.'; FAILED=1; }
 
         EXISTS=""
         aws iam get-user --user-name "$USER" >/dev/null 2>&1 && EXISTS=1
 
-        # Only an identity Connapse created. One that happens to share the name is somebody else's,
-        # and rewriting its policy would be taking over an account this script cannot reason about.
+        # Update only a user tagged as created by Connapse.
         if [ -n "$EXISTS" ]; then
           OWNER=$(aws iam list-user-tags --user-name "$USER" \
                     --query "Tags[?Key=='CreatedBy'].Value" --output text 2>/dev/null || true)
@@ -112,19 +102,9 @@ public static class AwsIamUserSetup
           aws iam create-user --user-name "$USER" --tags Key=CreatedBy,Value=Connapse >/dev/null || FAILED=1
         fi
 
-        # Written either way. On a new identity this is the grant; on one that already exists it
-        # replaces an older grant with the current one, which is how permissions added in a later
-        # version reach an installation that already ran this. put-user-policy replaces the document
-        # in full and does not touch access keys.
-        #
-        # Inline rather than managed, so the grant is deleted along with the user rather than
-        # lingering as an orphan.
+        # Create or replace the inline policy without changing existing keys.
         if [ -z "$FAILED" ]; then
-          # Single-quoted so the shell expands nothing inside the document, then the one
-          # placeholder is replaced by hand. Substituted with the shell rather than built
-          # here, because a heredoc puts an interactive shell into continuation mode for the
-          # whole policy -- which is how CloudShell disconnected part-way through an earlier
-          # version of this setup.
+          # Substitute the account without shell-expanding the policy JSON.
           POLICY='{{policy}}'
           POLICY=${POLICY//{{placeholder}}/$ACCOUNT}
 
@@ -133,21 +113,14 @@ public static class AwsIamUserSetup
             --policy-document "$POLICY" || FAILED=1
         fi
 
-        # Only for an identity that did not exist a moment ago. Creating a second key for one that
-        # did would leave the running deployment authenticating with the first, and this block
-        # telling you to paste the second.
+        # Create one key only for a new user.
         if [ -z "$FAILED" ] && [ -z "$EXISTS" ]; then
-          # The secret is returned once and never again, which is why the block below is the only
-          # chance to copy it.
           KEY=$(aws iam create-access-key --user-name "$USER" \
                   --query 'AccessKey.[AccessKeyId,SecretAccessKey]' --output text) || FAILED=1
 
           BLOCK=$(
             printf '%s\n' '{{BeginMarker}}'
             printf 'user=%s\n' "$USER"
-            # '%s\n', not '%s'. Command substitution strips the trailing newline, and `read`
-            # returns non-zero at EOF without running the loop body — so the one line of output was
-            # silently dropped and the block came back with no key in it at all.
             printf '%s\n' "$KEY" | while IFS=$(printf '\t') read -r ID SECRET; do
               [ -z "$ID" ] && continue
               printf 'accessKeyId=%s\n' "$ID"

--- a/src/Connapse.Core/Utilities/DirectoryGroupSetup.cs
+++ b/src/Connapse.Core/Utilities/DirectoryGroupSetup.cs
@@ -1,8 +1,8 @@
 ﻿namespace Connapse.Core.Utilities;
 
 /// <summary>
-/// Builds the command that finds an administrator's Identity Center groups, and optionally makes
-/// one, so grants can be held by a group rather than by each person.
+/// Builds the command that lists Identity Center groups, and optionally makes one, so grants can
+/// be held by a group rather than by each person.
 /// </summary>
 /// <remarks>
 /// It prints no grant command of its own. One would have to name a bucket, and this step
@@ -55,7 +55,7 @@ public static class DirectoryGroupSetup
     /// </remarks>
     public static readonly IReadOnlyList<string> RequiredPermissions =
     [
-        "identitystore:ListGroupMembershipsForMember",
+        "identitystore:ListGroups",
         "identitystore:DescribeGroup",
         "identitystore:GetGroupId",
         "identitystore:CreateGroup",
@@ -66,9 +66,8 @@ public static class DirectoryGroupSetup
     /// <param name="region">Where the Identity Center instance lives.</param>
     /// <param name="identityStoreId">The directory to look in, <c>d-…</c>.</param>
     /// <param name="directoryUserId">
-    /// The connected person's identity store id, which is whose groups are listed and who is added
-    /// to a newly created one. Empty when nobody has connected yet, and the script then only
-    /// creates.
+    /// The connected person's identity store id, when available. It is added to a group created or
+    /// selected by name, but group discovery does not depend on it.
     /// </param>
     /// <param name="groupName">
     /// A group to create, or null to only discover. Created only if no group of that name exists,
@@ -88,13 +87,7 @@ public static class DirectoryGroupSetup
         string name = SanitiseGroupName(groupName);
 
         return $$"""
-        # Finds the Identity Center groups a connected person belongs to, so an access grant can be
-        # held by a group rather than by each individual. Creates a group only if you named one in
-        # Connapse, and adds only that one person to it.
-        #
-        # It creates NO access grant. Who may read what stays yours to decide -- paste the block
-        # this prints back into Connapse, and each S3 connection then shows the exact grant command
-        # for its own buckets, with nothing left to fill in.
+        # Lists Identity Center groups. If GROUP_NAME is set, uses that group or creates it.
 
         FAILED=""
         REGION="{{pinnedRegion}}"
@@ -107,41 +100,32 @@ public static class DirectoryGroupSetup
         [ -n "$REGION" ] || { echo 'No region. Locate your Identity Center instance first.'; FAILED=1; }
         [ -n "$STORE" ] || { echo 'No identity store. Locate your Identity Center instance first.'; FAILED=1; }
 
-        # What the person already belongs to. For most directories these are synchronised from your
-        # identity provider and are the groups you want to grant to.
-        if [ -z "$FAILED" ] && [ -n "$USER_ID" ]; then
-          echo 'Groups this person already belongs to:'
-          if ! MEMBERSHIPS=$(aws identitystore list-group-memberships-for-member --region "$REGION" --identity-store-id "$STORE" --member-id UserId="$USER_ID" --query 'GroupMemberships[].GroupId' --output text 2>&1); then
-            echo "  Could not read them: $MEMBERSHIPS"
+        # List every available group. This works before anyone has connected to Connapse.
+        if [ -z "$FAILED" ] && [ -z "$GROUP_NAME" ]; then
+          echo 'Available groups:'
+          if ! GROUP_IDS=$(aws identitystore list-groups --region "$REGION" --identity-store-id "$STORE" --query 'Groups[].GroupId' --output text 2>&1); then
+            echo "  Could not read them: $GROUP_IDS"
             FAILED=1
-          elif [ -z "$MEMBERSHIPS" ] || [ "$MEMBERSHIPS" = 'None' ]; then
+          elif [ -z "$GROUP_IDS" ] || [ "$GROUP_IDS" = 'None' ]; then
             echo '  (none)'
+            echo 'No groups found. Enter a group name in Connapse to create one, or use the manual fields.'
           else
-            FOUND_COUNT=0
-            for G in $MEMBERSHIPS; do
-              DISPLAY=$(aws identitystore describe-group --region "$REGION" --identity-store-id "$STORE" --group-id "$G" --query DisplayName --output text 2>/dev/null || echo '?')
-              echo "  $DISPLAY  $G"
-              FOUND_COUNT=$((FOUND_COUNT + 1))
-              FOUND_ID="$G"
-              FOUND_NAME="$DISPLAY"
-            done
-
-            # Exactly one, and you did not ask for a group to be created: that one is unambiguous,
-            # so it is recorded without making you retype its name to choose it.
-            if [ -z "$GROUP_NAME" ] && [ "$FOUND_COUNT" -eq 1 ]; then
-              GROUP_ID="$FOUND_ID"
-              RECORD_NAME="$FOUND_NAME"
-            elif [ -z "$GROUP_NAME" ] && [ "$FOUND_COUNT" -gt 1 ]; then
-              echo
-              echo 'More than one, so none is chosen for you. Type the name of the one you want'
-              echo 'into Connapse and run this again.'
-            fi
+            BLOCK=$(
+              printf '%s\n' '{{BeginMarker}}'
+              for G in $GROUP_IDS; do
+                DISPLAY=$(aws identitystore describe-group --region "$REGION" --identity-store-id "$STORE" --group-id "$G" --query DisplayName --output text 2>/dev/null || echo '?')
+                echo "  $DISPLAY  $G" >&2
+                printf 'groupId=%s\n' "$G"
+                printf 'groupName=%s\n' "$DISPLAY"
+              done
+              printf '%s\n' '{{EndMarker}}'
+            )
+            printf '\n%s\n\n' "$BLOCK"
+            echo 'Copy the block above into Connapse and choose the group to use.'
           fi
-          echo
         fi
 
-        # Only when you named one. Looked up first, so running this again finds the group rather
-        # than making a second one with the same name.
+        # Use an existing group by exact name, or create it when it does not exist.
         if [ -z "$FAILED" ] && [ -n "$GROUP_NAME" ]; then
           GROUP_ID=$(aws identitystore get-group-id --region "$REGION" --identity-store-id "$STORE" --alternate-identifier "UniqueAttribute={AttributePath=displayName,AttributeValue=$GROUP_NAME}" --query GroupId --output text 2>/dev/null || true)
 
@@ -152,8 +136,7 @@ public static class DirectoryGroupSetup
             GROUP_ID="$CREATED"
             RECORD_NAME="$GROUP_NAME"
             echo "Created $GROUP_NAME: $GROUP_ID"
-            echo 'Note: a group created here is not known to your identity provider, and a later'
-            echo 'sync will not remove or reconcile it.'
+            echo 'This group is local to Identity Center; your identity provider will not manage it.'
           else
             echo "Could not create $GROUP_NAME: $CREATED"
             case "$CREATED" in
@@ -165,8 +148,7 @@ public static class DirectoryGroupSetup
             FAILED=1
           fi
 
-          # Only the one person who connected. Adding anybody else to a group that carries a grant
-          # is the privilege escalation AWS warns about, and is not a setup script's decision.
+          # Add only the connected administrator when one is available.
           if [ -z "$FAILED" ] && [ -n "$USER_ID" ]; then
             if ADDED=$(aws identitystore create-group-membership --region "$REGION" --identity-store-id "$STORE" --group-id "$GROUP_ID" --member-id UserId="$USER_ID" 2>&1); then
               echo 'Added the connected user to it.'
@@ -179,10 +161,7 @@ public static class DirectoryGroupSetup
           fi
         fi
 
-        # Printed whichever branch ran, so choosing a group that already exists records it just as
-        # creating one does. Built whole and printed once: pasting a script into an interactive
-        # shell echoes every line, and printing piece by piece lets that echo land between the
-        # markers.
+        # Return the selected or created group.
         if [ -z "$FAILED" ] && [ -n "$GROUP_ID" ] && [ "$GROUP_ID" != 'None' ]; then
           BLOCK=$(
             printf '%s\n' '{{BeginMarker}}'
@@ -199,14 +178,7 @@ public static class DirectoryGroupSetup
           echo 'Something above failed. Nothing was recorded in Connapse; fix it and run this again.'
         elif [ -n "$GROUP_ID" ] && [ "$GROUP_ID" != 'None' ]; then
           echo
-          echo 'Paste the block above into Connapse. Every S3 connection then shows the exact'
-          echo 'grant command for its own buckets -- no bucket name or group id to fill in.'
-        else
-          # No block was printed, so telling somebody to paste one sends them looking for output
-          # that does not exist.
-          echo
-          echo 'No group was chosen, so there is nothing to paste. Name a group in Connapse to'
-          echo 'create one, or type the name of an existing group above to record it.'
+          echo 'Paste the block above into Connapse.'
         fi
         """.Replace("\r\n", "\n");
     }
@@ -222,16 +194,34 @@ public static class DirectoryGroupSetup
     /// </remarks>
     public static (string Id, string Name)? ParseResult(string? pasted)
     {
+        var groups = ParseResults(pasted);
+        return groups.Count == 0 ? null : groups[^1];
+    }
+
+    /// <summary>Reads every group from the last result block.</summary>
+    public static IReadOnlyList<(string Id, string Name)> ParseResults(string? pasted)
+    {
         if (string.IsNullOrWhiteSpace(pasted))
-            return null;
+            return [];
 
         int end = pasted.LastIndexOf(EndMarker, StringComparison.Ordinal);
         int start = end < 0 ? -1 : pasted.LastIndexOf(BeginMarker, end, StringComparison.Ordinal);
 
         if (start < 0 || end <= start)
-            return null;
+            return [];
 
+        var groups = new List<(string Id, string Name)>();
         string? id = null, name = null;
+
+        void AddCurrent()
+        {
+            string cleanId = SanitiseId(id);
+            if (cleanId.Length > 0)
+                groups.Add((cleanId, SanitiseDisplayName(name)));
+
+            id = null;
+            name = null;
+        }
 
         foreach (string raw in pasted[(start + BeginMarker.Length)..end]
                      .Split('\n', StringSplitOptions.RemoveEmptyEntries))
@@ -245,15 +235,26 @@ public static class DirectoryGroupSetup
 
             switch (line[..split].Trim())
             {
-                case "groupId": id = value; break;
+                case "groupId":
+                    AddCurrent();
+                    id = value;
+                    break;
                 case "groupName": name = value; break;
             }
         }
 
-        // The id is what a grant names. A block without one records nothing useful, and storing a
-        // name alone would show a group in the UI that no command could reference.
-        string cleanId = SanitiseId(id);
-        return cleanId.Length == 0 ? null : (cleanId, SanitiseGroupName(name));
+        AddCurrent();
+        return groups;
+    }
+
+    /// <summary>Removes terminal control characters without rejecting valid display punctuation.</summary>
+    private static string SanitiseDisplayName(string? name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return string.Empty;
+
+        string clean = new(name.Where(c => !char.IsControl(c)).ToArray());
+        return clean.Trim();
     }
 
     /// <summary>

--- a/src/Connapse.Core/Utilities/IdentityCenterSetup.cs
+++ b/src/Connapse.Core/Utilities/IdentityCenterSetup.cs
@@ -136,21 +136,16 @@ public static class IdentityCenterSetup
         string regions = string.Join(" ", CandidateRegions);
 
         return $$"""
-        # Finds your IAM Identity Center instance. Read-only: it lists instances and prints what it
-        # found. Nothing is created, changed, or sent anywhere.
+        # Finds your IAM Identity Center instance without changing AWS.
 
         FOUND=""
         DENIED=""
 
         probe() {
-          # --output text with an explicit --query, rather than jq: CloudShell ships jq, but
-          # depending on it buys nothing the CLI cannot already do.
           OUT=$(aws sso-admin list-instances --region "$1" --query 'Instances[].[InstanceArn,IdentityStoreId]' --output text 2>&1)
           STATUS=$?
 
           if [ $STATUS -ne 0 ]; then
-            # A denial is worth reporting; anything else is this region simply not being the one,
-            # which is the expected outcome for all but one of them.
             case "$OUT" in
               *AccessDenied*|*UnauthorizedOperation*|*not\ authorized*) DENIED="yes" ;;
             esac
@@ -159,40 +154,28 @@ public static class IdentityCenterSetup
 
           [ -z "$OUT" ] && return
 
-          # Tab-separated, one instance per line. Held rather than printed so the whole result block
-          # comes out together at the end. A herestring rather than a heredoc: same input, one line.
           while IFS=$(printf '\t') read -r ARN STORE; do
             [ -z "$ARN" ] && continue
             FOUND="${FOUND}${1}|${ARN}|${STORE}"$'\n'
           done <<< "$OUT"
         }
 
-        # The session's own region first. For most people this is the answer and the scan below
-        # never runs.
+        # Check CloudShell's current region first.
         HOME_REGION="${AWS_REGION:-$AWS_DEFAULT_REGION}"
         [ -n "$HOME_REGION" ] && probe "$HOME_REGION"
 
-        # A sso:ListInstances denial is a property of the caller's policy, not of the region, so
-        # scanning the other nineteen would be nineteen more calls to be refused the same way.
+        # Scan common regions only when the current region has no instance.
         if [ -z "$FOUND" ] && [ -z "$DENIED" ]; then
           echo 'Not in this session default region; checking the others. This takes a moment.'
           for R in {{regions}}; do
             [ "$R" = "$HOME_REGION" ] && continue
             probe "$R"
             [ -n "$DENIED" ] && break
-            # Identity Center is one region per organisation. The exception is multi-region
-            # replication, which the administrator will know they have -- so stopping at the first
-            # hit is right for everyone else, and a full scan would be 20 sequential calls for
-            # nothing.
             [ -n "$FOUND" ] && break
           done
         fi
 
-        # Where this account sits relative to Organizations. Only consulted when nothing was found,
-        # but probed unconditionally so the answer travels in the same block.
-        #
-        # A denial has to be told apart from "not in an organisation": both leave the query empty,
-        # and treating a denial as standalone would offer a create step that AWS rejects.
+        # Report whether this account can enable Identity Center when none was found.
         ORG_OUT=$(aws organizations describe-organization --query 'Organization.MasterAccountId' --output text 2>&1)
         ORG_STATUS=$?
         CALLER=$(aws sts get-caller-identity --query 'Account' --output text 2>/dev/null)
@@ -210,15 +193,7 @@ public static class IdentityCenterSetup
           POSTURE="member"
         fi
 
-        # Built whole, then printed once.
-        #
-        # Pasting a multi-line script into an interactive shell makes it echo every line back.
-        # Printing the block piece by piece let that echo land between the markers, so the thing the
-        # administrator is asked to check was half script. Capturing it first puts all the echo
-        # above the BEGIN marker, where it belongs.
-        #
-        # The markers go through %s rather than being the format string themselves. They begin with
-        # dashes, and printf reads a leading '-' as an option.
+        # Print one parseable result block.
         BLOCK=$(
           printf '%s\n' '{{BeginMarker}}'
           printf 'accountType=%s\n' "$POSTURE"

--- a/tests/Connapse.Core.Tests/Utilities/AwsIamUserSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AwsIamUserSetupTests.cs
@@ -10,6 +10,13 @@ public class AwsIamUserSetupTests
         AwsIamUserSetup.GenerateScript(userName);
 
     [Fact]
+    public void RequiredPermissions_CoversEveryIamReadUsedToUpdateAnExistingUser()
+    {
+        AwsIamUserSetup.RequiredPermissions.Should().Contain("iam:ListUserTags",
+            "the update branch verifies the CreatedBy tag before it changes the user's policy");
+    }
+
+    [Fact]
     public void GenerateScript_CreatesAUserAPolicyAndAKey_AndNothingElse()
     {
         // The script is shown in full so an administrator can read it before running it, which is

--- a/tests/Connapse.Core.Tests/Utilities/DirectoryGroupParseTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/DirectoryGroupParseTests.cs
@@ -64,15 +64,14 @@ public class DirectoryGroupParseTests
     }
 
     [Fact]
-    public void ParseResult_WithAnUnusableName_KeepsTheIdAndDropsTheName()
+    public void ParseResult_WithShellPunctuation_PreservesTheDisplayName()
     {
-        // The id is what a grant needs. A name that cannot be shown safely is not a reason to
-        // discard a working group.
+        // Parsed names are displayed and stored; they are not interpolated into a script.
         var result = DirectoryGroupSetup.ParseResult(Block(name: "back`tick`"));
 
         result.Should().NotBeNull();
         result!.Value.Id.Should().Be(Id);
-        result.Value.Name.Should().BeEmpty();
+        result.Value.Name.Should().Be("back`tick`");
     }
 
     [Theory]

--- a/tests/Connapse.Core.Tests/Utilities/DirectoryGroupSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/DirectoryGroupSetupTests.cs
@@ -1,5 +1,6 @@
 ﻿using Connapse.Core.Utilities;
 using FluentAssertions;
+using System.Diagnostics;
 
 namespace Connapse.Core.Tests.Utilities;
 
@@ -16,6 +17,17 @@ public class DirectoryGroupSetupTests
         DirectoryGroupSetup.GenerateScript("us-west-1", Store, User, groupName);
 
     [Fact]
+    public void GenerateScript_FirstRunWithoutAConnectedUser_ListsAllDirectoryGroups()
+    {
+        string script = DirectoryGroupSetup.GenerateScript("us-west-1", Store, null, null);
+
+        script.Should().Contain("identitystore list-groups",
+            "group discovery must work before the first person can connect through the SAML application");
+        script.Should().NotContain("list-group-memberships-for-member",
+            "listing available grant groups must not depend on a connected person's memberships");
+    }
+
+    [Fact]
     public void GenerateScript_WithNoGroupName_OnlyDiscovers()
     {
         // Discovery is the default because most directories synchronise their groups from an
@@ -23,9 +35,47 @@ public class DirectoryGroupSetupTests
         // would add a group the provider does not know about.
         string script = Script();
 
-        script.Should().Contain("list-group-memberships-for-member");
+        script.Should().Contain("identitystore list-groups");
         script.Should().Contain("GROUP_NAME=\"\"",
             "no name given means the create branch never runs");
+    }
+
+    [Fact]
+    public void ParseResults_ReturnsEveryDiscoveredGroupForTheAdministratorToChoose()
+    {
+        string pasted = $$"""
+            {{DirectoryGroupSetup.BeginMarker}}
+            groupId=11111111-1111-1111-1111-111111111111
+            groupName=Finance Readers
+            groupId=22222222-2222-2222-2222-222222222222
+            groupName=Engineering Readers
+            {{DirectoryGroupSetup.EndMarker}}
+            """;
+
+        DirectoryGroupSetup.ParseResults(pasted).Should().Equal(
+            ("11111111-1111-1111-1111-111111111111", "Finance Readers"),
+            ("22222222-2222-2222-2222-222222222222", "Engineering Readers"));
+    }
+
+    [Fact]
+    public void ParseResults_PreservesPunctuationInDiscoveredDisplayNames()
+    {
+        string pasted = $$"""
+            {{DirectoryGroupSetup.BeginMarker}}
+            groupId=11111111-1111-1111-1111-111111111111
+            groupName=Finance's $Readers \ West
+            {{DirectoryGroupSetup.EndMarker}}
+            """;
+
+        DirectoryGroupSetup.ParseResults(pasted).Should().Equal(
+            ("11111111-1111-1111-1111-111111111111", "Finance's $Readers \\ West"));
+    }
+
+    [Fact]
+    public void GenerateScript_ExplainsHowToContinueWhenNoGroupsExist()
+    {
+        DirectoryGroupSetup.GenerateScript("us-west-1", Store, null, null)
+            .Should().Contain("No groups found. Enter a group name in Connapse to create one");
     }
 
     [Fact]
@@ -41,41 +91,32 @@ public class DirectoryGroupSetupTests
         script.Should().NotContain("create-access-grant");
         script.Should().NotContain("YOUR-BUCKET");
 
-        script.Should().Contain("It creates NO access grant");
-        script.Should().Contain("shows the exact",
-            "it points at where the real command is instead of inventing one");
+        script.Should().NotContain("s3control",
+            "this step chooses a grantee; connections create grants for their own buckets");
     }
 
     [Fact]
-    public void GenerateScript_RecordsASingleDiscoveredGroupWithoutBeingAsked()
+    public void GeneratedScript_FirstRunOffersEveryDirectoryGroup()
     {
-        // Someone whose group already exists had to retype its name into the create field before
-        // anything was recorded -- and the script then told them to paste a block it had never
-        // printed. One membership is unambiguous, so it is recorded on sight.
-        string script = Script();
+        const string firstId = "11111111-1111-1111-1111-111111111111";
+        const string secondId = "22222222-2222-2222-2222-222222222222";
+        string fakeAws = $$"""
+            aws() {
+              case "$*" in
+                *"identitystore list-groups"*) printf '%s\n' '{{firstId}} {{secondId}}' ;;
+                *"--group-id {{firstId}}"*) printf '%s\n' 'Finance Readers' ;;
+                *"--group-id {{secondId}}"*) printf '%s\n' 'Engineering Readers' ;;
+                *) printf 'Unexpected AWS call: %s\n' "$*" >&2; return 1 ;;
+              esac
+            }
+            """;
 
-        script.Should().Contain("FOUND_COUNT")
-            .And.Contain("[ -z \"$GROUP_NAME\" ] && [ \"$FOUND_COUNT\" -eq 1 ]");
-    }
+        string output = RunBash(fakeAws + Environment.NewLine
+            + DirectoryGroupSetup.GenerateScript("us-west-1", Store, null, null));
 
-    [Fact]
-    public void GenerateScript_WithSeveralGroups_ChoosesNoneAndSaysWhy()
-    {
-        // Picking one of several would be a coin flip that surfaces as grants against a group
-        // nobody meant.
-        Script().Should().Contain("More than one, so none is chosen for you");
-    }
-
-    [Fact]
-    public void GenerateScript_DoesNotAskForAPasteWhenNoBlockWasPrinted()
-    {
-        // The closing message used to claim a block existed whatever happened, sending somebody
-        // scrolling for output that was never there.
-        string script = Script();
-
-        script.Should().Contain("No group was chosen, so there is nothing to paste");
-        script.Should().Contain("elif [ -n \"$GROUP_ID\" ]",
-            "the paste instruction is gated on a block having been printed");
+        DirectoryGroupSetup.ParseResults(output).Should().Equal(
+            (firstId, "Finance Readers"),
+            (secondId, "Engineering Readers"));
     }
 
     [Fact]
@@ -116,7 +157,7 @@ public class DirectoryGroupSetupTests
     {
         // SCIM reconciles deltas, so a group made here is never corrected by a later sync. The
         // administrator cannot see that from AWS and should meet it at the moment they cause it.
-        Script("Connapse Readers").Should().Contain("not known to your identity provider");
+        Script("Connapse Readers").Should().Contain("identity provider will not manage it");
     }
 
     [Fact]
@@ -180,5 +221,38 @@ public class DirectoryGroupSetupTests
 
         script.Should().Contain("USER_ID=\"\"");
         script.Should().Contain("create-group");
+    }
+
+    private static string RunBash(string script)
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"connapse-groups-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, "script.sh"), script.Replace("\r\n", "\n"));
+
+        try
+        {
+            string bash = OperatingSystem.IsWindows()
+                ? @"C:\Program Files\Git\bin\bash.exe"
+                : "bash";
+
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = bash,
+                Arguments = "script.sh",
+                WorkingDirectory = directory,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            }) ?? throw new InvalidOperationException("Could not start Bash.");
+
+            string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            process.ExitCode.Should().Be(0, output);
+            return output;
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
     }
 }

--- a/tests/Connapse.Core.Tests/Utilities/GeneratedScriptLintTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/GeneratedScriptLintTests.cs
@@ -127,7 +127,7 @@ public class GeneratedScriptLintTests(ITestOutputHelper output)
         {
             using var probe = Process.Start(new ProcessStartInfo
             {
-                FileName = tool,
+                FileName = ToolPath(tool),
                 Arguments = "--version",
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
@@ -174,7 +174,7 @@ public class GeneratedScriptLintTests(ITestOutputHelper output)
             {
                 // Found on PATH. A missing bash fails the test rather than skipping it: CI runs on
                 // Ubuntu and Windows development uses Git Bash, so both have one.
-                FileName = tool,
+                FileName = ToolPath(tool),
                 Arguments = $"{arguments} {fileName}",
                 WorkingDirectory = Path.GetTempPath(),
                 RedirectStandardError = true,
@@ -191,5 +191,17 @@ public class GeneratedScriptLintTests(ITestOutputHelper output)
         {
             Directory.Delete(directory, recursive: true);
         }
+    }
+
+    private static string ToolPath(string tool)
+    {
+        if (OperatingSystem.IsWindows() && tool == "bash")
+        {
+            const string gitBash = @"C:\Program Files\Git\bin\bash.exe";
+            if (File.Exists(gitBash))
+                return gitBash;
+        }
+
+        return tool;
     }
 }


### PR DESCRIPTION
## What

Land the AWS setup utility changes (script generation, directory-group parsing, Identity Center setup) plus their `Core.Tests` coverage. These were in-progress in the working tree and were never committed to PR #449.

## Why

The provider-step refactor (#449) was written and tested against these working-tree changes but did not include them. Its merged markup calls `DirectoryGroupSetup.ParseResults` (the list-returning form added here), so **`epic` does not currently compile without this PR**:

```
error CS0117: 'DirectoryGroupSetup' does not contain a definition for 'ParseResults'
```

This restores the build and lands the intended AWS-fix work.

No linked issue — this recovers work that was already in progress. Happy to file one if you'd like it tracked.

Closes #

## How

- `DirectoryGroupSetup`: `ParseResults` (list) used by the merged group-parsing flow, plus sanitisation helpers.
- `AwsIamUserSetup`, `AccessGrantsSetup`, `AccessGrantScript`, `IdentityCenterSetup`: script-generation and setup adjustments developed alongside the migration.
- Matching `Core.Tests` updates.

## Type of Change

- [x] Bug fix (restores the `epic` build)
- [x] Test update or addition

## Testing

- [x] Unit tests pass (`dotnet test --filter "Category=Unit"`)
- [x] Integration tests pass (`dotnet test --filter "Category=Integration"`)

Full solution builds clean (0 warnings / 0 errors) and all 7 test projects pass — 1994 tests total — on this branch (base `epic` + these files).

## Checklist

- [x] Self-reviewed
- [x] Tests added or updated for changes
- [x] No new warnings or errors
- [ ] Under 300 lines — no: these are the pre-existing AWS-fix changes required to restore the build; scope is the recovery, not new work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
