### PR TITLE
feat: S3 access grant management (create + cleanup + role update), reviewed & hardened

### DIFF
--- a/docs/superpowers/plans/2026-09-02-auto-create-access-grants.md
+++ b/docs/superpowers/plans/2026-09-02-auto-create-access-grants.md
@@ -1,0 +1,780 @@
+# Auto-create S3 Access Grants Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Connapse's own AWS identity create the S3 Access Grants that make a connection's buckets searchable per-user, so an admin clicks a button on the connection instead of pasting a CloudShell script.
+
+**Architecture:** Mirror the existing read path (`IAccessGrantsReader` → `S3AccessGrantsReader`) with a write twin. A pure `GrantPlanner` decides which grants to create vs. skip (unit-tested); a thin `S3AccessGrantsWriter` does the AWS I/O with Connapse's `ConnapseAwsCredentials` (verified manually/live, matching the reader). The role's `ConnapseRead` policy gains the grant-write actions. On the connection page, a "Grant access" button calls the writer and degrades to the existing CloudShell script when the identity is denied.
+
+**Tech Stack:** .NET 10, C#, Blazor Server, AWS SDK for .NET (`AWSSDK.S3Control`), xUnit + FluentAssertions + NSubstitute.
+
+**Spec:** [docs/superpowers/specs/2026-09-02-aws-auto-create-access-grants-design.md](../specs/2026-09-02-aws-auto-create-access-grants-design.md)
+
+## Global Constraints
+
+- .NET 10; file-scoped namespaces; nullable enabled; implicit usings.
+- Records for DTOs/results; primary constructors for DI. Don't use `var` for primitive types; no `dynamic`.
+- Async all the way — never `.Result`/`.Wait()`.
+- **READ grants only** — never create WRITE or READWRITE (a write-only grant read back as readable is a disclosure).
+- **Idempotent** — existing grants are read first and skipped; a second run creates nothing.
+- **Fail-closed on partial error** — one location's failure never aborts the rest, and the result reports exactly which failed and why; never a silent partial success.
+- **Connection's region only** — a grant is created against the Access Grants instance in the bucket's region; the writer is only ever called with the connection's own region.
+- When logging user-controlled values (region, grantee id) wrap them with `LogSanitizer.Sanitize(...)` from `Connapse.Core.Utilities`.
+- Test naming: `MethodName_Scenario_ExpectedResult`; tag unit tests `[Trait("Category", "Unit")]`.
+- Commit message types: `feat:`, `test:`, `refactor:`. End commit messages with the Co-Authored-By trailer.
+
+---
+
+### Task 1: Pure grant planner
+
+The one piece that guarantees the writer creates exactly the scope shape the reader and `GrantCoverageReporter` expect. Given the connection's ungranted locations and the grantee's existing grant scopes, decide which subprefixes to create and which are already covered. Reuses `AccessGrantScript.SanitiseLocation` so the location→subprefix shaping has a single source.
+
+**Files:**
+- Create: `src/Connapse.Core/Utilities/GrantPlanner.cs`
+- Test: `tests/Connapse.Core.Tests/Utilities/GrantPlannerTests.cs`
+
+**Interfaces:**
+- Consumes: `AccessGrantScript.SanitiseLocation(string?)` (existing, public — trims, rejects unsafe, drops trailing slash).
+- Produces:
+  - `GrantPlanner.Plan(IEnumerable<string> requestedLocations, IEnumerable<string> existingScopes) → GrantPlan`
+  - `record GrantPlan(IReadOnlyList<string> ToCreate, IReadOnlyList<string> AlreadyGranted)` — each string is a subprefix in the form `bucket/prefix/*` (no `s3://`), ready to pass as `S3SubPrefix`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class GrantPlannerTests
+{
+    [Fact]
+    public void Plan_LocationWithNoExistingGrant_IsToCreateAsSubPrefixStar()
+    {
+        var plan = GrantPlanner.Plan(["my-bucket/docs"], existingScopes: []);
+
+        plan.ToCreate.Should().ContainSingle().Which.Should().Be("my-bucket/docs/*");
+        plan.AlreadyGranted.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Plan_LocationAlreadyGranted_IsSkipped()
+    {
+        var plan = GrantPlanner.Plan(
+            ["my-bucket/docs"],
+            existingScopes: ["s3://my-bucket/docs/*"]);
+
+        plan.ToCreate.Should().BeEmpty();
+        plan.AlreadyGranted.Should().ContainSingle().Which.Should().Be("my-bucket/docs/*");
+    }
+
+    [Fact]
+    public void Plan_BucketRoot_BecomesBucketStar()
+    {
+        var plan = GrantPlanner.Plan(["my-bucket"], existingScopes: []);
+
+        plan.ToCreate.Should().ContainSingle().Which.Should().Be("my-bucket/*");
+    }
+
+    [Fact]
+    public void Plan_TrailingSlashAndDuplicates_AreNormalisedAndDeduped()
+    {
+        var plan = GrantPlanner.Plan(
+            ["my-bucket/docs/", "my-bucket/docs"],
+            existingScopes: []);
+
+        plan.ToCreate.Should().ContainSingle().Which.Should().Be("my-bucket/docs/*");
+    }
+
+    [Fact]
+    public void Plan_UnsafeLocation_IsDropped()
+    {
+        var plan = GrantPlanner.Plan(["bad bucket$name"], existingScopes: []);
+
+        plan.ToCreate.Should().BeEmpty();
+        plan.AlreadyGranted.Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Core.Tests --filter "FullyQualifiedName~GrantPlannerTests"`
+Expected: FAIL — `GrantPlanner` does not exist (compile error).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```csharp
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Decides which S3 Access Grants to create for a grantee, given the grants they already hold.
+/// </summary>
+/// <remarks>
+/// Pure so it can be tested without AWS, and so the subprefix shape — <c>bucket/prefix/*</c> — has
+/// one source shared with <see cref="AccessGrantScript"/>. The writer creates exactly what this
+/// returns; if the shape drifted from what the reader parses, a grant just created would still read
+/// as ungranted.
+/// </remarks>
+public static class GrantPlanner
+{
+    /// <summary>Splits requested locations into those needing a grant and those already covered.</summary>
+    /// <param name="requestedLocations">
+    /// Buckets, each optionally followed by <c>/</c> and a prefix — the connection's ungranted
+    /// locations.
+    /// </param>
+    /// <param name="existingScopes">
+    /// The grantee's current grant scopes as AWS reports them, e.g. <c>s3://bucket/prefix/*</c>.
+    /// </param>
+    public static GrantPlan Plan(
+        IEnumerable<string> requestedLocations, IEnumerable<string> existingScopes)
+    {
+        var existing = new HashSet<string>(
+            (existingScopes ?? []).Select(s => s?.Trim() ?? string.Empty),
+            StringComparer.Ordinal);
+
+        var toCreate = new List<string>();
+        var alreadyGranted = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (string location in requestedLocations ?? [])
+        {
+            string sanitised = AccessGrantScript.SanitiseLocation(location);
+            if (sanitised.Length == 0)
+                continue;
+
+            // The shape a grant is created and read back as. AWS refuses a grant on the bare
+            // s3:// location, so every one names a bucket and the trailing star makes it a subtree.
+            string subPrefix = sanitised + "/*";
+
+            if (!seen.Add(subPrefix))
+                continue;
+
+            if (existing.Contains("s3://" + subPrefix))
+                alreadyGranted.Add(subPrefix);
+            else
+                toCreate.Add(subPrefix);
+        }
+
+        return new GrantPlan(toCreate, alreadyGranted);
+    }
+}
+
+/// <summary>The outcome of planning grants: what to create, and what already exists.</summary>
+public record GrantPlan(IReadOnlyList<string> ToCreate, IReadOnlyList<string> AlreadyGranted);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Core.Tests --filter "FullyQualifiedName~GrantPlannerTests"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Utilities/GrantPlanner.cs tests/Connapse.Core.Tests/Utilities/GrantPlannerTests.cs
+git commit -m "feat: grant planner deciding which S3 access grants to create"
+```
+
+---
+
+### Task 2: Grant writer interface + S3 implementation + DI
+
+Add the write twin of the reader. The interface and result types live in Core beside `IAccessGrantsReader`; the S3 implementation lives beside `S3AccessGrantsReader` and is constructed identically. The AWS-I/O class is not unit-tested at the client boundary — the reader isn't either — so its correctness rests on Task 1's planner tests plus the live-AWS check in Task 5's verification.
+
+**Files:**
+- Create: `src/Connapse.Core/Interfaces/IAccessGrantsWriter.cs` (namespace `Connapse.Core`, matching `IAccessGrantsReader.cs`)
+- Create: `src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs`
+- Modify: `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs:219` (register beside the reader)
+
+**Interfaces:**
+- Consumes: `AccessGrantee` (existing, `Connapse.Core`), `GrantPlanner.Plan(...)` / `GrantPlan` (Task 1), `ConnapseAwsCredentials`, `IOptionsMonitor<IdentityCenterSettings>` (both already injected into `S3AccessGrantsReader`).
+- Produces:
+  - `IAccessGrantsWriter.GrantReadAsync(AccessGrantee grantee, string region, IReadOnlyList<string> locations, CancellationToken ct = default) → Task<GrantWriteResult>`
+  - `record GrantWriteResult(IReadOnlyList<string> Created, IReadOnlyList<string> AlreadyGranted, IReadOnlyList<GrantWriteFailure> Failed, bool AccessDenied)` with `bool Succeeded => Failed.Count == 0;`
+  - `record GrantWriteFailure(string Location, string Reason)`
+
+- [ ] **Step 1: Create the interface and result types**
+
+```csharp
+namespace Connapse.Core;
+
+/// <summary>One location that could not be granted, and why.</summary>
+public record GrantWriteFailure(string Location, string Reason);
+
+/// <summary>The outcome of creating grants for one grantee against one region.</summary>
+/// <param name="Created">Subprefixes a grant was created for.</param>
+/// <param name="AlreadyGranted">Subprefixes a grant already covered (nothing created).</param>
+/// <param name="Failed">Locations that could not be granted, with the AWS reason.</param>
+/// <param name="AccessDenied">
+/// True when a failure was AWS <c>AccessDenied</c> — Connapse's identity is not (yet) allowed to
+/// create grants, so the UI should fall back to the admin-run CloudShell script rather than present
+/// the failure as broken.
+/// </param>
+public record GrantWriteResult(
+    IReadOnlyList<string> Created,
+    IReadOnlyList<string> AlreadyGranted,
+    IReadOnlyList<GrantWriteFailure> Failed,
+    bool AccessDenied)
+{
+    /// <summary>Nothing failed.</summary>
+    public bool Succeeded => Failed.Count == 0;
+
+    /// <summary>An empty result — nothing requested, or the feature is not configured.</summary>
+    public static readonly GrantWriteResult Nothing = new([], [], [], AccessDenied: false);
+}
+
+/// <summary>
+/// Creates S3 Access Grants using Connapse's own AWS identity.
+/// </summary>
+/// <remarks>
+/// The write twin of <see cref="IAccessGrantsReader"/>. Connapse now creates grants as well as
+/// reading them: its runtime identity is deliberately no longer read-only, so a compromise of that
+/// identity can create grants. The blast radius is stated to the administrator on the setup page
+/// (see <c>S3SetupPolicy.ManagedIdentitySummary</c>).
+/// </remarks>
+public interface IAccessGrantsWriter
+{
+    /// <summary>
+    /// Creates one READ grant per location for <paramref name="grantee"/>, against the Access
+    /// Grants instance in <paramref name="region"/>. Idempotent: existing grants are read first and
+    /// skipped. Never creates WRITE or READWRITE.
+    /// </summary>
+    Task<GrantWriteResult> GrantReadAsync(
+        AccessGrantee grantee, string region,
+        IReadOnlyList<string> locations, CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 2: Write the S3 implementation**
+
+Mirror `S3AccessGrantsReader` (`src/Connapse.Storage/CloudScope/S3AccessGrantsReader.cs`) — same constructor, same account-id caching, same `IsConfigured` guard, same "SDK leaves collections null" handling.
+
+```csharp
+using System.Net;
+using Amazon;
+using Amazon.S3Control;
+using Amazon.S3Control.Model;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+using Connapse.Core;
+using Connapse.Core.Utilities;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Creates S3 Access Grants with Connapse's own AWS identity.
+/// </summary>
+/// <remarks>
+/// The write twin of <see cref="S3AccessGrantsReader"/>, built the same way and against the same
+/// account. It reads the grantee's existing grants once and creates only what
+/// <see cref="GrantPlanner"/> says is missing, so a rerun converges rather than duplicates.
+/// </remarks>
+public sealed class S3AccessGrantsWriter(
+    ConnapseAwsCredentials credentials,
+    IOptionsMonitor<IdentityCenterSettings> options) : IAccessGrantsWriter
+{
+    private string? accountId;
+
+    /// <inheritdoc />
+    public async Task<GrantWriteResult> GrantReadAsync(
+        AccessGrantee grantee, string region,
+        IReadOnlyList<string> locations, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(grantee.Id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(region);
+
+        if (!options.CurrentValue.IsConfigured || locations.Count == 0)
+            return GrantWriteResult.Nothing;
+
+        var endpoint = RegionEndpoint.GetBySystemName(region);
+        string account = await ResolveAccountIdAsync(endpoint, ct);
+
+        using var client = new AmazonS3ControlClient(
+            credentials, new AmazonS3ControlConfig { RegionEndpoint = endpoint });
+
+        GrantPlan plan;
+        try
+        {
+            string? locationId = await FindRootLocationAsync(client, account, ct);
+            if (locationId is null)
+                return AllFailed(locations,
+                    "No s3:// location is registered. Run the Access Grants setup step in Connapse first.",
+                    accessDenied: false);
+
+            IReadOnlyList<string> existing = await ListGranteeScopesAsync(client, account, grantee, ct);
+            plan = GrantPlanner.Plan(locations, existing);
+
+            return await CreateAsync(client, account, grantee, plan, locationId, ct);
+        }
+        catch (AmazonS3ControlException ex) when (IsAccessDenied(ex))
+        {
+            // The identity cannot even look up the location or existing grants. Report every
+            // requested location as denied so the UI shows the CloudShell fallback rather than a
+            // partial, confusing result.
+            return AllFailed(locations, ex.Message, accessDenied: true);
+        }
+    }
+
+    private async Task<GrantWriteResult> CreateAsync(
+        AmazonS3ControlClient client, string account, AccessGrantee grantee,
+        GrantPlan plan, string locationId, CancellationToken ct)
+    {
+        var created = new List<string>();
+        var alreadyGranted = new List<string>(plan.AlreadyGranted);
+        var failed = new List<GrantWriteFailure>();
+        bool accessDenied = false;
+
+        foreach (string subPrefix in plan.ToCreate)
+        {
+            try
+            {
+                await client.CreateAccessGrantAsync(new CreateAccessGrantRequest
+                {
+                    AccountId = account,
+                    AccessGrantsLocationId = locationId,
+                    AccessGrantsLocationConfiguration =
+                        new AccessGrantsLocationConfiguration { S3SubPrefix = subPrefix },
+                    Permission = Permission.READ,
+                    Grantee = new Grantee
+                    {
+                        GranteeType = grantee.IsGroup
+                            ? GranteeType.DIRECTORY_GROUP
+                            : GranteeType.DIRECTORY_USER,
+                        GranteeIdentifier = grantee.Id,
+                    },
+                }, ct);
+
+                created.Add(subPrefix);
+            }
+            catch (AmazonS3ControlException ex) when (IsConflict(ex))
+            {
+                // The read-then-create race backstop: already there is success, not failure.
+                alreadyGranted.Add(subPrefix);
+            }
+            catch (AmazonS3ControlException ex)
+            {
+                if (IsAccessDenied(ex))
+                    accessDenied = true;
+
+                // Keep going: one bad bucket must not hide the rest.
+                failed.Add(new GrantWriteFailure(subPrefix, ex.Message));
+            }
+        }
+
+        return new GrantWriteResult(created, alreadyGranted, failed, accessDenied);
+    }
+
+    private static async Task<string?> FindRootLocationAsync(
+        AmazonS3ControlClient client, string account, CancellationToken ct)
+    {
+        var response = await client.ListAccessGrantsLocationsAsync(
+            new ListAccessGrantsLocationsRequest { AccountId = account }, ct);
+
+        return (response.AccessGrantsLocationsList ?? [])
+            .FirstOrDefault(l => l.LocationScope == "s3://")
+            ?.AccessGrantsLocationId;
+    }
+
+    private static async Task<IReadOnlyList<string>> ListGranteeScopesAsync(
+        AmazonS3ControlClient client, string account, AccessGrantee grantee, CancellationToken ct)
+    {
+        List<string> scopes = [];
+        string? nextToken = null;
+
+        do
+        {
+            var response = await client.ListAccessGrantsAsync(
+                new ListAccessGrantsRequest
+                {
+                    AccountId = account,
+                    GranteeType = grantee.IsGroup
+                        ? GranteeType.DIRECTORY_GROUP
+                        : GranteeType.DIRECTORY_USER,
+                    GranteeIdentifier = grantee.Id,
+                    NextToken = nextToken,
+                }, ct);
+
+            // Null, not empty, when the account holds no grants — the AWS SDK leaves response
+            // collections unset rather than initialising them.
+            scopes.AddRange((response.AccessGrantsList ?? [])
+                .Select(g => g.GrantScope)
+                .Where(s => !string.IsNullOrWhiteSpace(s))!);
+
+            nextToken = response.NextToken;
+        }
+        while (!string.IsNullOrEmpty(nextToken));
+
+        return scopes;
+    }
+
+    private async Task<string> ResolveAccountIdAsync(RegionEndpoint region, CancellationToken ct)
+    {
+        if (accountId is { Length: > 0 })
+            return accountId;
+
+        using var sts = new AmazonSecurityTokenServiceClient(
+            credentials, new AmazonSecurityTokenServiceConfig { RegionEndpoint = region });
+
+        var identity = await sts.GetCallerIdentityAsync(new GetCallerIdentityRequest(), ct);
+        accountId = identity.Account;
+        return accountId;
+    }
+
+    private static GrantWriteResult AllFailed(
+        IReadOnlyList<string> locations, string reason, bool accessDenied) =>
+        new([], [], [.. locations.Select(l => new GrantWriteFailure(l, reason))], accessDenied);
+
+    private static bool IsAccessDenied(AmazonS3ControlException ex) =>
+        ex.StatusCode == HttpStatusCode.Forbidden
+        || (ex.ErrorCode?.Contains("AccessDenied", StringComparison.OrdinalIgnoreCase) ?? false);
+
+    private static bool IsConflict(AmazonS3ControlException ex) =>
+        ex.StatusCode == HttpStatusCode.Conflict
+        || (ex.ErrorCode?.Contains("Conflict", StringComparison.OrdinalIgnoreCase) ?? false)
+        || (ex.Message?.Contains("already", StringComparison.OrdinalIgnoreCase) ?? false);
+}
+```
+
+- [ ] **Step 3: Register in DI**
+
+In `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs`, immediately after the reader registration at line 219:
+
+```csharp
+services.AddSingleton<IAccessGrantsReader, CloudScope.S3AccessGrantsReader>();
+services.AddSingleton<IAccessGrantsWriter, CloudScope.S3AccessGrantsWriter>();
+```
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `dotnet build src/Connapse.Storage`
+Expected: SUCCEEDS. (If `Grantee`, `Permission`, `AccessGrantsLocationConfiguration`, or `ListAccessGrantsLocationsRequest` resolve to a different name in the installed `AWSSDK.S3Control` version, correct the member names against IntelliSense — the shapes exist in the SDK the reader already uses.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Interfaces/IAccessGrantsWriter.cs src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+git commit -m "feat: create S3 access grants with Connapse's own identity"
+```
+
+---
+
+### Task 3: Grant-write permissions in the role policy
+
+The role can only create grants if its `ConnapseRead` policy allows it, and the policy's self-description must stop claiming read-only. `S3SetupPolicy.ForManagedIdentity()` is embedded verbatim into the Roles Anywhere setup script (`AwsRolesAnywhereSetup.GenerateScript`, which attaches it as the `ConnapseRead` policy), so editing it here flows straight into what the role is granted.
+
+**Files:**
+- Modify: `src/Connapse.Core/Utilities/S3SetupPolicy.cs` — extend `StorageStatements` (the `ConnapseReadGrants` statement) and rewrite `ManagedIdentitySummary`.
+- Test: `tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs` (extend)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `S3SetupPolicy.ForManagedIdentity()` now includes `s3:CreateAccessGrant` and `s3:ListAccessGrantsLocations`; `S3SetupPolicy.ManagedIdentitySummary` no longer claims read-only.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `S3SetupPolicyTests`:
+
+```csharp
+[Fact]
+public void ForManagedIdentity_GrantsCreateAccessGrant()
+{
+    string policy = S3SetupPolicy.ForManagedIdentity();
+
+    policy.Should().Contain("s3:CreateAccessGrant");
+    policy.Should().Contain("s3:ListAccessGrantsLocations");
+}
+
+[Fact]
+public void ManagedIdentitySummary_DoesNotClaimReadOnly()
+{
+    // The identity now creates access grants; a summary that still says it cannot change
+    // anything would be a false statement on the setup page.
+    S3SetupPolicy.ManagedIdentitySummary.Should().NotContain("cannot write");
+    S3SetupPolicy.ManagedIdentitySummary.Should().Contain("access grant", Exactly.Once());
+}
+```
+
+(If `Exactly` is not in scope, assert `.ToLowerInvariant().Should().Contain("access grant")` instead.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test tests/Connapse.Core.Tests --filter "FullyQualifiedName~S3SetupPolicyTests"`
+Expected: FAIL — the two new grant actions are absent and the summary still says "cannot write, delete, or change anything".
+
+- [ ] **Step 3: Extend the policy statement**
+
+In `S3SetupPolicy.cs`, replace the `ConnapseReadGrants` statement inside `StorageStatements` so it carries the write actions alongside the read, and update its comment to say so. The old statement:
+
+```csharp
+new Dictionary<string, object>
+{
+    ["Sid"] = "ConnapseReadGrants",
+    ["Effect"] = "Allow",
+    ["Action"] = new[] { "s3:ListAccessGrants" },
+    ["Resource"] = $"arn:aws:s3:*:{AccountPlaceholder}:access-grants/*"
+},
+```
+
+becomes:
+
+```csharp
+// Connapse both reads and now creates access grants. Creating a grant is an access-control
+// decision the runtime identity is deliberately allowed to make (see ManagedIdentitySummary);
+// ListAccessGrantsLocations finds the s3:// location a grant attaches to. Same access-grants
+// resource as the read, and the account is substituted by the script from sts:GetCallerIdentity.
+new Dictionary<string, object>
+{
+    ["Sid"] = "ConnapseManageGrants",
+    ["Effect"] = "Allow",
+    ["Action"] = new[]
+    {
+        "s3:ListAccessGrants",
+        "s3:ListAccessGrantsLocations",
+        "s3:CreateAccessGrant"
+    },
+    ["Resource"] = $"arn:aws:s3:*:{AccountPlaceholder}:access-grants/*"
+},
+```
+
+- [ ] **Step 4: Rewrite the summary**
+
+Replace `ManagedIdentitySummary`:
+
+```csharp
+public const string ManagedIdentitySummary =
+    "reading every S3 bucket in the account. It cannot write, delete, or change anything.";
+```
+
+with:
+
+```csharp
+public const string ManagedIdentitySummary =
+    "reading every S3 bucket in the account, and creating S3 access grants (granting directory "
+    + "groups read access to buckets). It cannot read, write, delete, or change the objects "
+    + "themselves beyond reading them.";
+```
+
+Also soften the one-line "read-only" claims in the `ForManagedIdentity` doc-comment where it says the identity is "read-only across every AWS storage service" and "the identity is read-only, belongs to Connapse alone" — reword to note it can also create access grants. (Comment-only; no behaviour.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet test tests/Connapse.Core.Tests --filter "FullyQualifiedName~S3SetupPolicyTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Check the Roles Anywhere setup test still holds**
+
+Run: `dotnet test tests/Connapse.Core.Tests --filter "FullyQualifiedName~AwsRolesAnywhereSetupTests"`
+Expected: PASS. If a test asserts the embedded policy's exact content or the old `ConnapseReadGrants` Sid, update that assertion to match the new `ConnapseManageGrants` statement — the policy is embedded by that script generator.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Connapse.Core/Utilities/S3SetupPolicy.cs tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
+git commit -m "feat: allow the Connapse role to create S3 access grants"
+```
+
+---
+
+### Task 4: "Grant access" button on the connection
+
+Replace the copy-the-command affordance with a button that creates the grants directly, refreshes coverage in place, and falls back to the CloudShell script only when the identity is denied. The script (`AccessGrantScript` / `GrantCommand`) is kept as that fallback.
+
+**Files:**
+- Modify: `src/Connapse.Web/Components/Pages/Connections.razor` — the markup block at lines 800–824 and the `@code` region around `GrantCommand`/`CopyGrantCommand` (~1260–1341).
+
+**Interfaces:**
+- Consumes: `IAccessGrantsWriter.GrantReadAsync(...)` (Task 2); existing `SamlOptions.CurrentValue` (`HasGrantGroup`, `GrantGroupId`, `GrantGroupName`), `coverage` (`HasWarning`, `Ungranted`), `form.Region`, `RefreshUngrantedAsync()`, `RegionMismatch`, `GrantGroupLabel`, `GrantCommand`.
+
+- [ ] **Step 1: Inject the writer**
+
+Near the other `@inject` lines at the top of `Connections.razor`, add:
+
+```razor
+@inject IAccessGrantsWriter GrantsWriter
+```
+
+- [ ] **Step 2: Add the grant action to the `@code` block**
+
+Add beside `CopyGrantCommand` (the `Connapse.Core` namespace holding `AccessGrantee` is already available in the page's usings via `GrantCommand`; if not, add `@using Connapse.Core`):
+
+```csharp
+private bool granting;
+private string? grantResultMessage;
+private bool grantResultOk;
+private bool grantFellBack;   // an AccessDenied pushed us back to the CloudShell script
+
+/// <summary>Whether Connapse can offer to create the grants itself.</summary>
+/// <remarks>
+/// The same conditions the command was shown under: a group is configured, this connection has
+/// ungranted buckets, and the regions are not mismatched. When true the button is offered; the
+/// CloudShell script appears only after <see cref="grantFellBack"/> is set by an AccessDenied.
+/// </remarks>
+private bool CanGrant =>
+    SamlOptions.CurrentValue.HasGrantGroup
+    && coverage is { HasWarning: true }
+    && RegionMismatch is null;
+
+private async Task GrantAccess()
+{
+    grantResultMessage = null;
+    grantFellBack = false;
+    granting = true;
+
+    try
+    {
+        var signIn = SamlOptions.CurrentValue;
+        var grantee = new AccessGrantee(IsGroup: true, Id: signIn.GrantGroupId);
+
+        var result = await GrantsWriter.GrantReadAsync(
+            grantee, form.Region, coverage!.Ungranted, CancellationToken.None);
+
+        if (result.Succeeded)
+        {
+            // Re-check so the warning clears in place, no page reload.
+            await RefreshCoverageAsync();
+            grantResultOk = true;
+            grantResultMessage = result.Created.Count > 0
+                ? $"Granted read access to {GrantGroupLabel} on {result.Created.Count} location(s). "
+                  + "Searches start returning these documents within a minute."
+                : $"{GrantGroupLabel} was already granted everything here.";
+        }
+        else if (result.AccessDenied)
+        {
+            // Connapse's identity is not allowed to create grants (a bring-your-own narrow role,
+            // or the policy not applied yet). Fall back to the admin-run CloudShell script.
+            grantFellBack = true;
+            grantResultOk = false;
+            grantResultMessage =
+                "Connapse's AWS identity is not allowed to create access grants. "
+                + "Use the CloudShell command below instead, or add s3:CreateAccessGrant to its policy.";
+        }
+        else
+        {
+            grantResultOk = false;
+            grantResultMessage =
+                "Could not grant on: "
+                + string.Join("; ", result.Failed.Select(f => $"{f.Location} ({f.Reason})"));
+        }
+    }
+    catch (Exception ex)
+    {
+        grantResultOk = false;
+        grantResultMessage = $"Could not create the grants: {ex.Message}";
+    }
+    finally
+    {
+        granting = false;
+    }
+}
+```
+
+- [ ] **Step 3: Add a coverage refresh for this one connection**
+
+`RefreshUngrantedAsync` walks the whole page; the button needs the currently-edited connection's `coverage` recomputed. Add:
+
+```csharp
+/// <summary>Recomputes this connection's grant coverage after a grant is created.</summary>
+private async Task RefreshCoverageAsync()
+{
+    coverage = await GrantCoverage.CheckAsync(AllowedList());
+    await RefreshUngrantedAsync();
+}
+```
+
+(Confirm the field/method names against the file: `coverage` is the current connection's report, `GrantCoverage` is the injected reporter, and `AllowedList()` yields this form's locations. If the page already exposes a single-connection refresh, call that instead of duplicating.)
+
+- [ ] **Step 4: Replace the markup block**
+
+Replace the `else if (GrantCommand is { Length: > 0 } grantCommand)` branch (lines 800–824) with the button-first version. The CloudShell block moves behind `grantFellBack`:
+
+```razor
+                                else if (CanGrant)
+                                {
+                                    <div class="mt-2">
+                                        <div class="small mb-1">
+                                            Grant read access to <strong>@(GrantGroupLabel)</strong>
+                                            for the buckets above, using Connapse's AWS identity.
+                                        </div>
+                                        <div class="d-flex flex-wrap gap-2 align-items-center">
+                                            <button type="button" class="btn btn-sm btn-primary"
+                                                    @onclick="GrantAccess" disabled="@granting">
+                                                @if (granting)
+                                                {
+                                                    <span class="spinner-border spinner-border-sm me-1"></span>
+                                                }
+                                                <span class="bi-key me-1"></span> Grant access
+                                            </button>
+                                            @if (grantResultMessage is { Length: > 0 })
+                                            {
+                                                <span class="small @(grantResultOk ? "text-success" : "text-danger")">
+                                                    @grantResultMessage
+                                                </span>
+                                            }
+                                        </div>
+
+                                        @if (grantFellBack && GrantCommand is { Length: > 0 } grantCommand)
+                                        {
+                                            <div class="small mt-2 mb-1">
+                                                Run this in AWS CloudShell with your own credentials instead:
+                                            </div>
+                                            <pre class="bg-body-tertiary border rounded p-2 small mb-1" style="max-height:14rem;overflow:auto"><code>@grantCommand</code></pre>
+                                            <div class="d-flex flex-wrap gap-2">
+                                                <button type="button" class="btn btn-sm btn-outline-secondary"
+                                                        @onclick="CopyGrantCommand">
+                                                    <span class="bi-clipboard me-1"></span> Copy command
+                                                </button>
+                                                <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"
+                                                   href="https://console.aws.amazon.com/cloudshell/home">
+                                                    <span class="bi-terminal me-1"></span> Open CloudShell
+                                                    <span class="bi-box-arrow-up-right ms-1 small"></span>
+                                                </a>
+                                                <span class="align-self-center small @(grantCopySucceeded ? "text-success" : "text-danger")">
+                                                    @grantCopyMessage
+                                                </span>
+                                            </div>
+                                        }
+                                    </div>
+                                }
+```
+
+The `RegionMismatch` branch above it and the `else` branch below it (choose a group) are unchanged.
+
+- [ ] **Step 5: Build and run the app to verify manually**
+
+Run: `dotnet build src/Connapse.Web`
+Expected: SUCCEEDS.
+
+Manual check (needs a configured Identity Center + grant group + an S3 connection with an ungranted bucket, per CLAUDE.md's run instructions):
+1. Open the connection; confirm the ungranted-bucket warning shows a **Grant access** button (not a CloudShell command).
+2. Click it. With the policy from Task 3 applied to Connapse's role, the warning clears and the success line appears.
+3. Re-open the connection; the button is gone (coverage satisfied) — proving idempotency end to end.
+4. To see the fallback, point Connapse at a role lacking `s3:CreateAccessGrant`: the button yields the AccessDenied message and reveals the CloudShell script.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Connapse.Web/Components/Pages/Connections.razor
+git commit -m "feat: grant S3 access from the connection instead of a CloudShell script"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 grant writer (interface + impl + DI) → Tasks 1 (planner) + 2 (writer/DI). ✅
+- §2 policy + summary → Task 3. The spec's preflight required-actions extension is **not** implemented: that green/yellow/red action-probe does not exist on this branch (the current `ProviderSetupReader.Access()` is a binary can-read-S3 check; the probe belongs to the unmerged Roles Anywhere UI PR). Forward-note: when that PR lands, add `s3:CreateAccessGrant` to its declared required-actions set so a role missing it shows yellow. Deliberately out of scope here. ✅ (scope narrowed vs. spec — noted)
+- §3 UI button + graceful degradation, script kept → Task 4. ✅
+- §4 safety invariants (READ only, idempotent, fail-closed, region) → enforced in Tasks 1–2 and asserted in Task 1 tests; carried in Global Constraints. ✅
+- §5 testing → planner unit tests (Task 1), policy unit tests (Task 3); writer AWS-I/O and UI verified manually/live per codebase precedent (no bUnit harness, reader has no client-boundary unit test). ✅
+
+**Placeholder scan:** No TBD/TODO; all code blocks concrete. The two "confirm the member/method name against the file/SDK" notes (Task 2 Step 4, Task 4 Step 3) are guardrails against version/name drift, not deferred work.
+
+**Type consistency:** `GrantPlanner.Plan → GrantPlan{ToCreate, AlreadyGranted}` (Task 1) consumed in Task 2's `CreateAsync`. `GrantWriteResult{Created, AlreadyGranted, Failed, AccessDenied}` + `Succeeded` (Task 2) consumed in Task 4's `GrantAccess`. `AccessGrantee(IsGroup, Id)` matches the existing record. Subprefix shape `bucket/prefix/*` is produced once (planner) and passed unchanged as `S3SubPrefix`.
+
+**Deviation from spec:** the preflight extension (spec §2, second bullet) is dropped as not-yet-applicable and recorded as a forward-note above.

--- a/docs/superpowers/plans/2026-09-03-orphaned-access-grant-cleanup.md
+++ b/docs/superpowers/plans/2026-09-03-orphaned-access-grant-cleanup.md
@@ -676,7 +676,13 @@ git add src/Connapse.Web/Components/Pages/Providers.razor
 git commit -m "feat: admin button to clean up orphaned access grants"
 ```
 
-### Task 3.5: Instance tag (multi-instance scoping, spec §6)
+### Task 3.5: Instance tag (multi-instance scoping, spec §6) — DEFERRED
+
+**Status: deferred.** Not built in the initial epic. Reason: the instance fingerprint has no clean
+universal source in `S3AccessGrantsWriter` (the Roles Anywhere trust-anchor ARN is not wired into
+the writer, and ambient on-AWS deployments hold no cert at all), and the common single-instance case
+is correct without it. Resolving the fingerprint source is a design decision for the owner. The
+single-instance assumption is documented in `GrantReconciliationService`'s remarks. When taken up:
 
 **Files:**
 - Modify: `S3AccessGrantsWriter.CreateAsync` (add `connapse:instance` tag) and `GrantTags` (add `InstanceKey`).

--- a/docs/superpowers/plans/2026-09-03-orphaned-access-grant-cleanup.md
+++ b/docs/superpowers/plans/2026-09-03-orphaned-access-grant-cleanup.md
@@ -1,0 +1,698 @@
+# Orphaned S3 Access Grant cleanup — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect S3 Access Grants that Connapse created but no connection still needs (or that belong to a superseded grant group) and delete them, safely and automatically.
+
+**Architecture:** Provenance-tag every grant at creation so cleanup only ever deletes grants Connapse can prove are its own. A Hangfire recurring sweep (plus an admin button) builds the union of allowed-locations across all S3 connections, finds tagged grants whose scope that union no longer covers, confirms provenance via tags, and deletes them — with a hard fail-closed abort on any incomplete input and a circuit breaker against implausibly large deletions.
+
+**Tech Stack:** .NET 10, C#, Blazor Server, AWS SDK for .NET (`AWSSDK.S3Control`), Hangfire (PostgreSQL), xUnit + FluentAssertions + NSubstitute.
+
+**Spec:** [docs/superpowers/specs/2026-09-03-orphaned-access-grant-cleanup-design.md](../specs/2026-09-03-orphaned-access-grant-cleanup-design.md)
+
+## Global Constraints
+
+- .NET 10; file-scoped namespaces; nullable enabled. Records for DTOs; primary constructors for DI. No `var` for primitives; no `dynamic`. Async all the way.
+- **Only ever delete a grant confirmed `connapse:managed=true` by tag**, that is a DIRECTORY_GROUP grant, and whose scope no connection covers. Never delete IAM or directory-user grants, and never an untagged / admin-authored grant.
+- **Fail-closed:** any failure enumerating connections, or any unparseable connection config, aborts the whole reconcile tick — deletion requires a *complete* union. Mirror `AwsSearchScopeResolver`.
+- **Circuit breaker:** a tick whose candidate set exceeds the configured plausibility threshold aborts and alerts instead of deleting.
+- `DeleteAccessGrant` is one-per-call and **not idempotent** — a missing id throws `NotFoundException`; catch and fold into a NotFound bucket.
+- One `AmazonS3ControlClient` **per region**; `AccountId` on every request.
+- Log every deletion at audit level; sanitize user-controlled values with `LogSanitizer.Sanitize`.
+- Test naming `MethodName_Scenario_ExpectedResult`; unit tests `[Trait("Category", "Unit")]`. Commit types `feat:`/`test:`/`refactor:`; end messages with the Co-Authored-By trailer.
+
+---
+
+# PR 1 — Tag grants on create (the enabler)
+
+Ships first: small, safe, and the prerequisite for any safe deletion. Grants created after this are GC-able; grants before it stay untagged and are never auto-deleted (by design).
+
+### Task 1.1: Stamp the provenance tag on every created grant
+
+**Files:**
+- Modify: `src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs` (the `CreateAccessGrantAsync` call in `CreateAsync`)
+- Create: `src/Connapse.Core/Utilities/GrantTags.cs` (the tag constants, so create and cleanup share one source)
+- Test: `tests/Connapse.Core.Tests/Utilities/GrantTagsTests.cs`
+
+**Interfaces:**
+- Produces: `GrantTags.ManagedKey` = `"connapse:managed"`, `GrantTags.ManagedValue` = `"true"`.
+
+- [ ] **Step 1: Write the failing test for the tag constants**
+
+```csharp
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class GrantTagsTests
+{
+    [Fact]
+    public void ManagedTag_IsTheConnapseProvenanceMarker()
+    {
+        // The one marker cleanup keys on. Kept out of the writer so create and the reconciler
+        // cannot drift on the string that decides whether a grant is deletable.
+        GrantTags.ManagedKey.Should().Be("connapse:managed");
+        GrantTags.ManagedValue.Should().Be("true");
+        GrantTags.ManagedKey.Should().NotStartWith("aws:"); // AWS rejects aws:-prefixed tag keys
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `dotnet test tests/Connapse.Core.Tests --filter "FullyQualifiedName~GrantTagsTests"`
+Expected: FAIL — `GrantTags` does not exist.
+
+- [ ] **Step 3: Create the constants**
+
+```csharp
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// The tags Connapse stamps on the S3 Access Grants it creates, so a cleanup pass can prove a
+/// grant is its own before deleting it.
+/// </summary>
+/// <remarks>
+/// One source shared by the writer (which applies them) and the reconciler (which requires them
+/// before deleting). AWS forbids tag keys beginning <c>aws:</c>. Tags are write-only through the
+/// grant read path — <c>ListAccessGrants</c> does not return them — so the reconciler reads them
+/// back per-candidate via <c>ListTagsForResource</c>.
+/// </remarks>
+public static class GrantTags
+{
+    /// <summary>Present with <see cref="ManagedValue"/> exactly on grants Connapse created.</summary>
+    public const string ManagedKey = "connapse:managed";
+
+    /// <summary>The value <see cref="ManagedKey"/> carries.</summary>
+    public const string ManagedValue = "true";
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `dotnet test tests/Connapse.Core.Tests --filter "FullyQualifiedName~GrantTagsTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Apply the tag in the writer**
+
+In `S3AccessGrantsWriter.CreateAsync`, add `Tags` to the `CreateAccessGrantRequest` (the SDK type is `Amazon.S3Control.Model.Tag`):
+
+```csharp
+await client.CreateAccessGrantAsync(new CreateAccessGrantRequest
+{
+    AccountId = account,
+    AccessGrantsLocationId = locationId,
+    AccessGrantsLocationConfiguration =
+        new AccessGrantsLocationConfiguration { S3SubPrefix = subPrefix },
+    Permission = Permission.READ,
+    Grantee = new Grantee
+    {
+        GranteeType = grantee.IsGroup ? GranteeType.DIRECTORY_GROUP : GranteeType.DIRECTORY_USER,
+        GranteeIdentifier = grantee.Id,
+    },
+    // Provenance: cleanup deletes only grants carrying this tag.
+    Tags = [new Tag { Key = GrantTags.ManagedKey, Value = GrantTags.ManagedValue }],
+}, ct);
+```
+
+Add `using Connapse.Core.Utilities;` if not present. (The `connapse:instance` tag from spec §6 is added in PR 3, where instance-scoped deletion consumes it and the fingerprint source is resolved.)
+
+- [ ] **Step 6: Build to verify the SDK `Tag` shape compiles**
+
+Run: `dotnet build src/Connapse.Storage`
+Expected: SUCCEEDS. (If `Tag`/`Tags` resolve differently in the installed `AWSSDK.S3Control`, correct against IntelliSense — the `Tags` request field and `Tag{Key,Value}` type exist in the S3 Control model.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Connapse.Core/Utilities/GrantTags.cs tests/Connapse.Core.Tests/Utilities/GrantTagsTests.cs src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs
+git commit -m "feat: tag Connapse-created S3 access grants for later cleanup"
+```
+
+---
+
+# PR 2 — Reader detail, delete path, and policy
+
+The plumbing a reconciler needs: read grant ids + grantees back, delete by id, and let the role do it. No automatic behaviour yet — exercised via unit tests and (in PR 3) the admin button.
+
+### Task 2.1: Surface full grant detail from the reader
+
+**Files:**
+- Modify: `src/Connapse.Core/Interfaces/IAccessGrantsReader.cs` (add `AccessGrantDetail` record + `ListAllAsync`)
+- Modify: `src/Connapse.Storage/CloudScope/S3AccessGrantsReader.cs` (implement `ListAllAsync`)
+- Test: covered indirectly (AWS-client class, no unit test at the client boundary — matching the existing reader); the projection shape is asserted in Task 3.x's candidate-selection unit tests via the pure type.
+
+**Interfaces:**
+- Produces:
+  - `record AccessGrantDetail(string AccessGrantId, string AccessGrantArn, AccessGrantee Grantee, string GrantScope, string? Permission, string AccessGrantsLocationId)`
+  - `IAccessGrantsReader.ListAllAsync(string region, CancellationToken ct = default) → Task<IReadOnlyList<AccessGrantDetail>>`
+
+- [ ] **Step 1: Add the record and interface method**
+
+In `IAccessGrantsReader.cs` (namespace `Connapse.Core`):
+
+```csharp
+/// <summary>One S3 access grant, with everything cleanup needs to identify and delete it.</summary>
+/// <remarks>
+/// Distinct from <see cref="AccessGrantRecord"/>, which the search/coverage paths use and which
+/// deliberately drops the id and grantee. Deletion needs the <c>AccessGrantId</c>, the ARN (to read
+/// tags back), and the grantee (to tell the configured group from a superseded one).
+/// </remarks>
+public record AccessGrantDetail(
+    string AccessGrantId, string AccessGrantArn, AccessGrantee Grantee,
+    string GrantScope, string? Permission, string AccessGrantsLocationId);
+```
+
+Add to the `IAccessGrantsReader` interface:
+
+```csharp
+/// <summary>
+/// Every grant in the instance in <paramref name="region"/>, with id, ARN and grantee — for
+/// reconciliation. Grantee-blind: the reconciler needs all groups, including one that is no longer
+/// configured.
+/// </summary>
+Task<IReadOnlyList<AccessGrantDetail>> ListAllAsync(string region, CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Implement it in `S3AccessGrantsReader`**
+
+Mirror `ListAllScopesAsync`'s paging, keeping the id/ARN/grantee this time:
+
+```csharp
+/// <inheritdoc />
+public async Task<IReadOnlyList<AccessGrantDetail>> ListAllAsync(
+    string region, CancellationToken ct = default)
+{
+    ArgumentException.ThrowIfNullOrWhiteSpace(region);
+
+    if (!options.CurrentValue.IsConfigured)
+        return [];
+
+    var endpoint = RegionEndpoint.GetBySystemName(region);
+    string account = await ResolveAccountIdAsync(endpoint, ct);
+
+    using var client = new AmazonS3ControlClient(
+        credentials, new AmazonS3ControlConfig { RegionEndpoint = endpoint });
+
+    List<AccessGrantDetail> grants = [];
+    string? nextToken = null;
+
+    do
+    {
+        var response = await client.ListAccessGrantsAsync(
+            new ListAccessGrantsRequest { AccountId = account, NextToken = nextToken }, ct);
+
+        foreach (var g in response.AccessGrantsList ?? [])
+        {
+            if (string.IsNullOrWhiteSpace(g.AccessGrantId) || string.IsNullOrWhiteSpace(g.GrantScope))
+                continue;
+
+            var grantee = g.Grantee is { } who
+                ? new AccessGrantee(
+                    IsGroup: who.GranteeType == GranteeType.DIRECTORY_GROUP,
+                    Id: who.GranteeIdentifier ?? string.Empty)
+                : new AccessGrantee(IsGroup: false, Id: string.Empty);
+
+            grants.Add(new AccessGrantDetail(
+                g.AccessGrantId, g.AccessGrantArn ?? string.Empty, grantee,
+                g.GrantScope, g.Permission?.Value, g.AccessGrantsLocationId ?? string.Empty));
+        }
+
+        nextToken = response.NextToken;
+    }
+    while (!string.IsNullOrEmpty(nextToken));
+
+    return grants;
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build src/Connapse.Storage`
+Expected: SUCCEEDS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Connapse.Core/Interfaces/IAccessGrantsReader.cs src/Connapse.Storage/CloudScope/S3AccessGrantsReader.cs
+git commit -m "feat: read S3 access grant id, ARN and grantee for reconciliation"
+```
+
+### Task 2.2: Add the delete path to the writer + tag read-back
+
+**Files:**
+- Modify: `src/Connapse.Core/Interfaces/IAccessGrantsWriter.cs` (add `RevokeAsync` + `GrantRevokeResult`, and `AreManagedAsync` provenance read)
+- Modify: `src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs`
+
+**Interfaces:**
+- Produces:
+  - `record GrantRevokeResult(IReadOnlyList<string> Deleted, IReadOnlyList<string> NotFound, IReadOnlyList<GrantWriteFailure> Failed, bool AccessDenied)`
+  - `IAccessGrantsWriter.RevokeAsync(string region, IReadOnlyList<string> grantIds, CancellationToken ct = default) → Task<GrantRevokeResult>`
+  - `IAccessGrantsWriter.FilterManagedAsync(string region, IReadOnlyList<string> grantArns, CancellationToken ct = default) → Task<IReadOnlyList<string>>` — returns the subset of ARNs tagged `connapse:managed=true`.
+
+- [ ] **Step 1: Add the result type and interface methods** to `IAccessGrantsWriter.cs`:
+
+```csharp
+/// <summary>The outcome of deleting grants by id in one region.</summary>
+public record GrantRevokeResult(
+    IReadOnlyList<string> Deleted,
+    IReadOnlyList<string> NotFound,
+    IReadOnlyList<GrantWriteFailure> Failed,
+    bool AccessDenied);
+```
+
+Add to `IAccessGrantsWriter`:
+
+```csharp
+/// <summary>Deletes the named grants in <paramref name="region"/>. A missing id is NotFound, not a
+/// failure — DeleteAccessGrant is not idempotent, so a concurrent delete must not fail the run.</summary>
+Task<GrantRevokeResult> RevokeAsync(
+    string region, IReadOnlyList<string> grantIds, CancellationToken ct = default);
+
+/// <summary>The subset of <paramref name="grantArns"/> tagged as Connapse-managed. Tags are not
+/// returned by ListAccessGrants, so this reads them back per grant via ListTagsForResource.</summary>
+Task<IReadOnlyList<string>> FilterManagedAsync(
+    string region, IReadOnlyList<string> grantArns, CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Implement both in `S3AccessGrantsWriter`**
+
+```csharp
+/// <inheritdoc />
+public async Task<GrantRevokeResult> RevokeAsync(
+    string region, IReadOnlyList<string> grantIds, CancellationToken ct = default)
+{
+    ArgumentException.ThrowIfNullOrWhiteSpace(region);
+
+    if (!options.CurrentValue.IsConfigured || grantIds.Count == 0)
+        return new GrantRevokeResult([], [], [], AccessDenied: false);
+
+    var endpoint = RegionEndpoint.GetBySystemName(region);
+    string account = await ResolveAccountIdAsync(endpoint, ct);
+
+    using var client = new AmazonS3ControlClient(
+        credentials, new AmazonS3ControlConfig { RegionEndpoint = endpoint });
+
+    var deleted = new List<string>();
+    var notFound = new List<string>();
+    var failed = new List<GrantWriteFailure>();
+    bool accessDenied = false;
+
+    foreach (string id in grantIds)
+    {
+        try
+        {
+            await client.DeleteAccessGrantAsync(
+                new DeleteAccessGrantRequest { AccountId = account, AccessGrantId = id }, ct);
+            deleted.Add(id);
+        }
+        catch (AmazonS3ControlException ex) when (IsNotFound(ex))
+        {
+            notFound.Add(id); // already gone -> success from our point of view
+        }
+        catch (AmazonS3ControlException ex)
+        {
+            if (IsAccessDenied(ex)) accessDenied = true;
+            failed.Add(new GrantWriteFailure(id, ex.Message));
+        }
+    }
+
+    return new GrantRevokeResult(deleted, notFound, failed, accessDenied);
+}
+
+/// <inheritdoc />
+public async Task<IReadOnlyList<string>> FilterManagedAsync(
+    string region, IReadOnlyList<string> grantArns, CancellationToken ct = default)
+{
+    if (!options.CurrentValue.IsConfigured || grantArns.Count == 0)
+        return [];
+
+    var endpoint = RegionEndpoint.GetBySystemName(region);
+    using var client = new AmazonS3ControlClient(
+        credentials, new AmazonS3ControlConfig { RegionEndpoint = endpoint });
+
+    var managed = new List<string>();
+
+    foreach (string arn in grantArns)
+    {
+        try
+        {
+            var tags = await client.ListTagsForResourceAsync(
+                new ListTagsForResourceRequest { ResourceArn = arn }, ct);
+
+            bool isManaged = (tags.Tags ?? []).Any(t =>
+                t.Key == Connapse.Core.Utilities.GrantTags.ManagedKey
+                && t.Value == Connapse.Core.Utilities.GrantTags.ManagedValue);
+
+            if (isManaged)
+                managed.Add(arn);
+        }
+        catch (AmazonS3ControlException)
+        {
+            // Provenance unconfirmed -> fail safe, treat as not ours (never deleted).
+        }
+    }
+
+    return managed;
+}
+
+private static bool IsNotFound(AmazonS3ControlException ex) =>
+    ex.StatusCode == System.Net.HttpStatusCode.NotFound
+    || (ex.ErrorCode?.Contains("NotFound", StringComparison.OrdinalIgnoreCase) ?? false);
+```
+
+(`ListTagsForResourceRequest.ResourceArn`, `DeleteAccessGrantRequest`, and `Tag` are in `Amazon.S3Control.Model`, already imported.)
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build src/Connapse.Storage`
+Expected: SUCCEEDS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Connapse.Core/Interfaces/IAccessGrantsWriter.cs src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs
+git commit -m "feat: delete S3 access grants and confirm provenance by tag"
+```
+
+### Task 2.3: Grant the delete permission in the role policy
+
+**Files:**
+- Modify: `src/Connapse.Core/Utilities/S3SetupPolicy.cs` (`ConnapseManageGrants` statement + summary)
+- Test: `tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public void ForManagedIdentity_GrantsDeleteAndTagAccessGrant()
+{
+    var manage = Statement(S3SetupPolicy.ForManagedIdentity(), "ConnapseManageGrants");
+    var actions = manage.GetProperty("Action").EnumerateArray().Select(a => a.GetString());
+
+    // Cleanup needs delete; provenance needs tag-on-create and reading tags back.
+    actions.Should().Contain(["s3:DeleteAccessGrant", "s3:TagResource", "s3:ListTagsForResource"]);
+}
+```
+
+- [ ] **Step 2: Run it — Expected: FAIL** (`dotnet test tests/Connapse.Core.Tests --filter "FullyQualifiedName~S3SetupPolicyTests"`).
+
+- [ ] **Step 3: Extend the `ConnapseManageGrants` action list** in `S3SetupPolicy.StorageStatements`:
+
+```csharp
+["Action"] = new[]
+{
+    "s3:ListAccessGrants",
+    "s3:ListAccessGrantsLocations",
+    "s3:CreateAccessGrant",
+    "s3:DeleteAccessGrant",
+    "s3:TagResource",
+    "s3:ListTagsForResource"
+},
+```
+
+Update the statement's comment to note it now also deletes and tags grants, and update `ManagedIdentitySummary` to say the identity can create **and remove** access grants.
+
+- [ ] **Step 4: Run tests — Expected: PASS** (also re-run `AwsRolesAnywhereSetupTests`, which embeds this policy).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Utilities/S3SetupPolicy.cs tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
+git commit -m "feat: allow the Connapse role to delete and tag S3 access grants"
+```
+
+---
+
+# PR 3 — The reconciler (sweep + button + safety rails)
+
+Ties it together. The pure decision logic is unit-tested exhaustively; the AWS I/O and Hangfire wiring follow existing patterns and are verified manually/live.
+
+### Task 3.1: The pure orphan/candidate selector
+
+The heart of the feature, and where all the safety logic that *can* be pure lives. Given the union of allowed-locations, all grant details, and the configured group, decide which grant ids to delete — reusing `GrantCoverage.Overlaps` for the scope test.
+
+**Files:**
+- Create: `src/Connapse.Core/Utilities/GrantReconciler.cs`
+- Modify: `src/Connapse.Core/Utilities/GrantCoverage.cs` — make `Normalise`/`Overlaps` reusable (e.g. `internal` → visible to this class, or add a public `Overlaps(scope, location)` façade). Follow the existing visibility; do not duplicate the matcher.
+- Test: `tests/Connapse.Core.Tests/Utilities/GrantReconcilerTests.cs`
+
+**Interfaces:**
+- Consumes: `AccessGrantDetail` (PR 2), `GrantCoverage.Overlaps`.
+- Produces:
+  - `GrantReconciler.SelectOrphans(IReadOnlyList<AccessGrantDetail> grants, IReadOnlyList<string> unionLocations, string configuredGroupId) → OrphanSelection`
+  - `record OrphanSelection(IReadOnlyList<AccessGrantDetail> Candidates)` — grants that are DIRECTORY_GROUP, orphaned by scope, and (current or previous group). Provenance-by-tag is applied *after* this, on the narrowed set, because it needs an AWS call.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Connapse.Core;
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class GrantReconcilerTests
+{
+    private static AccessGrantDetail Grant(string scope, bool group = true, string id = "g", string grp = "grp-1") =>
+        new(AccessGrantId: id, AccessGrantArn: "arn:" + id,
+            Grantee: new AccessGrantee(IsGroup: group, Id: grp),
+            GrantScope: scope, Permission: "READ", AccessGrantsLocationId: "default");
+
+    [Fact]
+    public void SelectOrphans_ScopeCoveredByAConnection_IsNotACandidate()
+    {
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://my-bucket/docs/*")],
+            unionLocations: ["my-bucket/docs"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectOrphans_ScopeCoveredByNoConnection_IsACandidate()
+    {
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://old-bucket/*")],
+            unionLocations: ["my-bucket/docs"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().ContainSingle().Which.AccessGrantId.Should().Be("g");
+    }
+
+    [Fact]
+    public void SelectOrphans_PreviousGroupOrphan_IsACandidate()
+    {
+        // A group that is no longer configured, whose scope nothing covers — a previous-group orphan.
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://old-bucket/*", grp: "grp-OLD")],
+            unionLocations: ["my-bucket/docs"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void SelectOrphans_PreviousGroupButStillCovered_IsLeftAlone()
+    {
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://my-bucket/docs/*", grp: "grp-OLD")],
+            unionLocations: ["my-bucket/docs"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectOrphans_NonGroupGrant_IsNeverACandidate()
+    {
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://old-bucket/*", group: false)],
+            unionLocations: ["my-bucket/docs"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run — Expected: FAIL** (`GrantReconciler` missing).
+
+- [ ] **Step 3: Implement**
+
+```csharp
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Decides which access grants are orphaned — held by a directory group, covered by no connection.
+/// Pure: the AWS-touching provenance check and deletion happen around it.
+/// </summary>
+/// <remarks>
+/// The scope test is <see cref="GrantCoverage"/>'s boundary-aware overlap, the same matcher the
+/// coverage reporter uses in the create direction, so "granted" and "orphaned" cannot disagree.
+/// This selector is deliberately group-only and does not read tags: provenance requires an AWS call
+/// and is applied to the (small) candidate set afterwards.
+/// </remarks>
+public static class GrantReconciler
+{
+    public static OrphanSelection SelectOrphans(
+        IReadOnlyList<AccessGrantDetail> grants,
+        IReadOnlyList<string> unionLocations,
+        string configuredGroupId)
+    {
+        var candidates = new List<AccessGrantDetail>();
+
+        foreach (var grant in grants)
+        {
+            // Never touch anything but a directory-group grant.
+            if (!grant.Grantee.IsGroup || string.IsNullOrWhiteSpace(grant.Grantee.Id))
+                continue;
+
+            // Orphaned = its scope overlaps no allowed location across every connection.
+            bool covered = unionLocations.Any(loc => GrantCoverage.Overlaps(grant.GrantScope, loc));
+            if (covered)
+                continue;
+
+            // Current-group orphan or previous-group orphan — both delete; the difference is only
+            // which group id it belongs to, and both are handled the same once orphaned.
+            candidates.Add(grant);
+        }
+
+        return new OrphanSelection(candidates);
+    }
+}
+
+/// <summary>Grants selected for deletion, before the AWS provenance-tag confirmation.</summary>
+public record OrphanSelection(IReadOnlyList<AccessGrantDetail> Candidates);
+```
+
+If `GrantCoverage.Overlaps` is not currently accessible from here, add a thin public façade on `GrantCoverage` that calls the existing internal matcher (do not copy the logic). Confirm the exact current signature of the internal `Overlaps`/`Normalise` before wiring.
+
+- [ ] **Step 4: Run — Expected: PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Utilities/GrantReconciler.cs src/Connapse.Core/Utilities/GrantCoverage.cs tests/Connapse.Core.Tests/Utilities/GrantReconcilerTests.cs
+git commit -m "feat: pure selector for orphaned group access grants"
+```
+
+### Task 3.2: The reconcile service (union + fail-closed + circuit breaker + provenance + delete)
+
+**Files:**
+- Create: `src/Connapse.Web/Services/GrantReconciliationService.cs` (Web, so it can reach `IConnectionStore`, `IAwsGrantRegions`, `IAccessGrantsReader/Writer`, settings — same layer as `AwsSearchScopeResolver` consumers)
+- Modify: DI registration in the appropriate `ServiceCollectionExtensions`
+- Test: `tests/Connapse.Web.Tests/Services/GrantReconciliationServiceTests.cs` (NSubstitute the reader/writer/connection store)
+
+**Interfaces:**
+- Produces: `IGrantReconciliationService.ReconcileAsync(bool enforce, CancellationToken ct) → Task<ReconcileReport>` where `ReconcileReport(int Scanned, int Orphaned, int Deleted, IReadOnlyList<string> Aborted)` and `Aborted` carries the fail-closed/circuit-breaker reasons. `enforce=false` computes and reports without deleting (used by the button's preview; the sweep calls `enforce=true`).
+
+- [ ] **Step 1: Write failing tests for the safety rails** (the parts that are testable with mocks):
+
+```csharp
+// 1. Connection enumeration failure -> aborts, deletes nothing.
+[Fact] public async Task Reconcile_ConnectionListThrows_AbortsWithoutDeleting() { /* substitute IConnectionStore.ListAsync to throw; assert writer.RevokeAsync never called and report.Aborted non-empty */ }
+
+// 2. Circuit breaker: candidates exceed threshold -> abort.
+[Fact] public async Task Reconcile_ImplausiblyManyCandidates_TripsCircuitBreaker() { /* reader returns many managed orphans, empty union; assert no delete, Aborted names the breaker */ }
+
+// 3. Happy path: one orphan, tagged -> deleted.
+[Fact] public async Task Reconcile_TaggedOrphan_IsDeleted() { /* reader ListAllAsync returns 1 group orphan; writer.FilterManagedAsync returns its ARN; assert RevokeAsync called with its id */ }
+
+// 4. Untagged orphan -> never deleted.
+[Fact] public async Task Reconcile_UntaggedOrphan_IsSkipped() { /* FilterManagedAsync returns empty; assert RevokeAsync not called */ }
+```
+
+Write these fully against the concrete interfaces (substitute `IConnectionStore`, `IAccessGrantsReader`, `IAccessGrantsWriter`, `IAwsGrantRegions`, `IOptionsMonitor<SamlSignInSettings>`).
+
+- [ ] **Step 2: Run — Expected: FAIL.**
+
+- [ ] **Step 3: Implement `GrantReconciliationService`**, in this order per tick:
+  1. Read `SamlSignInSettings`; capture `GrantGroupId`/`HasGrantGroup`.
+  2. **Union:** `connections.ListAsync(0, int.MaxValue, ct)` filtered to `Provider == S3`; parse each with `StorageLocationPolicy.ReadAllowedLocations`. On **any** exception, or **any** connection whose config won't parse, return a `ReconcileReport` with an `Aborted` reason and **do not delete** (fail-closed).
+  3. For each region in `regions.ListAsync(ct)`: `reader.ListAllAsync(region)`; `GrantReconciler.SelectOrphans(...)`.
+  4. **Circuit breaker:** if candidate count in a region exceeds the configured threshold (a `GrantReconciliationSettings.MaxDeletePerTick`, default e.g. 50, and/or "= the entire managed set"), abort that region with a logged alert; delete nothing there.
+  5. **Provenance:** `writer.FilterManagedAsync(region, candidateArns)`; keep only confirmed-managed.
+  6. If `enforce`, `writer.RevokeAsync(region, managedOrphanIds)`; log each deletion at audit level (`LogSanitizer`).
+  7. Aggregate into `ReconcileReport`.
+
+- [ ] **Step 4: Run — Expected: PASS.** Then `dotnet build`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Web/Services/GrantReconciliationService.cs tests/Connapse.Web.Tests/Services/GrantReconciliationServiceTests.cs [DI file]
+git commit -m "feat: fail-closed reconcile service for orphaned access grants"
+```
+
+### Task 3.3: Hangfire recurring sweep
+
+**Files:**
+- Create: `src/Connapse.Background/Jobs/GrantReconciliationJobs.cs` (`IGrantReconciliationJobs`)
+- Modify: `src/Connapse.Background/HangfireServiceCollectionExtensions.cs` (register `AddScoped`)
+- Modify: `src/Connapse.Web/Program.cs` (recurring-job registration, next to `summary-sweep-stale-containers` ~line 351)
+
+- [ ] **Step 1: Implement the job**, mirroring `SummaryJobs.SweepStaleContainersAsync`: a scoped class injecting `IGrantReconciliationService` + `ILogger`, one method `ReconcileAsync` decorated `[Queue(JobQueues.Default)]` and `[AutomaticRetry(Attempts = 0)]` and `[DisableConcurrentExecution(600)]`, calling `service.ReconcileAsync(enforce: true, ct)` and logging the report.
+
+- [ ] **Step 2: Register** the job `AddScoped<IGrantReconciliationJobs, GrantReconciliationJobs>()` in `AddConnapseHangfire`, and in `Program.cs` add:
+
+```csharp
+recurringJobs.AddOrUpdate<IGrantReconciliationJobs>(
+    "grant-reconcile-orphaned", j => j.ReconcileAsync(default), "*/30 * * * *");
+```
+
+(30-minute cadence; adjust to taste. Idempotent AddOrUpdate, safe every boot — same as the summary sweep.)
+
+- [ ] **Step 3: Build the solution** — Expected: SUCCEEDS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Connapse.Background/Jobs/GrantReconciliationJobs.cs src/Connapse.Background/HangfireServiceCollectionExtensions.cs src/Connapse.Web/Program.cs
+git commit -m "feat: recurring sweep to reconcile orphaned access grants"
+```
+
+### Task 3.4: Admin "Clean up orphaned grants" button
+
+**Files:**
+- Modify: the AWS provider admin page (`src/Connapse.Web/Components/Pages/Providers.razor`, near the per-user-permissions section) — a button calling `IGrantReconciliationService.ReconcileAsync(enforce: true, ct)` and showing the returned `ReconcileReport` (scanned / orphaned / deleted / any aborted reason). Follow the existing button/result-line pattern used by the grant/reset actions.
+
+- [ ] **Step 1: Add the button + result line**, gated on per-user permissions being configured. On click, call the service, render the report (e.g. "Removed N orphaned grants" or the abort reason).
+
+- [ ] **Step 2: Build** — Expected: SUCCEEDS.
+
+- [ ] **Step 3: Manual verification** (needs the live AWS test instance + at least one Connapse-created grant whose bucket has been removed from every connection): click the button; confirm the orphaned grant is deleted and an admin grant over the same bucket is left intact; confirm removing all connections then running does NOT wipe everything (circuit breaker / fail-closed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Connapse.Web/Components/Pages/Providers.razor
+git commit -m "feat: admin button to clean up orphaned access grants"
+```
+
+### Task 3.5: Instance tag (multi-instance scoping, spec §6)
+
+**Files:**
+- Modify: `S3AccessGrantsWriter.CreateAsync` (add `connapse:instance` tag) and `GrantTags` (add `InstanceKey`).
+- Modify: `GrantReconciliationService` — when a `GrantReconciliationSettings.MultiInstanceScoping` flag is on, `FilterManagedAsync` (or a variant) also requires the instance tag to match this instance's fingerprint; default off (single-instance deletes any managed orphan).
+- Resolve the fingerprint source: reuse the stable per-instance identifier the Roles Anywhere credential already establishes (e.g. a hash of the stored `TrustAnchorArn`), or a persisted install-id GUID when ambient/BYO. Pick one concretely during this task and document it.
+
+- [ ] Steps: add the constant + tag on create; extend the provenance filter to check the instance tag under the flag; unit-test that under scoping-on a grant tagged for another instance is not selected. Commit `feat: scope grant cleanup to the creating Connapse instance`.
+
+---
+
+## Self-Review
+
+**Spec coverage:** §Provenance/tagging → Task 1.1 (+ instance in 3.5). §1 → PR1. §2 reader → 2.1. §3 delete+policy → 2.2, 2.3. §4 reconciler (union, fail-closed, candidate, circuit breaker, provenance, delete) → 3.1 (pure selection) + 3.2 (service safety rails) + 3.3 (sweep) + 3.4 (button). §5 previous-group → covered in 3.1 (grantee ≠ configured group still selected when orphaned) and its test. §6 multi-instance → 3.5. §7 safety invariants → enforced across 3.1/3.2 and asserted in 3.2's tests. §8 testing → per task. §9 delivery/build order → the three PR sections. ✅
+
+**Placeholder scan:** Task 3.2 Step 1 gives test *names + intent* rather than full bodies, and 3.5 is a compact task — both are the more-distant, larger tasks where the exact mock wiring depends on the interfaces built in 3.1/2.x; flagged here so the implementer writes them fully at that point rather than treating the outline as done. No TBD/TODO in the load-bearing near-term tasks (PR1, PR2, 3.1).
+
+**Type consistency:** `AccessGrantDetail` (2.1) is consumed by `GrantReconciler.SelectOrphans` (3.1) and the service (3.2). `GrantRevokeResult`/`RevokeAsync` and `FilterManagedAsync` (2.2) are consumed by the service (3.2). `GrantTags.ManagedKey/Value` (1.1) is used by create (1.1) and the provenance filter (2.2). `GrantCoverage.Overlaps` reused by 3.1 rather than re-derived.
+
+**Deviation from spec:** the `connapse:instance` tag is applied in PR3/Task 3.5 rather than PR1 (spec §1 lists both at create), because its fingerprint source and its only consumer (instance-scoped deletion) both live in the multi-instance work. Recorded here; the `connapse:managed` provenance marker — the one deletion actually gates on — still ships in PR1.

--- a/docs/superpowers/specs/2026-09-02-aws-auto-create-access-grants-design.md
+++ b/docs/superpowers/specs/2026-09-02-aws-auto-create-access-grants-design.md
@@ -1,0 +1,207 @@
+# Auto-create S3 Access Grants with the Connapse role
+
+**Status:** Design — approved in brainstorming, pending spec review
+**Date:** 2026-09-02
+**Builds on:** the Roles Anywhere runtime identity (PRs #454–#457) and the
+per-user permissions feature (S3 Access Grants + Identity Center SAML sign-in).
+
+## Problem
+
+A connection's buckets are searchable per-user only once a directory group has
+an S3 Access Grant covering them. Today Connapse never creates that grant: when
+a connection has ungranted buckets, [Connections.razor](../../../src/Connapse.Web/Components/Pages/Connections.razor)
+builds a CloudShell script (`GrantCommand`, ~line 1268) from
+[`AccessGrantScript`](../../../src/Connapse.Core/Utilities/AccessGrantScript.cs)
+and the admin pastes it into AWS CloudShell to run with their own credentials.
+
+That was a deliberate constraint: *Connapse reads grants but never writes them,
+because a grant is an access-control decision and Connapse's identity has no
+permission to make it.* The constraint is stated in
+[`AccessGrantScript`](../../../src/Connapse.Core/Utilities/AccessGrantScript.cs),
+[`AccessGrantsSetup`](../../../src/Connapse.Core/Utilities/AccessGrantsSetup.cs),
+and [`IAccessGrantsReader`](../../../src/Connapse.Core/Interfaces/IAccessGrantsReader.cs).
+
+Now that Connapse has its own real AWS identity (Roles Anywhere / ambient role),
+the constraint is being **reversed by an explicit product decision**: Connapse's
+role should create the grants directly, so the admin never leaves the connection
+page. The owner's words: "I don't want to be limited by read only, it doesn't
+make sense for this project."
+
+## The reversal, stated plainly
+
+This gives Connapse's **standing runtime identity** the authority to create S3
+Access Grants. The security consequence, so an admin meets it on the setup page
+rather than in IAM:
+
+- Today a compromise of Connapse's role/private key lets an attacker *read* what
+  Connapse can read (already structural — a RAG system ingests with no user
+  present). It cannot grant a directory group access to a bucket; that authority
+  lives with a human admin, so AWS Access Grants + CloudTrail remain an
+  authorization record Connapse cannot fabricate.
+- After this change, a compromise can also *create* grants — Connapse's identity
+  becomes a writer of access-control decisions. This is accepted deliberately.
+
+Consequence for the code: `S3SetupPolicy` is **no longer read-only**, and its
+self-description must stop claiming it is (see §2).
+
+## Scope
+
+**In:** automate the per-group grants surfaced on the connector page — the thing
+`AccessGrantScript` generates.
+
+**Out:** the one-time infra setup (`AccessGrantsSetup`: the Access Grants
+instance, `s3://` location, and location role). That step creates IAM roles and
+an Access Grants instance, which would need `iam:CreateRole` / `iam:PutRolePolicy`
+on Connapse's *runtime* identity — a far larger, more dangerous authority than
+grant creation, for something done exactly once. It stays admin-run via the
+existing CloudFormation. The infra is the prerequisite that registers the
+`s3://` location grants attach to; the writer discovers that location and fails
+with a clear "run the Access Grants setup step first" when it is absent — the
+same message the script prints today.
+
+## §1 Grant writer (Core interface + Storage impl)
+
+Mirror the existing read path (`IAccessGrantsReader` → `S3AccessGrantsReader`).
+
+**`IAccessGrantsWriter`** (new, in `Connapse.Core`, beside `IAccessGrantsReader`):
+
+```csharp
+/// <summary>The result of creating grants for one grantee against one region.</summary>
+public record GrantWriteResult(
+    IReadOnlyList<string> Created,       // locations a grant was created for
+    IReadOnlyList<string> AlreadyGranted,// locations already covered (skipped)
+    IReadOnlyList<GrantWriteFailure> Failed); // locations that could not be granted
+
+public record GrantWriteFailure(string Location, string Reason);
+
+public interface IAccessGrantsWriter
+{
+    /// <summary>
+    /// Creates one READ grant per location for the grantee, against the Access
+    /// Grants instance in <paramref name="region"/>. Idempotent: existing grants
+    /// are read first and skipped. Never creates WRITE or READWRITE.
+    /// </summary>
+    Task<GrantWriteResult> GrantReadAsync(
+        AccessGrantee grantee, string region,
+        IReadOnlyList<string> locations, CancellationToken ct = default);
+}
+```
+
+**`S3AccessGrantsWriter`** (new, in `Connapse.Storage/CloudScope`), constructed
+exactly like `S3AccessGrantsReader` — `ConnapseAwsCredentials` +
+`IOptionsMonitor<IdentityCenterSettings>`. Behaviour mirrors the shell logic in
+`AccessGrantScript.GenerateScript`, so the two stay semantically identical:
+
+1. Guard: `IsConfigured` false → return an empty result (nothing to do).
+2. Resolve account id via STS (reuse the reader's cached-per-process pattern).
+3. Find the `s3://` location: `ListAccessGrantsLocationsAsync`, take the entry
+   whose `LocationScope == "s3://"`. None → every location fails with
+   "No s3:// location is registered — run the Access Grants setup step first."
+4. Read existing grants for the grantee once (`ListAccessGrantsAsync` with the
+   grantee filter) and collect their `GrantScope`s.
+5. For each requested location, normalise to the script's subprefix form:
+   `SanitiseLocation(location)` then append `/*` → `bucket/prefix/*`. Compare
+   against existing scopes as `s3://bucket/prefix/*`; a match → `AlreadyGranted`.
+6. Otherwise `CreateAccessGrantAsync` with
+   `AccessGrantsLocationId = <found>`,
+   `AccessGrantsLocationConfiguration.S3SubPrefix = "bucket/prefix/*"`,
+   `Permission = READ`,
+   `Grantee = { GranteeType = DIRECTORY_GROUP|DIRECTORY_USER, GranteeIdentifier = id }`.
+   Success → `Created`. A `Conflict`/`already exists` error → `AlreadyGranted`
+   (the read-then-create race backstop, same as the script). Any other error →
+   `Failed` with the AWS reason; keep going so one bad bucket does not hide the
+   rest.
+
+The subprefix form must match the reader/coverage side exactly (`GrantScope`
+parsing and `GrantCoverageReporter`), or a grant the writer just created would
+still read as ungranted. Reuse `AccessGrantScript.SanitiseLocation` (already
+public and already the single source of that shape) rather than re-deriving it.
+
+**DI:** register `IAccessGrantsWriter` → `S3AccessGrantsWriter` in
+`Connapse.Storage`'s `ServiceCollectionExtensions`, next to the reader.
+
+## §2 Policy + preflight
+
+Connapse's role must actually be allowed to do this, and an admin must be able to
+see when it is not.
+
+- **`S3SetupPolicy`.** Add a statement (or extend `ConnapseReadGrants`) granting
+  `s3:CreateAccessGrant` and `s3:ListAccessGrantsLocations` on the same
+  `arn:aws:s3:*:<account>:access-grants/*` resource as the existing
+  `s3:ListAccessGrants`. `s3:ListAccessGrants` is already present.
+- **Stop claiming read-only.** `ManagedIdentitySummary` currently reads
+  "…It cannot write, delete, or change anything." That becomes false. Rewrite it
+  to state that the identity can create S3 Access Grants (grant directory groups
+  read access to buckets) in addition to reading, and adjust the read-only
+  framing in the `ForManagedIdentity` doc-comment. This is the surface where the
+  admin meets the new authority — it must be honest.
+- **Preflight required-actions set** (the design's green/yellow/red probe in
+  [`ProviderSetupReader`](../../../src/Connapse.Web/Services/ProviderSetupReader.cs)):
+  add `s3:CreateAccessGrant` (and `s3:ListAccessGrantsLocations`) to the declared
+  set so a role missing them renders **yellow** with the exact action named,
+  rather than the admin discovering it only when a grant button fails. The set is
+  data by design ("adding write actions later extends the set without a
+  redesign"), so this is the extension it anticipated.
+
+## §3 UI
+
+On the connection (Connections.razor), the current "copy this command" affordance
+built from `GrantCommand` becomes a **"Grant access" button**:
+
+- Shown under the same condition as today's command: a grant group is configured
+  (`HasGrantGroup`) and the connection has a coverage warning
+  (`coverage.HasWarning`), in a region that is not a `RegionMismatch`.
+- Click → call `IAccessGrantsWriter.GrantReadAsync(grantee, form.Region,
+  coverage.Ungranted, isGroup: true)` with the configured `GrantGroupId`. Use the
+  **connection's** region, not the directory's — a grant is created against the
+  Access Grants instance in the bucket's region (the same reason the script does).
+- On success, re-run the coverage check in place so the warning clears without a
+  page reload — reuse `RefreshUngrantedAsync` / `GrantCoverage.CheckAsync`.
+  Surface a short result line: created N, already granted M.
+- **Graceful degradation.** If the writer returns failures whose reason is
+  `AccessDenied` (a bring-your-own narrow role, or the policy not yet updated),
+  fall back to showing the existing `AccessGrantScript` CloudShell command as the
+  escape hatch — the same try-direct-then-degrade pattern
+  [`ProviderResetAction`](../../../src/Connapse.Web/Components/Providers/ProviderResetAction.razor)
+  uses for trust-anchor deletion. `AccessGrantScript` is therefore **kept**, no
+  longer the default path.
+- The region-mismatch guard (`RegionMismatch`) and its message are unchanged: a
+  grant that AWS would reject is still not offered, button or script.
+
+## §4 Safety invariants (must hold)
+
+- **READ only.** Never create WRITE or READWRITE, matching
+  `AccessGrantRecord.PermitsRead` — a write-only grant read back as readable is a
+  disclosure the per-user layer already guards against.
+- **Idempotent / re-runnable.** Existing grants are skipped; a second click
+  creates nothing and reports what is already there.
+- **Fail-closed on partial error.** One bucket's failure does not abort the rest,
+  and the UI reports exactly which failed and why — never a silent partial.
+- **No new grantee shapes.** Group grants only from the UI (as today); the writer
+  accepts `isGroup` so a user grant remains expressible, but the page grants the
+  one configured group.
+- **Nothing bypasses the region rule.** The writer is only ever called with the
+  connection's own region.
+
+## §5 Testing
+
+- **Unit — `S3AccessGrantsWriter`** (mock `AmazonS3ControlClient` at the SDK
+  boundary, as the reader's tests do): location discovered vs. missing; existing
+  grant skipped; new grant created with the exact `S3SubPrefix`/`READ`/grantee;
+  `Conflict` mapped to already-granted; other error collected as a failure while
+  the loop continues; empty when `IsConfigured` is false.
+- **Unit — `S3SetupPolicy`:** the policy now includes `s3:CreateAccessGrant` and
+  `s3:ListAccessGrantsLocations` on the access-grants resource; the summary no
+  longer asserts read-only. (Extend the existing `S3SetupPolicyTests`.)
+- **Unit — preflight mapping:** a role missing `s3:CreateAccessGrant` maps to
+  yellow naming that action.
+- **Integration:** grant creation against a stubbed S3 Control (no live AWS in
+  CI, matching existing fixtures); the coverage warning clears after a successful
+  write.
+
+## §6 Delivery
+
+One focused change — new interface + service + DI, a policy/preflight edit, and
+the UI swap — within the project's PR-size limit, so a single PR against its own
+issue (issue-first rule). Branch `feature/<issue>-auto-create-access-grants`.
+`AccessGrantScript` and its tests are retained as the fallback.

--- a/docs/superpowers/specs/2026-09-03-orphaned-access-grant-cleanup-design.md
+++ b/docs/superpowers/specs/2026-09-03-orphaned-access-grant-cleanup-design.md
@@ -1,0 +1,185 @@
+# Orphaned S3 Access Grant cleanup
+
+**Status:** Design — brainstorming decisions captured, pending spec review
+**Date:** 2026-09-03
+**Builds on:** the grant-creation feature (`IAccessGrantsWriter` / `S3AccessGrantsWriter`,
+`GrantPlanner`, the "Connapse writes grants now" reversal — see
+[2026-09-02-aws-auto-create-access-grants-design.md](2026-09-02-aws-auto-create-access-grants-design.md))
+and the per-user permissions feature (S3 Access Grants + Identity Center SAML).
+
+## Problem
+
+Connapse now creates S3 Access Grants that authorize the configured directory group to see a
+bucket's documents in per-user search. Nothing removes them. When a bucket is dropped from a
+connection's allowed-locations (Connapse stops indexing it), or a connection is deleted, or the
+admin changes the grant group, the grant lingers in AWS as **dangling authorization** — pointing at
+content Connapse no longer serves, or held by a group nobody configured any more. AWS has no native
+expiry or GC for grants; the application must reconcile them itself.
+
+Note the boundary being cleaned: the grant is **not** owned by the connection. Removing a bucket
+stops indexing (app-level, via `ConnectorFactory`'s allowlist) — it does not touch Connapse's
+account-wide IAM read, and it does not touch the grant. This feature reconciles the *grants*.
+
+## Decisions (from brainstorming)
+
+1. **Delete via a periodic reconcile sweep, plus an explicit admin "Clean up orphaned grants"
+   button.** The sweep is self-healing (a missed edit still gets reconciled next tick); the button
+   gives immediacy. Rejected: delete-on-connection-edit — it fires once, so any missed event leaves
+   a permanent orphan, and it couples an access-control delete to an unrelated save.
+2. **Enforce immediately** — the first run deletes, no dry-run phase. Because there is no observation
+   window, the safety rails in §7 are mandatory, not optional: provenance-tag gating, a fail-closed
+   abort on an incomplete connection picture, a bulk-delete circuit breaker, and loud audit logging.
+3. **Include previous-group cleanup** — grants held by a directory group that is no longer the
+   configured one are orphaned too (§5).
+4. **Leave pre-tagging grants alone.** Grants created before tagging ships — including those the
+   create feature has already made — are untagged, so cleanup treats them as admin-authored and
+   never deletes them. Documented as needing manual removal if unwanted. No "adopt existing" path.
+
+## Provenance: the mechanism that makes deletion safe
+
+The load-bearing find: **`CreateAccessGrantRequest` accepts `Tags`.** Connapse stamps every grant it
+creates, and cleanup deletes **only grants it can prove are its own**. Without this, a grant's scope
+and grantee cannot distinguish a Connapse grant from an admin's hand-made one over the same
+bucket/group, and auto-delete would be unsafe.
+
+Tag set applied at creation:
+- `connapse:managed = true` — the provenance marker; the necessary condition for deletion.
+- `connapse:instance = <instance fingerprint>` — which Connapse deployment created it (§6).
+
+**Read-back caveat (AWS):** `ListAccessGrants` returns the grant's id, grantee, scope, and ARN but
+**not** its tags. Provenance is confirmed per-candidate via `ListTagsForResource(ARN)` after the
+candidate set is already narrowed (right group + orphaned scope), so it is a handful of calls, not a
+scan. (The Resource Groups Tagging API is the bulk pre-filter if a deployment ever holds tens of
+thousands of grants.) Provenance is only as strong as the tag: an admin who strips it makes the
+grant look admin-authored, which fails **safe** — it is skipped, never deleted.
+
+## §1 Tag on create (prerequisite — ship first)
+
+Add the tag set above to the `CreateAccessGrantRequest` built in
+`S3AccessGrantsWriter.CreateAsync`. Small, safe, and the enabler for everything below — worth
+shipping ahead of the reconciler so grants created in the interim are already GC-able. Requires
+`s3:TagResource`-at-create (covered by `s3:CreateAccessGrant` with the `Tags` parameter; confirm the
+role can pass tags). The instance fingerprint comes from the same per-instance identity the Roles
+Anywhere setup already establishes.
+
+## §2 Reader enhancement — surface the grant id and grantee
+
+Deletion is impossible today: `AccessGrantRecord` carries scope / object-flag / application-ARN /
+permission, and `S3AccessGrantsReader` discards the AWS `AccessGrantId` and `Grantee`. Add a fuller
+read:
+
+- New record `AccessGrantDetail(string AccessGrantId, string AccessGrantArn, AccessGrantee Grantee,
+  string GrantScope, string? Permission, string AccessGrantsLocationId)`.
+- New `IAccessGrantsReader.ListAllAsync(string region, ct)` returning `IReadOnlyList<AccessGrantDetail>`
+  — every grant in the instance, grantee-blind (the reconciler needs all groups, to catch the
+  previous group). Mirrors `ListAllScopesAsync`'s pattern but keeps the id, ARN, and grantee.
+
+`ListForGranteeAsync` / `ListAllScopesAsync` are unchanged (the search path and coverage reporter
+still use them).
+
+## §3 Delete path — writer method + policy
+
+- `IAccessGrantsWriter.RevokeAsync(string region, IReadOnlyList<string> grantIds, ct)` →
+  `GrantRevokeResult(IReadOnlyList<string> Deleted, IReadOnlyList<string> NotFound,
+  IReadOnlyList<GrantWriteFailure> Failed, bool AccessDenied)`. Implemented in `S3AccessGrantsWriter`,
+  reusing its account resolution, per-region client construction, and `IsAccessDenied`. `DeleteAccessGrant`
+  is **one grant per call** (no batch) and **not idempotent** — a missing id throws `NotFoundException`,
+  caught and folded into `NotFound` so a concurrent delete never fails the run.
+- Add `s3:DeleteAccessGrant` to `S3SetupPolicy`'s `ConnapseManageGrants` statement (on the same
+  `access-grants` resource) and to `AccessGrantScript.RequiredPermissions` if the CloudShell fallback
+  ever needs to mirror it. Another write action on the runtime identity — the same knowingly-accepted
+  tradeoff as create, updated in `ManagedIdentitySummary`.
+
+## §4 The reconciler — sweep + button
+
+A new `IGrantReconciliationJobs` in `src/Connapse.Background/Jobs/`, following the existing Hangfire
+recurring-sweep pattern (`SummaryJobs.SweepStaleContainersAsync`): registered `AddScoped` in
+`AddConnapseHangfire`, wired as a recurring job in `Program.cs` alongside the summary sweep,
+`[AutomaticRetry(Attempts = 0)]` (a failed tick just waits for the next). The admin button calls the
+same reconcile method directly.
+
+**Per-tick algorithm:**
+1. Guard: no configured grant group (`!SamlSignInSettings.HasGrantGroup`) → still run, but only
+   previous-group cleanup is possible (§5); if there is also no way to know any managed grant is
+   wanted, do nothing.
+2. Build the **union of allowed-locations across every S3 connection**:
+   `IConnectionStore.ListAsync(0, int.MaxValue)` filtered to `Provider == S3`, each parsed with
+   `StorageLocationPolicy.ReadAllowedLocations` (the enforcement-grade parser — not the Razor form
+   path). **Fail-closed:** if the list read throws, or any connection's config will not parse, the
+   union is incomplete → **abort the tick, delete nothing** (an incomplete union makes still-needed
+   grants look orphaned). Mirrors `AwsSearchScopeResolver`'s "any part fails → deny the whole thing".
+3. For each region in `IAwsGrantRegions.ListAsync`, read all grants (`ListAllAsync`). A region whose
+   read fails is skipped for deletion that tick (we simply do not delete what we cannot fully see);
+   the union is global, so skipping a region does not risk a wrong delete.
+4. A grant is a **deletion candidate** when all hold:
+   - its grantee is a directory **group**, and either the **configured** group (orphaned-scope case)
+     or a **non-configured** group (previous-group case, §5);
+   - its scope overlaps **no** location in the union — reuse `GrantCoverage.Overlaps` /
+     `GrantCoverage.Normalise` (the same boundary-aware matcher the coverage reporter uses in the
+     create direction), not `GrantScope.Parse`;
+   - `ListTagsForResource(ARN)` confirms `connapse:managed = true` **and** the instance tag per §6.
+5. **Circuit breaker:** if the candidate set is an implausibly large share of all managed grants in a
+   region (e.g. ≥ a configured threshold, default "all of them / more than N"), abort and log an
+   alert rather than delete — the signature of a union that came back wrongly empty. This substitutes
+   for the dry-run window the "enforce immediately" choice removed.
+6. `RevokeAsync` the survivors, region by region. Log every deletion at audit level with the grant id,
+   scope, and grantee (sanitised via `LogSanitizer`).
+
+## §5 Previous-group cleanup
+
+When the admin changes `GrantGroupId`, only the current id is stored — the old group's grants can be
+found only by reading grantees back from AWS. `ListAllAsync` returns the grantee, so the reconciler
+already sees them. A grant held by a **group other than the configured one**, tagged
+`connapse:managed` (+ instance, §6), whose scope no connection covers, is a previous-group orphan and
+is deleted. A grant held by another group but whose scope **is** still covered is left alone (the
+admin may have re-pointed deliberately); only orphaned-scope previous-group grants are removed.
+
+## §6 Multi-instance consideration
+
+A grant is account-wide; two Connapse deployments can share one AWS account and grant group. Instance
+A must not delete a grant that instance B's connections still justify — A's union only sees A's
+connections. The `connapse:instance` tag scopes this: **each instance deletes only grants tagged with
+its own instance fingerprint.** Consequence: a grant instance A created but no longer needs, that
+instance B also relies on, is still A's to delete — but B would re-offer/re-create it on its next
+coverage check, so the steady state self-corrects. For the common single-instance-per-account case
+this is a no-op. Documented limitation: cross-instance shared grants are reconciled per-creator, not
+globally.
+
+## §7 Safety invariants (mandatory — no dry-run buffer)
+
+- **Provenance-gated:** never delete a grant without a confirmed `connapse:managed` (+ instance) tag.
+  Untagged / differently-tagged / admin-authored → never touched.
+- **Fail-closed on incomplete input:** any failure enumerating connections, or any unparseable
+  connection config, aborts the whole tick. Deletion requires a *complete* union.
+- **Circuit breaker:** refuse a tick whose candidate set exceeds the plausibility threshold.
+- **Idempotent-safe deletes:** `NotFoundException` folds into `NotFound`, never fails the run.
+- **Group grants only, READ semantics irrelevant to deletion** — but only ever delete DIRECTORY_GROUP
+  grants Connapse tagged; never IAM or directory-user grants.
+- **Loud audit logging** of every deletion; this is an access-control change and must be traceable.
+
+## §8 Testing
+
+- **Unit — orphan predicate:** extend `GrantCoverage` (or a sibling `Orphaned(grantScopes,
+  allowedLocations)`) with cases: scope covered by one of several connections is **not** orphaned;
+  boundary case (`logs` vs `logs-archive`); object vs prefix scope; empty union.
+- **Unit — candidate selection:** given a set of `AccessGrantDetail` + a union + a configured group,
+  the correct grants are selected (configured-group orphan, previous-group orphan, admin grant
+  skipped-by-tag, still-covered grant skipped, wrong-instance grant skipped), and the circuit breaker
+  trips at threshold.
+- **Unit — `S3SetupPolicy`:** `s3:DeleteAccessGrant` present; summary updated.
+- **Unit — reader projection:** `ListAllAsync` surfaces id + grantee + ARN + location.
+- **Integration:** reconcile against a stubbed S3 Control (list → tags → delete), asserting a
+  connection-enumeration failure deletes nothing.
+- AWS-touching writer/reader delete paths verified manually/live per codebase precedent (no bUnit /
+  no client-boundary unit tests, matching the reader).
+
+## §9 Delivery / build order
+
+Its own epic, staged so each PR is independently useful and testable:
+
+1. **Tag on create** (§1) — smallest, safe, ships first so interim grants are GC-able. Own issue/PR.
+2. **Reader detail + delete path + policy** (§2, §3) — the plumbing, no automatic behaviour yet;
+   exercised by the admin button.
+3. **Reconciler** (§4, §5, §6) — the sweep, the button, the safety rails (§7).
+
+Each PR references its own GitHub issue per the issue-first rule.

--- a/docs/superpowers/specs/2026-09-03-update-role-permissions-design.md
+++ b/docs/superpowers/specs/2026-09-03-update-role-permissions-design.md
@@ -1,0 +1,82 @@
+# Update Connapse's role permissions when they change
+
+**Status:** Design (bounded) — approved in brainstorming
+**Date:** 2026-09-03
+**Builds on:** the grant create/cleanup work that widened `S3SetupPolicy.ForManagedIdentity()`.
+
+## Problem
+
+`S3SetupPolicy.ForManagedIdentity()` is applied to Connapse's role **once**, when the admin runs
+the Roles Anywhere setup script. Widening it later (adding `s3:CreateAccessGrant`, then the cleanup
+actions) does nothing for a role already created — the install keeps the old inline policy and every
+new action returns `AccessDenied`. Observed live: a role set up before the grant-create feature
+could not create grants; the connection page correctly fell back to the CloudShell script, but there
+was no path to bring the role's **own** policy up to date.
+
+The policy comment already predicted this: "widening it here does nothing for an identity that
+already exists … keeps the narrower policy and fails the new service with AccessDenied."
+
+## Constraint that shapes the solution
+
+**Connapse never edits IAM at runtime.** A runtime identity that could rewrite its own policy could
+grant itself anything — privilege escalation. So Connapse cannot update the role itself. As with
+initial setup and the grant script, it generates a command the admin runs with their own
+credentials. `iam:PutRolePolicy` replaces an inline policy of the same name in place, so re-applying
+`ConnapseRead` updates it and touches nothing else (trust anchor, profile, access key all untouched).
+
+## Decisions (from brainstorming)
+
+1. **Always-available update command**, not drift auto-detection. An "Update role permissions"
+   affordance on the AWS provider Access card that always shows the current `put-role-policy`
+   command. Idempotent, so running it when nothing changed is harmless. (Drift detection can come
+   later.)
+2. **Covers Roles Anywhere and ambient/BYO.** Roles Anywhere: the exact command, role name and
+   account taken from the stored `RoleArn`. Ambient: show the policy document to apply to whatever
+   role Connapse runs as (Connapse did not create it and does not know its name).
+
+## §1 Command generator (Core)
+
+`AwsRolePolicyUpdate` in `Connapse.Core/Utilities`, pure, reusing `S3SetupPolicy.ForManagedIdentity()`
+as the single source of the policy:
+
+- `const string PolicyName = "ConnapseRead";` — matches what `AwsRolesAnywhereSetup` attaches.
+- `string? GenerateCommand(string? roleArn)` — parses the account and role **name** (last segment
+  after `role/`) out of the ARN, substitutes the account into the policy's `__CONNAPSE_ACCOUNT_ID__`
+  placeholder, and returns:
+  `aws iam put-role-policy --role-name <name> --policy-name ConnapseRead --policy-document '<policy>'`.
+  Returns null when the ARN will not parse (so the UI shows the ambient path instead).
+- `string PolicyDocument(string? account)` — the policy JSON with the account substituted (or the
+  placeholder kept when the account is unknown), for the ambient/BYO display.
+
+## §2 UI (AWS provider Access card, `Providers.razor`)
+
+An "Update role permissions" block on the Access card, always shown when AWS is in use:
+
+- Explains: run this if Connapse's permissions changed (e.g. after an update) and a feature reports
+  `AccessDenied` — it brings the role's `ConnapseRead` policy up to the current set. Safe to re-run.
+- **Roles Anywhere** (`GetRolesAnywhereAsync("aws")` returns a config with a `RoleArn`): show
+  `GenerateCommand(config.RoleArn)` with a copy button + Open CloudShell link — the same affordance
+  pattern the Roles Anywhere setup script and the grant script already use.
+- **Ambient** (no stored Roles Anywhere config): show `PolicyDocument(account)` and a note to apply
+  it to the role Connapse runs as. The account is resolved from a `WhoAmI` probe when available,
+  else the placeholder is shown with an instruction to substitute it.
+
+## §3 Pointer from the AccessDenied fallback
+
+The grant button's fallback message in `Connections.razor` ("…not allowed to create access grants…
+add s3:CreateAccessGrant to its policy") gains a pointer to the AWS provider page's Access card,
+where the update command now lives — so the admin who hits the denial is sent to the fix.
+
+## §4 Testing
+
+- **Unit — `AwsRolePolicyUpdate`:** a Roles Anywhere ARN yields a command naming the right role,
+  `--policy-name ConnapseRead`, the real account (not the placeholder), and the current actions
+  (`s3:CreateAccessGrant`, `s3:DeleteAccessGrant`); a role ARN with a path takes the last segment; a
+  malformed ARN returns null; `PolicyDocument` substitutes the account and, with none, keeps the
+  placeholder.
+- UI verified manually (no bUnit harness).
+
+## §5 Delivery
+
+Its own issue/PR. One Core utility + a Providers.razor affordance + a one-line copy pointer on
+Connections.razor.

--- a/src/Connapse.Background/HangfireServiceCollectionExtensions.cs
+++ b/src/Connapse.Background/HangfireServiceCollectionExtensions.cs
@@ -94,6 +94,7 @@ public static class HangfireServiceCollectionExtensions
         // Job-class registrations — Hangfire activator resolves these via this IServiceProvider.
         services.AddScoped<Jobs.IIngestionJobs, Jobs.IngestionJobs>();
         services.AddScoped<Jobs.ISummaryJobs, Jobs.SummaryJobs>();
+        services.AddScoped<Jobs.IGrantReconciliationJobs, Jobs.GrantReconciliationJobs>();
 
         // Bridge the legacy IIngestionQueue API onto Hangfire. Replaces the in-memory
         // Channel-based queue + IngestionWorker that previously lived in Connapse.Ingestion.

--- a/src/Connapse.Background/Jobs/GrantReconciliationJobs.cs
+++ b/src/Connapse.Background/Jobs/GrantReconciliationJobs.cs
@@ -1,0 +1,36 @@
+using Connapse.Core;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+
+namespace Connapse.Background.Jobs;
+
+/// <summary>
+/// Recurring sweep that deletes S3 access grants no connection needs any more.
+/// </summary>
+/// <remarks>
+/// Thin: every safety decision lives in <see cref="IGrantReconciliationService"/>. Mirrors
+/// <see cref="SummaryJobs.SweepStaleContainersAsync"/> — recurring, no Hangfire retry (a failed tick
+/// just waits for the next), and non-reentrant so two ticks never delete against each other.
+/// </remarks>
+public sealed class GrantReconciliationJobs(
+    IGrantReconciliationService reconciler,
+    ILogger<GrantReconciliationJobs> logger) : IGrantReconciliationJobs
+{
+    [Queue(JobQueues.Default)]
+    [AutomaticRetry(Attempts = 0)] // Recurring; on failure just wait until the next tick.
+    [DisableConcurrentExecution(timeoutInSeconds: 600)]
+    public async Task ReconcileAsync(CancellationToken ct)
+    {
+        var report = await reconciler.ReconcileAsync(enforce: true, ct);
+
+        // Quiet on a clean, do-nothing tick; noisy when something happened or was held back.
+        if (report.Deleted > 0 || report.Aborted.Count > 0 || report.Failed.Count > 0)
+        {
+            logger.LogInformation(
+                "Grant reconcile: scanned {Scanned}, orphaned {Orphaned}, deleted {Deleted}, "
+                + "held back {Aborted}, failed {Failed}",
+                report.Scanned, report.Orphaned, report.Deleted,
+                report.Aborted.Count, report.Failed.Count);
+        }
+    }
+}

--- a/src/Connapse.Background/Jobs/IGrantReconciliationJobs.cs
+++ b/src/Connapse.Background/Jobs/IGrantReconciliationJobs.cs
@@ -1,0 +1,16 @@
+using Hangfire;
+
+namespace Connapse.Background.Jobs;
+
+/// <summary>
+/// Hangfire handler for the recurring orphaned-access-grant cleanup.
+/// </summary>
+/// <remarks>
+/// The <c>[Queue]</c> attribute is on the interface method, as with the other job interfaces,
+/// because Hangfire reads it there when the recurring job is registered against the interface.
+/// </remarks>
+public interface IGrantReconciliationJobs
+{
+    [Queue(JobQueues.Default)]
+    Task ReconcileAsync(CancellationToken ct);
+}

--- a/src/Connapse.Core/Interfaces/IAccessGrantsReader.cs
+++ b/src/Connapse.Core/Interfaces/IAccessGrantsReader.cs
@@ -51,6 +51,17 @@ public record AccessGrantRecord(
         || string.Equals(Permission, "READWRITE", StringComparison.OrdinalIgnoreCase);
 }
 
+/// <summary>One S3 access grant, with everything cleanup needs to identify and delete it.</summary>
+/// <remarks>
+/// Distinct from <see cref="AccessGrantRecord"/>, which the search/coverage paths use and which
+/// deliberately drops the id and grantee. Deletion needs the <c>AccessGrantId</c>, the ARN (to read
+/// the provenance tag back, since <c>ListAccessGrants</c> does not return tags), and the grantee (to
+/// tell the configured group from a superseded one).
+/// </remarks>
+public record AccessGrantDetail(
+    string AccessGrantId, string AccessGrantArn, AccessGrantee Grantee,
+    string GrantScope, string? Permission, string AccessGrantsLocationId);
+
 /// <summary>
 /// Reads S3 Access Grants using Connapse's own AWS identity.
 /// </summary>
@@ -96,6 +107,17 @@ public interface IAccessGrantsReader
     /// </para>
     /// </remarks>
     Task<IReadOnlyList<string>> ListAllScopesAsync(string region, CancellationToken ct = default);
+
+    /// <summary>
+    /// Every grant in the instance in <paramref name="region"/>, with id, ARN and grantee — for
+    /// reconciliation.
+    /// </summary>
+    /// <remarks>
+    /// Grantee-blind: the reconciler needs every group's grants, including a group that is no longer
+    /// the configured one, so a superseded group's orphans can be found. Not an authorization answer
+    /// — <see cref="ListForGranteeAsync"/> remains the only thing that decides what a search may read.
+    /// </remarks>
+    Task<IReadOnlyList<AccessGrantDetail>> ListAllAsync(string region, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Connapse.Core/Interfaces/IAccessGrantsWriter.cs
+++ b/src/Connapse.Core/Interfaces/IAccessGrantsWriter.cs
@@ -1,0 +1,47 @@
+namespace Connapse.Core;
+
+/// <summary>One location that could not be granted, and why.</summary>
+public record GrantWriteFailure(string Location, string Reason);
+
+/// <summary>The outcome of creating grants for one grantee against one region.</summary>
+/// <param name="Created">Subprefixes a grant was created for.</param>
+/// <param name="AlreadyGranted">Subprefixes a grant already covered (nothing created).</param>
+/// <param name="Failed">Locations that could not be granted, with the AWS reason.</param>
+/// <param name="AccessDenied">
+/// True when a failure was AWS <c>AccessDenied</c> — Connapse's identity is not (yet) allowed to
+/// create grants, so the UI should fall back to the admin-run CloudShell script rather than present
+/// the failure as broken.
+/// </param>
+public record GrantWriteResult(
+    IReadOnlyList<string> Created,
+    IReadOnlyList<string> AlreadyGranted,
+    IReadOnlyList<GrantWriteFailure> Failed,
+    bool AccessDenied)
+{
+    /// <summary>Nothing failed.</summary>
+    public bool Succeeded => Failed.Count == 0;
+
+    /// <summary>An empty result — nothing requested, or the feature is not configured.</summary>
+    public static readonly GrantWriteResult Nothing = new([], [], [], AccessDenied: false);
+}
+
+/// <summary>
+/// Creates S3 Access Grants using Connapse's own AWS identity.
+/// </summary>
+/// <remarks>
+/// The write twin of <see cref="IAccessGrantsReader"/>. Connapse now creates grants as well as
+/// reading them: its runtime identity is deliberately no longer read-only, so a compromise of that
+/// identity can create grants. The blast radius is stated to the administrator on the setup page
+/// (see <c>S3SetupPolicy.ManagedIdentitySummary</c>).
+/// </remarks>
+public interface IAccessGrantsWriter
+{
+    /// <summary>
+    /// Creates one READ grant per location for <paramref name="grantee"/>, against the Access
+    /// Grants instance in <paramref name="region"/>. Idempotent: existing grants are read first and
+    /// skipped. Never creates WRITE or READWRITE.
+    /// </summary>
+    Task<GrantWriteResult> GrantReadAsync(
+        AccessGrantee grantee, string region,
+        IReadOnlyList<string> locations, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/IAccessGrantsWriter.cs
+++ b/src/Connapse.Core/Interfaces/IAccessGrantsWriter.cs
@@ -25,6 +25,21 @@ public record GrantWriteResult(
     public static readonly GrantWriteResult Nothing = new([], [], [], AccessDenied: false);
 }
 
+/// <summary>The outcome of deleting grants by id in one region.</summary>
+/// <param name="Deleted">Grant ids removed.</param>
+/// <param name="NotFound">
+/// Grant ids AWS reported as already gone. <c>DeleteAccessGrant</c> is not idempotent, so a
+/// concurrent delete surfaces here rather than as a failure — from the caller's point of view the
+/// grant is gone either way.
+/// </param>
+/// <param name="Failed">Grant ids that could not be deleted, with the AWS reason.</param>
+/// <param name="AccessDenied">True when a failure was AWS <c>AccessDenied</c>.</param>
+public record GrantRevokeResult(
+    IReadOnlyList<string> Deleted,
+    IReadOnlyList<string> NotFound,
+    IReadOnlyList<GrantWriteFailure> Failed,
+    bool AccessDenied);
+
 /// <summary>
 /// Creates S3 Access Grants using Connapse's own AWS identity.
 /// </summary>
@@ -44,4 +59,24 @@ public interface IAccessGrantsWriter
     Task<GrantWriteResult> GrantReadAsync(
         AccessGrantee grantee, string region,
         IReadOnlyList<string> locations, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes the named grants in <paramref name="region"/>. A missing id is reported as NotFound,
+    /// never a failure — <c>DeleteAccessGrant</c> is not idempotent, so a concurrent delete must not
+    /// fail the run.
+    /// </summary>
+    Task<GrantRevokeResult> RevokeAsync(
+        string region, IReadOnlyList<string> grantIds, CancellationToken ct = default);
+
+    /// <summary>
+    /// The subset of <paramref name="grantArns"/> tagged as Connapse-managed.
+    /// </summary>
+    /// <remarks>
+    /// Tags are not returned by <c>ListAccessGrants</c>, so this reads them back per grant via
+    /// <c>ListTagsForResource</c>. A grant whose tags cannot be read is treated as not ours (fail
+    /// safe — it is never deleted), because provenance is the one gate that keeps cleanup from
+    /// removing an administrator's own grant.
+    /// </remarks>
+    Task<IReadOnlyList<string>> FilterManagedAsync(
+        string region, IReadOnlyList<string> grantArns, CancellationToken ct = default);
 }

--- a/src/Connapse.Core/Interfaces/IGrantReconciliationService.cs
+++ b/src/Connapse.Core/Interfaces/IGrantReconciliationService.cs
@@ -1,0 +1,34 @@
+namespace Connapse.Core;
+
+/// <summary>The outcome of one reconcile run.</summary>
+/// <param name="Scanned">Grants read across all regions.</param>
+/// <param name="Orphaned">Group grants whose scope no connection covers.</param>
+/// <param name="Deleted">Grants actually removed (0 when not enforcing).</param>
+/// <param name="Aborted">
+/// Reasons a run, or one region, deleted nothing — an incomplete connection view, a tripped circuit
+/// breaker, or an unreadable region. Non-empty means cleanup held back on purpose.
+/// </param>
+/// <param name="Failed">Grants a delete call rejected.</param>
+public record ReconcileReport(
+    int Scanned, int Orphaned, int Deleted,
+    IReadOnlyList<string> Aborted, IReadOnlyList<GrantWriteFailure> Failed)
+{
+    /// <summary>A run that deleted nothing because it could not act safely.</summary>
+    public static ReconcileReport Abort(string reason) => new(0, 0, 0, [reason], []);
+}
+
+/// <summary>
+/// Deletes S3 Access Grants Connapse created that no connection needs any more.
+/// </summary>
+/// <remarks>
+/// A Core interface so the Hangfire job (in the Background layer) can depend on it while the
+/// implementation lives in the Web layer with the AWS plumbing and the admin page it also serves.
+/// </remarks>
+public interface IGrantReconciliationService
+{
+    /// <summary>
+    /// Reconciles once. <paramref name="enforce"/> false computes and logs what it would delete
+    /// without deleting; true deletes.
+    /// </summary>
+    Task<ReconcileReport> ReconcileAsync(bool enforce, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Models/GrantReconciliationSettings.cs
+++ b/src/Connapse.Core/Models/GrantReconciliationSettings.cs
@@ -1,0 +1,28 @@
+namespace Connapse.Core;
+
+/// <summary>
+/// Controls the sweep that deletes S3 Access Grants no connection needs any more.
+/// </summary>
+/// <remarks>
+/// Deletion is the dangerous direction, so this carries a kill switch and a circuit-breaker limit.
+/// Both have safe defaults and need no configuration to work; a deployment that wants to pause
+/// cleanup or raise the batch ceiling sets them under <see cref="SectionName"/>.
+/// </remarks>
+public record GrantReconciliationSettings
+{
+    /// <summary>The settings section this binds to.</summary>
+    public const string SectionName = "Identity:GrantReconciliation";
+
+    /// <summary>Whether the reconciler runs at all. A pause switch, not a mode.</summary>
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>
+    /// The most grants the sweep will delete in one region in one run before refusing.
+    /// </summary>
+    /// <remarks>
+    /// The circuit breaker. A run that wants to delete more than this many grants in a region is far
+    /// more likely to be acting on a wrongly-empty view of the connections than to have found that
+    /// many genuine orphans, so it aborts and alerts instead — the substitute for a dry-run window.
+    /// </remarks>
+    public int MaxDeletePerTick { get; init; } = 50;
+}

--- a/src/Connapse.Core/Utilities/AwsRolePolicyUpdate.cs
+++ b/src/Connapse.Core/Utilities/AwsRolePolicyUpdate.cs
@@ -1,0 +1,78 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Builds the command that brings Connapse's role permissions up to date.
+/// </summary>
+/// <remarks>
+/// <see cref="S3SetupPolicy.ForManagedIdentity"/> is applied to the role once, at setup. Widening it
+/// later — a new action for a new feature — does nothing for a role that already exists, which then
+/// fails the new action with <c>AccessDenied</c>. This regenerates the same <c>ConnapseRead</c>
+/// policy so an administrator can re-apply it.
+/// <para>
+/// Connapse does not run it. A runtime identity that could rewrite its own policy could grant itself
+/// anything, so IAM editing stays with the administrator's own credentials — the same rule as the
+/// initial setup and the grant script. <c>iam:PutRolePolicy</c> replaces an inline policy of the
+/// same name in place, so re-applying updates it and touches nothing else.
+/// </para>
+/// </remarks>
+public static class AwsRolePolicyUpdate
+{
+    /// <summary>The inline policy name, matching what <c>AwsRolesAnywhereSetup</c> attaches.</summary>
+    public const string PolicyName = "ConnapseRead";
+
+    /// <summary>
+    /// The <c>put-role-policy</c> command for the role at <paramref name="roleArn"/>, or null when
+    /// the ARN will not parse (in which case the caller shows the ambient path instead).
+    /// </summary>
+    public static string? GenerateCommand(string? roleArn)
+    {
+        if (ParseRoleArn(roleArn) is not var (account, roleName))
+            return null;
+
+        string policy = PolicyDocument(account).Replace("\r\n", "\n");
+
+        return $"aws iam put-role-policy --role-name {roleName} "
+             + $"--policy-name {PolicyName} --policy-document '{policy}'";
+    }
+
+    /// <summary>
+    /// The <c>ConnapseRead</c> policy document, for a role Connapse did not create (ambient / BYO).
+    /// </summary>
+    /// <param name="account">
+    /// The AWS account, substituted into the policy. When null the placeholder is kept, so the admin
+    /// substitutes their own.
+    /// </param>
+    public static string PolicyDocument(string? account) =>
+        S3SetupPolicy.ForManagedIdentity().Replace(
+            S3SetupPolicy.AccountPlaceholder,
+            string.IsNullOrWhiteSpace(account) ? S3SetupPolicy.AccountPlaceholder : account);
+
+    /// <summary>Pulls the account and role <b>name</b> out of a role ARN.</summary>
+    /// <remarks>
+    /// <c>put-role-policy</c> takes the role name, not its path, so a path-prefixed ARN
+    /// (<c>role/team/name</c>) reduces to its last segment.
+    /// </remarks>
+    private static (string Account, string RoleName)? ParseRoleArn(string? roleArn)
+    {
+        if (string.IsNullOrWhiteSpace(roleArn))
+            return null;
+
+        // arn:aws:iam::<account>:role/<optional/path/><name>
+        string[] parts = roleArn.Split(':');
+        if (parts.Length < 6 || parts[2] != "iam")
+            return null;
+
+        string account = parts[4];
+        if (account.Length == 0 || !account.All(char.IsAsciiDigit))
+            return null;
+
+        const string prefix = "role/";
+        if (!parts[5].StartsWith(prefix, StringComparison.Ordinal))
+            return null;
+
+        string path = parts[5][prefix.Length..];
+        string roleName = path.Contains('/') ? path[(path.LastIndexOf('/') + 1)..] : path;
+
+        return roleName.Length == 0 ? null : (account, roleName);
+    }
+}

--- a/src/Connapse.Core/Utilities/AwsRolePolicyUpdate.cs
+++ b/src/Connapse.Core/Utilities/AwsRolePolicyUpdate.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Connapse.Core.Utilities;
 
 /// <summary>
@@ -29,10 +31,20 @@ public static class AwsRolePolicyUpdate
         if (ParseRoleArn(roleArn) is not var (account, roleName))
             return null;
 
-        string policy = PolicyDocument(account).Replace("\r\n", "\n");
+        // Single-line JSON on purpose. A multi-line policy inside single quotes works in CloudShell
+        // (bash) but breaks in PowerShell, where a single-quoted string cannot span lines — so the
+        // command a Windows admin pastes locally would fail. Compacted, it is one safe argument.
+        string policy = Compact(PolicyDocument(account));
 
         return $"aws iam put-role-policy --role-name {roleName} "
              + $"--policy-name {PolicyName} --policy-document '{policy}'";
+    }
+
+    /// <summary>Re-serialises a policy document onto one line.</summary>
+    private static string Compact(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return JsonSerializer.Serialize(document.RootElement);
     }
 
     /// <summary>

--- a/src/Connapse.Core/Utilities/AwsRolePolicyUpdate.cs
+++ b/src/Connapse.Core/Utilities/AwsRolePolicyUpdate.cs
@@ -85,6 +85,18 @@ public static class AwsRolePolicyUpdate
         string path = parts[5][prefix.Length..];
         string roleName = path.Contains('/') ? path[(path.LastIndexOf('/') + 1)..] : path;
 
-        return roleName.Length == 0 ? null : (account, roleName);
+        // Enforce IAM's role-name grammar before this name is interpolated, unquoted, into a shell
+        // command an administrator is told to run. AWS allows [\w+=,.@-] up to 64 chars; anything
+        // else (a space, a quote, a semicolon) cannot be a real role name and must not reach a shell.
+        // The normal save path validates the ARN against AWS, but a migrated or tampered stored value
+        // must not be trusted to have done so.
+        if (roleName.Length is 0 or > 64)
+            return null;
+
+        if (!roleName.All(c =>
+                char.IsAsciiLetterOrDigit(c) || c is '_' or '+' or '=' or ',' or '.' or '@' or '-'))
+            return null;
+
+        return (account, roleName);
     }
 }

--- a/src/Connapse.Core/Utilities/DirectoryGroupSetup.cs
+++ b/src/Connapse.Core/Utilities/DirectoryGroupSetup.cs
@@ -96,6 +96,8 @@ public static class DirectoryGroupSetup
         GROUP_NAME="{{name}}"
         GROUP_ID=""
         RECORD_NAME=""
+        BLOCK=""
+        BLOCK_HINT=""
 
         [ -n "$REGION" ] || { echo 'No region. Locate your Identity Center instance first.'; FAILED=1; }
         [ -n "$STORE" ] || { echo 'No identity store. Locate your Identity Center instance first.'; FAILED=1; }
@@ -110,6 +112,8 @@ public static class DirectoryGroupSetup
             echo '  (none)'
             echo 'No groups found. Enter a group name in Connapse to create one, or use the manual fields.'
           else
+            # The block is built now but printed at the very end, so the group listing above is
+            # not split from the thing to copy by everything the create branch would print between.
             BLOCK=$(
               printf '%s\n' '{{BeginMarker}}'
               for G in $GROUP_IDS; do
@@ -120,8 +124,7 @@ public static class DirectoryGroupSetup
               done
               printf '%s\n' '{{EndMarker}}'
             )
-            printf '\n%s\n\n' "$BLOCK"
-            echo 'Copy the block above into Connapse and choose the group to use.'
+            BLOCK_HINT='Copy the block above into Connapse and choose the group to use.'
           fi
         fi
 
@@ -161,7 +164,8 @@ public static class DirectoryGroupSetup
           fi
         fi
 
-        # Return the selected or created group.
+        # Build the block for the selected or created group. Printed with the discovery block below,
+        # at the end, so both paths leave the thing to copy as the last thing on screen.
         if [ -z "$FAILED" ] && [ -n "$GROUP_ID" ] && [ "$GROUP_ID" != 'None' ]; then
           BLOCK=$(
             printf '%s\n' '{{BeginMarker}}'
@@ -169,16 +173,17 @@ public static class DirectoryGroupSetup
             printf 'groupName=%s\n' "$RECORD_NAME"
             printf '%s\n' '{{EndMarker}}'
           )
-          printf '\n%s\n\n' "$BLOCK"
-          echo 'Copy the block above into Connapse so it can name this group for you.'
+          BLOCK_HINT='Copy the block above into Connapse so it can name this group for you.'
         fi
 
+        # Whichever path ran, the block to paste comes last — after the listing, after any create
+        # messages — so it never scrolls off in the middle of the output.
         if [ -n "$FAILED" ]; then
           echo
           echo 'Something above failed. Nothing was recorded in Connapse; fix it and run this again.'
-        elif [ -n "$GROUP_ID" ] && [ "$GROUP_ID" != 'None' ]; then
-          echo
-          echo 'Paste the block above into Connapse.'
+        elif [ -n "$BLOCK" ]; then
+          printf '\n%s\n\n' "$BLOCK"
+          echo "$BLOCK_HINT"
         fi
         """.Replace("\r\n", "\n");
     }

--- a/src/Connapse.Core/Utilities/GrantCoverage.cs
+++ b/src/Connapse.Core/Utilities/GrantCoverage.cs
@@ -56,6 +56,27 @@ public static class GrantCoverage
     }
 
     /// <summary>
+    /// Whether <paramref name="grantScope"/> still reaches any of <paramref name="allowedLocations"/>.
+    /// </summary>
+    /// <remarks>
+    /// The reverse of <see cref="Ungranted"/>: that asks which locations no grant reaches; this asks
+    /// whether one grant reaches any location — the question cleanup asks to decide a grant is
+    /// orphaned. Same boundary-aware overlap, one source of truth, so "granted" and "orphaned"
+    /// cannot disagree. A scope no location covers is orphaned.
+    /// </remarks>
+    public static bool IsScopeCovered(string? grantScope, IEnumerable<string>? allowedLocations)
+    {
+        string scope = Normalise(grantScope);
+        if (scope.Length == 0)
+            return false;
+
+        return (allowedLocations ?? [])
+            .Select(l => l?.Trim())
+            .Where(l => !string.IsNullOrEmpty(l))
+            .Any(l => Overlaps(scope, Normalise(Scheme + l!)));
+    }
+
+    /// <summary>
     /// Reduces a scope or location to the URI prefix it stands for.
     /// </summary>
     /// <remarks>

--- a/src/Connapse.Core/Utilities/GrantCoverage.cs
+++ b/src/Connapse.Core/Utilities/GrantCoverage.cs
@@ -56,15 +56,20 @@ public static class GrantCoverage
     }
 
     /// <summary>
-    /// Whether <paramref name="grantScope"/> still reaches any of <paramref name="allowedLocations"/>.
+    /// Whether <paramref name="grantScope"/> is fully contained within one of
+    /// <paramref name="allowedLocations"/> — i.e. everything the grant permits is still allowed.
     /// </summary>
     /// <remarks>
-    /// The reverse of <see cref="Ungranted"/>: that asks which locations no grant reaches; this asks
-    /// whether one grant reaches any location — the question cleanup asks to decide a grant is
-    /// orphaned. Same boundary-aware overlap, one source of truth, so "granted" and "orphaned"
-    /// cannot disagree. A scope no location covers is orphaned.
+    /// The question cleanup asks to decide a grant is still justified, and it is <b>directional</b>,
+    /// which <see cref="Ungranted"/>'s symmetric <see cref="Overlaps"/> is not. A grant on the whole
+    /// bucket <c>s3://acme*</c> merely <i>overlaps</i> an allowed location narrowed to
+    /// <c>acme/team</c>, but it grants far more than that location permits — so overlap would keep an
+    /// over-broad grant alive after a connection is narrowed, leaving the group authorised over data
+    /// deliberately removed. Containment is the correct test: the grant survives only when some
+    /// allowed location is a boundary-aware prefix of (or equal to) the grant's scope. A grant
+    /// broader than every allowed location is orphaned.
     /// </remarks>
-    public static bool IsScopeCovered(string? grantScope, IEnumerable<string>? allowedLocations)
+    public static bool IsScopeWithinAllowed(string? grantScope, IEnumerable<string>? allowedLocations)
     {
         string scope = Normalise(grantScope);
         if (scope.Length == 0)
@@ -73,7 +78,23 @@ public static class GrantCoverage
         return (allowedLocations ?? [])
             .Select(l => l?.Trim())
             .Where(l => !string.IsNullOrEmpty(l))
-            .Any(l => Overlaps(scope, Normalise(Scheme + l!)));
+            .Any(l => Contains(container: Normalise(Scheme + l!), scope));
+    }
+
+    /// <summary>Whether <paramref name="container"/> is a boundary-aware prefix of (or equals) <paramref name="inner"/>.</summary>
+    /// <remarks>
+    /// Boundary-aware so <c>s3://logs</c> does not appear to contain <c>s3://logs-archive/x</c>: a
+    /// location whose name merely starts the same way is somebody else's data.
+    /// </remarks>
+    private static bool Contains(string container, string inner)
+    {
+        if (container.Length == 0 || inner.Length < container.Length)
+            return false;
+
+        if (!inner.StartsWith(container, StringComparison.Ordinal))
+            return false;
+
+        return inner.Length == container.Length || inner[container.Length] == '/';
     }
 
     /// <summary>

--- a/src/Connapse.Core/Utilities/GrantPlanner.cs
+++ b/src/Connapse.Core/Utilities/GrantPlanner.cs
@@ -1,0 +1,57 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Decides which S3 Access Grants to create for a grantee, given the grants they already hold.
+/// </summary>
+/// <remarks>
+/// Pure so it can be tested without AWS, and so the subprefix shape — <c>bucket/prefix/*</c> — has
+/// one source shared with <see cref="AccessGrantScript"/>. The writer creates exactly what this
+/// returns; if the shape drifted from what the reader parses, a grant just created would still read
+/// as ungranted.
+/// </remarks>
+public static class GrantPlanner
+{
+    /// <summary>Splits requested locations into those needing a grant and those already covered.</summary>
+    /// <param name="requestedLocations">
+    /// Buckets, each optionally followed by <c>/</c> and a prefix — the connection's ungranted
+    /// locations.
+    /// </param>
+    /// <param name="existingScopes">
+    /// The grantee's current grant scopes as AWS reports them, e.g. <c>s3://bucket/prefix/*</c>.
+    /// </param>
+    public static GrantPlan Plan(
+        IEnumerable<string> requestedLocations, IEnumerable<string> existingScopes)
+    {
+        var existing = new HashSet<string>(
+            (existingScopes ?? []).Select(s => s?.Trim() ?? string.Empty),
+            StringComparer.Ordinal);
+
+        var toCreate = new List<string>();
+        var alreadyGranted = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (string location in requestedLocations ?? [])
+        {
+            string sanitised = AccessGrantScript.SanitiseLocation(location);
+            if (sanitised.Length == 0)
+                continue;
+
+            // The shape a grant is created and read back as. AWS refuses a grant on the bare
+            // s3:// location, so every one names a bucket and the trailing star makes it a subtree.
+            string subPrefix = sanitised + "/*";
+
+            if (!seen.Add(subPrefix))
+                continue;
+
+            if (existing.Contains("s3://" + subPrefix))
+                alreadyGranted.Add(subPrefix);
+            else
+                toCreate.Add(subPrefix);
+        }
+
+        return new GrantPlan(toCreate, alreadyGranted);
+    }
+}
+
+/// <summary>The outcome of planning grants: what to create, and what already exists.</summary>
+public record GrantPlan(IReadOnlyList<string> ToCreate, IReadOnlyList<string> AlreadyGranted);

--- a/src/Connapse.Core/Utilities/GrantReconciler.cs
+++ b/src/Connapse.Core/Utilities/GrantReconciler.cs
@@ -5,21 +5,23 @@ namespace Connapse.Core.Utilities;
 /// </summary>
 /// <remarks>
 /// Pure: the AWS-touching provenance check (is this grant tagged as ours) and the deletion happen
-/// around it. The scope test is <see cref="GrantCoverage.IsScopeCovered"/>, the same boundary-aware
-/// overlap the coverage reporter uses in the create direction, so "granted" and "orphaned" cannot
-/// disagree.
+/// around it. The scope test is <see cref="GrantCoverage.IsScopeWithinAllowed"/>, a directional
+/// containment — a grant survives only when everything it permits is still within an allowed
+/// location.
 /// <para>
 /// Group-only and tag-blind by design. A user grant is never touched, and provenance requires an AWS
-/// call, so it is applied to the (small) candidate set afterwards rather than here. Both the current
-/// group's orphans and a superseded group's orphans are selected — an orphaned group grant is an
-/// orphaned group grant whichever group holds it; the only question that matters is whether any
-/// connection still reaches its scope.
+/// call, so it is applied to the (small) candidate set afterwards rather than here. A grant is an
+/// orphan when <b>either</b> it belongs to a group that is no longer the configured one (a leftover
+/// after the grant group was changed — Connapse only ever creates grants for the configured group,
+/// so a managed grant to any other group should not exist) <b>or</b> its scope is broader than any
+/// allowed location (a connection was narrowed or removed). Both are stale authorisation.
 /// </para>
 /// </remarks>
 public static class GrantReconciler
 {
     /// <summary>
-    /// The group grants whose scope no location in <paramref name="unionLocations"/> reaches.
+    /// The group grants that should no longer exist: those for a superseded group, or whose scope is
+    /// no longer contained in any location in <paramref name="unionLocations"/>.
     /// </summary>
     /// <param name="grants">Every grant in a region (from <c>IAccessGrantsReader.ListAllAsync</c>).</param>
     /// <param name="unionLocations">
@@ -28,9 +30,8 @@ public static class GrantReconciler
     /// pass a partial one here.
     /// </param>
     /// <param name="configuredGroupId">
-    /// The currently configured grant group. Unused for the orphan decision itself (a superseded
-    /// group's orphans are deleted too), but carried so callers that want to treat the two cases
-    /// differently can.
+    /// The currently configured grant group. A managed grant held by any other group is stale (the
+    /// admin changed the group) and is selected regardless of its scope.
     /// </param>
     public static OrphanSelection SelectOrphans(
         IReadOnlyList<AccessGrantDetail> grants,
@@ -45,8 +46,13 @@ public static class GrantReconciler
             if (!grant.Grantee.IsGroup || string.IsNullOrWhiteSpace(grant.Grantee.Id))
                 continue;
 
-            // Orphaned = its scope overlaps no allowed location across every connection.
-            if (GrantCoverage.IsScopeCovered(grant.GrantScope, unionLocations))
+            bool isConfiguredGroup = string.Equals(
+                grant.Grantee.Id, configuredGroupId, StringComparison.Ordinal);
+
+            // A grant for the configured group whose scope is still fully within an allowed location
+            // is the one thing to keep. Everything else — a previous group's grant, or a scope
+            // broader than anything now allowed — is an orphan.
+            if (isConfiguredGroup && GrantCoverage.IsScopeWithinAllowed(grant.GrantScope, unionLocations))
                 continue;
 
             candidates.Add(grant);

--- a/src/Connapse.Core/Utilities/GrantReconciler.cs
+++ b/src/Connapse.Core/Utilities/GrantReconciler.cs
@@ -1,0 +1,60 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Decides which access grants are orphaned — held by a directory group, reached by no connection.
+/// </summary>
+/// <remarks>
+/// Pure: the AWS-touching provenance check (is this grant tagged as ours) and the deletion happen
+/// around it. The scope test is <see cref="GrantCoverage.IsScopeCovered"/>, the same boundary-aware
+/// overlap the coverage reporter uses in the create direction, so "granted" and "orphaned" cannot
+/// disagree.
+/// <para>
+/// Group-only and tag-blind by design. A user grant is never touched, and provenance requires an AWS
+/// call, so it is applied to the (small) candidate set afterwards rather than here. Both the current
+/// group's orphans and a superseded group's orphans are selected — an orphaned group grant is an
+/// orphaned group grant whichever group holds it; the only question that matters is whether any
+/// connection still reaches its scope.
+/// </para>
+/// </remarks>
+public static class GrantReconciler
+{
+    /// <summary>
+    /// The group grants whose scope no location in <paramref name="unionLocations"/> reaches.
+    /// </summary>
+    /// <param name="grants">Every grant in a region (from <c>IAccessGrantsReader.ListAllAsync</c>).</param>
+    /// <param name="unionLocations">
+    /// The allowed-locations of every S3 connection, unioned. Must be the <b>complete</b> set — an
+    /// incomplete union makes still-needed grants look orphaned, so the caller aborts rather than
+    /// pass a partial one here.
+    /// </param>
+    /// <param name="configuredGroupId">
+    /// The currently configured grant group. Unused for the orphan decision itself (a superseded
+    /// group's orphans are deleted too), but carried so callers that want to treat the two cases
+    /// differently can.
+    /// </param>
+    public static OrphanSelection SelectOrphans(
+        IReadOnlyList<AccessGrantDetail> grants,
+        IReadOnlyList<string> unionLocations,
+        string configuredGroupId)
+    {
+        var candidates = new List<AccessGrantDetail>();
+
+        foreach (var grant in grants)
+        {
+            // Never touch anything but a directory-group grant.
+            if (!grant.Grantee.IsGroup || string.IsNullOrWhiteSpace(grant.Grantee.Id))
+                continue;
+
+            // Orphaned = its scope overlaps no allowed location across every connection.
+            if (GrantCoverage.IsScopeCovered(grant.GrantScope, unionLocations))
+                continue;
+
+            candidates.Add(grant);
+        }
+
+        return new OrphanSelection(candidates);
+    }
+}
+
+/// <summary>Grants selected for deletion, before the AWS provenance-tag confirmation.</summary>
+public record OrphanSelection(IReadOnlyList<AccessGrantDetail> Candidates);

--- a/src/Connapse.Core/Utilities/GrantTags.cs
+++ b/src/Connapse.Core/Utilities/GrantTags.cs
@@ -1,0 +1,20 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// The tags Connapse stamps on the S3 Access Grants it creates, so a cleanup pass can prove a
+/// grant is its own before deleting it.
+/// </summary>
+/// <remarks>
+/// One source shared by the writer (which applies them) and the reconciler (which requires them
+/// before deleting). AWS forbids tag keys beginning <c>aws:</c>. Tags are write-only through the
+/// grant read path — <c>ListAccessGrants</c> does not return them — so the reconciler reads them
+/// back per-candidate via <c>ListTagsForResource</c>.
+/// </remarks>
+public static class GrantTags
+{
+    /// <summary>Present with <see cref="ManagedValue"/> exactly on grants Connapse created.</summary>
+    public const string ManagedKey = "connapse:managed";
+
+    /// <summary>The value <see cref="ManagedKey"/> carries.</summary>
+    public const string ManagedValue = "true";
+}

--- a/src/Connapse.Core/Utilities/S3SetupPolicy.cs
+++ b/src/Connapse.Core/Utilities/S3SetupPolicy.cs
@@ -126,9 +126,9 @@ public static class S3SetupPolicy
     /// One sentence describing <see cref="ForManagedIdentity"/>, for the operator about to run it.
     /// </summary>
     public const string ManagedIdentitySummary =
-        "reading every S3 bucket in the account and creating S3 access grants, which grant "
-        + "directory groups read access to buckets. The only thing it creates is a grant: it "
-        + "writes no object and deletes nothing.";
+        "reading every S3 bucket in the account and creating and removing S3 access grants, which "
+        + "grant directory groups read access to buckets. The only things it changes are grants: it "
+        + "writes no object and deletes no data.";
 
     /// <summary>
     /// Every statement in the managed identity's policy, one group per AWS storage service.
@@ -191,7 +191,14 @@ public static class S3SetupPolicy
             {
                 "s3:ListAccessGrants",
                 "s3:ListAccessGrantsLocations",
-                "s3:CreateAccessGrant"
+                "s3:CreateAccessGrant",
+                // Delete + tag: Connapse tags every grant it creates and later removes the ones no
+                // connection needs. ListTagsForResource reads a grant's tag back (ListAccessGrants
+                // does not return tags), which is how cleanup proves a grant is Connapse's own
+                // before deleting it.
+                "s3:DeleteAccessGrant",
+                "s3:TagResource",
+                "s3:ListTagsForResource"
             },
             ["Resource"] = $"arn:aws:s3:*:{AccountPlaceholder}:access-grants/*"
         },

--- a/src/Connapse.Core/Utilities/S3SetupPolicy.cs
+++ b/src/Connapse.Core/Utilities/S3SetupPolicy.cs
@@ -211,7 +211,25 @@ public static class S3SetupPolicy
         {
             ["Sid"] = "ConnapseReadDirectory",
             ["Effect"] = "Allow",
-            ["Action"] = PermissionResolutionActions.Where(a => a.StartsWith("identitystore:")).ToArray(),
+            // The scope-resolution reads, plus DescribeGroup. CreateAccessGrant calls DescribeGroup
+            // internally to validate a directory-group grantee, so without it creating a group grant
+            // fails with an AccessDenied that names identitystore, not s3 -- invisible to anyone
+            // reading only the s3 actions.
+            ["Action"] = PermissionResolutionActions
+                .Where(a => a.StartsWith("identitystore:"))
+                .Append("identitystore:DescribeGroup")
+                .ToArray(),
+            ["Resource"] = "*"
+        },
+        // Creating a grant to a directory user or group makes S3 Access Grants validate the Identity
+        // Center instance and application on the caller's behalf. AWS documents both as required for
+        // any directory grantee; the old CloudShell script never needed them because the administrator
+        // running it already had them, and Connapse creating the grant itself does not.
+        new Dictionary<string, object>
+        {
+            ["Sid"] = "ConnapseValidateIdentityCenter",
+            ["Effect"] = "Allow",
+            ["Action"] = new[] { "sso:DescribeInstance", "sso:DescribeApplication" },
             ["Resource"] = "*"
         }
     ];

--- a/src/Connapse.Core/Utilities/S3SetupPolicy.cs
+++ b/src/Connapse.Core/Utilities/S3SetupPolicy.cs
@@ -72,8 +72,9 @@ public static class S3SetupPolicy
     ];
 
     /// <summary>
-    /// The complete grant for the identity Connapse creates for itself: read-only across every
-    /// AWS storage service Connapse can read from.
+    /// The complete grant for the identity Connapse creates for itself: read across every AWS
+    /// storage service Connapse can read from, plus creating the S3 access grants that make a
+    /// connection searchable per-user.
     /// </summary>
     /// <remarks>
     /// One policy, not a choice of several. The easy setup exists to remove decisions, and a scope
@@ -88,11 +89,14 @@ public static class S3SetupPolicy
     /// re-reads. That produces a policy edited under pressure, not least privilege.
     /// </para>
     /// <para>
-    /// What it costs, plainly: a leaked key reads every object in the account, and any Connapse
-    /// administrator can point a source at any bucket, which moves that decision out of IAM and
-    /// into this application. Against that — the identity is read-only, belongs to Connapse alone,
-    /// and revoking it touches nobody else's access. The narrowing lives in each connection's
-    /// allowed-locations list, which <c>ConnectorFactory</c> enforces on every read.
+    /// What it costs, plainly: a leaked key reads every object in the account, any Connapse
+    /// administrator can point a source at any bucket, and — the one authority beyond reading —
+    /// the identity can create S3 access grants, so a compromise of it can grant a directory group
+    /// read access to a bucket. That last is a deliberate reversal: creating grants used to be an
+    /// administrator's decision run in AWS, and is now Connapse's, made knowingly to remove a
+    /// CloudShell trip. Against all this — the identity writes no object, belongs to Connapse
+    /// alone, and revoking it touches nobody else's access. The narrowing lives in each
+    /// connection's allowed-locations list, which <c>ConnectorFactory</c> enforces on every read.
     /// </para>
     /// <para>
     /// S3 alone today because S3 is the only AWS storage <c>ConnectionProvider</c> names. Adding
@@ -122,7 +126,9 @@ public static class S3SetupPolicy
     /// One sentence describing <see cref="ForManagedIdentity"/>, for the operator about to run it.
     /// </summary>
     public const string ManagedIdentitySummary =
-        "reading every S3 bucket in the account. It cannot write, delete, or change anything.";
+        "reading every S3 bucket in the account and creating S3 access grants, which grant "
+        + "directory groups read access to buckets. The only thing it creates is a grant: it "
+        + "writes no object and deletes nothing.";
 
     /// <summary>
     /// Every statement in the managed identity's policy, one group per AWS storage service.
@@ -163,20 +169,30 @@ public static class S3SetupPolicy
             // without it this names buckets, and every object read is denied.
             ["Resource"] = "arn:aws:s3:::*/*"
         },
-        // Split in two because only one half can be scoped.
+        // Named at the Access Grants instances of this account. AWS documents that resource form
+        // for these actions, and it is the one worth narrowing: it is where the identity both
+        // enumerates what every grantee may read and creates new grants.
         //
-        // The grant read is named at the Access Grants instances of this account. AWS documents
-        // that resource form for this action, and it is the one worth narrowing: it is the call
-        // that can enumerate what every grantee in the instance may read.
+        // CreateAccessGrant is the deliberate exception to this policy being read-only. Connapse
+        // now creates the grants that make a connection's buckets searchable per-user rather than
+        // printing a script for an administrator to run -- so a compromise of this identity can
+        // create grants, which the operator is told in ManagedIdentitySummary. ListAccessGrants-
+        // Locations finds the s3:// location a grant attaches to. The grant is still bounded to
+        // the access-grants resource; nothing here touches an object.
         //
         // The region is a wildcard because this script runs before the Identity Center region is
         // known -- it is the step that mints the credential the later steps use. The account is
         // substituted by the script from sts:GetCallerIdentity.
         new Dictionary<string, object>
         {
-            ["Sid"] = "ConnapseReadGrants",
+            ["Sid"] = "ConnapseManageGrants",
             ["Effect"] = "Allow",
-            ["Action"] = new[] { "s3:ListAccessGrants" },
+            ["Action"] = new[]
+            {
+                "s3:ListAccessGrants",
+                "s3:ListAccessGrantsLocations",
+                "s3:CreateAccessGrant"
+            },
             ["Resource"] = $"arn:aws:s3:*:{AccountPlaceholder}:access-grants/*"
         },
         // Resource "*", and deliberately not narrowed on a guess. AWS's own Identity Store policy

--- a/src/Connapse.Storage/CloudScope/S3AccessGrantsReader.cs
+++ b/src/Connapse.Storage/CloudScope/S3AccessGrantsReader.cs
@@ -133,6 +133,58 @@ public sealed class S3AccessGrantsReader(
         return scopes;
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AccessGrantDetail>> ListAllAsync(
+        string region, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(region);
+
+        if (!options.CurrentValue.IsConfigured)
+            return [];
+
+        var endpoint = RegionEndpoint.GetBySystemName(region);
+        string account = await ResolveAccountIdAsync(endpoint, ct);
+
+        using var client = new AmazonS3ControlClient(
+            credentials, new AmazonS3ControlConfig { RegionEndpoint = endpoint });
+
+        List<AccessGrantDetail> grants = [];
+        string? nextToken = null;
+
+        do
+        {
+            var response = await client.ListAccessGrantsAsync(
+                new ListAccessGrantsRequest { AccountId = account, NextToken = nextToken }, ct);
+
+            // Null, not empty, when the account holds no grants — the AWS SDK leaves response
+            // collections unset rather than initialising them.
+            foreach (var g in response.AccessGrantsList ?? [])
+            {
+                if (string.IsNullOrWhiteSpace(g.AccessGrantId) || string.IsNullOrWhiteSpace(g.GrantScope))
+                    continue;
+
+                var grantee = g.Grantee is { } who
+                    ? new AccessGrantee(
+                        IsGroup: who.GranteeType == GranteeType.DIRECTORY_GROUP,
+                        Id: who.GranteeIdentifier ?? string.Empty)
+                    : new AccessGrantee(IsGroup: false, Id: string.Empty);
+
+                grants.Add(new AccessGrantDetail(
+                    g.AccessGrantId,
+                    g.AccessGrantArn ?? string.Empty,
+                    grantee,
+                    g.GrantScope,
+                    g.Permission?.Value,
+                    g.AccessGrantsLocationId ?? string.Empty));
+            }
+
+            nextToken = response.NextToken;
+        }
+        while (!string.IsNullOrEmpty(nextToken));
+
+        return grants;
+    }
+
     /// <summary>
     /// Whether a grant names one object rather than everything beneath a prefix.
     /// </summary>

--- a/src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs
+++ b/src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs
@@ -208,12 +208,25 @@ public sealed class S3AccessGrantsWriter(
     private static async Task<string?> FindRootLocationAsync(
         AmazonS3ControlClient client, string account, CancellationToken ct)
     {
-        var response = await client.ListAccessGrantsLocationsAsync(
-            new ListAccessGrantsLocationsRequest { AccountId = account }, ct);
+        // Paged: the s3:// location may not be on the first page, and missing it would fail every
+        // grant with a misleading "no s3:// location is registered".
+        string? nextToken = null;
+        do
+        {
+            var response = await client.ListAccessGrantsLocationsAsync(
+                new ListAccessGrantsLocationsRequest { AccountId = account, NextToken = nextToken }, ct);
 
-        return (response.AccessGrantsLocationsList ?? [])
-            .FirstOrDefault(l => l.LocationScope == "s3://")
-            ?.AccessGrantsLocationId;
+            string? root = (response.AccessGrantsLocationsList ?? [])
+                .FirstOrDefault(l => l.LocationScope == "s3://")
+                ?.AccessGrantsLocationId;
+            if (root is not null)
+                return root;
+
+            nextToken = response.NextToken;
+        }
+        while (!string.IsNullOrEmpty(nextToken));
+
+        return null;
     }
 
     private static async Task<IReadOnlyList<string>> ListGranteeScopesAsync(

--- a/src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs
+++ b/src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs
@@ -90,6 +90,12 @@ public sealed class S3AccessGrantsWriter(
                             : GranteeType.DIRECTORY_USER,
                         GranteeIdentifier = grantee.Id,
                     },
+                    // Provenance: cleanup deletes only grants carrying this tag, so it can never
+                    // remove a grant an administrator authored by hand over the same bucket.
+                    Tags = [new Amazon.S3Control.Model.Tag
+                    {
+                        Key = GrantTags.ManagedKey, Value = GrantTags.ManagedValue,
+                    }],
                 }, ct);
 
                 created.Add(subPrefix);

--- a/src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs
+++ b/src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs
@@ -118,6 +118,93 @@ public sealed class S3AccessGrantsWriter(
         return new GrantWriteResult(created, alreadyGranted, failed, accessDenied);
     }
 
+    /// <inheritdoc />
+    public async Task<GrantRevokeResult> RevokeAsync(
+        string region, IReadOnlyList<string> grantIds, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(region);
+
+        if (!options.CurrentValue.IsConfigured || grantIds.Count == 0)
+            return new GrantRevokeResult([], [], [], AccessDenied: false);
+
+        var endpoint = RegionEndpoint.GetBySystemName(region);
+        string account = await ResolveAccountIdAsync(endpoint, ct);
+
+        using var client = new AmazonS3ControlClient(
+            credentials, new AmazonS3ControlConfig { RegionEndpoint = endpoint });
+
+        var deleted = new List<string>();
+        var notFound = new List<string>();
+        var failed = new List<GrantWriteFailure>();
+        bool accessDenied = false;
+
+        foreach (string id in grantIds)
+        {
+            try
+            {
+                await client.DeleteAccessGrantAsync(
+                    new DeleteAccessGrantRequest { AccountId = account, AccessGrantId = id }, ct);
+                deleted.Add(id);
+            }
+            catch (AmazonS3ControlException ex) when (IsNotFound(ex))
+            {
+                // Already gone — success from our point of view, not a failure.
+                notFound.Add(id);
+            }
+            catch (AmazonS3ControlException ex)
+            {
+                if (IsAccessDenied(ex))
+                    accessDenied = true;
+
+                // Keep going: one grant's failure must not hide the rest.
+                failed.Add(new GrantWriteFailure(id, ex.Message));
+            }
+        }
+
+        return new GrantRevokeResult(deleted, notFound, failed, accessDenied);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> FilterManagedAsync(
+        string region, IReadOnlyList<string> grantArns, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(region);
+
+        if (!options.CurrentValue.IsConfigured || grantArns.Count == 0)
+            return [];
+
+        var endpoint = RegionEndpoint.GetBySystemName(region);
+
+        using var client = new AmazonS3ControlClient(
+            credentials, new AmazonS3ControlConfig { RegionEndpoint = endpoint });
+
+        var managed = new List<string>();
+
+        foreach (string arn in grantArns)
+        {
+            if (string.IsNullOrWhiteSpace(arn))
+                continue;
+
+            try
+            {
+                var tags = await client.ListTagsForResourceAsync(
+                    new ListTagsForResourceRequest { ResourceArn = arn }, ct);
+
+                bool isManaged = (tags.Tags ?? []).Any(t =>
+                    t.Key == GrantTags.ManagedKey && t.Value == GrantTags.ManagedValue);
+
+                if (isManaged)
+                    managed.Add(arn);
+            }
+            catch (AmazonS3ControlException)
+            {
+                // Provenance unconfirmed -> fail safe, treat as not ours. Never deleted.
+            }
+        }
+
+        return managed;
+    }
+
     private static async Task<string?> FindRootLocationAsync(
         AmazonS3ControlClient client, string account, CancellationToken ct)
     {
@@ -181,6 +268,10 @@ public sealed class S3AccessGrantsWriter(
     private static bool IsAccessDenied(AmazonS3ControlException ex) =>
         ex.StatusCode == HttpStatusCode.Forbidden
         || (ex.ErrorCode?.Contains("AccessDenied", StringComparison.OrdinalIgnoreCase) ?? false);
+
+    private static bool IsNotFound(AmazonS3ControlException ex) =>
+        ex.StatusCode == HttpStatusCode.NotFound
+        || (ex.ErrorCode?.Contains("NotFound", StringComparison.OrdinalIgnoreCase) ?? false);
 
     private static bool IsConflict(AmazonS3ControlException ex) =>
         ex.StatusCode == HttpStatusCode.Conflict

--- a/src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs
+++ b/src/Connapse.Storage/CloudScope/S3AccessGrantsWriter.cs
@@ -1,0 +1,183 @@
+using System.Net;
+using Amazon;
+using Amazon.S3Control;
+using Amazon.S3Control.Model;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+using Connapse.Core;
+using Connapse.Core.Utilities;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Creates S3 Access Grants with Connapse's own AWS identity.
+/// </summary>
+/// <remarks>
+/// The write twin of <see cref="S3AccessGrantsReader"/>, built the same way and against the same
+/// account. It reads the grantee's existing grants once and creates only what
+/// <see cref="GrantPlanner"/> says is missing, so a rerun converges rather than duplicates.
+/// </remarks>
+public sealed class S3AccessGrantsWriter(
+    ConnapseAwsCredentials credentials,
+    IOptionsMonitor<IdentityCenterSettings> options) : IAccessGrantsWriter
+{
+    private string? accountId;
+
+    /// <inheritdoc />
+    public async Task<GrantWriteResult> GrantReadAsync(
+        AccessGrantee grantee, string region,
+        IReadOnlyList<string> locations, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(grantee.Id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(region);
+
+        if (!options.CurrentValue.IsConfigured || locations.Count == 0)
+            return GrantWriteResult.Nothing;
+
+        var endpoint = RegionEndpoint.GetBySystemName(region);
+        string account = await ResolveAccountIdAsync(endpoint, ct);
+
+        using var client = new AmazonS3ControlClient(
+            credentials, new AmazonS3ControlConfig { RegionEndpoint = endpoint });
+
+        try
+        {
+            string? locationId = await FindRootLocationAsync(client, account, ct);
+            if (locationId is null)
+                return AllFailed(locations,
+                    "No s3:// location is registered. Run the Access Grants setup step in Connapse first.",
+                    accessDenied: false);
+
+            IReadOnlyList<string> existing = await ListGranteeScopesAsync(client, account, grantee, ct);
+            GrantPlan plan = GrantPlanner.Plan(locations, existing);
+
+            return await CreateAsync(client, account, grantee, plan, locationId, ct);
+        }
+        catch (AmazonS3ControlException ex) when (IsAccessDenied(ex))
+        {
+            // The identity cannot even look up the location or existing grants. Report every
+            // requested location as denied so the UI shows the CloudShell fallback rather than a
+            // partial, confusing result.
+            return AllFailed(locations, ex.Message, accessDenied: true);
+        }
+    }
+
+    private async Task<GrantWriteResult> CreateAsync(
+        AmazonS3ControlClient client, string account, AccessGrantee grantee,
+        GrantPlan plan, string locationId, CancellationToken ct)
+    {
+        var created = new List<string>();
+        var alreadyGranted = new List<string>(plan.AlreadyGranted);
+        var failed = new List<GrantWriteFailure>();
+        bool accessDenied = false;
+
+        foreach (string subPrefix in plan.ToCreate)
+        {
+            try
+            {
+                await client.CreateAccessGrantAsync(new CreateAccessGrantRequest
+                {
+                    AccountId = account,
+                    AccessGrantsLocationId = locationId,
+                    AccessGrantsLocationConfiguration =
+                        new AccessGrantsLocationConfiguration { S3SubPrefix = subPrefix },
+                    Permission = Permission.READ,
+                    Grantee = new Grantee
+                    {
+                        GranteeType = grantee.IsGroup
+                            ? GranteeType.DIRECTORY_GROUP
+                            : GranteeType.DIRECTORY_USER,
+                        GranteeIdentifier = grantee.Id,
+                    },
+                }, ct);
+
+                created.Add(subPrefix);
+            }
+            catch (AmazonS3ControlException ex) when (IsConflict(ex))
+            {
+                // The read-then-create race backstop: already there is success, not failure.
+                alreadyGranted.Add(subPrefix);
+            }
+            catch (AmazonS3ControlException ex)
+            {
+                if (IsAccessDenied(ex))
+                    accessDenied = true;
+
+                // Keep going: one bad bucket must not hide the rest.
+                failed.Add(new GrantWriteFailure(subPrefix, ex.Message));
+            }
+        }
+
+        return new GrantWriteResult(created, alreadyGranted, failed, accessDenied);
+    }
+
+    private static async Task<string?> FindRootLocationAsync(
+        AmazonS3ControlClient client, string account, CancellationToken ct)
+    {
+        var response = await client.ListAccessGrantsLocationsAsync(
+            new ListAccessGrantsLocationsRequest { AccountId = account }, ct);
+
+        return (response.AccessGrantsLocationsList ?? [])
+            .FirstOrDefault(l => l.LocationScope == "s3://")
+            ?.AccessGrantsLocationId;
+    }
+
+    private static async Task<IReadOnlyList<string>> ListGranteeScopesAsync(
+        AmazonS3ControlClient client, string account, AccessGrantee grantee, CancellationToken ct)
+    {
+        List<string> scopes = [];
+        string? nextToken = null;
+
+        do
+        {
+            var response = await client.ListAccessGrantsAsync(
+                new ListAccessGrantsRequest
+                {
+                    AccountId = account,
+                    GranteeType = grantee.IsGroup
+                        ? GranteeType.DIRECTORY_GROUP
+                        : GranteeType.DIRECTORY_USER,
+                    GranteeIdentifier = grantee.Id,
+                    NextToken = nextToken,
+                }, ct);
+
+            // Null, not empty, when the account holds no grants — the AWS SDK leaves response
+            // collections unset rather than initialising them.
+            scopes.AddRange((response.AccessGrantsList ?? [])
+                .Select(g => g.GrantScope)
+                .Where(s => !string.IsNullOrWhiteSpace(s))!);
+
+            nextToken = response.NextToken;
+        }
+        while (!string.IsNullOrEmpty(nextToken));
+
+        return scopes;
+    }
+
+    private async Task<string> ResolveAccountIdAsync(RegionEndpoint region, CancellationToken ct)
+    {
+        if (accountId is { Length: > 0 })
+            return accountId;
+
+        using var sts = new AmazonSecurityTokenServiceClient(
+            credentials, new AmazonSecurityTokenServiceConfig { RegionEndpoint = region });
+
+        var identity = await sts.GetCallerIdentityAsync(new GetCallerIdentityRequest(), ct);
+        accountId = identity.Account;
+        return accountId;
+    }
+
+    private static GrantWriteResult AllFailed(
+        IReadOnlyList<string> locations, string reason, bool accessDenied) =>
+        new([], [], [.. locations.Select(l => new GrantWriteFailure(l, reason))], accessDenied);
+
+    private static bool IsAccessDenied(AmazonS3ControlException ex) =>
+        ex.StatusCode == HttpStatusCode.Forbidden
+        || (ex.ErrorCode?.Contains("AccessDenied", StringComparison.OrdinalIgnoreCase) ?? false);
+
+    private static bool IsConflict(AmazonS3ControlException ex) =>
+        ex.StatusCode == HttpStatusCode.Conflict
+        || (ex.ErrorCode?.Contains("Conflict", StringComparison.OrdinalIgnoreCase) ?? false)
+        || (ex.Message?.Contains("already", StringComparison.OrdinalIgnoreCase) ?? false);
+}

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -217,6 +217,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();
         services.AddSingleton<IAccessGrantsReader, CloudScope.S3AccessGrantsReader>();
+        services.AddSingleton<IAccessGrantsWriter, CloudScope.S3AccessGrantsWriter>();
 
         // Registered here rather than in Connapse.Search, whose own registration is a TryAdd for
         // the unrestricted default. This one resolves real grants, and it must win.

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -821,28 +821,6 @@
                                                 </span>
                                             }
                                         </div>
-
-                                        @if (grantFellBack && GrantCommand is { Length: > 0 } grantCommand)
-                                        {
-                                            <div class="small mt-2 mb-1">
-                                                Run this in AWS CloudShell with your own credentials instead:
-                                            </div>
-                                            <pre class="bg-body-tertiary border rounded p-2 small mb-1" style="max-height:14rem;overflow:auto"><code>@grantCommand</code></pre>
-                                            <div class="d-flex flex-wrap gap-2">
-                                                <button type="button" class="btn btn-sm btn-outline-secondary"
-                                                        @onclick="CopyGrantCommand">
-                                                    <span class="bi-clipboard me-1"></span> Copy command
-                                                </button>
-                                                <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"
-                                                   href="https://console.aws.amazon.com/cloudshell/home">
-                                                    <span class="bi-terminal me-1"></span> Open CloudShell
-                                                    <span class="bi-box-arrow-up-right ms-1 small"></span>
-                                                </a>
-                                                <span class="align-self-center small @(grantCopySucceeded ? "text-success" : "text-danger")">
-                                                    @grantCopyMessage
-                                                </span>
-                                            </div>
-                                        }
                                     </div>
                                 }
                                 else
@@ -850,7 +828,7 @@
                                     <div class="small mt-2">
                                         Choose a group to grant to in
                                         <a href="/admin/providers/aws">the AWS provider setup</a>,
-                                        and the exact command appears here.
+                                        and a Grant access button appears here.
                                     </div>
                                 }
                             </div>
@@ -1281,34 +1259,6 @@
     }
 
     /// <summary>
-    /// The command that grants this connection's buckets, or empty when no group has been chosen.
-    /// </summary>
-    /// <remarks>
-    /// Built here rather than on the providers page because a grant names a bucket, and a bucket is
-    /// a property of a connection. The global version could not know it, so it printed a
-    /// placeholder — and was run with the placeholder still in it.
-    /// </remarks>
-    private string GrantCommand
-    {
-        get
-        {
-            var signIn = SamlOptions.CurrentValue;
-
-            if (!signIn.HasGrantGroup || coverage is not { HasWarning: true })
-                return string.Empty;
-
-            // Only the buckets nothing covers. Re-granting one that already works would be noise
-            // in a command whose whole point is that everything in it is needed.
-            // The connection's region, not the directory's. A grant is created against the
-            // Access Grants instance in the region the bucket lives in, and using the Identity
-            // Center region instead fails as InvalidAccessGrant with "The requested S3 Bucket is
-            // in a different region" -- which names the symptom and not the cause.
-            return AccessGrantScript.GenerateScript(
-                form.Region, coverage.Ungranted, signIn.GrantGroupId, isGroup: true);
-        }
-    }
-
-    /// <summary>
     /// The two regions when a grant could never be created, or null when they agree.
     /// </summary>
     /// <remarks>
@@ -1342,37 +1292,20 @@
         }
     }
 
-    /// <summary>What to call the group in the sentence above the command.</summary>
+    /// <summary>What to call the group in the sentence beside the Grant access button.</summary>
     private string GrantGroupLabel =>
         SamlOptions.CurrentValue.GrantGroupName is { Length: > 0 } name
             ? name
             : "the chosen group";
 
-    private string? grantCopyMessage;
-    private bool grantCopySucceeded;
-
-    private async Task CopyGrantCommand()
-    {
-        grantCopyMessage = null;
-
-        grantCopySucceeded = await JS.InvokeAsync<bool>(
-            "connapse.copyToClipboard", GrantCommand);
-
-        grantCopyMessage = grantCopySucceeded
-            ? "Copied."
-            : "Could not copy — select the command above and copy it manually.";
-    }
-
     private bool granting;
     private string? grantResultMessage;
     private bool grantResultOk;
-    private bool grantFellBack;   // an AccessDenied pushed us back to the CloudShell script
 
     /// <summary>Whether Connapse can offer to create the grants itself.</summary>
     /// <remarks>
-    /// The same conditions the command was shown under: a group is configured, this connection has
-    /// ungranted buckets, and the regions are not mismatched. When true the button is offered; the
-    /// CloudShell script appears only after <see cref="grantFellBack"/> is set by an AccessDenied.
+    /// A group is configured, this connection has ungranted buckets, and the regions are not
+    /// mismatched. When true the Grant access button is offered.
     /// </remarks>
     private bool CanGrant =>
         SamlOptions.CurrentValue.HasGrantGroup
@@ -1390,7 +1323,6 @@
     private async Task GrantAccess()
     {
         grantResultMessage = null;
-        grantFellBack = false;
         granting = true;
 
         try
@@ -1399,7 +1331,7 @@
             var grantee = new AccessGrantee(IsGroup: true, Id: signIn.GrantGroupId);
 
             var result = await GrantsWriter.GrantReadAsync(
-                grantee, form.Region, coverage!.Ungranted, CancellationToken.None);
+                grantee, form.Region ?? string.Empty, coverage!.Ungranted, CancellationToken.None);
 
             if (result.Succeeded)
             {
@@ -1415,14 +1347,12 @@
             }
             else if (result.AccessDenied)
             {
-                // Connapse's identity is not allowed to create grants (a bring-your-own narrow
-                // role, or the policy not applied yet). Fall back to the admin-run CloudShell script.
-                grantFellBack = true;
+                // Connapse's identity is not allowed to create grants (a bring-your-own narrow role,
+                // or the policy not applied yet). The fix lives on the provider page, not here.
                 grantResultOk = false;
                 grantResultMessage =
                     "Connapse's AWS identity is not allowed to create access grants. Update its role "
-                    + "permissions on the AWS provider page (Access → Update role permissions), or "
-                    + "use the CloudShell command below.";
+                    + "permissions on the AWS provider page: Access → Update role permissions.";
             }
             else
             {

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -1310,7 +1310,8 @@
     private bool CanGrant =>
         SamlOptions.CurrentValue.HasGrantGroup
         && coverage is { HasWarning: true }
-        && RegionMismatch is null;
+        && RegionMismatch is null
+        && !string.IsNullOrWhiteSpace(form.Region);
 
     /// <summary>
     /// Creates the missing grants with Connapse's own AWS identity, then clears the warning.

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -1420,8 +1420,9 @@
                 grantFellBack = true;
                 grantResultOk = false;
                 grantResultMessage =
-                    "Connapse's AWS identity is not allowed to create access grants. Use the "
-                    + "CloudShell command below instead, or add s3:CreateAccessGrant to its policy.";
+                    "Connapse's AWS identity is not allowed to create access grants. Update its role "
+                    + "permissions on the AWS provider page (Access → Update role permissions), or "
+                    + "use the CloudShell command below.";
             }
             else
             {

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -20,6 +20,7 @@
 @inject IS3Discovery S3Discovery
 @inject IProviderSetupReader SetupReader
 @inject IGrantCoverageReporter GrantCoverage
+@inject IAccessGrantsWriter GrantsWriter
 @inject IOptionsMonitor<IdentityCenterSettings> IdentityCenterOptions
 @inject IOptionsMonitor<SamlSignInSettings> SamlOptions
 
@@ -797,29 +798,51 @@
                                         </div>
                                     </div>
                                 }
-                                else if (GrantCommand is { Length: > 0 } grantCommand)
+                                else if (CanGrant)
                                 {
                                     <div class="mt-2">
                                         <div class="small mb-1">
-                                            Grants read access to
-                                            <strong>@(GrantGroupLabel)</strong>, for the buckets
-                                            above. Connapse never runs it.
+                                            Grant read access to <strong>@(GrantGroupLabel)</strong>
+                                            for the buckets above, using Connapse's AWS identity.
                                         </div>
-                                        <pre class="bg-body-tertiary border rounded p-2 small mb-1" style="max-height:14rem;overflow:auto"><code>@grantCommand</code></pre>
-                                        <div class="d-flex flex-wrap gap-2">
-                                            <button type="button" class="btn btn-sm btn-outline-secondary"
-                                                    @onclick="CopyGrantCommand">
-                                                <span class="bi-clipboard me-1"></span> Copy command
+                                        <div class="d-flex flex-wrap gap-2 align-items-center">
+                                            <button type="button" class="btn btn-sm btn-primary"
+                                                    @onclick="GrantAccess" disabled="@granting">
+                                                @if (granting)
+                                                {
+                                                    <span class="spinner-border spinner-border-sm me-1"></span>
+                                                }
+                                                <span class="bi-key me-1"></span> Grant access
                                             </button>
-                                            <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"
-                                               href="https://console.aws.amazon.com/cloudshell/home">
-                                                <span class="bi-terminal me-1"></span> Open CloudShell
-                                                <span class="bi-box-arrow-up-right ms-1 small"></span>
-                                            </a>
-                                            <span class="align-self-center small @(grantCopySucceeded ? "text-success" : "text-danger")">
-                                                @grantCopyMessage
-                                            </span>
+                                            @if (grantResultMessage is { Length: > 0 })
+                                            {
+                                                <span class="small @(grantResultOk ? "text-success" : "text-danger")">
+                                                    @grantResultMessage
+                                                </span>
+                                            }
                                         </div>
+
+                                        @if (grantFellBack && GrantCommand is { Length: > 0 } grantCommand)
+                                        {
+                                            <div class="small mt-2 mb-1">
+                                                Run this in AWS CloudShell with your own credentials instead:
+                                            </div>
+                                            <pre class="bg-body-tertiary border rounded p-2 small mb-1" style="max-height:14rem;overflow:auto"><code>@grantCommand</code></pre>
+                                            <div class="d-flex flex-wrap gap-2">
+                                                <button type="button" class="btn btn-sm btn-outline-secondary"
+                                                        @onclick="CopyGrantCommand">
+                                                    <span class="bi-clipboard me-1"></span> Copy command
+                                                </button>
+                                                <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"
+                                                   href="https://console.aws.amazon.com/cloudshell/home">
+                                                    <span class="bi-terminal me-1"></span> Open CloudShell
+                                                    <span class="bi-box-arrow-up-right ms-1 small"></span>
+                                                </a>
+                                                <span class="align-self-center small @(grantCopySucceeded ? "text-success" : "text-danger")">
+                                                    @grantCopyMessage
+                                                </span>
+                                            </div>
+                                        }
                                     </div>
                                 }
                                 else
@@ -1338,6 +1361,85 @@
         grantCopyMessage = grantCopySucceeded
             ? "Copied."
             : "Could not copy — select the command above and copy it manually.";
+    }
+
+    private bool granting;
+    private string? grantResultMessage;
+    private bool grantResultOk;
+    private bool grantFellBack;   // an AccessDenied pushed us back to the CloudShell script
+
+    /// <summary>Whether Connapse can offer to create the grants itself.</summary>
+    /// <remarks>
+    /// The same conditions the command was shown under: a group is configured, this connection has
+    /// ungranted buckets, and the regions are not mismatched. When true the button is offered; the
+    /// CloudShell script appears only after <see cref="grantFellBack"/> is set by an AccessDenied.
+    /// </remarks>
+    private bool CanGrant =>
+        SamlOptions.CurrentValue.HasGrantGroup
+        && coverage is { HasWarning: true }
+        && RegionMismatch is null;
+
+    /// <summary>
+    /// Creates the missing grants with Connapse's own AWS identity, then clears the warning.
+    /// </summary>
+    /// <remarks>
+    /// The connection's region, not the directory's — a grant is created against the Access Grants
+    /// instance in the bucket's region. On AccessDenied it falls back to the CloudShell script the
+    /// administrator runs themselves, rather than presenting the setup as broken.
+    /// </remarks>
+    private async Task GrantAccess()
+    {
+        grantResultMessage = null;
+        grantFellBack = false;
+        granting = true;
+
+        try
+        {
+            var signIn = SamlOptions.CurrentValue;
+            var grantee = new AccessGrantee(IsGroup: true, Id: signIn.GrantGroupId);
+
+            var result = await GrantsWriter.GrantReadAsync(
+                grantee, form.Region, coverage!.Ungranted, CancellationToken.None);
+
+            if (result.Succeeded)
+            {
+                // Re-check so the warning clears in place, no page reload.
+                await RefreshCoverageAsync();
+                await RefreshUngrantedAsync();
+
+                grantResultOk = true;
+                grantResultMessage = result.Created.Count > 0
+                    ? $"Granted read access to {GrantGroupLabel} on {result.Created.Count} location(s). "
+                      + "Searches start returning these documents within a minute."
+                    : $"{GrantGroupLabel} was already granted everything here.";
+            }
+            else if (result.AccessDenied)
+            {
+                // Connapse's identity is not allowed to create grants (a bring-your-own narrow
+                // role, or the policy not applied yet). Fall back to the admin-run CloudShell script.
+                grantFellBack = true;
+                grantResultOk = false;
+                grantResultMessage =
+                    "Connapse's AWS identity is not allowed to create access grants. Use the "
+                    + "CloudShell command below instead, or add s3:CreateAccessGrant to its policy.";
+            }
+            else
+            {
+                grantResultOk = false;
+                grantResultMessage =
+                    "Could not grant on: "
+                    + string.Join("; ", result.Failed.Select(f => $"{f.Location} ({f.Reason})"));
+            }
+        }
+        catch (Exception ex)
+        {
+            grantResultOk = false;
+            grantResultMessage = $"Could not create the grants: {ex.Message}";
+        }
+        finally
+        {
+            granting = false;
+        }
     }
 
     /// <summary>Line endings an allowed-locations field may arrive with.</summary>

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -25,6 +25,7 @@
 @inject IAwsIdentityLinkReader AwsIdentityLinks
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject ILogger<Providers> Logger
+@inject IGrantReconciliationService GrantCleanup
 @using System.Security.Claims
 @using Microsoft.AspNetCore.Components.Authorization
 @rendermode InteractiveServer
@@ -272,9 +273,16 @@
                                               rows="3" autocomplete="off" @bind="manualCertPem"></textarea>
                                 </div>
                                 <div class="col-12">
-                                    <label class="form-label small" for="ra-key">Private key (PEM)</label>
+                                    <label class="form-label small" for="ra-key">
+                                        Private key (PEM)
+                                        @if (hasStoredRaCredential)
+                                        {
+                                            <span class="text-muted">— leave blank to keep the current key</span>
+                                        }
+                                    </label>
                                     <textarea id="ra-key" class="form-control form-control-sm font-monospace"
-                                              rows="3" autocomplete="off" @bind="manualPrivateKeyPem"></textarea>
+                                              rows="3" autocomplete="off" @bind="manualPrivateKeyPem"
+                                              placeholder="@(hasStoredRaCredential ? "Kept unless you paste a new key" : null)"></textarea>
                                 </div>
                             </div>
                             <button type="button" class="btn btn-sm btn-primary mt-3"
@@ -283,7 +291,12 @@
                                 <span class="bi-save me-1"></span> Check and save
                             </button>
                             <div class="form-text">
-                                The private key is stored encrypted, the same way SFTP private keys are.
+                                The private key is the only secret here and is never shown back; it is
+                                stored encrypted, the same way SFTP private keys are.
+                                @if (hasStoredRaCredential)
+                                {
+                                    <text>The other values are filled in from the stored credential.</text>
+                                }
                             </div>
                         </div>
                     }
@@ -1006,6 +1019,21 @@
                         <ProviderResetAction Label="Reset default group"
                                              ConfirmLabel="Confirm group reset"
                                              OnReset="ClearGrantGroup" />
+
+                        <button type="button" class="btn btn-sm btn-outline-danger"
+                                @onclick="CleanUpOrphanedGrants" disabled="@cleaningGrants">
+                            @if (cleaningGrants)
+                            {
+                                <span class="spinner-border spinner-border-sm me-1"></span>
+                            }
+                            <span class="bi-trash me-1"></span> Clean up orphaned grants
+                        </button>
+                        @if (grantCleanupMessage is { Length: > 0 })
+                        {
+                            <span class="small ms-2 align-self-center @(grantCleanupOk ? "text-success" : "text-danger")">
+                                @grantCleanupMessage
+                            </span>
+                        }
                     }
                 </Actions>
             </ProviderStepCard>
@@ -1042,6 +1070,58 @@
 
     private string? grantsCopyMessage;
     private bool grantsCopySucceeded;
+
+    private bool cleaningGrants;
+    private string? grantCleanupMessage;
+    private bool grantCleanupOk;
+
+    /// <summary>
+    /// Deletes S3 access grants Connapse created that no connection needs any more.
+    /// </summary>
+    /// <remarks>
+    /// The same reconcile the recurring sweep runs, on demand. All the safety — provenance by tag,
+    /// the fail-closed abort on an incomplete connection view, the circuit breaker — lives in the
+    /// service; this only reports what it did or why it held back.
+    /// </remarks>
+    private async Task CleanUpOrphanedGrants()
+    {
+        grantCleanupMessage = null;
+        cleaningGrants = true;
+
+        try
+        {
+            var report = await GrantCleanup.ReconcileAsync(enforce: true);
+
+            if (report.Aborted.Count > 0)
+            {
+                grantCleanupOk = false;
+                grantCleanupMessage = "Held back — " + string.Join(" ", report.Aborted);
+            }
+            else if (report.Failed.Count > 0)
+            {
+                grantCleanupOk = false;
+                grantCleanupMessage =
+                    $"Removed {report.Deleted}, but {report.Failed.Count} could not be deleted.";
+            }
+            else
+            {
+                grantCleanupOk = true;
+                grantCleanupMessage = report.Deleted > 0
+                    ? $"Removed {report.Deleted} orphaned grant(s)."
+                    : "Nothing to clean up — no orphaned grants.";
+            }
+        }
+        catch (Exception ex)
+        {
+            grantCleanupOk = false;
+            grantCleanupMessage = $"Could not run cleanup: {ex.Message}";
+            Logger.LogWarning(ex, "Orphaned grant cleanup from the admin page failed");
+        }
+        finally
+        {
+            cleaningGrants = false;
+        }
+    }
 
     /// <summary>The finished sign-in, or null while any part of it is outstanding.</summary>
     private SamlSignInSettings? SamlSignIn =>
@@ -1231,6 +1311,17 @@
     private string? manualCertPem;
     private string? manualPrivateKeyPem;
 
+    /// <summary>
+    /// The stored config the manual form was last loaded from — the concurrency token.
+    /// </summary>
+    /// <remarks>
+    /// Two jobs. On load it tells an untouched field (still equal to what was loaded) apart from one
+    /// the operator edited, so a re-check refreshes the former without clobbering the latter. On a
+    /// blank-key save it is compared against a fresh read: if the stored credential changed since the
+    /// form loaded, the save is rejected and reloaded rather than silently overwriting the newer one.
+    /// </remarks>
+    private RolesAnywhereConfig? _lastLoadedConfig;
+
     /// <summary>Whether the replace-identity form is open over a working credential.</summary>
     private bool showSetup;
 
@@ -1251,14 +1342,18 @@
     private bool EnvironmentCredentialResolves =>
         AccessStatus is RequirementStatus.Satisfied or RequirementStatus.Warning;
 
-    /// <summary>Whether the manual (bring-your-own) Roles Anywhere form has every value it needs.</summary>
+    /// <summary>
+    /// Whether the manual (bring-your-own) Roles Anywhere form has every value it needs. The private
+    /// key is required only for a first credential; when one is already stored, a blank key keeps the
+    /// existing one (it cannot be shown back, so requiring it would trap an operator editing an ARN).
+    /// </summary>
     private bool CanSaveManualRa =>
         !string.IsNullOrWhiteSpace(manualTrustAnchorArn)
         && !string.IsNullOrWhiteSpace(manualProfileArn)
         && !string.IsNullOrWhiteSpace(manualRoleArn)
         && !string.IsNullOrWhiteSpace(manualRegion)
         && !string.IsNullOrWhiteSpace(manualCertPem)
-        && !string.IsNullOrWhiteSpace(manualPrivateKeyPem);
+        && (!string.IsNullOrWhiteSpace(manualPrivateKeyPem) || hasStoredRaCredential);
 
     /// <summary>Looks up one of the current provider's requirements by name.</summary>
     private ProviderRequirement? Requirement(string name) =>
@@ -1510,24 +1605,84 @@
     /// <summary>Saves the credential from the script's ARN block, pairing them with the generated leaf.</summary>
     private async Task SaveRolesAnywhereFromScript(AwsRolesAnywhereArns arns)
     {
-        if (raKeypair is null) return;
+        // Guard acquired synchronously, before any await, so a second click cannot enter this handler
+        // while the first is suspended.
+        if (awsBusy || raKeypair is null) return;
+        awsBusy = true;
+        try
+        {
+            var config = new RolesAnywhereConfig(
+                raKeypair.LeafCertificatePem, arns.TrustAnchorArn, arns.ProfileArn, arns.RoleArn, arns.Region);
 
-        var config = new RolesAnywhereConfig(
-            raKeypair.LeafCertificatePem, arns.TrustAnchorArn, arns.ProfileArn, arns.RoleArn, arns.Region);
-
-        await SaveValidatedRolesAnywhere(config, raKeypair.LeafPrivateKeyPem, null);
+            await SaveValidatedRolesAnywhereCore(config, raKeypair.LeafPrivateKeyPem, null);
+        }
+        finally
+        {
+            awsBusy = false;
+        }
     }
 
     /// <summary>Saves a bring-your-own credential typed into the manual-values form.</summary>
     private async Task SaveManualRolesAnywhere()
     {
-        if (!CanSaveManualRa) return;
+        // Guard acquired synchronously, before any await (the blank-key read below yields), so two
+        // fast clicks cannot both proceed and have the second dereference fields the first has cleared.
+        if (awsBusy || !CanSaveManualRa) return;
+        awsBusy = true;
+        try
+        {
+            // Snapshot the form before any await, so a concurrent reset can never null these mid-flight.
+            var config = new RolesAnywhereConfig(
+                manualCertPem!.Trim(), manualTrustAnchorArn!.Trim(), manualProfileArn!.Trim(),
+                manualRoleArn!.Trim(), manualRegion!.Trim());
+            string? privateKeyPem = manualPrivateKeyPem?.Trim();
 
-        var config = new RolesAnywhereConfig(
-            manualCertPem!.Trim(), manualTrustAnchorArn!.Trim(), manualProfileArn!.Trim(),
-            manualRoleArn!.Trim(), manualRegion!.Trim());
+            // A blank key when editing means "keep the current one" — the stored key is fetched and
+            // re-validated against the (possibly edited) config, so an operator can change an ARN
+            // without having a key they were never shown.
+            if (string.IsNullOrWhiteSpace(privateKeyPem))
+            {
+                RolesAnywhereCredentialMaterial? material;
+                try
+                {
+                    material = await CredentialStore.GetRolesAnywhereMaterialAsync("aws");
+                }
+                catch (Exception ex)
+                {
+                    saveSuccess = false;
+                    saveMessage = $"Could not read the stored private key, so it must be re-entered: {ex.Message}";
+                    return;
+                }
 
-        await SaveValidatedRolesAnywhere(config, manualPrivateKeyPem!.Trim(), null);
+                if (material is null)
+                {
+                    saveSuccess = false;
+                    saveMessage = "Enter the private key — there is no stored credential to keep it from.";
+                    return;
+                }
+
+                // Optimistic concurrency: if the stored credential changed since this form loaded,
+                // reusing the current key with the form's older ARNs could silently reinstate a config
+                // another administrator just replaced (e.g. undo a narrowed role). Reject and reload
+                // instead, so the operator reviews the newer values before overwriting.
+                if (_lastLoadedConfig is not null && material.Config != _lastLoadedConfig)
+                {
+                    saveSuccess = false;
+                    saveMessage = "This credential was changed elsewhere since you opened the form. It has "
+                        + "been reloaded — review the values and save again.";
+                    await RefreshSetups();
+                    return;
+                }
+
+                privateKeyPem = material.PrivateKeyPem;
+            }
+
+            await SaveValidatedRolesAnywhereCore(config, privateKeyPem, null);
+        }
+        finally
+        {
+            awsBusy = false;
+        }
     }
 
     /// <summary>
@@ -1538,10 +1693,10 @@
     /// first (a real <c>CreateSession</c>) and stored only if that succeeds. A bad cert, ARN, or
     /// region therefore never destroys the last working credential — nothing is written on failure,
     /// and the form is left intact so the operator can fix and retry without regenerating.
+    /// <para>The caller holds the <c>awsBusy</c> guard; this core never touches it.</para>
     /// </remarks>
-    private async Task SaveValidatedRolesAnywhere(RolesAnywhereConfig config, string privateKeyPem, string? principal)
+    private async Task SaveValidatedRolesAnywhereCore(RolesAnywhereConfig config, string privateKeyPem, string? principal)
     {
-        awsBusy = true;
         try
         {
             RolesAnywhereValidationResult result = await RaValidator.ValidateAsync(config, privateKeyPem);
@@ -1554,13 +1709,16 @@
 
             await CredentialStore.SaveRolesAnywhereAsync("aws", config, privateKeyPem, principal, null);
 
-            // The secret material is not kept around once stored; the whole handshake resets.
+            // The secret material is not kept around once stored; the whole handshake resets. Clearing
+            // the loaded-config token forces the next load to re-fill the form from the newly stored
+            // configuration.
             raKeypair = null;
             raPasted = null;
             raRegion = null;
             raResetCleanup = null;
             manualTrustAnchorArn = manualProfileArn = manualRoleArn = manualRegion = null;
             manualCertPem = manualPrivateKeyPem = null;
+            _lastLoadedConfig = null;
             showSetup = false;
             copyMessage = null;
 
@@ -1576,10 +1734,6 @@
             saveSuccess = false;
             saveMessage = $"Could not store the AWS credential: {ex.Message} " +
                           "Your entries are still below — try again.";
-        }
-        finally
-        {
-            awsBusy = false;
         }
     }
 
@@ -1636,7 +1790,25 @@
 
         try
         {
-            hasStoredRaCredential = await CredentialStore.GetRolesAnywhereAsync("aws") is not null;
+            RolesAnywhereConfig? config = await CredentialStore.GetRolesAnywhereAsync("aws");
+            hasStoredRaCredential = config is not null;
+
+            // Fill the manual (bring-your-own) fields from the stored, non-secret configuration so
+            // editing a configured credential shows its current values rather than blank boxes. Only
+            // the private key is secret; it is never rendered, so it stays blank and a blank key on
+            // save means "keep the current one". Each field is refreshed only when it still equals what
+            // was last loaded — an untouched field — so a re-check picks up a concurrent change while an
+            // in-progress edit is never overwritten. (Initially both sides are null, so the first load
+            // fills every field.)
+            if (config is not null)
+            {
+                manualTrustAnchorArn = AwsAccessCard.RefreshManualField(manualTrustAnchorArn, _lastLoadedConfig?.TrustAnchorArn, config.TrustAnchorArn);
+                manualProfileArn = AwsAccessCard.RefreshManualField(manualProfileArn, _lastLoadedConfig?.ProfileArn, config.ProfileArn);
+                manualRoleArn = AwsAccessCard.RefreshManualField(manualRoleArn, _lastLoadedConfig?.RoleArn, config.RoleArn);
+                manualRegion = AwsAccessCard.RefreshManualField(manualRegion, _lastLoadedConfig?.Region, config.Region);
+                manualCertPem = AwsAccessCard.RefreshManualField(manualCertPem, _lastLoadedConfig?.CertificatePem, config.CertificatePem);
+            }
+            _lastLoadedConfig = config;
         }
         catch (Exception ex)
         {

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -670,11 +670,13 @@
                        should meet that fact while deciding, not afterwards in IAM. *@
                     <div class="alert alert-secondary small">
                         <span class="bi-info-circle me-1"></span>
-                        Connapse's own AWS identity needs four read-only permissions for this:
-                        <code>s3:ListAccessGrants</code>, <code>identitystore:GetUserId</code>,
-                        <code>identitystore:DescribeUser</code> and
-                        <code>identitystore:ListGroupMembershipsForMember</code>. None of them reads an
-                        object.
+                        Connapse's own AWS identity needs, for this, to read access grants and the
+                        directory (<code>s3:ListAccessGrants</code>, the <code>identitystore</code> reads,
+                        and <code>sso:DescribeInstance</code>/<code>DescribeApplication</code>) and to
+                        create and remove the S3 access grants that scope search
+                        (<code>s3:CreateAccessGrant</code>, <code>s3:DeleteAccessGrant</code>,
+                        <code>s3:TagResource</code>). The only thing it changes is a grant — it never
+                        reads, writes, or deletes an object.
                         <span class="d-block mt-1">
                             <code>s3:ListAccessGrants</code> is worth knowing about specifically: AWS does
                             not scope it to one user, so it lets Connapse enumerate everyone's grants rather

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -446,6 +446,58 @@
                                              ConfirmLabel="Remove — AWS access stays live"
                                              HelpText="Deletes the Roles Anywhere certificate and ARNs stored in Connapse. It does NOT revoke access in AWS: the trust anchor and profile stay enabled and the certificate keeps working until it expires. A CloudShell command to revoke it is shown afterwards — run it now if you are removing a credential you believe is compromised." />
                     }
+
+                    @* Bring the role's ConnapseRead policy up to date after a Connapse update adds a
+                       permission. iam:PutRolePolicy replaces it in place, so this is safe to re-run.
+                       Connapse never runs it: a runtime identity that could rewrite its own policy
+                       could grant itself anything, so IAM editing stays with the administrator. *@
+                    @if (AccessMode is AwsAccessMode.RolesAnywhere or AwsAccessMode.NotStored)
+                    {
+                        <button type="button" class="btn btn-sm btn-outline-secondary"
+                                @onclick="() => showRolePolicyUpdate = !showRolePolicyUpdate">
+                            <span class="bi-arrow-repeat me-1"></span> Update role permissions
+                        </button>
+                        @if (showRolePolicyUpdate)
+                        {
+                            <div class="w-100 mt-2">
+                                @if (RolePolicyUpdateCommand is { Length: > 0 } updateCmd)
+                                {
+                                    <div class="small mb-1">
+                                        Run this if a feature reports Connapse is not allowed to do
+                                        something in AWS — it re-applies the current
+                                        <code>ConnapseRead</code> policy to the role. Safe to re-run;
+                                        it changes nothing else. Connapse never runs it.
+                                    </div>
+                                    <pre class="bg-body-tertiary border rounded p-2 small mb-1" style="max-height:16rem;overflow:auto"><code>@updateCmd</code></pre>
+                                    <div class="d-flex flex-wrap gap-2">
+                                        <button type="button" class="btn btn-sm btn-outline-secondary"
+                                                @onclick="CopyRolePolicyUpdate">
+                                            <span class="bi-clipboard me-1"></span> Copy command
+                                        </button>
+                                        <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"
+                                           href="https://console.aws.amazon.com/cloudshell/home">
+                                            <span class="bi-terminal me-1"></span> Open CloudShell
+                                        </a>
+                                        <span class="align-self-center small @(rolePolicyCopyOk ? "text-success" : "text-danger")">
+                                            @rolePolicyCopyMessage
+                                        </span>
+                                    </div>
+                                }
+                                else
+                                {
+                                    @* Ambient / bring-your-own role: Connapse did not create it and does
+                                       not know its name, so it shows the policy to apply rather than a
+                                       ready command. *@
+                                    <div class="small mb-1">
+                                        Connapse uses a role from its environment here. Apply this
+                                        <code>ConnapseRead</code> policy to that role (replace the account
+                                        id if the placeholder is shown):
+                                    </div>
+                                    <pre class="bg-body-tertiary border rounded p-2 small mb-0" style="max-height:16rem;overflow:auto"><code>@AwsRolePolicyUpdate.PolicyDocument(null)</code></pre>
+                                }
+                            </div>
+                        }
+                    }
                 </Actions>
             </ProviderStepCard>
 
@@ -1074,6 +1126,30 @@
     private bool cleaningGrants;
     private string? grantCleanupMessage;
     private bool grantCleanupOk;
+
+    private bool showRolePolicyUpdate;
+    private string? rolePolicyCopyMessage;
+    private bool rolePolicyCopyOk;
+
+    /// <summary>
+    /// The command to re-apply Connapse's role policy, or null when there is no stored Roles Anywhere
+    /// role (the ambient case shows the policy document to apply by hand instead).
+    /// </summary>
+    private string? RolePolicyUpdateCommand =>
+        _lastLoadedConfig?.RoleArn is { Length: > 0 } arn
+            ? AwsRolePolicyUpdate.GenerateCommand(arn)
+            : null;
+
+    private async Task CopyRolePolicyUpdate()
+    {
+        if (RolePolicyUpdateCommand is not { Length: > 0 } command)
+            return;
+
+        rolePolicyCopyOk = await JS.InvokeAsync<bool>("connapse.copyToClipboard", command);
+        rolePolicyCopyMessage = rolePolicyCopyOk
+            ? "Copied."
+            : "Could not copy — select the command above and copy it manually.";
+    }
 
     /// <summary>
     /// Deletes S3 access grants Connapse created that no connection needs any more.

--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -356,6 +356,14 @@ using (var scope = app.Services.CreateScope())
         recurringJobId: "summary-sweep-stale-containers",
         methodCall: s => s.SweepStaleContainersAsync(default),
         cronExpression: "*/5 * * * *");
+
+    // Every 30 minutes: delete S3 access grants Connapse created that no connection needs any
+    // more (a bucket removed, a connection deleted, or the grant group changed). Fail-closed and
+    // provenance-gated inside the service — a failed tick just waits for the next.
+    recurringJobManager.AddOrUpdate<Connapse.Background.Jobs.IGrantReconciliationJobs>(
+        recurringJobId: "grant-reconcile-orphaned",
+        methodCall: j => j.ReconcileAsync(default),
+        cronExpression: "*/30 * * * *");
 }
 
 app.UseAntiforgery();

--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -154,6 +154,10 @@ builder.Services.AddScoped<ICloudScopeService, CloudScopeService>();
 builder.Services.AddScoped<SourceScopePreflight>();
 builder.Services.AddScoped<IProviderSetupReader, ProviderSetupReader>();
 
+// Deletes S3 access grants Connapse created that no connection needs any more. Fail-closed and
+// provenance-gated; run on a schedule (see the recurring job below) and from the AWS provider page.
+builder.Services.AddScoped<IGrantReconciliationService, GrantReconciliationService>();
+
 // So an MCP tool can name its caller. Tools receive an IServiceProvider and nothing else, so
 // without this the MCP surface cannot resolve a principal at all — and #421 will deny what it
 // cannot identify, which would silently turn every MCP search into no results.

--- a/src/Connapse.Web/Services/GrantReconciliationService.cs
+++ b/src/Connapse.Web/Services/GrantReconciliationService.cs
@@ -16,6 +16,14 @@ namespace Connapse.Web.Services;
 /// that will not parse, one that declares no allowlist (and so could index any bucket, making no
 /// grant provably orphaned), an unreadable region — makes it hold back rather than guess. This is the
 /// same discipline as <c>AwsSearchScopeResolver</c>: an answer that cannot be trusted is not acted on.
+/// <para>
+/// Single-instance assumption: it deletes any grant tagged <c>connapse:managed</c> whose scope no
+/// connection covers, computed from <b>this</b> deployment's connections. Where two Connapse
+/// deployments share one AWS account and grant group, one could delete a grant the other still
+/// needs. Per-instance scoping (design §6, a <c>connapse:instance</c> tag matched on delete) is a
+/// deferred follow-up — the fingerprint source is unresolved and does not affect the common
+/// single-instance case.
+/// </para>
 /// </remarks>
 public sealed class GrantReconciliationService(
     IConnectionStore connections,

--- a/src/Connapse.Web/Services/GrantReconciliationService.cs
+++ b/src/Connapse.Web/Services/GrantReconciliationService.cs
@@ -43,52 +43,20 @@ public sealed class GrantReconciliationService(
 
         // 1. The complete union of allowed-locations across every S3 connection. Any gap aborts —
         //    an incomplete union makes still-needed grants look orphaned.
-        var union = new List<string>();
+        var (union, unionAbort) = await TryBuildUnionAsync(ct);
+        if (unionAbort is not null)
+            return ReconcileReport.Abort(unionAbort);
 
-        IReadOnlyList<Connection> conns;
-        try
-        {
-            conns = await connections.ListAsync(0, int.MaxValue, ct);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Grant reconcile: could not list connections; deleting nothing");
-            return ReconcileReport.Abort("Could not read the connections, so nothing was deleted.");
-        }
+        // An empty union is ambiguous — no S3 connections at all, or none with a usable allowlist —
+        // and it makes every grant look orphaned. Fail closed rather than delete the whole set on a
+        // state that is indistinguishable from connections that failed to load.
+        if (union!.Count == 0)
+            return ReconcileReport.Abort(
+                "No S3 connection allowed-locations were found, so every grant would look orphaned. "
+                + "Nothing was deleted.");
 
-        foreach (var connection in conns.Where(c => c.Provider == ConnectionProvider.S3))
-        {
-            IReadOnlyList<string>? locations;
-            try
-            {
-                using var document = JsonDocument.Parse(
-                    string.IsNullOrWhiteSpace(connection.ConfigJson) ? "{}" : connection.ConfigJson);
-                locations = StorageLocationPolicy.ReadAllowedLocations(document.RootElement);
-            }
-            catch (JsonException)
-            {
-                return ReconcileReport.Abort(
-                    $"Connection '{connection.Name}' has configuration that will not parse, so no "
-                    + "grant could be proven orphaned. Nothing was deleted.");
-            }
-
-            // Absent allowlist -> the connection may index any bucket, so no grant is provably
-            // orphaned. Fail closed rather than delete against an unbounded connection.
-            if (locations is null)
-                return ReconcileReport.Abort(
-                    $"Connection '{connection.Name}' declares no allowed-locations, so it could reach "
-                    + "any bucket and no grant can be shown orphaned. Nothing was deleted.");
-
-            // Present-but-malformed (StorageLocationPolicy's blank-entry sentinel) is unreadable.
-            if (locations.Any(string.IsNullOrWhiteSpace))
-                return ReconcileReport.Abort(
-                    $"Connection '{connection.Name}' has a malformed allowed-locations list. "
-                    + "Nothing was deleted.");
-
-            union.AddRange(locations);
-        }
-
-        // 2. Per region: select orphans, circuit-break, confirm provenance, delete.
+        // 2. Per region: select orphans, confirm provenance, circuit-break on what would ACTUALLY be
+        //    deleted, re-validate against a fresh union, then delete.
         string groupId = saml.CurrentValue.GrantGroupId ?? string.Empty;
         int scanned = 0, orphaned = 0, deleted = 0;
         var aborts = new List<string>();
@@ -127,28 +95,18 @@ public sealed class GrantReconciliationService(
             if (candidates.Count == 0)
                 continue;
 
-            // Circuit breaker: an implausibly large deletion is the signature of a bad union.
-            if (candidates.Count > cfg.MaxDeletePerTick)
-            {
-                string breaker =
-                    $"Refused to delete {candidates.Count} grants in {region} (limit "
-                    + $"{cfg.MaxDeletePerTick}) — this looks like an incomplete view, not that many "
-                    + "real orphans. Nothing was deleted there.";
-                logger.LogWarning("Grant reconcile circuit breaker: {Reason}", breaker);
-                aborts.Add(breaker);
-                continue;
-            }
-
-            // Provenance: keep only grants Connapse tagged as its own.
-            var arns = candidates
-                .Select(c => c.AccessGrantArn)
-                .Where(a => !string.IsNullOrWhiteSpace(a))
-                .ToList();
-
+            // Provenance FIRST: only grants Connapse tagged are ever deletable. This runs before the
+            // circuit breaker deliberately — an account full of unrelated administrator-authored
+            // orphans must not trip the breaker and permanently block cleanup of Connapse's own stale
+            // grants (nor let an attacker create that condition as a denial of service).
             IReadOnlyList<string> managedArns;
             try
             {
-                managedArns = await writer.FilterManagedAsync(region, arns, ct);
+                managedArns = await writer.FilterManagedAsync(
+                    region,
+                    candidates.Select(c => c.AccessGrantArn)
+                        .Where(a => !string.IsNullOrWhiteSpace(a)).ToList(),
+                    ct);
             }
             catch (Exception ex)
             {
@@ -163,6 +121,19 @@ public sealed class GrantReconciliationService(
             if (toDelete.Count == 0)
                 continue;
 
+            // Circuit breaker on what would actually be deleted — Connapse's own grants — not on
+            // every orphan. Deleting this many of our own at once is the signature of a bad view.
+            if (toDelete.Count > cfg.MaxDeletePerTick)
+            {
+                string breaker =
+                    $"Refused to delete {toDelete.Count} Connapse grants in {region} (limit "
+                    + $"{cfg.MaxDeletePerTick}) — that many at once looks like an incomplete view, not "
+                    + "real orphans. Nothing was deleted there.";
+                logger.LogWarning("Grant reconcile circuit breaker: {Reason}", breaker);
+                aborts.Add(breaker);
+                continue;
+            }
+
             if (!enforce)
             {
                 foreach (var g in toDelete)
@@ -173,15 +144,45 @@ public sealed class GrantReconciliationService(
                 continue;
             }
 
-            var result = await writer.RevokeAsync(
-                region, toDelete.Select(g => g.AccessGrantId).ToList(), ct);
+            // Re-validate against a FRESH union read right before deleting. This closes the window
+            // where a connection was added or widened after step 1 and now needs one of these grants:
+            // a grant that has become covered is dropped, and if the fresh view cannot be built (or is
+            // now empty) nothing is deleted in this region.
+            var (freshUnion, freshAbort) = await TryBuildUnionAsync(ct);
+            if (freshAbort is not null || freshUnion is null || freshUnion.Count == 0)
+            {
+                aborts.Add($"The connection view changed while reconciling {region}; skipped deletion there.");
+                continue;
+            }
+
+            var stillOrphaned = GrantReconciler
+                .SelectOrphans(toDelete, freshUnion, saml.CurrentValue.GrantGroupId ?? string.Empty)
+                .Candidates;
+            if (stillOrphaned.Count == 0)
+                continue;
+
+            GrantRevokeResult result;
+            try
+            {
+                result = await writer.RevokeAsync(
+                    region, stillOrphaned.Select(g => g.AccessGrantId).ToList(), ct);
+            }
+            catch (Exception ex)
+            {
+                // Guard like the reads above: a transient non-AWS failure must skip this region, not
+                // abort the whole sweep and every region after it.
+                logger.LogWarning(ex, "Grant reconcile: delete failed in {Region}; skipping",
+                    LogSanitizer.Sanitize(region));
+                aborts.Add($"Could not delete grants in {region}; skipped it.");
+                continue;
+            }
 
             deleted += result.Deleted.Count;
             failures.AddRange(result.Failed);
 
             foreach (string id in result.Deleted)
             {
-                var g = toDelete.First(x => x.AccessGrantId == id);
+                var g = stillOrphaned.First(x => x.AccessGrantId == id);
                 logger.LogWarning(
                     "Deleted orphaned access grant {Id} (scope {Scope}, group {Group}) in {Region}",
                     LogSanitizer.Sanitize(g.AccessGrantId), LogSanitizer.Sanitize(g.GrantScope),
@@ -190,5 +191,54 @@ public sealed class GrantReconciliationService(
         }
 
         return new ReconcileReport(scanned, orphaned, deleted, aborts, failures);
+    }
+
+    /// <summary>
+    /// Reads the complete allowed-locations union across every S3 connection, or an abort reason when
+    /// the picture is incomplete — a connection whose config will not parse, one that declares no
+    /// allowlist (so it could reach any bucket), or a malformed list. A null reason means the union is
+    /// complete and safe to reconcile against; a non-null reason means delete nothing.
+    /// </summary>
+    private async Task<(List<string>? Union, string? AbortReason)> TryBuildUnionAsync(CancellationToken ct)
+    {
+        IReadOnlyList<Connection> conns;
+        try
+        {
+            conns = await connections.ListAsync(0, int.MaxValue, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Grant reconcile: could not list connections");
+            return (null, "Could not read the connections, so nothing was deleted.");
+        }
+
+        var union = new List<string>();
+        foreach (var connection in conns.Where(c => c.Provider == ConnectionProvider.S3))
+        {
+            IReadOnlyList<string>? locations;
+            try
+            {
+                using var document = JsonDocument.Parse(
+                    string.IsNullOrWhiteSpace(connection.ConfigJson) ? "{}" : connection.ConfigJson);
+                locations = StorageLocationPolicy.ReadAllowedLocations(document.RootElement);
+            }
+            catch (JsonException)
+            {
+                return (null, $"Connection '{connection.Name}' has configuration that will not parse, "
+                    + "so no grant could be proven orphaned. Nothing was deleted.");
+            }
+
+            if (locations is null)
+                return (null, $"Connection '{connection.Name}' declares no allowed-locations, so it "
+                    + "could reach any bucket and no grant can be shown orphaned. Nothing was deleted.");
+
+            if (locations.Any(string.IsNullOrWhiteSpace))
+                return (null, $"Connection '{connection.Name}' has a malformed allowed-locations list. "
+                    + "Nothing was deleted.");
+
+            union.AddRange(locations);
+        }
+
+        return (union, null);
     }
 }

--- a/src/Connapse.Web/Services/GrantReconciliationService.cs
+++ b/src/Connapse.Web/Services/GrantReconciliationService.cs
@@ -1,0 +1,213 @@
+using System.Text.Json;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Web.Services;
+
+/// <summary>The outcome of one reconcile run.</summary>
+/// <param name="Scanned">Grants read across all regions.</param>
+/// <param name="Orphaned">Group grants whose scope no connection covers.</param>
+/// <param name="Deleted">Grants actually removed (0 when not enforcing).</param>
+/// <param name="Aborted">
+/// Reasons a run, or one region, deleted nothing — an incomplete connection view, a tripped circuit
+/// breaker, or an unreadable region. Non-empty means cleanup held back on purpose.
+/// </param>
+/// <param name="Failed">Grants a delete call rejected.</param>
+public record ReconcileReport(
+    int Scanned, int Orphaned, int Deleted,
+    IReadOnlyList<string> Aborted, IReadOnlyList<GrantWriteFailure> Failed)
+{
+    /// <summary>A run that deleted nothing because it could not act safely.</summary>
+    public static ReconcileReport Abort(string reason) => new(0, 0, 0, [reason], []);
+}
+
+/// <summary>
+/// Deletes S3 Access Grants Connapse created that no connection needs any more.
+/// </summary>
+/// <remarks>
+/// The dangerous direction, so it is fail-closed throughout: it deletes only grants it can prove are
+/// its own (by tag), only when it has a <b>complete</b> view of every connection's allowed-locations,
+/// and never more than the circuit-breaker limit in one region. Any gap in the input — a connection
+/// that will not parse, one that declares no allowlist (and so could index any bucket, making no
+/// grant provably orphaned), an unreadable region — makes it hold back rather than guess. This is the
+/// same discipline as <c>AwsSearchScopeResolver</c>: an answer that cannot be trusted is not acted on.
+/// </remarks>
+public sealed class GrantReconciliationService(
+    IConnectionStore connections,
+    IAwsGrantRegions regions,
+    IAccessGrantsReader reader,
+    IAccessGrantsWriter writer,
+    IOptionsMonitor<SamlSignInSettings> saml,
+    IOptionsMonitor<GrantReconciliationSettings> settings,
+    ILogger<GrantReconciliationService> logger) : IGrantReconciliationService
+{
+    /// <inheritdoc />
+    public async Task<ReconcileReport> ReconcileAsync(bool enforce, CancellationToken ct = default)
+    {
+        var cfg = settings.CurrentValue;
+        if (!cfg.Enabled)
+            return ReconcileReport.Abort("Grant reconciliation is switched off.");
+
+        // 1. The complete union of allowed-locations across every S3 connection. Any gap aborts —
+        //    an incomplete union makes still-needed grants look orphaned.
+        var union = new List<string>();
+
+        IReadOnlyList<Connection> conns;
+        try
+        {
+            conns = await connections.ListAsync(0, int.MaxValue, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Grant reconcile: could not list connections; deleting nothing");
+            return ReconcileReport.Abort("Could not read the connections, so nothing was deleted.");
+        }
+
+        foreach (var connection in conns.Where(c => c.Provider == ConnectionProvider.S3))
+        {
+            IReadOnlyList<string>? locations;
+            try
+            {
+                using var document = JsonDocument.Parse(
+                    string.IsNullOrWhiteSpace(connection.ConfigJson) ? "{}" : connection.ConfigJson);
+                locations = StorageLocationPolicy.ReadAllowedLocations(document.RootElement);
+            }
+            catch (JsonException)
+            {
+                return ReconcileReport.Abort(
+                    $"Connection '{connection.Name}' has configuration that will not parse, so no "
+                    + "grant could be proven orphaned. Nothing was deleted.");
+            }
+
+            // Absent allowlist -> the connection may index any bucket, so no grant is provably
+            // orphaned. Fail closed rather than delete against an unbounded connection.
+            if (locations is null)
+                return ReconcileReport.Abort(
+                    $"Connection '{connection.Name}' declares no allowed-locations, so it could reach "
+                    + "any bucket and no grant can be shown orphaned. Nothing was deleted.");
+
+            // Present-but-malformed (StorageLocationPolicy's blank-entry sentinel) is unreadable.
+            if (locations.Any(string.IsNullOrWhiteSpace))
+                return ReconcileReport.Abort(
+                    $"Connection '{connection.Name}' has a malformed allowed-locations list. "
+                    + "Nothing was deleted.");
+
+            union.AddRange(locations);
+        }
+
+        // 2. Per region: select orphans, circuit-break, confirm provenance, delete.
+        string groupId = saml.CurrentValue.GrantGroupId ?? string.Empty;
+        int scanned = 0, orphaned = 0, deleted = 0;
+        var aborts = new List<string>();
+        var failures = new List<GrantWriteFailure>();
+
+        IReadOnlyList<string> regionList;
+        try
+        {
+            regionList = await regions.ListAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Grant reconcile: could not resolve regions; deleting nothing");
+            return ReconcileReport.Abort("Could not resolve the AWS regions, so nothing was deleted.");
+        }
+
+        foreach (string region in regionList)
+        {
+            IReadOnlyList<AccessGrantDetail> grants;
+            try
+            {
+                grants = await reader.ListAllAsync(region, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Grant reconcile: could not read grants in {Region}; skipping",
+                    LogSanitizer.Sanitize(region));
+                aborts.Add($"Could not read grants in {region}; skipped it.");
+                continue;
+            }
+
+            scanned += grants.Count;
+
+            var candidates = GrantReconciler.SelectOrphans(grants, union, groupId).Candidates;
+            orphaned += candidates.Count;
+            if (candidates.Count == 0)
+                continue;
+
+            // Circuit breaker: an implausibly large deletion is the signature of a bad union.
+            if (candidates.Count > cfg.MaxDeletePerTick)
+            {
+                string breaker =
+                    $"Refused to delete {candidates.Count} grants in {region} (limit "
+                    + $"{cfg.MaxDeletePerTick}) — this looks like an incomplete view, not that many "
+                    + "real orphans. Nothing was deleted there.";
+                logger.LogWarning("Grant reconcile circuit breaker: {Reason}", breaker);
+                aborts.Add(breaker);
+                continue;
+            }
+
+            // Provenance: keep only grants Connapse tagged as its own.
+            var arns = candidates
+                .Select(c => c.AccessGrantArn)
+                .Where(a => !string.IsNullOrWhiteSpace(a))
+                .ToList();
+
+            IReadOnlyList<string> managedArns;
+            try
+            {
+                managedArns = await writer.FilterManagedAsync(region, arns, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Grant reconcile: could not confirm provenance in {Region}; skipping",
+                    LogSanitizer.Sanitize(region));
+                aborts.Add($"Could not confirm which grants are Connapse's in {region}; skipped it.");
+                continue;
+            }
+
+            var managed = managedArns.ToHashSet(StringComparer.Ordinal);
+            var toDelete = candidates.Where(c => managed.Contains(c.AccessGrantArn)).ToList();
+            if (toDelete.Count == 0)
+                continue;
+
+            if (!enforce)
+            {
+                foreach (var g in toDelete)
+                    logger.LogInformation(
+                        "Grant reconcile (report only): would delete orphaned grant {Id} scope {Scope} in {Region}",
+                        LogSanitizer.Sanitize(g.AccessGrantId), LogSanitizer.Sanitize(g.GrantScope),
+                        LogSanitizer.Sanitize(region));
+                continue;
+            }
+
+            var result = await writer.RevokeAsync(
+                region, toDelete.Select(g => g.AccessGrantId).ToList(), ct);
+
+            deleted += result.Deleted.Count;
+            failures.AddRange(result.Failed);
+
+            foreach (string id in result.Deleted)
+            {
+                var g = toDelete.First(x => x.AccessGrantId == id);
+                logger.LogWarning(
+                    "Deleted orphaned access grant {Id} (scope {Scope}, group {Group}) in {Region}",
+                    LogSanitizer.Sanitize(g.AccessGrantId), LogSanitizer.Sanitize(g.GrantScope),
+                    LogSanitizer.Sanitize(g.Grantee.Id), LogSanitizer.Sanitize(region));
+            }
+        }
+
+        return new ReconcileReport(scanned, orphaned, deleted, aborts, failures);
+    }
+}
+
+/// <summary>Deletes S3 Access Grants no connection needs any more. See <see cref="GrantReconciliationService"/>.</summary>
+public interface IGrantReconciliationService
+{
+    /// <summary>
+    /// Reconciles once. <paramref name="enforce"/> false computes and logs what it would delete
+    /// without deleting; true deletes.
+    /// </summary>
+    Task<ReconcileReport> ReconcileAsync(bool enforce, CancellationToken ct = default);
+}

--- a/src/Connapse.Web/Services/GrantReconciliationService.cs
+++ b/src/Connapse.Web/Services/GrantReconciliationService.cs
@@ -6,23 +6,6 @@ using Microsoft.Extensions.Options;
 
 namespace Connapse.Web.Services;
 
-/// <summary>The outcome of one reconcile run.</summary>
-/// <param name="Scanned">Grants read across all regions.</param>
-/// <param name="Orphaned">Group grants whose scope no connection covers.</param>
-/// <param name="Deleted">Grants actually removed (0 when not enforcing).</param>
-/// <param name="Aborted">
-/// Reasons a run, or one region, deleted nothing — an incomplete connection view, a tripped circuit
-/// breaker, or an unreadable region. Non-empty means cleanup held back on purpose.
-/// </param>
-/// <param name="Failed">Grants a delete call rejected.</param>
-public record ReconcileReport(
-    int Scanned, int Orphaned, int Deleted,
-    IReadOnlyList<string> Aborted, IReadOnlyList<GrantWriteFailure> Failed)
-{
-    /// <summary>A run that deleted nothing because it could not act safely.</summary>
-    public static ReconcileReport Abort(string reason) => new(0, 0, 0, [reason], []);
-}
-
 /// <summary>
 /// Deletes S3 Access Grants Connapse created that no connection needs any more.
 /// </summary>
@@ -200,14 +183,4 @@ public sealed class GrantReconciliationService(
 
         return new ReconcileReport(scanned, orphaned, deleted, aborts, failures);
     }
-}
-
-/// <summary>Deletes S3 Access Grants no connection needs any more. See <see cref="GrantReconciliationService"/>.</summary>
-public interface IGrantReconciliationService
-{
-    /// <summary>
-    /// Reconciles once. <paramref name="enforce"/> false computes and logs what it would delete
-    /// without deleting; true deletes.
-    /// </summary>
-    Task<ReconcileReport> ReconcileAsync(bool enforce, CancellationToken ct = default);
 }

--- a/src/Connapse.Web/Services/GrantReconciliationService.cs
+++ b/src/Connapse.Web/Services/GrantReconciliationService.cs
@@ -41,19 +41,18 @@ public sealed class GrantReconciliationService(
         if (!cfg.Enabled)
             return ReconcileReport.Abort("Grant reconciliation is switched off.");
 
-        // 1. The complete union of allowed-locations across every S3 connection. Any gap aborts —
-        //    an incomplete union makes still-needed grants look orphaned.
-        var (union, unionAbort) = await TryBuildUnionAsync(ct);
-        if (unionAbort is not null)
-            return ReconcileReport.Abort(unionAbort);
+        // 1. The complete union of allowed-locations across every S3 connection. A gap in the read —
+        //    a connection that will not parse, one that declares no allowlist — aborts, because it
+        //    makes still-needed grants look orphaned. An empty union is NOT a gap: a successful read
+        //    that finds no S3 connections (or only deny-all ones) means those grants genuinely have
+        //    nothing to justify them, so they are cleaned up like any other orphan (the circuit
+        //    breaker still guards against an implausibly large sweep). A failed read throws and is
+        //    caught inside the helper as an abort, so it never reaches here as an empty union.
+        var buildResult = await TryBuildUnionAsync(ct);
+        if (buildResult.AbortReason is not null)
+            return ReconcileReport.Abort(buildResult.AbortReason);
 
-        // An empty union is ambiguous — no S3 connections at all, or none with a usable allowlist —
-        // and it makes every grant look orphaned. Fail closed rather than delete the whole set on a
-        // state that is indistinguishable from connections that failed to load.
-        if (union!.Count == 0)
-            return ReconcileReport.Abort(
-                "No S3 connection allowed-locations were found, so every grant would look orphaned. "
-                + "Nothing was deleted.");
+        var union = buildResult.Union!;
 
         // 2. Per region: select orphans, confirm provenance, circuit-break on what would ACTUALLY be
         //    deleted, re-validate against a fresh union, then delete.
@@ -144,14 +143,17 @@ public sealed class GrantReconciliationService(
                 continue;
             }
 
-            // Re-validate against a FRESH union read right before deleting. This closes the window
+            // Re-validate against a FRESH union read right before deleting. This narrows the window
             // where a connection was added or widened after step 1 and now needs one of these grants:
-            // a grant that has become covered is dropped, and if the fresh view cannot be built (or is
-            // now empty) nothing is deleted in this region.
+            // a grant that has become covered is dropped, and the current group is re-read too. A read
+            // failure here (not an empty result) skips deletion in this region. The window between
+            // this read and RevokeAsync below cannot be fully closed without a lock spanning a DB read
+            // and an AWS call; its worst case is a just-added grant deleted and re-granted, which is
+            // recoverable, so it is accepted rather than locked.
             var (freshUnion, freshAbort) = await TryBuildUnionAsync(ct);
-            if (freshAbort is not null || freshUnion is null || freshUnion.Count == 0)
+            if (freshAbort is not null || freshUnion is null)
             {
-                aborts.Add($"The connection view changed while reconciling {region}; skipped deletion there.");
+                aborts.Add($"The connection view could not be re-read while reconciling {region}; skipped deletion there.");
                 continue;
             }
 

--- a/tests/Connapse.Core.Tests/Utilities/AwsRolePolicyUpdateTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AwsRolePolicyUpdateTests.cs
@@ -54,6 +54,11 @@ public class AwsRolePolicyUpdateTests
     [InlineData("not-an-arn")]
     [InlineData("arn:aws:s3:::some-bucket")]
     [InlineData("arn:aws:iam::notanaccount:role/x")]
+    // Role name with shell metacharacters / spaces is not a valid IAM name and must never reach
+    // the generated command (it is interpolated unquoted).
+    [InlineData("arn:aws:iam::086015909943:role/x; Start-Process calc; #")]
+    [InlineData("arn:aws:iam::086015909943:role/has space")]
+    [InlineData("arn:aws:iam::086015909943:role/x'y")]
     public void GenerateCommand_MalformedArn_ReturnsNull(string? arn)
     {
         AwsRolePolicyUpdate.GenerateCommand(arn).Should().BeNull();

--- a/tests/Connapse.Core.Tests/Utilities/AwsRolePolicyUpdateTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AwsRolePolicyUpdateTests.cs
@@ -32,6 +32,13 @@ public class AwsRolePolicyUpdateTests
     }
 
     [Fact]
+    public void GenerateCommand_IsOneLine_SoItPastesIntoAnyShell()
+    {
+        // A multi-line policy inside single quotes breaks in PowerShell; the command must be one line.
+        AwsRolePolicyUpdate.GenerateCommand(RoleArn).Should().NotContain("\n").And.NotContain("\r");
+    }
+
+    [Fact]
     public void GenerateCommand_RoleArnWithAPath_TakesTheLastSegmentAsTheName()
     {
         string cmd = AwsRolePolicyUpdate.GenerateCommand(

--- a/tests/Connapse.Core.Tests/Utilities/AwsRolePolicyUpdateTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AwsRolePolicyUpdateTests.cs
@@ -1,0 +1,70 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class AwsRolePolicyUpdateTests
+{
+    private const string RoleArn = "arn:aws:iam::086015909943:role/connapse-ra-bce2666b59d80ef9";
+
+    [Fact]
+    public void GenerateCommand_NamesTheRoleAndTheConnapseReadPolicy()
+    {
+        string cmd = AwsRolePolicyUpdate.GenerateCommand(RoleArn)!;
+
+        cmd.Should().StartWith("aws iam put-role-policy");
+        cmd.Should().Contain("--role-name connapse-ra-bce2666b59d80ef9");
+        cmd.Should().Contain("--policy-name ConnapseRead");
+    }
+
+    [Fact]
+    public void GenerateCommand_SubstitutesTheAccountAndCarriesTheCurrentActions()
+    {
+        string cmd = AwsRolePolicyUpdate.GenerateCommand(RoleArn)!;
+
+        cmd.Should().Contain("086015909943");
+        cmd.Should().NotContain(S3SetupPolicy.AccountPlaceholder);
+        // The whole point: an old role gets the actions added since it was created.
+        cmd.Should().Contain("s3:CreateAccessGrant");
+        cmd.Should().Contain("s3:DeleteAccessGrant");
+    }
+
+    [Fact]
+    public void GenerateCommand_RoleArnWithAPath_TakesTheLastSegmentAsTheName()
+    {
+        string cmd = AwsRolePolicyUpdate.GenerateCommand(
+            "arn:aws:iam::086015909943:role/team/connapse-ra-x")!;
+
+        cmd.Should().Contain("--role-name connapse-ra-x");
+        cmd.Should().NotContain("team/");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-an-arn")]
+    [InlineData("arn:aws:s3:::some-bucket")]
+    [InlineData("arn:aws:iam::notanaccount:role/x")]
+    public void GenerateCommand_MalformedArn_ReturnsNull(string? arn)
+    {
+        AwsRolePolicyUpdate.GenerateCommand(arn).Should().BeNull();
+    }
+
+    [Fact]
+    public void PolicyDocument_SubstitutesTheAccount()
+    {
+        string policy = AwsRolePolicyUpdate.PolicyDocument("086015909943");
+
+        policy.Should().Contain("086015909943");
+        policy.Should().NotContain(S3SetupPolicy.AccountPlaceholder);
+    }
+
+    [Fact]
+    public void PolicyDocument_NoAccount_KeepsThePlaceholderToSubstitute()
+    {
+        AwsRolePolicyUpdate.PolicyDocument(null)
+            .Should().Contain(S3SetupPolicy.AccountPlaceholder);
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/GrantPlannerTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/GrantPlannerTests.cs
@@ -1,0 +1,56 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class GrantPlannerTests
+{
+    [Fact]
+    public void Plan_LocationWithNoExistingGrant_IsToCreateAsSubPrefixStar()
+    {
+        var plan = GrantPlanner.Plan(["my-bucket/docs"], existingScopes: []);
+
+        plan.ToCreate.Should().ContainSingle().Which.Should().Be("my-bucket/docs/*");
+        plan.AlreadyGranted.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Plan_LocationAlreadyGranted_IsSkipped()
+    {
+        var plan = GrantPlanner.Plan(
+            ["my-bucket/docs"],
+            existingScopes: ["s3://my-bucket/docs/*"]);
+
+        plan.ToCreate.Should().BeEmpty();
+        plan.AlreadyGranted.Should().ContainSingle().Which.Should().Be("my-bucket/docs/*");
+    }
+
+    [Fact]
+    public void Plan_BucketRoot_BecomesBucketStar()
+    {
+        var plan = GrantPlanner.Plan(["my-bucket"], existingScopes: []);
+
+        plan.ToCreate.Should().ContainSingle().Which.Should().Be("my-bucket/*");
+    }
+
+    [Fact]
+    public void Plan_TrailingSlashAndDuplicates_AreNormalisedAndDeduped()
+    {
+        var plan = GrantPlanner.Plan(
+            ["my-bucket/docs/", "my-bucket/docs"],
+            existingScopes: []);
+
+        plan.ToCreate.Should().ContainSingle().Which.Should().Be("my-bucket/docs/*");
+    }
+
+    [Fact]
+    public void Plan_UnsafeLocation_IsDropped()
+    {
+        var plan = GrantPlanner.Plan(["bad bucket$name"], existingScopes: []);
+
+        plan.ToCreate.Should().BeEmpty();
+        plan.AlreadyGranted.Should().BeEmpty();
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/GrantReconcilerTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/GrantReconcilerTests.cs
@@ -1,0 +1,96 @@
+using Connapse.Core;
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class GrantReconcilerTests
+{
+    private static AccessGrantDetail Grant(
+        string scope, bool group = true, string id = "g", string grp = "grp-1") =>
+        new(AccessGrantId: id, AccessGrantArn: "arn:" + id,
+            Grantee: new AccessGrantee(IsGroup: group, Id: grp),
+            GrantScope: scope, Permission: "READ", AccessGrantsLocationId: "default");
+
+    [Fact]
+    public void SelectOrphans_ScopeCoveredByAConnection_IsNotACandidate()
+    {
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://my-bucket/docs/*")],
+            unionLocations: ["my-bucket/docs"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectOrphans_ScopeCoveredByNoConnection_IsACandidate()
+    {
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://old-bucket/*")],
+            unionLocations: ["my-bucket/docs"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().ContainSingle().Which.AccessGrantId.Should().Be("g");
+    }
+
+    [Fact]
+    public void SelectOrphans_ScopeCoveredByOneOfSeveralConnections_IsNotACandidate()
+    {
+        // The union matters: a bucket removed from one connection is not orphaned if another covers it.
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://shared-bucket/*")],
+            unionLocations: ["other-bucket", "shared-bucket/team"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectOrphans_PreviousGroupOrphan_IsACandidate()
+    {
+        // A group that is no longer configured, whose scope nothing covers — a previous-group orphan.
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://old-bucket/*", grp: "grp-OLD")],
+            unionLocations: ["my-bucket/docs"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void SelectOrphans_PreviousGroupButStillCovered_IsLeftAlone()
+    {
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://my-bucket/docs/*", grp: "grp-OLD")],
+            unionLocations: ["my-bucket/docs"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectOrphans_NonGroupGrant_IsNeverACandidate()
+    {
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://old-bucket/*", group: false)],
+            unionLocations: ["my-bucket/docs"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectOrphans_SimilarBucketPrefix_DoesNotCount_AsCovered()
+    {
+        // s3://logs must not read as covered by a connection allowing "logs-archive".
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://logs/*")],
+            unionLocations: ["logs-archive"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().ContainSingle();
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/GrantReconcilerTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/GrantReconcilerTests.cs
@@ -37,15 +37,28 @@ public class GrantReconcilerTests
     }
 
     [Fact]
-    public void SelectOrphans_ScopeCoveredByOneOfSeveralConnections_IsNotACandidate()
+    public void SelectOrphans_GrantNarrowerThanAnAllowedLocation_IsNotACandidate()
     {
-        // The union matters: a bucket removed from one connection is not orphaned if another covers it.
+        // Grant is a subtree of what a whole-bucket connection allows -> still fully justified.
+        var sel = GrantReconciler.SelectOrphans(
+            [Grant("s3://shared-bucket/team/*")],
+            unionLocations: ["shared-bucket"],
+            configuredGroupId: "grp-1");
+
+        sel.Candidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectOrphans_GrantBroaderThanTheNarrowedAllowedLocation_IsACandidate()
+    {
+        // The narrowing fail-open: a whole-bucket grant is NOT justified once the connection is
+        // narrowed to one prefix. Overlap would wrongly keep it; containment revokes it.
         var sel = GrantReconciler.SelectOrphans(
             [Grant("s3://shared-bucket/*")],
             unionLocations: ["other-bucket", "shared-bucket/team"],
             configuredGroupId: "grp-1");
 
-        sel.Candidates.Should().BeEmpty();
+        sel.Candidates.Should().ContainSingle().Which.GrantScope.Should().Be("s3://shared-bucket/*");
     }
 
     [Fact]
@@ -61,14 +74,16 @@ public class GrantReconcilerTests
     }
 
     [Fact]
-    public void SelectOrphans_PreviousGroupButStillCovered_IsLeftAlone()
+    public void SelectOrphans_PreviousGroupGrant_IsACandidate_EvenWhenScopeStillCovered()
     {
+        // Changing the grant group must revoke the old group's grants, even for a still-connected
+        // bucket -- otherwise the old group's members keep seeing the data (stale-authorisation leak).
         var sel = GrantReconciler.SelectOrphans(
             [Grant("s3://my-bucket/docs/*", grp: "grp-OLD")],
             unionLocations: ["my-bucket/docs"],
             configuredGroupId: "grp-1");
 
-        sel.Candidates.Should().BeEmpty();
+        sel.Candidates.Should().ContainSingle();
     }
 
     [Fact]

--- a/tests/Connapse.Core.Tests/Utilities/GrantTagsTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/GrantTagsTests.cs
@@ -1,0 +1,19 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class GrantTagsTests
+{
+    [Fact]
+    public void ManagedTag_IsTheConnapseProvenanceMarker()
+    {
+        // The one marker cleanup keys on. Kept out of the writer so create and the reconciler
+        // cannot drift on the string that decides whether a grant is deletable.
+        GrantTags.ManagedKey.Should().Be("connapse:managed");
+        GrantTags.ManagedValue.Should().Be("true");
+        GrantTags.ManagedKey.Should().NotStartWith("aws:"); // AWS rejects aws:-prefixed tag keys
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
@@ -38,12 +38,13 @@ public class S3SetupPolicyTests
     }
 
     [Fact]
-    public void ForManagedIdentity_ReadsEverythingAndChangesNothing()
+    public void ForManagedIdentity_ReadsEverythingAndCreatesGrants()
     {
-        // The whole trade rests on this. A credential that can read every bucket is a real cost,
-        // accepted knowingly; one that can also delete them is a different product. Connapse has no
-        // write surface against a source at all -- IConnector does not expose one -- so a policy
-        // granting more asks for authority the product cannot use.
+        // The trade: the identity reads every bucket -- a real cost accepted knowingly -- and now
+        // also creates S3 access grants, the one write it is deliberately given so Connapse can
+        // grant a group access without a CloudShell trip. It still cannot touch an object beyond
+        // reading it: Connapse has no write surface against a source (IConnector exposes none), so
+        // no object-write action belongs here.
         var actions = Parse(S3SetupPolicy.ForManagedIdentity()).GetProperty("Statement")
             .EnumerateArray()
             .SelectMany(x => x.GetProperty("Action").EnumerateArray())
@@ -52,18 +53,36 @@ public class S3SetupPolicyTests
 
         actions.Should().BeEquivalentTo([
             "s3:ListAllMyBuckets", "s3:ListBucket", "s3:GetBucketLocation", "s3:GetObject",
-            // Resolving what a person may read. None of these touches an object, and they are here
-            // rather than in a second policy so one document describes everything the identity can
-            // do.
-            "s3:ListAccessGrants", "identitystore:GetUserId", "identitystore:DescribeUser",
+            // Resolving what a person may read, and creating the grants that let them. These are
+            // here rather than in a second policy so one document describes everything the identity
+            // can do.
+            "s3:ListAccessGrants", "s3:ListAccessGrantsLocations", "s3:CreateAccessGrant",
+            "identitystore:GetUserId", "identitystore:DescribeUser",
             "identitystore:ListGroupMembershipsForMember"
         ]);
 
-        // Read-only, whichever service. The verb is the guard: Get, List and Describe cannot change
-        // anything, and no wildcard is allowed to smuggle one in.
+        // The only write is CreateAccessGrant. Every other action is a Get, List or Describe, and
+        // no wildcard is allowed to smuggle a broader one in.
         actions.Should().OnlyContain(a =>
-            a.Contains(":Get") || a.Contains(":List") || a.Contains(":Describe"));
+            a == "s3:CreateAccessGrant"
+            || a.Contains(":Get") || a.Contains(":List") || a.Contains(":Describe"));
         actions.Should().NotContain(a => a.Contains("*"));
+
+        // No object-write, ever: the grant is the sole create, and it is on access-grants, not S3
+        // objects.
+        actions.Should().NotContain(["s3:PutObject", "s3:DeleteObject", "s3:DeleteBucket"]);
+    }
+
+    [Fact]
+    public void ForManagedIdentity_GrantsCreateAccessGrantOnTheAccessGrantsResource()
+    {
+        var manage = Statement(S3SetupPolicy.ForManagedIdentity(), "ConnapseManageGrants");
+
+        manage.GetProperty("Action").EnumerateArray().Select(a => a.GetString())
+            .Should().Contain(["s3:CreateAccessGrant", "s3:ListAccessGrantsLocations"]);
+
+        // Bounded to access-grants -- creating a grant is not authority over objects.
+        manage.GetProperty("Resource").GetString().Should().Contain(":access-grants/");
     }
 
     [Fact]
@@ -104,12 +123,16 @@ public class S3SetupPolicyTests
     }
 
     [Fact]
-    public void ManagedIdentitySummary_SaysBothWhatItReadsAndWhatItCannotDo()
+    public void ManagedIdentitySummary_SaysItReadsBucketsAndCreatesGrants()
     {
         // This sentence is what an operator reads before running a script that mints a credential.
-        // "Every bucket" without "cannot write" describes something scarier than what is granted.
+        // It must name the read reach AND the new grant-creating authority -- the identity is no
+        // longer read-only, so the old "cannot write, delete, or change anything" claim would be a
+        // false reassurance about a credential that can now create access grants.
         S3SetupPolicy.ManagedIdentitySummary.Should()
-            .Contain("every S3 bucket").And.Contain("cannot write");
+            .Contain("every S3 bucket")
+            .And.Contain("access grant")
+            .And.NotContain("cannot write, delete, or change anything");
     }
 
     [Theory]

--- a/tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
@@ -53,23 +53,26 @@ public class S3SetupPolicyTests
 
         actions.Should().BeEquivalentTo([
             "s3:ListAllMyBuckets", "s3:ListBucket", "s3:GetBucketLocation", "s3:GetObject",
-            // Resolving what a person may read, and creating the grants that let them. These are
-            // here rather than in a second policy so one document describes everything the identity
-            // can do.
+            // Resolving what a person may read, creating the grants that let them, and removing the
+            // grants no connection needs. These are here rather than in a second policy so one
+            // document describes everything the identity can do.
             "s3:ListAccessGrants", "s3:ListAccessGrantsLocations", "s3:CreateAccessGrant",
+            "s3:DeleteAccessGrant", "s3:TagResource", "s3:ListTagsForResource",
             "identitystore:GetUserId", "identitystore:DescribeUser",
             "identitystore:ListGroupMembershipsForMember"
         ]);
 
-        // The only write is CreateAccessGrant. Every other action is a Get, List or Describe, and
-        // no wildcard is allowed to smuggle a broader one in.
+        // The only writes are grant management — create, delete, tag. Everything else is a Get,
+        // List or Describe, and no wildcard is allowed to smuggle a broader one in.
+        string[] grantManagementWrites =
+            ["s3:CreateAccessGrant", "s3:DeleteAccessGrant", "s3:TagResource"];
         actions.Should().OnlyContain(a =>
-            a == "s3:CreateAccessGrant"
+            grantManagementWrites.Contains(a)
             || a.Contains(":Get") || a.Contains(":List") || a.Contains(":Describe"));
         actions.Should().NotContain(a => a.Contains("*"));
 
-        // No object-write, ever: the grant is the sole create, and it is on access-grants, not S3
-        // objects.
+        // No object-write, ever: the only delete is DeleteAccessGrant (an access-control record),
+        // never an object or a bucket.
         actions.Should().NotContain(["s3:PutObject", "s3:DeleteObject", "s3:DeleteBucket"]);
     }
 
@@ -82,6 +85,19 @@ public class S3SetupPolicyTests
             .Should().Contain(["s3:CreateAccessGrant", "s3:ListAccessGrantsLocations"]);
 
         // Bounded to access-grants -- creating a grant is not authority over objects.
+        manage.GetProperty("Resource").GetString().Should().Contain(":access-grants/");
+    }
+
+    [Fact]
+    public void ForManagedIdentity_GrantsDeleteAndTagAccessGrant()
+    {
+        // Cleanup needs delete; provenance needs tag-on-create and reading tags back.
+        var manage = Statement(S3SetupPolicy.ForManagedIdentity(), "ConnapseManageGrants");
+
+        manage.GetProperty("Action").EnumerateArray().Select(a => a.GetString())
+            .Should().Contain(["s3:DeleteAccessGrant", "s3:TagResource", "s3:ListTagsForResource"]);
+
+        // Still bounded to the access-grants resource -- deletion never reaches an object.
         manage.GetProperty("Resource").GetString().Should().Contain(":access-grants/");
     }
 

--- a/tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/S3SetupPolicyTests.cs
@@ -34,7 +34,7 @@ public class S3SetupPolicyTests
         var root = Parse(S3SetupPolicy.ForManagedIdentity());
 
         root.GetProperty("Version").GetString().Should().Be("2012-10-17");
-        root.GetProperty("Statement").GetArrayLength().Should().Be(5);
+        root.GetProperty("Statement").GetArrayLength().Should().Be(6);
     }
 
     [Fact]
@@ -59,7 +59,9 @@ public class S3SetupPolicyTests
             "s3:ListAccessGrants", "s3:ListAccessGrantsLocations", "s3:CreateAccessGrant",
             "s3:DeleteAccessGrant", "s3:TagResource", "s3:ListTagsForResource",
             "identitystore:GetUserId", "identitystore:DescribeUser",
-            "identitystore:ListGroupMembershipsForMember"
+            "identitystore:ListGroupMembershipsForMember",
+            // Creating a directory-group grant validates the grantee and the Identity Center instance.
+            "identitystore:DescribeGroup", "sso:DescribeInstance", "sso:DescribeApplication"
         ]);
 
         // The only writes are grant management — create, delete, tag. Everything else is a Get,
@@ -86,6 +88,21 @@ public class S3SetupPolicyTests
 
         // Bounded to access-grants -- creating a grant is not authority over objects.
         manage.GetProperty("Resource").GetString().Should().Contain(":access-grants/");
+    }
+
+    [Fact]
+    public void ForManagedIdentity_CanCreateGrantsForDirectoryGroups()
+    {
+        // Creating a group grant makes S3 Access Grants validate the grantee (DescribeGroup) and the
+        // Identity Center instance (sso). Missing any of these fails the create with an AccessDenied
+        // that names sso/identitystore, not s3 -- the bug this guards against.
+        var actions = Parse(S3SetupPolicy.ForManagedIdentity()).GetProperty("Statement")
+            .EnumerateArray()
+            .SelectMany(x => x.GetProperty("Action").EnumerateArray())
+            .Select(a => a.GetString());
+
+        actions.Should().Contain(
+            ["identitystore:DescribeGroup", "sso:DescribeInstance", "sso:DescribeApplication"]);
     }
 
     [Fact]

--- a/tests/Connapse.Web.Tests/Services/GrantReconciliationServiceTests.cs
+++ b/tests/Connapse.Web.Tests/Services/GrantReconciliationServiceTests.cs
@@ -95,21 +95,27 @@ public class GrantReconciliationServiceTests
     }
 
     [Fact]
-    public async Task Reconcile_NoS3Connections_AbortsWithoutDeleting()
+    public async Task Reconcile_NoS3Connections_DeletesManagedGrantsAsOrphaned()
     {
-        // An empty union (no S3 connections) makes every grant look orphaned; fail closed.
+        // A successful read finding no S3 connections means those grants genuinely have nothing to
+        // justify them — they are orphans and get cleaned up (the breaker still caps the volume). A
+        // read *failure* aborts separately (Reconcile_ConnectionListThrows_AbortsWithoutDeleting).
         var h = Build();
         h.Connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<Connection>>(_ => []);
+        h.Reader.ListAllAsync("us-east-1", Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<AccessGrantDetail>>(_ => [GroupGrant("s3://gone-bucket/*", "g1")]);
+        h.Writer.FilterManagedAsync("us-east-1", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<string>>(_ => ["arn:g1"]);
+        h.Writer.RevokeAsync("us-east-1", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new GrantRevokeResult(["g1"], [], [], AccessDenied: false));
 
         var report = await h.Service.ReconcileAsync(enforce: true);
 
-        report.Aborted.Should().NotBeEmpty();
-        report.Deleted.Should().Be(0);
-        // Aborts before it ever reads grants or deletes.
-        await h.Reader.DidNotReceive().ListAllAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await h.Writer.DidNotReceive().RevokeAsync(
-            Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        report.Deleted.Should().Be(1);
+        await h.Writer.Received().RevokeAsync(
+            "us-east-1", Arg.Is<IReadOnlyList<string>>(ids => ids.Contains("g1")),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Connapse.Web.Tests/Services/GrantReconciliationServiceTests.cs
+++ b/tests/Connapse.Web.Tests/Services/GrantReconciliationServiceTests.cs
@@ -95,22 +95,88 @@ public class GrantReconciliationServiceTests
     }
 
     [Fact]
-    public async Task Reconcile_ImplausiblyManyCandidates_TripsCircuitBreaker()
+    public async Task Reconcile_NoS3Connections_AbortsWithoutDeleting()
     {
+        // An empty union (no S3 connections) makes every grant look orphaned; fail closed.
+        var h = Build();
+        h.Connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<Connection>>(_ => []);
+
+        var report = await h.Service.ReconcileAsync(enforce: true);
+
+        report.Aborted.Should().NotBeEmpty();
+        report.Deleted.Should().Be(0);
+        // Aborts before it ever reads grants or deletes.
+        await h.Reader.DidNotReceive().ListAllAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await h.Writer.DidNotReceive().RevokeAsync(
+            Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reconcile_ManyManagedOrphans_TripsCircuitBreaker()
+    {
+        // The breaker measures what would ACTUALLY be deleted (managed grants), after provenance.
         var h = Build(maxDeletePerTick: 1);
         h.Connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<Connection>>(_ => [S3("{\"allowedLocations\":[\"kept-bucket\"]}")]);
         h.Reader.ListAllAsync("us-east-1", Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<AccessGrantDetail>>(_ =>
                 [GroupGrant("s3://gone-a/*", "g1"), GroupGrant("s3://gone-b/*", "g2")]);
+        h.Writer.FilterManagedAsync("us-east-1", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<string>>(_ => ["arn:g1", "arn:g2"]);
 
         var report = await h.Service.ReconcileAsync(enforce: true);
 
         report.Aborted.Should().NotBeEmpty();
         report.Deleted.Should().Be(0);
-        // The breaker fires before provenance is even read.
-        await h.Writer.DidNotReceive().FilterManagedAsync(
+        await h.Writer.DidNotReceive().RevokeAsync(
             Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reconcile_UnrelatedAdminOrphans_DoNotBlockManagedCleanup()
+    {
+        // 60 admin-authored orphans (untagged) must not trip the breaker; the one managed orphan
+        // still gets deleted (regression for provenance-before-breaker ordering).
+        var h = Build(maxDeletePerTick: 50);
+        h.Connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<Connection>>(_ => [S3("{\"allowedLocations\":[\"kept-bucket\"]}")]);
+        var many = Enumerable.Range(0, 60)
+            .Select(i => GroupGrant($"s3://admin-{i}/*", $"a{i}", grp: "grp-1")).ToList();
+        many.Add(GroupGrant("s3://gone-bucket/*", "mine"));
+        h.Reader.ListAllAsync("us-east-1", Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<AccessGrantDetail>>(_ => many);
+        h.Writer.FilterManagedAsync("us-east-1", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<string>>(_ => ["arn:mine"]); // only ours is tagged
+        h.Writer.RevokeAsync("us-east-1", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new GrantRevokeResult(["mine"], [], [], AccessDenied: false));
+
+        var report = await h.Service.ReconcileAsync(enforce: true);
+
+        report.Deleted.Should().Be(1);
+        await h.Writer.Received().RevokeAsync(
+            "us-east-1", Arg.Is<IReadOnlyList<string>>(ids => ids.Contains("mine")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reconcile_GrantBecomesCoveredOnRevalidation_IsNotDeleted()
+    {
+        // Race fix: a connection is added between the first union read and the delete, now covering
+        // the grant. The fresh re-validation drops it.
+        var h = Build();
+        h.Connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<Connection>>(
+                _ => [S3("{\"allowedLocations\":[\"kept-bucket\"]}")],                       // initial
+                _ => [S3("{\"allowedLocations\":[\"kept-bucket\",\"gone-bucket\"]}")]);       // re-validate
+        h.Reader.ListAllAsync("us-east-1", Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<AccessGrantDetail>>(_ => [GroupGrant("s3://gone-bucket/*", "g1")]);
+        h.Writer.FilterManagedAsync("us-east-1", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<string>>(_ => ["arn:g1"]);
+
+        var report = await h.Service.ReconcileAsync(enforce: true);
+
+        report.Deleted.Should().Be(0);
         await h.Writer.DidNotReceive().RevokeAsync(
             Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Connapse.Web.Tests/Services/GrantReconciliationServiceTests.cs
+++ b/tests/Connapse.Web.Tests/Services/GrantReconciliationServiceTests.cs
@@ -1,0 +1,159 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Web.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Connapse.Web.Tests.Services;
+
+[Trait("Category", "Unit")]
+public class GrantReconciliationServiceTests
+{
+    private static readonly DateTime When = new(2026, 9, 3, 0, 0, 0, DateTimeKind.Utc);
+
+    private static Connection S3(string? configJson) =>
+        new(Guid.NewGuid(), "s3-conn", ConnectionProvider.S3, configJson, null, When, When);
+
+    private static AccessGrantDetail GroupGrant(string scope, string id, string grp = "grp-1") =>
+        new(AccessGrantId: id, AccessGrantArn: "arn:" + id,
+            Grantee: new AccessGrantee(IsGroup: true, Id: grp),
+            GrantScope: scope, Permission: "READ", AccessGrantsLocationId: "default");
+
+    private sealed record Harness(
+        GrantReconciliationService Service,
+        IConnectionStore Connections,
+        IAwsGrantRegions Regions,
+        IAccessGrantsReader Reader,
+        IAccessGrantsWriter Writer);
+
+    private static Harness Build(
+        int maxDeletePerTick = 50, string groupId = "grp-1")
+    {
+        var connections = Substitute.For<IConnectionStore>();
+        var regions = Substitute.For<IAwsGrantRegions>();
+        var reader = Substitute.For<IAccessGrantsReader>();
+        var writer = Substitute.For<IAccessGrantsWriter>();
+
+        regions.ListAsync(Arg.Any<CancellationToken>()).Returns<IReadOnlyList<string>>(_ => ["us-east-1"]);
+
+        var service = new GrantReconciliationService(
+            connections, regions, reader, writer,
+            Options.Create(new SamlSignInSettings { GrantGroupId = groupId }).AsMonitor(),
+            Options.Create(new GrantReconciliationSettings { MaxDeletePerTick = maxDeletePerTick }).AsMonitor(),
+            NullLogger<GrantReconciliationService>.Instance);
+
+        return new Harness(service, connections, regions, reader, writer);
+    }
+
+    [Fact]
+    public async Task Reconcile_ConnectionListThrows_AbortsWithoutDeleting()
+    {
+        var h = Build();
+        h.Connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("db down"));
+
+        var report = await h.Service.ReconcileAsync(enforce: true);
+
+        report.Aborted.Should().NotBeEmpty();
+        report.Deleted.Should().Be(0);
+        await h.Writer.DidNotReceive().RevokeAsync(
+            Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reconcile_UnrestrictedConnection_AbortsWithoutDeleting()
+    {
+        // A connection that declares no allowed-locations could index any bucket, so no grant is
+        // provably orphaned -> fail closed.
+        var h = Build();
+        h.Connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<Connection>>(_ => [S3("{\"region\":\"us-east-1\"}")]);
+
+        var report = await h.Service.ReconcileAsync(enforce: true);
+
+        report.Aborted.Should().NotBeEmpty();
+        await h.Writer.DidNotReceive().RevokeAsync(
+            Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reconcile_MalformedConnectionConfig_AbortsWithoutDeleting()
+    {
+        var h = Build();
+        h.Connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<Connection>>(_ => [S3("not json{")]);
+
+        var report = await h.Service.ReconcileAsync(enforce: true);
+
+        report.Aborted.Should().NotBeEmpty();
+        await h.Writer.DidNotReceive().RevokeAsync(
+            Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reconcile_ImplausiblyManyCandidates_TripsCircuitBreaker()
+    {
+        var h = Build(maxDeletePerTick: 1);
+        h.Connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<Connection>>(_ => [S3("{\"allowedLocations\":[\"kept-bucket\"]}")]);
+        h.Reader.ListAllAsync("us-east-1", Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<AccessGrantDetail>>(_ =>
+                [GroupGrant("s3://gone-a/*", "g1"), GroupGrant("s3://gone-b/*", "g2")]);
+
+        var report = await h.Service.ReconcileAsync(enforce: true);
+
+        report.Aborted.Should().NotBeEmpty();
+        report.Deleted.Should().Be(0);
+        // The breaker fires before provenance is even read.
+        await h.Writer.DidNotReceive().FilterManagedAsync(
+            Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        await h.Writer.DidNotReceive().RevokeAsync(
+            Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reconcile_TaggedOrphan_IsDeleted()
+    {
+        var h = Build();
+        h.Connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<Connection>>(_ => [S3("{\"allowedLocations\":[\"kept-bucket\"]}")]);
+        h.Reader.ListAllAsync("us-east-1", Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<AccessGrantDetail>>(_ => [GroupGrant("s3://gone-bucket/*", "g1")]);
+        h.Writer.FilterManagedAsync("us-east-1", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<string>>(_ => ["arn:g1"]);
+        h.Writer.RevokeAsync("us-east-1", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new GrantRevokeResult(["g1"], [], [], AccessDenied: false));
+
+        var report = await h.Service.ReconcileAsync(enforce: true);
+
+        report.Deleted.Should().Be(1);
+        await h.Writer.Received().RevokeAsync(
+            "us-east-1",
+            Arg.Is<IReadOnlyList<string>>(ids => ids.Contains("g1")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reconcile_UntaggedOrphan_IsNeverDeleted()
+    {
+        var h = Build();
+        h.Connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<Connection>>(_ => [S3("{\"allowedLocations\":[\"kept-bucket\"]}")]);
+        h.Reader.ListAllAsync("us-east-1", Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<AccessGrantDetail>>(_ => [GroupGrant("s3://gone-bucket/*", "g1")]);
+        // Provenance says it is not ours.
+        h.Writer.FilterManagedAsync("us-east-1", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<string>>(_ => []);
+
+        var report = await h.Service.ReconcileAsync(enforce: true);
+
+        report.Orphaned.Should().Be(1);
+        report.Deleted.Should().Be(0);
+        await h.Writer.DidNotReceive().RevokeAsync(
+            Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## What this is

The full AWS S3 Access Grant management stack for per-user search permissions, reviewed and hardened:

1. **Create** — Connapse's own AWS identity creates the S3 access grants that scope per-user search, from the connection page (supersedes the CloudShell paste).
2. **Cleanup** — a fail-closed reconciler (Hangfire sweep + admin button) deletes grants Connapse created that no connection needs any more, gated by a provenance tag.
3. **Role-permission update** — a provider-page affordance that regenerates the `put-role-policy` command so an admin can bring an existing role up to date when Connapse's permissions change.
4. **The `sso`/`identitystore` permission fix** that makes directory-group grant creation actually work (found via CloudTrail).

Supersedes #461 (which was the cleanup subset only). This branch is a superset.

## ⚠️ Stacked

Targets `epic/aws-per-user-permissions`; the diff includes the create feature and a `fix/459` commit because they aren't on the epic yet. The substance is the grant create/cleanup/role-update work.

## Reviews (both required before merge)

**Codex adversarial review** found two genuine fail-open disclosures whose wrong behavior the unit tests had locked in as "correct":
- **Narrowing a connection didn't revoke the over-broad grant** — the reconciler used *symmetric* overlap. Fixed: directional containment (`GrantCoverage.IsScopeWithinAllowed`) — a grant survives only if fully within an allowed location.
- **Changing the grant group didn't revoke the old group's grants** — `SelectOrphans` ignored the configured group. Fixed: a managed grant to any non-configured group is an orphan regardless of scope.

Both wrong tests were corrected.

**Also fixed** (review findings, all with tests):
- TOCTOU race — the reconciler re-validates against a fresh union immediately before deleting.
- Circuit breaker ran before provenance and counted untrusted candidates — now runs after provenance on the managed count, so unrelated admin orphans can't block (or weaponise) cleanup.
- Empty-union handling — a *successful* read finding no S3 connections now cleans up the (orphaned) grants, capped by the breaker; a read *failure* aborts.
- Delete call guarded like the adjacent reads.
- `AwsRolePolicyUpdate` rejects role names outside IAM's grammar before the unquoted shell interpolation (injection guard); single-line JSON command (PowerShell-safe).
- Root-location lookup paginates.
- Providers page copy no longer claims the role is "four read-only permissions"; grant button requires a region.

**Accepted residuals (second Codex pass), with reasoning:**
- The TOCTOU window between the re-read and the AWS delete can't be fully closed without a lock spanning a DB read and an external call; worst case is a just-added grant deleted then re-granted — recoverable, background job. Documented and accepted.
- `GrantCoverage.Normalise` is shared with the shipped create-direction coverage; the flagged location-grammar edge is pre-existing, not a regression. Optional canonicalization tracked as follow-up.

## Deferred hardening (tracked as follow-up tasks)

- **IAM policy tag-conditions** — scope `Create/DeleteAccessGrant` to `connapse:managed` grants at the IAM level (defense-in-depth beyond the app's provenance gate). Needs live-AWS validation.
- **Per-instance provenance tag** (multi-deployment safety), **create no-op on a same-scope WRITE/other-app grant**, and **grants in a region whose last connection was removed**.

## Tested

**1,683 unit tests pass**; full solution builds clean. New coverage across the grant planner, writer (create/delete/provenance), reconciler selector (directional + group-aware), the fail-closed reconcile service (empty-union, breaker ordering, TOCTOU re-validate, provenance gate), the role-policy command (incl. injection cases), and the policy.

## Not verified here

Live-AWS round-trips (create/tag/delete) and the admin UI walkthroughs need a configured environment; implemented and built, exercised manually against a test instance during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
