### PR TITLE
fix: concurrency-safe SAML/group resets (#451)

### DIFF
--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1317,11 +1317,11 @@
         // incomplete, which the scope resolver reads as EnforcingButUnusable and denies — searches
         // return nothing for everyone until the application is set up again, rather than silently
         // widening the whole corpus to every user.
-        await SaveSamlSettings(new SamlSignInSettings
-        {
-            GrantGroupId = samlSettings.GrantGroupId,
-            GrantGroupName = samlSettings.GrantGroupName,
-        });
+        //
+        // Built from CurrentValue, not the samlSettings snapshot captured at page load: on a
+        // long-lived page another administrator may have changed the group since, and rebuilding
+        // from the stale copy would write that obsolete value back.
+        await SaveSamlSettings(GrantGroupOnly(SamlOptions.CurrentValue));
 
         if (saveSuccess)
         {
@@ -1332,18 +1332,31 @@
 
     private async Task ClearGrantGroup()
     {
-        await SaveSamlSettings(new SamlSignInSettings
-        {
-            EntityId = samlSettings.EntityId,
-            AcsUrl = samlSettings.AcsUrl,
-            IdpEntityId = samlSettings.IdpEntityId,
-            IdpSingleSignOnUrl = samlSettings.IdpSingleSignOnUrl,
-            IdpSigningCertificate = samlSettings.IdpSigningCertificate,
-        });
+        // CurrentValue, not the page-load snapshot: another administrator may have rotated the
+        // certificate or issuer since this page opened, and rebuilding the SAML fields from the
+        // stale copy would revert that rotation.
+        await SaveSamlSettings(WithoutGrantGroup(SamlOptions.CurrentValue));
 
         if (saveSuccess)
             pastedGroup = null;
     }
+
+    /// <summary>The SAML application settings without the default grant group.</summary>
+    private static SamlSignInSettings WithoutGrantGroup(SamlSignInSettings from) => new()
+    {
+        EntityId = from.EntityId,
+        AcsUrl = from.AcsUrl,
+        IdpEntityId = from.IdpEntityId,
+        IdpSingleSignOnUrl = from.IdpSingleSignOnUrl,
+        IdpSigningCertificate = from.IdpSigningCertificate,
+    };
+
+    /// <summary>Only the default grant group, without the SAML application settings.</summary>
+    private static SamlSignInSettings GrantGroupOnly(SamlSignInSettings from) => new()
+    {
+        GrantGroupId = from.GrantGroupId,
+        GrantGroupName = from.GrantGroupName,
+    };
 
     private async Task CopyIdentityScript()
     {

--- a/tests/Connapse.Web.Tests/Components/SamlResetConcurrencyTests.cs
+++ b/tests/Connapse.Web.Tests/Components/SamlResetConcurrencyTests.cs
@@ -1,0 +1,115 @@
+using System.Reflection;
+using Connapse.Core;
+using Connapse.Web.Components.Pages;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Web.Tests.Components;
+
+/// <summary>
+/// The two per-user-permission resets must not revert a change another administrator made while
+/// this page was open.
+/// </summary>
+/// <remarks>
+/// Both resets rebuild the whole <see cref="SamlSignInSettings"/> from a single source and save it.
+/// The bug they guard against is building from <c>samlSettings</c> — the copy captured once in
+/// <c>OnInitialized</c> — because a long-lived page would then write a page-load snapshot back over
+/// a certificate rotation or a group change made since. The fix builds from
+/// <c>SamlOptions.CurrentValue</c>, the live monitor value that reflects reloads from concurrent
+/// saves. These tests pin both the field-level transforms and the wiring that feeds them.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class SamlResetConcurrencyTests
+{
+    private static SamlSignInSettings Full(string certificate = "CERT", string groupId = "group-1") => new()
+    {
+        EntityId = "https://connapse.example.com/saml/connapse",
+        AcsUrl = "https://connapse.example.com/api/v1/auth/cloud/aws/acs",
+        IdpEntityId = "https://portal.sso.us-west-1.amazonaws.com/saml/assertion/EXAMPLE",
+        IdpSingleSignOnUrl = "https://portal.sso.us-west-1.amazonaws.com/saml/assertion/EXAMPLE",
+        IdpSigningCertificate = certificate,
+        GrantGroupId = groupId,
+        GrantGroupName = "Everyone",
+    };
+
+    private static SamlSignInSettings Invoke(string helper, SamlSignInSettings input)
+    {
+        MethodInfo? method = typeof(Providers).GetMethod(
+            helper, BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull($"{helper} should exist as a private static helper on Providers");
+        return (SamlSignInSettings)method!.Invoke(null, [input])!;
+    }
+
+    [Fact]
+    public void WithoutGrantGroup_KeepsTheApplicationAndDropsTheGroup()
+    {
+        SamlSignInSettings source = Full();
+        SamlSignInSettings result = Invoke("WithoutGrantGroup", source);
+
+        result.EntityId.Should().Be(source.EntityId);
+        result.AcsUrl.Should().Be(source.AcsUrl);
+        result.IdpEntityId.Should().Be(source.IdpEntityId);
+        result.IdpSingleSignOnUrl.Should().Be(source.IdpSingleSignOnUrl);
+        result.IdpSigningCertificate.Should().Be(source.IdpSigningCertificate);
+        result.HasGrantGroup.Should().BeFalse("clearing the group is the whole point of this reset");
+    }
+
+    [Fact]
+    public void GrantGroupOnly_KeepsTheGroupAndDropsTheApplication()
+    {
+        SamlSignInSettings source = Full();
+        SamlSignInSettings result = Invoke("GrantGroupOnly", source);
+
+        result.GrantGroupId.Should().Be(source.GrantGroupId);
+        result.GrantGroupName.Should().Be(source.GrantGroupName);
+        result.IsConfigured.Should().BeFalse("clearing the SAML application is the whole point of this reset");
+    }
+
+    [Fact]
+    public void GroupReset_TakesTheCertificateFromWhicheverSettingsItIsGiven()
+    {
+        // The reset feeds this helper SamlOptions.CurrentValue (the live value). Given the freshly
+        // rotated settings it carries the rotated certificate through; given a stale snapshot it
+        // would carry the old one. That difference is exactly why the reset must read the live
+        // value rather than the page-load snapshot.
+        Invoke("WithoutGrantGroup", Full(certificate: "ROTATED")).IdpSigningCertificate
+            .Should().Be("ROTATED");
+        Invoke("WithoutGrantGroup", Full(certificate: "STALE")).IdpSigningCertificate
+            .Should().Be("STALE");
+    }
+
+    [Fact]
+    public void ApplicationReset_TakesTheGroupFromWhicheverSettingsItIsGiven()
+    {
+        Invoke("GrantGroupOnly", Full(groupId: "rotated-group")).GrantGroupId
+            .Should().Be("rotated-group");
+        Invoke("GrantGroupOnly", Full(groupId: "stale-group")).GrantGroupId
+            .Should().Be("stale-group");
+    }
+
+    /// <summary>
+    /// The wiring the transforms depend on: both resets must read the live monitor value, not the
+    /// <c>samlSettings</c> snapshot. A transform that is correct but fed the stale copy reverts a
+    /// concurrent change just as surely, and that mistake is invisible to the transform tests above.
+    /// </summary>
+    [Fact]
+    public void BothSamlResets_BuildFromTheLiveSettingsNotThePageSnapshot()
+    {
+        string source = File.ReadAllText(Path.Combine(
+            PageTestPaths.RepositoryRoot(),
+            "src", "Connapse.Web", "Components", "Pages", "Providers.razor"));
+
+        MethodBody(source, "private async Task ClearGrantGroup()")
+            .Should().Contain("SamlOptions.CurrentValue");
+        MethodBody(source, "private async Task ClearSamlApplication()")
+            .Should().Contain("SamlOptions.CurrentValue");
+    }
+
+    private static string MethodBody(string source, string signature)
+    {
+        int start = source.IndexOf(signature, StringComparison.Ordinal);
+        start.Should().BePositive($"{signature} should exist");
+        int next = source.IndexOf("private ", start + signature.Length, StringComparison.Ordinal);
+        return next > start ? source[start..next] : source[start..];
+    }
+}


### PR DESCRIPTION
## What

Make the two per-user-permission resets (`ClearGrantGroup`, `ClearSamlApplication`) build the replacement `SamlSignInSettings` from the **live** monitor value (`SamlOptions.CurrentValue`) instead of the `samlSettings` snapshot captured once in `OnInitialized`.

## Why

Closes #451. On a long-lived page, another administrator can rotate the signing certificate/issuer or change the grant group. The old resets rebuilt the whole settings object from the page-load snapshot and saved it, silently reverting that concurrent change (a lost update → auth outage / trust regression). Flagged by a Codex adversarial review of #449.

## How

- Extracted two pure helpers, `WithoutGrantGroup` and `GrantGroupOnly`, that clear only the fields their reset owns.
- Both resets now pass `SamlOptions.CurrentValue` to those helpers, so a reset operates on the freshest stored view (which reflects reloads from concurrent saves) and preserves whatever the other fields currently hold.
- Reading the DB row directly (`ISettingsStore.GetAsync`) is deliberately avoided — an env-configured deployment has no row, and writing one would shadow the environment (the trap `SaveSamlSettings` documents). Full optimistic concurrency (reject-on-conflict) would need a store-wide version primitive and is out of scope; re-reading the live value closes the load-time snapshot window, which is the actual defect.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update or addition

## Testing

- [x] Unit tests pass (`dotnet test --filter "Category=Unit"`)
- [x] Integration tests pass (`dotnet test --filter "Category=Integration"`)

New `SamlResetConcurrencyTests` (5): both transforms preserve the fields they must and drop the ones they must; a rotated-vs-stale certificate scenario; and a source-level guard that both resets read `SamlOptions.CurrentValue`. Full `Connapse.Web.Tests` (111) and the integration rendering tests pass.

## Notes

A faithful end-to-end two-session render test would require a Blazor component renderer (bUnit / the full dependency graph), since the reset chains into `StateHasChanged`. Coverage here is the pure transforms plus a wiring guard, which is proportionate to the fix.

## Checklist

- [x] Under 300 lines
- [x] Does one thing
- [x] Self-reviewed
- [x] Tests added
- [x] No new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
