### PR TITLE
fix: audit AWS provider, S3 connection, and S3 source config pages (#468)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ See [SECURITY.md](SECURITY.md) for the full security policy.
 - [Architecture Guide](docs/architecture.md) - System design and component overview
 - [API Reference](docs/api.md) - REST API endpoints and examples
 - [Connectors Guide](docs/connectors.md) - Connector types, configuration, and background sync
+- [AWS Setup](docs/aws-setup.md) - Roles Anywhere access, IAM Identity Center, S3 Access Grants, troubleshooting
 - [Azure Identity Setup](docs/azure-identity-setup.md) - Azure AD OAuth2+PKCE integration
 - [Deployment Guide](docs/deployment.md) - Docker and production setup
 - [Security Policy](SECURITY.md) - Security limitations and roadmap

--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -1,0 +1,137 @@
+# AWS Setup
+
+> Part of [Connapse](https://github.com/Destrayon/Connapse) — open-source AI knowledge management platform.
+
+Connapse reads S3 as its own AWS identity, issued through **IAM Roles Anywhere**: a certificate
+generated on the Connapse host, exchanged with AWS for short-lived credentials. No access key is
+ever pasted in or stored. Per-user search permissions come from **S3 Access Grants**, read through
+**IAM Identity Center**; Connapse only reads grants, it never creates or deletes one.
+
+Everything below is configured on **Admin → Providers → AWS** (`/admin/providers/aws`), then a
+**connection** names which buckets may be used and a **source** picks one to index.
+
+## Prerequisites
+
+| Need | Why |
+|------|-----|
+| An AWS account, and a person who can open [CloudShell](https://console.aws.amazon.com/cloudshell/home) in it | Every guided step is one command pasted into CloudShell |
+| Permission for that person to run `iam:CreateRole`, `iam:PutRolePolicy`, `rolesanywhere:CreateTrustAnchor`, `rolesanywhere:CreateProfile` (plus the matching `Get`/`List` calls and `sts:GetCallerIdentity`) | The Access step creates a role, trust anchor, and profile |
+| Connapse served over **HTTPS**, or reached on `localhost` | Required only for per-user permissions: a SAML assertion is a bearer credential and is refused over plain HTTP elsewhere |
+| An IAM Identity Center instance, if you want per-user permissions | Grants are held against directory users and groups |
+
+Nothing on the provider page is required for a plain install. A deployment that reads S3 through an
+instance or task role can skip the Access step; the card says so when it detects that.
+
+## Step 1 — Access
+
+**What it is:** the identity Connapse syncs S3 with. Connections choose buckets; this decides whether any of them can reach AWS at all.
+
+### Easy setup with CloudShell (recommended)
+
+1. Enter the **AWS region** the trust anchor and profile should live in (for example `us-east-1`).
+2. Choose **Generate setup command**. Connapse mints a certificate locally; the private key never leaves the host.
+3. Copy the command, open CloudShell, paste it, and copy the block it prints (both `-----` marker lines included).
+4. Paste that block back into **Paste what it printed** and choose **Check and save**. Connapse asks AWS for a session with the new credential before storing anything, so a bad run never replaces a working one.
+
+Keep the page open until step 4 is done: the generated key exists only in that page. An abandoned run leaves one unused trust anchor in AWS, which the next run replaces.
+
+The role it creates is read-only: every S3 bucket in the account, plus the S3 Access Grants and Identity Center reads that per-user permissions need. Choose **Update role permissions** after upgrading Connapse to re-apply the current policy; Connapse never edits IAM itself.
+
+### Manual values
+
+For a Roles Anywhere setup you made yourself. Every field is verified against AWS before saving.
+
+| Field | Required | Where to get it |
+|-------|----------|-----------------|
+| Region | Yes | The region you created the trust anchor and profile in |
+| Certificate (PEM) | Yes | The certificate registered as the trust anchor, or a leaf it issued directly. Intermediate CAs are not supported |
+| Trust anchor ARN | Yes | [IAM Roles Anywhere console → Trust anchors](https://console.aws.amazon.com/rolesanywhere/home#/trust-anchors), on the trust anchor's page |
+| Role ARN | Yes | [IAM console → Roles](https://console.aws.amazon.com/iam/home#/roles), on the role's summary page |
+| Profile ARN | Yes | [IAM Roles Anywhere console → Profiles](https://console.aws.amazon.com/rolesanywhere/home#/profiles), on the profile's page |
+| Private key (PEM) | First save only | The key matching the certificate. Stored encrypted, never shown again; leave blank when editing to keep the current one |
+
+### Health
+
+The card shows when the credential was stored, when AWS last honoured it, and when the certificate expires. **Recheck** re-tests without re-entering anything. An expired certificate is reported as such and S3 sources stop syncing until access is set up again.
+
+**Remove stored credential** deletes only Connapse's copy. The trust anchor and profile stay enabled in AWS until you run the cleanup command the page shows afterwards.
+
+## Step 2 — IAM Identity Center
+
+**What it is:** the directory a person is looked up in when Connapse checks what they may read. This step only finds it; nothing is created.
+
+Identity Center lives in exactly one region per organisation, and looking in the wrong region reads as there being no instance at all. The guided scan runs a read-only command in CloudShell and prints what it found; paste the block back and choose **Use this instance**.
+
+| Field | Required | Where to get it |
+|-------|----------|-----------------|
+| Region | Yes | The one region the instance lives in |
+| Identity store ID | Yes | [IAM Identity Center console](https://console.aws.amazon.com/singlesignon/home) → Settings, beside the instance ARN (`d-…`) |
+| Instance ARN | Yes | Same page, or `aws sso-admin list-instances` (`arn:aws:sso:::instance/ssoins-…`) |
+
+## Step 3 — Per-user permissions
+
+**What it is:** the Identity Center application a person signs into to prove which directory user they are. Connapse uses it to filter search results to the S3 locations their access grants cover.
+
+The guided setup deploys a CloudFormation template that creates the S3 Access Grants instance and registers the `s3://` location. The SAML application itself must be created in the console — AWS offers no API for it. Labels on the form match the console's own names.
+
+| Field | Direction | Where to get it |
+|-------|-----------|-----------------|
+| Application SAML audience | Give to AWS | Prefilled from Connapse's address; type it into the application's metadata page |
+| Application ACS URL | Give to AWS | Prefilled from Connapse's address; type it into the same page |
+| IAM Identity Center SAML issuer URL | Take from AWS | In the **IAM Identity Center metadata** file the application page offers to download; pasting the whole file into the guided step fills all three |
+| IAM Identity Center sign-in URL | Take from AWS | Same file |
+| IAM Identity Center certificate | Take from AWS | Same file. Base64, with or without the `BEGIN CERTIFICATE` lines |
+
+Two things to get right in the console:
+
+- **Attribute mappings:** `Subject` → `${user:subject}`, format `unspecified`. Not `${user:preferredUsername}`, which gives the display name and matches nobody.
+- **Assign** the people or groups who may sign in. AWS refuses to turn the assignment requirement off for a SAML application.
+
+Grants are created in the S3 console (**S3 → Access Grants → Create grant**), naming a directory user or group and a bucket, prefix, or object. Connapse honours a new grant within a minute. Until a grant exists for a bucket, searches over it return nothing to anyone: filtering hides what it cannot confirm.
+
+**Buckets outside the Identity Center region are not covered.** See [covering buckets outside the Identity Center region](aws-per-user-permissions-multi-region.md).
+
+## Connection (Amazon S3)
+
+On **Connections → Add connection**, provider **Amazon S3**.
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| Name | Yes | Filled in from the first bucket you choose if left blank |
+| Allowed locations | No, but recommended | One bucket or `bucket/prefix/` per line. **Choose from buckets Connapse can see** lists them; each choice fills the region and the test target. Empty allows anything the identity can reach, logged as a warning at each sync |
+| Region | No | Looked up from the bucket. Set it only to override |
+| Role ARN (Cross-account access) | No | A role in another account that Connapse's identity may assume. From the role's summary page in the IAM console |
+| Bucket to test against | For testing | Not saved |
+
+**Test connection** reports which layers passed — reached AWS, authenticated, authorised, listed the bucket — and offers the raw AWS error on demand.
+
+## Source
+
+On **Sources → New source**, pick the connection; the **Bucket** list offers exactly what the connection allows. **Prefix** narrows the source to a subtree. Name is filled in from the bucket if left blank.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Access card: *Connapse has no AWS identity yet* | Nothing stored and nothing in the environment | Run the easy setup, or enter manual values |
+| *AWS did not accept this credential* on Check and save | Wrong region, a mistyped ARN, a certificate that does not match the key, or clock skew on the host | Re-check each value against the console; the message quotes AWS's reason. Nothing was changed |
+| Access card stays *Provisioning* | IAM is eventually consistent | Wait a minute and choose **Recheck** |
+| Access card says *authenticates but cannot read S3* | The role's policy is missing or out of date | Choose **Update role permissions** and run the command |
+| Test: *Authenticated, but not allowed to list bucket* | The identity lacks `s3:ListBucket`/`s3:GetObject` on that bucket, or the Role ARN is wrong | Attach the policy shown under **IAM policy granting exactly this access**, or fix the Role ARN |
+| Test: *no bucket … exists in <region>* | Wrong name, or wrong region | Choose the bucket from the list; clear the region so it is looked up |
+| Test: *Connapse has no AWS identity to test with* | The Access step is not done | Finish Step 1 |
+| Test: *AWS did not answer within N seconds* | Outbound access to `s3.<region>.amazonaws.com` is blocked | Check the server's network egress |
+| Bucket picker: *This identity may not list buckets* | The identity is scoped to named buckets and lacks `s3:ListAllMyBuckets` | Type the bucket name; this is not an error |
+| Identity Center scan: *The scan was refused* | The CloudShell user lacks `sso:ListInstances` | Add the listed permissions to that user and scan again |
+| Identity Center scan finds nothing | Wrong region, or no instance | Scan from the organisation's management account; enable an instance from the Identity Center console if none exists |
+| Per-user permissions: *cannot receive a sign-in at this address* | Connapse is reached over plain HTTP off loopback | Serve it over HTTPS, or open it on `localhost` |
+| Sign-in fails with a destination or audience mismatch | Connapse's address changed after the application was registered | Update the ACS URL and audience in the application to the values the form shows |
+| Sign-in works but every S3 search returns nothing | No grant covers the bucket, `Subject` is mapped to the display name, or the bucket is outside the Identity Center region | Create a grant; fix the attribute mapping; see the multi-region note above |
+| Sign-in stopped working after months | Identity Center rotated its certificate | Paste the new **IAM Identity Center certificate** into the form |
+| Sync stopped and the Access card says the certificate expired | The Roles Anywhere certificate reached its end date | Generate a new setup command and save; then run the cleanup command for the old trust anchor |
+
+## Removing AWS
+
+1. **Remove stored credential** on the Access card, then run the cleanup command it prints in CloudShell to delete the trust anchor, profile, and role.
+2. **Reset SAML application** clears the sign-in values; per-user filtering stays on, so S3 searches return nothing for anyone until it is set up again.
+3. Delete the application in the Identity Center console, and the Access Grants instance in the S3 console, if nothing else uses them.

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -44,7 +44,7 @@ Connections are created and edited on the **Connections** page, by administrator
 
 There is no secret field on a connection form, because Connapse does not accept pasted cloud keys.
 
-- **S3** authenticates through the AWS default credential chain — an instance profile, an IRSA role, or an SSO session. `roleArn` optionally names a role to assume on top of that.
+- **S3** authenticates as the identity set up on the AWS provider page (IAM Roles Anywhere, short-lived credentials from a locally generated certificate), or through the AWS default credential chain when nothing is stored there. `roleArn` optionally names a role to assume on top of that. See [AWS Setup](aws-setup.md).
 - **Azure Blob** authenticates through `DefaultAzureCredential` — a managed identity, a workload identity, or a developer sign-in. `managedIdentityClientId` optionally selects a specific user-assigned identity.
 - **Filesystem** has no credential at all; it runs as whatever account the server runs as.
 - **SFTP** is the one exception, and it is a narrow one: an SSH private key, encrypted at rest with the same DataProtection machinery everything else uses. The rule this does not break is about **cloud identities** — an AWS access key or an Azure secret is a credential a cloud provider already offers a better answer for, and Connapse refuses to be the worse one. An SSH key for a machine you run has no such alternative.

--- a/src/Connapse.Storage/ConnectionTesters/S3ConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/S3ConnectionTester.cs
@@ -21,12 +21,6 @@ namespace Connapse.Storage.ConnectionTesters;
 /// Through <see cref="ConnapseAwsCredentials"/>, which is the whole point of the test: it has to
 /// run as the thing that will do the work, or a pass means nothing.
 /// <para>
-/// It did not. Both clients were built without credentials, so the SDK fell back to its own default
-/// chain and never saw the key Connapse stores — the bucket picker beside this button listed
-/// buckets happily while the test reported "No AWS credentials found", from the same page, about
-/// the same account.
-/// </para>
-/// <para>
 /// A <c>RoleArn</c> is still assumed via STS when one is given, but from these credentials rather
 /// than from whatever the environment happens to offer.
 /// </para>
@@ -55,14 +49,20 @@ public class S3ConnectionTester : IConnectionTester
         var stopwatch = Stopwatch.StartNew();
         timeout ??= TimeSpan.FromSeconds(15);
 
+        // Named here so a failure message can say which bucket and region it was about.
+        string bucket = "?";
+        string regionName = "?";
+
         try
         {
             var config = ExtractConfig(settings);
+            bucket = config.BucketName;
+            regionName = config.Region;
 
             if (string.IsNullOrWhiteSpace(config.BucketName))
             {
                 return ConnectionTestResult.CreateFailure(
-                    "Bucket name is required",
+                    "Enter a bucket to test against.",
                     new Dictionary<string, object> { ["error"] = "Missing BucketName in config" });
             }
 
@@ -116,10 +116,12 @@ public class S3ConnectionTester : IConnectionTester
 
             var objectCount = listResponse.S3Objects?.Count ?? 0;
             var hasMore = listResponse.IsTruncated == true;
-            var message = $"Connected to S3 bucket '{config.BucketName}' in {config.Region}"
-                + (objectCount > 0
-                    ? $" ({objectCount}{(hasMore ? "+" : "")} object{(objectCount != 1 ? "s" : "")} found{(string.IsNullOrEmpty(config.Prefix) ? "" : $" under prefix '{config.Prefix}'")})"
-                    : $" (empty{(string.IsNullOrEmpty(config.Prefix) ? "" : $" under prefix '{config.Prefix}'")})");
+            // Says which layers passed: reached AWS, authenticated, authorised, and read the bucket.
+            string where = string.IsNullOrEmpty(config.Prefix) ? "" : $" under prefix '{config.Prefix}'";
+            string what = objectCount > 0
+                ? $"{objectCount}{(hasMore ? "+" : "")} object{(objectCount != 1 ? "s" : "")} found{where}"
+                : $"it is empty{where}";
+            var message = $"Reached AWS, authenticated, and listed bucket '{config.BucketName}' in {config.Region}: {what}.";
 
             return ConnectionTestResult.CreateSuccess(
                 message,
@@ -139,12 +141,20 @@ public class S3ConnectionTester : IConnectionTester
             stopwatch.Stop();
             _logger.LogWarning(ex, "S3 connection test failed with S3 error");
 
+            // Each one says which layer failed and what to change. The raw reason travels in the
+            // details, for the operator who wants it.
             var errorMessage = ex.StatusCode switch
             {
-                System.Net.HttpStatusCode.Forbidden => "Access denied: Insufficient permissions on this bucket",
-                System.Net.HttpStatusCode.Unauthorized => "Authentication failed: No valid AWS credentials found",
-                System.Net.HttpStatusCode.NotFound => "Bucket not found: Check the bucket name and region",
-                _ => $"S3 error: {ex.Message}"
+                System.Net.HttpStatusCode.Forbidden =>
+                    $"Authenticated, but not allowed to list bucket '{bucket}'. Give Connapse's identity "
+                    + "s3:ListBucket and s3:GetObject on it (the policy under the allowed locations does "
+                    + "exactly that), or check the Role ARN.",
+                System.Net.HttpStatusCode.Unauthorized =>
+                    "Reached AWS, but it rejected Connapse's credential. Check the Access step on the AWS provider page.",
+                System.Net.HttpStatusCode.NotFound =>
+                    $"Authenticated, but no bucket '{bucket}' exists in {regionName}. Check the name, or clear "
+                    + "the region so it is looked up from the bucket.",
+                _ => $"S3 refused the request ({ex.ErrorCode ?? "unknown code"}): {ex.Message}"
             };
 
             return ConnectionTestResult.CreateFailure(
@@ -163,8 +173,8 @@ public class S3ConnectionTester : IConnectionTester
             _logger.LogWarning(ex, "S3 connection test failed with client error");
 
             var message = ex.Message.Contains("credentials", StringComparison.OrdinalIgnoreCase)
-                ? "No AWS credentials found. Configure IAM role, environment variables (AWS_ACCESS_KEY_ID), or ~/.aws/credentials."
-                : $"AWS client error: {ex.Message}";
+                ? "Connapse has no AWS identity to test with. Set one up under Access on the AWS provider page."
+                : $"Could not reach AWS: {ex.Message}";
 
             return ConnectionTestResult.CreateFailure(
                 message,
@@ -181,7 +191,8 @@ public class S3ConnectionTester : IConnectionTester
             _logger.LogWarning(ex, "S3 connection test timed out");
 
             return ConnectionTestResult.CreateFailure(
-                $"Connection timed out after {timeout.Value.TotalSeconds:F1}s",
+                $"AWS did not answer within {timeout.Value.TotalSeconds:F0} seconds. Check that this server can reach "
+                + $"s3.{regionName}.amazonaws.com, then try again.",
                 new Dictionary<string, object>
                 {
                     ["error"] = "Timeout",

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -443,7 +443,7 @@
                                     </td>
                                     <td class="text-end">
                                         <button class="btn btn-sm btn-outline-secondary me-1" @onclick="() => StartEdit(c)">Edit</button>
-                                        <button class="btn btn-sm btn-outline-danger" @onclick="() => Delete(c)">Delete</button>
+                                        <button class="btn btn-sm btn-outline-danger" @onclick="() => ConfirmDelete(c)">Delete</button>
                                     </td>
                                 </tr>
                             }
@@ -460,15 +460,22 @@
             <h5>@(isNew ? "Add connection" : $"Edit {editing.Name}")</h5>
         </div>
 
-        <div class="col-md-6">
-            <label class="form-label">Name</label>
-            <input class="form-control" @bind="form.Name" placeholder="prod-docs-bucket" />
-            <div class="form-text">How this connection is referred to when creating a source.</div>
+        <div class="col-12" style="max-width:32rem">
+            <label class="form-label" for="connection-name">Name</label>
+            <input id="connection-name" class="form-control" @bind="form.Name" placeholder="prod-docs-bucket"
+                   aria-describedby="connection-name-help" />
+            <div id="connection-name-help" class="form-text">
+                How this connection is referred to when creating a source.
+                @if (form.Provider == ConnectionProvider.S3)
+                {
+                    <text>Filled in from the first bucket you choose if left blank.</text>
+                }
+            </div>
         </div>
 
-        <div class="col-md-6">
-            <label class="form-label">Provider</label>
-            <select class="form-select" @bind="form.Provider" disabled="@(!isNew)">
+        <div class="col-12" style="max-width:32rem">
+            <label class="form-label" for="connection-provider">Provider</label>
+            <select id="connection-provider" class="form-select" @bind="form.Provider" disabled="@(!isNew)">
                 <option value="@ConnectionProvider.S3">Amazon S3</option>
                 <option value="@ConnectionProvider.AzureBlob">Azure Blob Storage</option>
                 <option value="@ConnectionProvider.Filesystem">Local filesystem</option>
@@ -515,32 +522,6 @@
                 </div>
             }
 
-            @* Region is filled in by choosing a bucket below, and a cross-account role is a thing
-               most installations never touch. Both were first-screen fields on a form whose real
-               question is "which bucket", which is the one thing that was not asked directly. *@
-            <div class="col-md-6">
-                <label class="form-label">Region <span class="text-muted">(optional)</span></label>
-                <input class="form-control" @bind="form.Region" placeholder="Found from the bucket" />
-                <div class="form-text">
-                    Connapse asks AWS where the bucket lives when you choose one below. Set it only
-                    to override that.
-                </div>
-            </div>
-
-            <div class="col-12">
-                <details>
-                    <summary class="small text-muted" style="cursor:pointer">Cross-account access</summary>
-                    <div class="mt-2" style="max-width:32rem">
-                        <label class="form-label">Role ARN</label>
-                        <input class="form-control" @bind="form.RoleArn"
-                               placeholder="arn:aws:iam::123456789012:role/connapse" />
-                        <div class="form-text">
-                            Assumed via STS, so this connection reads another account's buckets
-                            rather than Connapse's own. Leave blank unless that is what you need.
-                        </div>
-                    </div>
-                </details>
-            </div>
         }
         else if (form.Provider == ConnectionProvider.AzureBlob)
         {
@@ -621,16 +602,17 @@
             </div>
 
             <div class="col-12">
-                <label class="form-label">
+                <label class="form-label" for="sftp-key">
                     Private key
                     @if (!isNew)
                     {
-                        <span class="text-muted">— leave blank to keep the stored key</span>
+                        <span class="text-muted">(optional — leave blank to keep the stored key)</span>
                     }
                 </label>
-                <textarea class="form-control font-monospace" rows="5" @bind="form.PrivateKey"
-                          placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;…"></textarea>
-                <div class="form-text">
+                <SecretTextArea Id="sftp-key" Rows="5" DescribedBy="sftp-key-help"
+                                Placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;…"
+                                @bind-Value="form.PrivateKey" />
+                <div id="sftp-key-help" class="form-text">
                     Encrypted at rest and never shown again. This is an SSH key for a server you run —
                     the rule that Connapse stores no cloud credentials is about AWS and Azure
                     identities, which are not stored and are not asked for.
@@ -645,9 +627,9 @@
             </div>
 
             <div class="col-md-6">
-                <label class="form-label">Key passphrase <span class="text-muted">(optional)</span></label>
-                <input class="form-control" type="password" @bind="form.Passphrase"
-                       placeholder="Only if the key is encrypted" />
+                <label class="form-label" for="sftp-passphrase">Key passphrase <span class="text-muted">(optional)</span></label>
+                <SecretTextArea Id="sftp-passphrase" Multiline="false" @bind-Value="form.Passphrase"
+                                Placeholder="Only if the key is encrypted" />
             </div>
 
             <div class="col-md-6">
@@ -725,17 +707,16 @@
         @if (form.IsCloudProvider)
         {
             <div class="col-12">
-                <label class="form-label">
+                <label class="form-label" for="allowed-locations">
                     Allowed locations <span class="text-muted">(one per line, optional)</span>
                 </label>
-                <textarea class="form-control font-monospace" rows="3" @bind="form.AllowedLocations"
+                <textarea id="allowed-locations" class="form-control font-monospace" rows="3" @bind="form.AllowedLocations"
+                          aria-describedby="allowed-locations-help"
                           placeholder="docs-bucket&#10;shared-bucket/team/"></textarea>
-                <div class="form-text">
-                    Bounds which buckets or containers a source on this connection may name. One
-                    connection credential is shared by every source that uses it, so without this a
-                    source can name anything the credential can reach. An entry naming only a bucket
-                    permits any prefix within it. Leave empty to allow any — currently permitted, with
-                    a warning logged.
+                <div id="allowed-locations-help" class="form-text">
+                    The buckets or containers a source on this connection may name; a bucket alone
+                    permits every prefix in it. Leave empty to allow anything the credential can
+                    reach, which is logged as a warning at each sync.
                 </div>
 
                 @* The list, rather than a name typed from memory. Connapse's own AWS identity is
@@ -750,6 +731,8 @@
                        belong to, and the one you want is found by reading rather than typing. *@
                     <div class="mt-2 position-relative" style="max-width:32rem">
                         <button type="button" class="btn btn-sm btn-outline-secondary"
+                                aria-expanded="@(bucketPickerOpen ? "true" : "false")"
+                                aria-controls="bucket-picker"
                                 @onclick="ToggleBucketPicker" disabled="@listingBuckets">
                             @if (listingBuckets)
                             {
@@ -765,12 +748,13 @@
 
                         @if (bucketPickerOpen)
                         {
-                            <div class="card mt-1 shadow-sm">
+                            <div id="bucket-picker" class="card mt-1 shadow-sm">
                                 <div class="card-body p-2">
                                     @* Escape closes, Enter takes the first match. Whoever is
                                        filtering has their hands on the keyboard already. *@
-                                    <input class="form-control form-control-sm mb-2"
-                                           placeholder="Search buckets"
+                                    <label class="form-label small mb-1" for="bucket-search">Search buckets</label>
+                                    <input id="bucket-search" class="form-control form-control-sm mb-2"
+                                           placeholder="Part of a bucket name"
                                            @bind="bucketFilter" @bind:event="oninput"
                                            @onkeydown="BucketSearchKey" @ref="bucketSearchBox" />
 
@@ -843,15 +827,49 @@
 
 
 
+        @if (form.Provider == ConnectionProvider.S3)
+        {
+            @* After the bucket, because choosing one fills the region in; a cross-account role is
+               a thing most installations never touch, so it stays behind a disclosure. *@
+            <div class="col-12" style="max-width:32rem">
+                <label class="form-label" for="s3-region">Region <span class="text-muted">(optional)</span></label>
+                <input id="s3-region" class="form-control font-monospace" @bind="form.Region"
+                       placeholder="Found from the bucket" aria-describedby="s3-region-help" />
+                <div id="s3-region-help" class="form-text">
+                    Filled in when you choose a bucket above, in the form <code>us-east-1</code>.
+                    Set it only to override that.
+                </div>
+            </div>
+
+            <div class="col-12">
+                <details>
+                    <summary class="small text-muted" style="cursor:pointer">Cross-account access</summary>
+                    <div class="mt-2" style="max-width:32rem">
+                        <label class="form-label" for="s3-role-arn">Role ARN <span class="text-muted">(optional)</span></label>
+                        <input id="s3-role-arn" class="form-control font-monospace" @bind="form.RoleArn"
+                               placeholder="arn:aws:iam::123456789012:role/connapse"
+                               aria-describedby="s3-role-arn-help" />
+                        <div id="s3-role-arn-help" class="form-text">
+                            A role in another account that Connapse's identity may assume, so this
+                            connection reads that account's buckets. Copy it from the role's summary
+                            page in the
+                            <a href="https://console.aws.amazon.com/iam/home#/roles" target="_blank" rel="noopener">IAM console</a>.
+                        </div>
+                    </div>
+                </details>
+            </div>
+        }
+
         @* ── Test ──────────────────────────────────────────────────── *@
         @if (form.IsCloudProvider)
         {
-            <div class="col-md-6">
-                <label class="form-label">
+            <div class="col-12" style="max-width:32rem">
+                <label class="form-label" for="probe-target">
                     @(form.Provider == ConnectionProvider.S3 ? "Bucket to test against" : "Container to test against")
                 </label>
-                <input class="form-control" @bind="probeTarget" placeholder="@ProbePlaceholder()" />
-                <div class="form-text">
+                <input id="probe-target" class="form-control font-monospace" @bind="probeTarget"
+                       placeholder="@ProbePlaceholder()" aria-describedby="probe-target-help" />
+                <div id="probe-target-help" class="form-text">
                     Not saved. The connection holds no bucket of its own, so testing needs one to probe.
                 </div>
             </div>
@@ -886,14 +904,53 @@
         @if (testMessage is not null)
         {
             <div class="col-12 mt-2">
-                <div class="alert @(testSuccess ? "alert-success" : "alert-danger") py-2 mb-0">
-                    <span class="@(testSuccess ? "bi-check-circle" : "bi-x-circle") me-2"></span>
+                <div class="alert @(testSuccess ? "alert-success" : "alert-danger") py-2 mb-0"
+                     role="@(testSuccess ? "status" : "alert")">
+                    <span class="@(testSuccess ? "bi-check-circle" : "bi-x-circle") me-2" aria-hidden="true"></span>
                     @testMessage
+                    @if (!testSuccess && form.Provider == ConnectionProvider.S3)
+                    {
+                        <a class="alert-link ms-1" target="_blank" rel="noopener"
+                           href="https://github.com/Destrayon/Connapse/blob/main/docs/aws-setup.md#troubleshooting">Troubleshooting</a>
+                    }
+                    @if (!testSuccess && testDetail is { Length: > 0 })
+                    {
+                        <details class="mt-1">
+                            <summary class="small">Raw error</summary>
+                            <pre class="small mb-0 mt-1" style="white-space:pre-wrap">@testDetail</pre>
+                        </details>
+                    }
                 </div>
             </div>
         }
     }
 </div>
+
+@if (pendingDelete is not null)
+{
+    <div class="modal show d-block" tabindex="-1" role="dialog" aria-modal="true"
+         aria-labelledby="delete-connection-title" style="background: rgba(0,0,0,.5);">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="delete-connection-title">Delete connection</h5>
+                    <button type="button" class="btn-close" aria-label="Close" @onclick="() => pendingDelete = null"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Delete <strong>@pendingDelete.Name</strong>?</p>
+                    <p class="text-muted small mb-0">
+                        No source uses it, so nothing stops syncing. What it points at is untouched;
+                        only Connapse's record of how to reach it is removed. This cannot be undone.
+                    </p>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" @onclick="() => pendingDelete = null">Cancel</button>
+                    <button class="btn btn-danger" @onclick="DeleteConfirmed">Delete connection</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
 
 @code {
     private List<Connection> connections = [];
@@ -911,6 +968,12 @@
     private bool statusSuccess;
     private string? testMessage;
     private bool testSuccess;
+
+    /// <summary>The provider's own error text behind a failed test, offered on demand.</summary>
+    private string? testDetail;
+
+    /// <summary>The connection whose deletion is awaiting confirmation.</summary>
+    private Connection? pendingDelete;
 
     protected override async Task OnInitializedAsync()
     {
@@ -992,8 +1055,7 @@
     /// </summary>
     /// <remarks>
     /// Through <c>IProviderSetupReader</c> rather than a probe of its own, so this page and the
-    /// provider page cannot disagree about whether AWS is set up. Duplicating that judgement is
-    /// what let the Access card and its own requirement drift apart before.
+    /// provider page cannot disagree about whether AWS is set up.
     /// </remarks>
     private RequirementStatus? awsAccess;
 
@@ -1132,6 +1194,11 @@
         if (string.IsNullOrWhiteSpace(probeTarget))
             probeTarget = bucket;
 
+        // A name nobody has typed is derived from the first bucket, so the common case of one
+        // connection per bucket needs nothing typed twice.
+        if (string.IsNullOrWhiteSpace(form.Name))
+            form.Name = bucket;
+
         await FillRegionFromBucket(bucket);
     }
 
@@ -1163,9 +1230,8 @@
 
     /// <summary>The least-privilege policy for whatever is currently allowed.</summary>
     /// <remarks>
-    /// One document covering every entry. This used to generate a policy per bucket and join them
-    /// with blank lines, which produces two top-level JSON objects — not a policy at all, and IAM
-    /// rejects it. Anyone allowing two buckets was handed output that could not be pasted.
+    /// One document covering every entry: two top-level JSON objects joined by a blank line are
+    /// not a policy, and IAM rejects them.
     /// </remarks>
     private string? S3PolicyForAllowed()
     {
@@ -1443,7 +1509,7 @@
                 await ConnectionStore.CreateAsync(
                     new CreateConnectionRequest(form.Name.Trim(), form.Provider, config, secret),
                     createdByUserId: null);
-                Succeed($"Connection '{form.Name.Trim()}' created.{HostRewriteSuffix()}");
+                Succeed($"Connection '{form.Name.Trim()}' created. Add a source on it to start indexing.{HostRewriteSuffix()}");
             }
             else
             {
@@ -1476,7 +1542,8 @@
         }
     }
 
-    private async Task Delete(Connection connection)
+    /// <summary>Refuses while sources depend on the connection; otherwise asks before deleting.</summary>
+    private void ConfirmDelete(Connection connection)
     {
         statusMessage = null;
 
@@ -1487,6 +1554,14 @@
             Fail($"'{connection.Name}' still has {connection.SourceCount} source(s) using it. Remove or repoint them first.");
             return;
         }
+
+        pendingDelete = connection;
+    }
+
+    private async Task DeleteConfirmed()
+    {
+        if (pendingDelete is not { } connection) return;
+        pendingDelete = null;
 
         try
         {
@@ -1532,10 +1607,17 @@
         return (credential.PrivateKey, NullIfBlank(form.Passphrase) ?? credential.Passphrase, null);
     }
 
+    /// <summary>The provider's own error text from a failed test, or null when there is none to show.</summary>
+    private static string? RawError(ConnectionTestResult result) =>
+        !result.Success && result.Details is { } details && details.TryGetValue("error", out object? raw)
+            ? raw?.ToString()
+            : null;
+
     private async Task Test()
     {
         testing = true;
         testMessage = null;
+        testDetail = null;
 
         try
         {
@@ -1575,6 +1657,7 @@
                 }, TimeSpan.FromSeconds(15));
 
                 testSuccess = sftpResult.Success;
+                testDetail = RawError(sftpResult);
 
                 // Which key was used, always. Two keys can be in play and they can disagree, so
                 // a bare "Connected" would leave the operator unsure what they just proved.
@@ -1626,6 +1709,7 @@
 
             testSuccess = result.Success;
             testMessage = result.Message;
+            testDetail = RawError(result);
         }
         catch (Exception ex)
         {

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -23,7 +23,9 @@
 @inject IJSRuntime JS
 @inject NavigationManager Navigation
 @inject ILogger<Providers> Logger
+@inject IAuditLogger AuditLogger
 @using System.Security.Claims
+@using System.Security.Cryptography.X509Certificates
 @using Microsoft.AspNetCore.Components.Authorization
 @rendermode InteractiveServer
 
@@ -138,6 +140,17 @@
 
         <h1 class="mb-3"><span class="bi-cloud-fill me-2"></span>@Current.DisplayName</h1>
 
+        @if (Key == "aws")
+        {
+            <p class="text-muted">
+                Three steps: the identity Connapse reads S3 with, the directory people are looked up
+                in, and the application they sign into. Every field, where to find its value, and
+                what each error means are in the
+                <a href="https://github.com/Destrayon/Connapse/blob/main/docs/aws-setup.md"
+                   target="_blank" rel="noopener">AWS setup guide</a>.
+            </p>
+        }
+
         @* AWS renders status and setup together below. Repeating these cards above those sections
            made the page read like two separate checklists for the same work. *@
         @if (Key != "aws")
@@ -191,8 +204,9 @@
         @if (!string.IsNullOrEmpty(saveMessage))
         {
             <div class="alert @(saveSuccess ? "alert-success" : "alert-danger") alert-dismissible fade show" role="alert">
+                <span class="@(saveSuccess ? "bi-check-circle" : "bi-x-circle") me-2" aria-hidden="true"></span>
                 @saveMessage
-                <button type="button" class="btn-close" @onclick="() => saveMessage = null"></button>
+                <button type="button" class="btn-close" aria-label="Dismiss" @onclick="() => saveMessage = null"></button>
             </div>
         }
 
@@ -205,12 +219,41 @@
                               StatusLabel="@RequirementLabel(AccessStatus)"
                               @bind-Expanded="showSetup"
                               EditLabel="Update or replace"
-                              EasyTitle="Easy setup with AWS CloudShell">
+                              EasyTitle="Easy setup with AWS CloudShell"
+                              EasyOpen="true">
                 <Summary>
                     <div>@AccessSummary</div>
                     @if (AccessRequirement?.Detail is { Length: > 0 } detail)
                     {
                         <div class="text-body-secondary font-monospace text-break">@detail</div>
+                    }
+                    @if (raStatus is { } stored)
+                    {
+                        <dl class="provider-step-values mt-2 mb-0">
+                            <dt>Stored</dt><dd>@stored.CreatedAt.ToString("u")</dd>
+                            <dt>Last confirmed</dt><dd>@(stored.VerifiedAt is { } confirmed ? confirmed.ToString("u") : "Not yet")</dd>
+                            @if (raCertificateExpires is { } expires)
+                            {
+                                <dt>Certificate expires</dt><dd>@expires.ToString("u")</dd>
+                            }
+                        </dl>
+                        @if (raCertificateExpires is { } expired && expired <= DateTime.UtcNow)
+                        {
+                            <div class="alert alert-danger py-2 mt-2 mb-0 small" role="alert">
+                                <span class="bi-x-circle me-1" aria-hidden="true"></span>
+                                The certificate has expired, so AWS refuses this credential and S3
+                                sources no longer sync. Set access up again below: generate a new
+                                command, or paste a new certificate and key.
+                            </div>
+                        }
+                        else if (raCertificateExpires is { } soon && soon <= DateTime.UtcNow.AddDays(30))
+                        {
+                            <div class="alert alert-warning py-2 mt-2 mb-0 small" role="status">
+                                <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                The certificate expires in @((soon - DateTime.UtcNow).Days) days. Generate
+                                a new setup command before then, or S3 sources stop syncing.
+                            </div>
+                        }
                     }
                     @if (AccessMode == AwsAccessMode.NotStored && EnvironmentCredentialResolves)
                     {
@@ -227,75 +270,104 @@
                 <ManualContent>
                     @* Bring-your-own: an administrator who provisioned Roles Anywhere themselves
                        enters their own ARNs and the certificate + key they registered. Hidden only
-                       while the requirements are still loading. *@
+                       while the requirements are still loading. Collapsed until a credential is
+                       stored: the guided setup below is the main route, and this is the edit form
+                       for what it stored. Fields run in the order the values are made in AWS. *@
                     @if (AccessMode is AwsAccessMode.RolesAnywhere or AwsAccessMode.NotStored)
                     {
-                        <div class="border rounded p-3 mb-3">
-                            <h3 class="h6 mb-1">Manual values</h3>
-                            <p class="small text-muted mb-3">
-                                Already set up IAM Roles Anywhere yourself? Enter the trust-anchor,
-                                profile, and role ARNs, the region, and the certificate + private key
-                                you registered. Connapse verifies them with AWS before saving.
+                        <details class="border rounded p-3 mb-3" open="@hasStoredRaCredential">
+                            <summary class="fw-semibold small">Manual values — a Roles Anywhere setup you made yourself</summary>
+                            <p class="small text-muted mt-3 mb-3">
+                                Enter the region, certificate, ARNs, and private key you registered in
+                                IAM Roles Anywhere. Connapse verifies them with AWS before saving.
+                                @if (hasStoredRaCredential)
+                                {
+                                    <text>Everything except the private key is filled in from the stored credential.</text>
+                                }
                             </p>
-                            <p class="small text-muted mb-3">
-                                <span class="bi-info-circle me-1"></span>
-                                The certificate must be the one registered as your trust anchor, or a
-                                leaf issued directly by it. Certificates issued through an intermediate
-                                CA are not supported yet.
-                            </p>
-                            <div class="row g-2">
-                                <div class="col-md-6">
-                                    <label class="form-label small" for="ra-ta">Trust anchor ARN</label>
-                                    <input id="ra-ta" class="form-control form-control-sm font-monospace"
-                                           autocomplete="off" @bind="manualTrustAnchorArn" />
-                                </div>
-                                <div class="col-md-6">
-                                    <label class="form-label small" for="ra-profile">Profile ARN</label>
-                                    <input id="ra-profile" class="form-control form-control-sm font-monospace"
-                                           autocomplete="off" @bind="manualProfileArn" />
-                                </div>
-                                <div class="col-md-6">
-                                    <label class="form-label small" for="ra-role">Role ARN</label>
-                                    <input id="ra-role" class="form-control form-control-sm font-monospace"
-                                           autocomplete="off" @bind="manualRoleArn" />
-                                </div>
-                                <div class="col-md-6">
+                            <div class="row g-2" style="max-width:44rem">
+                                <div class="col-12">
                                     <label class="form-label small" for="ra-region">Region</label>
                                     <input id="ra-region" class="form-control form-control-sm font-monospace"
-                                           placeholder="us-east-1" autocomplete="off" @bind="manualRegion" />
+                                           placeholder="us-east-1" aria-describedby="ra-region-help"
+                                           @bind="manualRegion" />
+                                    <div id="ra-region-help" class="form-text">
+                                        The region the trust anchor and profile were created in.
+                                    </div>
                                 </div>
                                 <div class="col-12">
                                     <label class="form-label small" for="ra-cert">Certificate (PEM)</label>
                                     <textarea id="ra-cert" class="form-control form-control-sm font-monospace"
-                                              rows="3" autocomplete="off" @bind="manualCertPem"></textarea>
+                                              rows="3" placeholder="-----BEGIN CERTIFICATE-----"
+                                              aria-describedby="ra-cert-help" @bind="manualCertPem"></textarea>
+                                    <div id="ra-cert-help" class="form-text">
+                                        The certificate registered as the trust anchor, or a leaf it issued
+                                        directly. Certificates issued through an intermediate CA are not supported.
+                                    </div>
+                                </div>
+                                <div class="col-12">
+                                    <label class="form-label small" for="ra-ta">Trust anchor ARN</label>
+                                    <input id="ra-ta" class="form-control form-control-sm font-monospace"
+                                           placeholder="arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/…"
+                                           aria-describedby="ra-ta-help" @bind="manualTrustAnchorArn" />
+                                    <div id="ra-ta-help" class="form-text">
+                                        Shown on the trust anchor's page in the
+                                        <a href="https://console.aws.amazon.com/rolesanywhere/home#/trust-anchors"
+                                           target="_blank" rel="noopener">IAM Roles Anywhere console</a>.
+                                    </div>
+                                </div>
+                                <div class="col-12">
+                                    <label class="form-label small" for="ra-role">Role ARN</label>
+                                    <input id="ra-role" class="form-control form-control-sm font-monospace"
+                                           placeholder="arn:aws:iam::123456789012:role/connapse"
+                                           aria-describedby="ra-role-help" @bind="manualRoleArn" />
+                                    <div id="ra-role-help" class="form-text">
+                                        The role the profile allows. Copy it from the role's summary page in the
+                                        <a href="https://console.aws.amazon.com/iam/home#/roles"
+                                           target="_blank" rel="noopener">IAM console</a>.
+                                    </div>
+                                </div>
+                                <div class="col-12">
+                                    <label class="form-label small" for="ra-profile">Profile ARN</label>
+                                    <input id="ra-profile" class="form-control form-control-sm font-monospace"
+                                           placeholder="arn:aws:rolesanywhere:us-east-1:123456789012:profile/…"
+                                           aria-describedby="ra-profile-help" @bind="manualProfileArn" />
+                                    <div id="ra-profile-help" class="form-text">
+                                        Shown on the profile's page in the
+                                        <a href="https://console.aws.amazon.com/rolesanywhere/home#/profiles"
+                                           target="_blank" rel="noopener">IAM Roles Anywhere console</a>.
+                                    </div>
                                 </div>
                                 <div class="col-12">
                                     <label class="form-label small" for="ra-key">
                                         Private key (PEM)
                                         @if (hasStoredRaCredential)
                                         {
-                                            <span class="text-muted">— leave blank to keep the current key</span>
+                                            <span class="text-muted">(optional — leave blank to keep the current key)</span>
                                         }
                                     </label>
-                                    <textarea id="ra-key" class="form-control form-control-sm font-monospace"
-                                              rows="3" autocomplete="off" @bind="manualPrivateKeyPem"
-                                              placeholder="@(hasStoredRaCredential ? "Kept unless you paste a new key" : null)"></textarea>
+                                    <SecretTextArea Id="ra-key" Rows="3" CssClass="form-control-sm"
+                                                    Placeholder="@(hasStoredRaCredential ? "Kept unless you paste a new key" : "-----BEGIN PRIVATE KEY-----")"
+                                                    DescribedBy="ra-key-help" @bind-Value="manualPrivateKeyPem" />
+                                    <div id="ra-key-help" class="form-text">
+                                        The key matching the certificate above. Stored encrypted and never shown again.
+                                    </div>
                                 </div>
                             </div>
                             <button type="button" class="btn btn-sm btn-primary mt-3"
                                     disabled="@(!CanSaveManualRa || awsBusy)"
                                     @onclick="SaveManualRolesAnywhere">
-                                <span class="bi-save me-1"></span> Check and save
-                            </button>
-                            <div class="form-text">
-                                The private key is the only secret here and is never shown back; it is
-                                stored encrypted, the same way SFTP private keys are.
-                                @if (hasStoredRaCredential)
+                                @if (awsBusy)
                                 {
-                                    <text>The other values are filled in from the stored credential.</text>
+                                    <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
                                 }
-                            </div>
-                        </div>
+                                else
+                                {
+                                    <span class="bi-save me-1" aria-hidden="true"></span>
+                                }
+                                Check and save
+                            </button>
+                        </details>
                     }
                 </ManualContent>
                 <EasyContent>
@@ -344,12 +416,23 @@
                             buckets its sources may actually name.
                         </p>
 
+                        <p class="small mb-2">
+                            <span class="bi-person-check me-1 text-muted" aria-hidden="true"></span>
+                            Run the command as someone allowed to create the role, trust anchor, and
+                            profile: it needs
+                            <code>@string.Join("</code>, <code>", AwsRolesAnywhereSetup.RequiredPermissions)</code>.
+                            It creates nothing else and is safe to run again.
+                        </p>
+
                         <div class="row g-2 mb-2">
                             <div class="col-md-5">
                                 <label class="form-label small mb-1" for="ra-easy-region">AWS region</label>
                                 <input id="ra-easy-region" class="form-control form-control-sm font-monospace"
-                                       placeholder="us-east-1" @bind="raRegion" @bind:event="oninput" />
-                                <div class="form-text">Where the trust anchor and profile are created. Required.</div>
+                                       placeholder="us-east-1" aria-describedby="ra-easy-region-help"
+                                       @bind="raRegion" @bind:event="oninput" />
+                                <div id="ra-easy-region-help" class="form-text">
+                                    Where the trust anchor and profile are created, for example <code>us-east-1</code>.
+                                </div>
                             </div>
                         </div>
 
@@ -385,16 +468,16 @@
                                     <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="CopyRolesAnywhereScript">
                                         <span class="bi-clipboard me-1"></span> Copy command
                                     </button>
-                                    <a class="btn btn-sm btn-primary" target="_blank" rel="noopener"
+                                    <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"
                                        href="https://console.aws.amazon.com/cloudshell/home">
                                         <span class="bi-terminal me-1"></span> Open CloudShell
                                         <span class="bi-box-arrow-up-right ms-1 small"></span>
                                     </a>
-                                    <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")">@copyMessage</span>
+                                    <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
                                 </div>
 
-                                <label class="form-label small mb-1">Paste what it printed</label>
-                                <textarea class="form-control font-monospace" rows="4" @bind="raPasted" @bind:event="oninput"
+                                <label class="form-label small mb-1" for="ra-paste">Paste what it printed</label>
+                                <textarea id="ra-paste" class="form-control font-monospace" rows="4" @bind="raPasted" @bind:event="oninput"
                                           placeholder="@AwsRolesAnywhereSetup.BeginMarker&#10;trustAnchorArn=…&#10;@AwsRolesAnywhereSetup.EndMarker"></textarea>
 
                                 @if (!string.IsNullOrWhiteSpace(raPasted))
@@ -416,7 +499,15 @@
                                             </span>
                                             <button type="button" class="btn btn-sm btn-primary"
                                                     @onclick="() => SaveRolesAnywhereFromScript(parsed)" disabled="@awsBusy">
-                                                <span class="bi-check-lg me-1"></span> Check and save
+                                                @if (awsBusy)
+                                                {
+                                                    <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+                                                }
+                                                else
+                                                {
+                                                    <span class="bi-check-lg me-1" aria-hidden="true"></span>
+                                                }
+                                                Check and save
                                             </button>
                                         </div>
                                         <div class="form-text">
@@ -431,7 +522,13 @@
                     }
                 </EasyContent>
                 <Actions>
-                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Recheck</button>
+                    @if (AccessStatus == RequirementStatus.Satisfied)
+                    {
+                        <a class="btn btn-sm btn-primary" href="/connections">
+                            <span class="bi-plug me-1" aria-hidden="true"></span> Add a connection
+                        </a>
+                    }
+                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups" disabled="@awsBusy">Recheck</button>
                     @if (AccessMode == AwsAccessMode.RolesAnywhere)
                     {
                         @* Named for what it does. It removes only Connapse's local copy; the AWS trust
@@ -451,12 +548,14 @@
                     @if (AccessMode is AwsAccessMode.RolesAnywhere or AwsAccessMode.NotStored)
                     {
                         <button type="button" class="btn btn-sm btn-outline-secondary"
+                                aria-expanded="@(showRolePolicyUpdate ? "true" : "false")"
+                                aria-controls="role-policy-update"
                                 @onclick="() => showRolePolicyUpdate = !showRolePolicyUpdate">
                             <span class="bi-arrow-repeat me-1"></span> Update role permissions
                         </button>
                         @if (showRolePolicyUpdate)
                         {
-                            <div class="w-100 mt-2">
+                            <div id="role-policy-update" class="w-100 mt-2">
                                 @if (RolePolicyUpdateCommand is { Length: > 0 } updateCmd)
                                 {
                                     <div class="small mb-1">
@@ -548,18 +647,18 @@
                                 @onclick="CopyIdentityCenterScript">
                             <span class="bi-clipboard me-1"></span> Copy command
                         </button>
-                        <a class="btn btn-sm btn-primary" target="_blank" rel="noopener"
+                        <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"
                            href="https://console.aws.amazon.com/cloudshell/home">
                             <span class="bi-terminal me-1"></span> Open CloudShell
                             <span class="bi-box-arrow-up-right ms-1 small"></span>
                         </a>
-                        <span class="align-self-center small @(identityCenterCopySucceeded ? "text-success" : "text-danger")">
+                        <span class="align-self-center small @(identityCenterCopySucceeded ? "text-success" : "text-danger")" role="status">
                             @identityCenterCopyMessage
                         </span>
                     </div>
 
-                    <label class="form-label small mb-1">Paste what it printed</label>
-                    <textarea class="form-control font-monospace" rows="4" @bind="pastedIdentityCenter"
+                    <label class="form-label small mb-1" for="idc-paste">Paste what it printed</label>
+                    <textarea id="idc-paste" class="form-control font-monospace" rows="4" @bind="pastedIdentityCenter"
                               @bind:event="oninput"
                               placeholder="@IdentityCenterSetup.BeginMarker&#10;region=…&#10;@IdentityCenterSetup.EndMarker"></textarea>
 
@@ -672,8 +771,8 @@
                             <code>s3:ListAccessGrants</code> is worth knowing about specifically: AWS does
                             not scope it to one user, so it lets Connapse enumerate everyone's grants rather
                             than only the person signing in. Connapse stores no credential belonging to
-                            anyone, which is the trade — a smaller blast radius than a per-user token, and a
-                            wider reach.
+                            anyone; the trade is that its one identity can read every grant, where a
+                            per-user token could read only that person's.
                         </span>
                     </div>
 
@@ -924,11 +1023,11 @@
                                     @if (SamlMetadata.Parse(pastedMetadata) is { } read)
                                     {
                                         <div class="border rounded p-2 small mb-2">
-                                            <div class="text-muted">Issuer</div>
+                                            <div class="text-muted">IAM Identity Center SAML issuer URL</div>
                                             <div class="font-monospace text-break mb-1">@read.EntityId</div>
-                                            <div class="text-muted">Sign-in URL</div>
+                                            <div class="text-muted">IAM Identity Center sign-in URL</div>
                                             <div class="font-monospace text-break mb-1">@read.SingleSignOnUrl</div>
-                                            <div class="text-muted">Signing certificate</div>
+                                            <div class="text-muted">IAM Identity Center certificate</div>
                                             <div class="font-monospace text-break">
                                                 @(read.SigningCertificate.Length > 48
                                                     ? read.SigningCertificate[..48] + "…"
@@ -1052,6 +1151,7 @@
         // to have landed, and a stale read would hand the form back the previous values.
         if (saveSuccess)
         {
+            await AuditIdentityCenterSaved(settings);
             identityCenterSettings = settings;
             showIdentityCenterSetup = false;
         }
@@ -1069,6 +1169,11 @@
             showIdentityCenterSetup = true;
         }
     }
+
+    /// <summary>Records who changed the Identity Center values, and to what. Blank values mean a reset.</summary>
+    private Task AuditIdentityCenterSaved(IdentityCenterSettings settings) =>
+        AuditLogger.LogAsync("provider.identity_center.saved", "provider", "aws",
+            new { settings.Region, settings.InstanceArn, settings.IdentityStoreId });
 
     /// <summary>What is recorded about the customer's Identity Center instance, if anything.</summary>
     private IdentityCenterSettings? IdentityCentre => IdentityCenterOptions.CurrentValue;
@@ -1106,6 +1211,7 @@
                 InstanceArn = found.InstanceArn,
                 IdentityStoreId = found.IdentityStoreId,
             };
+            await AuditIdentityCenterSaved(identityCenterSettings);
         }
 
         await RefreshSetups();
@@ -1205,6 +1311,28 @@
 
     /// <summary>Whether a Roles Anywhere credential is stored — loaded on refresh, drives mode and reset visibility.</summary>
     private bool hasStoredRaCredential;
+
+    /// <summary>When the stored credential was saved and last honoured by AWS; null when none is stored.</summary>
+    private ProviderCredentialStatus? raStatus;
+
+    /// <summary>When the stored certificate stops being accepted; null when unknown or none is stored.</summary>
+    private DateTime? raCertificateExpires;
+
+    /// <summary>Reads the expiry out of a certificate, or null when it cannot be parsed.</summary>
+    private static DateTime? CertificateExpiry(string? certificatePem)
+    {
+        if (string.IsNullOrWhiteSpace(certificatePem)) return null;
+
+        try
+        {
+            using var certificate = X509Certificate2.CreateFromPem(certificatePem);
+            return certificate.NotAfter.ToUniversalTime();
+        }
+        catch (Exception ex) when (ex is System.Security.Cryptography.CryptographicException or ArgumentException)
+        {
+            return null;
+        }
+    }
 
     /// <summary>Which credential the AWS Access card is describing — see <see cref="AwsAccessCard"/>.</summary>
     private AwsAccessMode AccessMode =>
@@ -1324,13 +1452,11 @@
     }
 
     /// <summary>
-    /// Clears the recorded pool, for an administrator who removed it in AWS.
+    /// Clears the recorded application, for an administrator who removed it in AWS.
     /// </summary>
     /// <remarks>
-    /// Connapse has no way to notice: it holds no credential that may read the account, and asking
-    /// AWS on every page load would be the beginning of one. So the values simply persist, and the
-    /// worst of them is the SAML audience — it is built from the pool id, so a stale one reads as
-    /// perfectly valid while naming a pool that no longer exists.
+    /// Connapse has no way to notice on its own: the stored values stay valid-looking while naming an
+    /// application that no longer exists, so removal has to be told to it.
     /// </remarks>
     private async Task ClearSamlApplication()
     {
@@ -1354,11 +1480,16 @@
     /// says so), which is why any prior paste-back is discarded — a script from the old CA would
     /// register a trust anchor the new leaf does not chain to.
     /// </remarks>
-    private void PrepareRolesAnywhereScript()
+    private async Task PrepareRolesAnywhereScript()
     {
         raKeypair = RolesAnywhereKeyGenerator.Generate();
         raPasted = null;
         copyMessage = null;
+
+        // Recorded so the time from starting setup to a verified credential can be read back
+        // out of the audit log, and an abandoned setup is visible as a start with no save.
+        await AuditLogger.LogAsync("provider.credential.setup_started", "provider", "aws",
+            new { Method = "RolesAnywhere", Region = raRegion });
     }
 
     private async Task CopyRolesAnywhereScript()
@@ -1491,6 +1622,8 @@
             }
 
             await CredentialStore.SaveRolesAnywhereAsync("aws", config, privateKeyPem, principal, null);
+            await AuditLogger.LogAsync("provider.credential.saved", "provider", "aws",
+                new { Method = "RolesAnywhere", config.RoleArn, config.Region });
 
             // The secret material is not kept around once stored; the whole handshake resets. Clearing
             // the loaded-config token forces the next load to re-fill the form from the newly stored
@@ -1539,6 +1672,8 @@
             RolesAnywhereConfig? config = await CredentialStore.GetRolesAnywhereAsync("aws");
 
             await CredentialStore.DeleteAsync("aws");
+            await AuditLogger.LogAsync("provider.credential.removed", "provider", "aws",
+                new { Method = "RolesAnywhere", config?.RoleArn, config?.Region });
 
             raResetCleanup = config is null
                 ? null
@@ -1575,6 +1710,8 @@
         {
             RolesAnywhereConfig? config = await CredentialStore.GetRolesAnywhereAsync("aws");
             hasStoredRaCredential = config is not null;
+            raStatus = config is null ? null : await CredentialStore.GetStatusAsync("aws");
+            raCertificateExpires = CertificateExpiry(config?.CertificatePem);
 
             // Fill the manual (bring-your-own) fields from the stored, non-secret configuration so
             // editing a configured credential shows its current values rather than blank boxes. Only
@@ -1599,6 +1736,8 @@
             // status speak; the card degrades to the setup path rather than throwing.
             Logger.LogWarning(ex, "Could not read the stored AWS Roles Anywhere credential");
             hasStoredRaCredential = false;
+            raStatus = null;
+            raCertificateExpires = null;
         }
     }
 
@@ -1700,6 +1839,12 @@
 
         await SaveSettings("samlsignin", settings);
 
+        if (saveSuccess)
+        {
+            await AuditLogger.LogAsync("provider.saml.saved", "provider", "aws",
+                new { settings.EntityId, settings.IdpEntityId, Configured = settings.IsConfigured });
+        }
+
         if (saveSuccess && enforcing != EnforcementOptions.CurrentValue.IsEnforcing)
         {
             await SaveSettings(
@@ -1723,8 +1868,7 @@
     /// <summary>The badge on a whole provider.</summary>
     private static string ProviderLabel(RequirementStatus status) => status switch
     {
-        // Some requirements met and some not. A complete label, unlike "Works, but", which left
-        // the reader holding an unfinished sentence in a chip four words wide.
+        // Some requirements met and some not.
         RequirementStatus.Warning => "Partly set up",
         _ => Label(status)
     };

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -23,11 +23,6 @@
     epic rather than an omission: the file tree exposed every synced object to any Connapse
     user regardless of what they could see in the source system.
 
-    An earlier version of this comment justified that by saying search already passes through
-    CloudScopeService. It does not — CloudScopeService has no production caller, and search
-    returns every document to every user (#421). Removing the file tree is still right, but it
-    narrows one surface rather than leaving the other one guarded.
-
     The aggregate document count is the one exception, accepted during design as a weak signal
     in exchange for the page being useful at all.
 *@
@@ -142,9 +137,9 @@
                                 @source.DocumentCount
                                 @if (source.FailedDocumentCount > 0)
                                 {
-                                    @* The count alone reported work that produced nothing as though it
-                                       had succeeded: the sync did list and enqueue correctly, and the
-                                       failure downstream had no way back to this page. *@
+                                    @* Shown beside the count: the sync lists and enqueues correctly
+                                       even when indexing later fails, and the count alone would read
+                                       as success. *@
                                     <span class="badge text-bg-danger ms-1"
                                           title="These files were found and queued, but could not be indexed. They are retried on the next sync.">
                                         @source.FailedDocumentCount failed
@@ -242,18 +237,19 @@
 
 @if (form is not null)
 {
-    <div class="modal show d-block" tabindex="-1" style="background: rgba(0,0,0,.5);">
+    <div class="modal show d-block" tabindex="-1" role="dialog" aria-modal="true"
+         aria-labelledby="new-source-title" style="background: rgba(0,0,0,.5);">
         <div class="modal-dialog modal-dialog-centered modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">New source</h5>
-                    <button type="button" class="btn-close" @onclick="CancelCreate"></button>
+                    <h5 class="modal-title" id="new-source-title">New source</h5>
+                    <button type="button" class="btn-close" aria-label="Close" @onclick="CancelCreate"></button>
                 </div>
                 <div class="modal-body">
                     @if (createError is not null)
                     {
-                        <div class="alert alert-danger py-2 small">
-                            <span class="bi-x-circle me-1"></span> @createError
+                        <div class="alert alert-danger py-2 small" role="alert">
+                            <span class="bi-x-circle me-1" aria-hidden="true"></span> @createError
                         </div>
                     }
                     @if (createWarning is not null)
@@ -261,33 +257,37 @@
                         @* Accepted but worth seeing. The allowlists are permissive when empty
                            today and refuse later, and this is the one moment an operator is
                            looking at the connection and could narrow it. *@
-                        <div class="alert alert-warning py-2 small">
-                            <span class="bi-exclamation-triangle me-1"></span> @createWarning
+                        <div class="alert alert-warning py-2 small" role="status">
+                            <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span> @createWarning
                         </div>
                     }
 
                     <div class="mb-3">
-                        <label class="form-label">Connection</label>
-                        <select class="form-select" value="@form.ConnectionId"
-                                @onchange="OnConnectionChanged">
+                        <label class="form-label" for="source-connection">Connection</label>
+                        <select id="source-connection" class="form-select" value="@form.ConnectionId"
+                                aria-describedby="source-connection-help" @onchange="OnConnectionChanged">
                             @foreach (var connection in connections)
                             {
                                 <option value="@connection.Id">@connection.Name (@connection.Provider)</option>
                             }
                         </select>
-                        <div class="form-text">
+                        <div id="source-connection-help" class="form-text">
                             The connection holds the credential. This source picks a scope inside it.
                         </div>
                     </div>
 
                     <div class="mb-3">
-                        <label class="form-label">Name</label>
-                        <input class="form-control" @bind="form.Name" placeholder="company-docs" />
+                        <label class="form-label" for="source-name">Name</label>
+                        <input id="source-name" class="form-control" @bind="form.Name" placeholder="company-docs"
+                               aria-describedby="source-name-help" />
+                        <div id="source-name-help" class="form-text">
+                            Filled in from the bucket or container you choose below if left blank.
+                        </div>
                     </div>
 
                     <div class="mb-3">
-                        <label class="form-label">Description (optional)</label>
-                        <input class="form-control" @bind="form.Description"
+                        <label class="form-label" for="source-description">Description <span class="text-muted">(optional)</span></label>
+                        <input id="source-description" class="form-control" @bind="form.Description"
                                placeholder="What is in here, and who it is for" />
                     </div>
 
@@ -301,7 +301,7 @@
                            and a name typed from memory saves cleanly, then fails at the first
                            sync or is refused by the scope preflight afterwards. *@
                         <div class="mb-3">
-                            <label class="form-label">
+                            <label class="form-label" for="source-container">
                                 @(selectedProvider == ConnectionProvider.S3 ? "Bucket" : "Blob container")
                             </label>
 
@@ -329,7 +329,8 @@
                                    Container puts "bucket/team" in bucketName, which the S3 and Azure
                                    connectors use as a literal bucket or container name. The source
                                    passes preflight and then never syncs. *@
-                                <select class="form-select font-monospace"
+                                <select id="source-container" class="form-select font-monospace"
+                                        aria-describedby="source-container-help"
                                         value="@selectedScope" @onchange="SelectScope">
                                     <option value="">Choose one…</option>
                                     @foreach (string scope in allowed)
@@ -343,7 +344,7 @@
                                    is an indirect guarantee the test cannot see, and weakening the
                                    count to accommodate two help links would cost more than the
                                    links are worth. *@
-                                <div class="form-text">
+                                <div id="source-container-help" class="form-text">
                                     @(selectedProvider == ConnectionProvider.S3 ? "Buckets" : "Containers")
                                     this connection is allowed to read. To use another, add it to
                                     that connection's allowed locations on the Connections page.
@@ -351,9 +352,10 @@
                             }
                             else
                             {
-                                <input class="form-control font-monospace" @bind="form.Container"
+                                <input id="source-container" class="form-control font-monospace" @bind="form.Container"
+                                       aria-describedby="source-container-help"
                                        placeholder="@(selectedProvider == ConnectionProvider.S3 ? "company-knowledge" : "knowledge")" />
-                                <div class="form-text">
+                                <div id="source-container-help" class="form-text">
                                     Which
                                     @(selectedProvider == ConnectionProvider.S3 ? "bucket" : "container")
                                     inside this connection the source reads. This connection lists
@@ -364,9 +366,10 @@
                         </div>
 
                         <div class="mb-3">
-                            <label class="form-label">Prefix (optional)</label>
-                            <input class="form-control font-monospace" @bind="form.Prefix" placeholder="docs/" />
-                            <div class="form-text">Narrows the source to a subtree. Everything below it is indexed.</div>
+                            <label class="form-label" for="source-prefix">Prefix <span class="text-muted">(optional)</span></label>
+                            <input id="source-prefix" class="form-control font-monospace" @bind="form.Prefix" placeholder="docs/"
+                                   aria-describedby="source-prefix-help" />
+                            <div id="source-prefix-help" class="form-text">Narrows the source to a subtree. Everything below it is indexed.</div>
                         </div>
                     }
                     @* SFTP shares this branch rather than getting its own. Its scope is the same
@@ -408,10 +411,10 @@
                     }
 
                     <div class="mb-0">
-                        <label class="form-label">Sync interval in seconds (optional)</label>
-                        <input type="number" class="form-control" min="60" @bind="form.SyncIntervalSeconds"
-                               placeholder="300" />
-                        <div class="form-text">Leave empty to use the configured default.</div>
+                        <label class="form-label" for="source-interval">Sync interval in seconds <span class="text-muted">(optional)</span></label>
+                        <input id="source-interval" type="number" class="form-control" min="60" @bind="form.SyncIntervalSeconds"
+                               placeholder="300" aria-describedby="source-interval-help" />
+                        <div id="source-interval-help" class="form-text">Leave empty to use the configured default. The minimum is 60.</div>
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -431,12 +434,13 @@
 
 @if (pendingDelete is not null)
 {
-    <div class="modal show d-block" tabindex="-1" style="background: rgba(0,0,0,.5);">
+    <div class="modal show d-block" tabindex="-1" role="dialog" aria-modal="true"
+         aria-labelledby="delete-source-title" style="background: rgba(0,0,0,.5);">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Delete source</h5>
-                    <button type="button" class="btn-close" @onclick="() => pendingDelete = null"></button>
+                    <h5 class="modal-title" id="delete-source-title">Delete source</h5>
+                    <button type="button" class="btn-close" aria-label="Close" @onclick="() => pendingDelete = null"></button>
                 </div>
                 <div class="modal-body">
                     <p>
@@ -568,6 +572,11 @@
         var (container, prefix) = StorageLocationPolicy.SplitEntry(selectedScope);
         form!.Container = container;
         form.Prefix = prefix;
+
+        // A name the operator has not typed is derived from what was chosen, so the common case
+        // of one source per bucket needs nothing typed twice.
+        if (string.IsNullOrWhiteSpace(form.Name))
+            form.Name = container;
     }
 
 

--- a/src/Connapse.Web/Components/Providers/ProviderSetupGuide.razor
+++ b/src/Connapse.Web/Components/Providers/ProviderSetupGuide.razor
@@ -1,9 +1,10 @@
-<details class="provider-setup-guide border rounded p-3 mt-3">
+<details class="provider-setup-guide border rounded p-3 mt-3" open="@Open">
     <summary class="fw-semibold small">@Title</summary>
     <div class="pt-3">@ChildContent</div>
 </details>
 
 @code {
     [Parameter] public string Title { get; set; } = "Easy setup";
+    [Parameter] public bool Open { get; set; }
     [Parameter, EditorRequired] public RenderFragment? ChildContent { get; set; }
 }

--- a/src/Connapse.Web/Components/Providers/ProviderStepCard.razor
+++ b/src/Connapse.Web/Components/Providers/ProviderStepCard.razor
@@ -41,7 +41,7 @@
                 @ManualContent
                 @if (EasyContent is not null)
                 {
-                    <ProviderSetupGuide Title="@EasyTitle">@EasyContent</ProviderSetupGuide>
+                    <ProviderSetupGuide Title="@EasyTitle" Open="@EasyOpen">@EasyContent</ProviderSetupGuide>
                 }
             </div>
         }
@@ -58,6 +58,9 @@
     [Parameter] public EventCallback<bool> ExpandedChanged { get; set; }
     [Parameter] public string EditLabel { get; set; } = "Edit setup";
     [Parameter] public string EasyTitle { get; set; } = "Easy setup";
+
+    /// <summary>Whether the easy-setup guide starts expanded. Set it where the guide is the main route.</summary>
+    [Parameter] public bool EasyOpen { get; set; }
     [Parameter] public RenderFragment? Summary { get; set; }
     [Parameter] public RenderFragment? ManualContent { get; set; }
     [Parameter] public RenderFragment? EasyContent { get; set; }

--- a/src/Connapse.Web/Components/Providers/ProviderStepCard.razor.css
+++ b/src/Connapse.Web/Components/Providers/ProviderStepCard.razor.css
@@ -17,6 +17,8 @@
 .provider-step__status { display: inline-flex; align-items: center; gap: .4rem; white-space: nowrap; font-size: .875rem; font-weight: 600; }
 .provider-step__summary { margin-top: .75rem; font-size: .875rem; overflow-wrap: anywhere; }
 .provider-step__actions { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: .75rem; }
+/* The destructive action sits apart from the others, at the far end of the row. */
+.provider-step__actions ::deep .provider-reset-action { margin-left: auto; }
 .provider-step__body { margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--bs-border-color); }
 .provider-step--satisfied { --provider-step-state: var(--color-success); }
 .provider-step--failed { --provider-step-state: var(--color-error); }

--- a/src/Connapse.Web/Components/Settings/IdentityCenterSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/IdentityCenterSettingsTab.razor
@@ -3,40 +3,45 @@
 @*
     The IAM Identity Center instance an administrator points Connapse at.
 
-    Every value here is an identifier the account owner can read off their own console, so unlike
-    the Cognito form next to it there is no secret to withhold and no field that has to survive a
-    blank submit. The guided scan fills these in; this is for someone who already knows them, or
-    who cannot run the scan because their policy refuses sso:ListInstances.
+    Every value here is an identifier the account owner can read off their own console, so there
+    is no secret to withhold and no field that has to survive a blank submit. The guided scan fills
+    these in; this is for someone who already knows them, or who cannot run the scan because their
+    policy refuses sso:ListInstances.
 *@
 
 <EditForm Model="@localSettings" OnValidSubmit="HandleSubmit">
     <DataAnnotationsValidator />
 
-    <div class="row g-3">
-        <div class="col-md-6">
+    <div class="row g-3" style="max-width:44rem">
+        <div class="col-12">
             <label class="form-label" for="idc-region">Region</label>
             <InputText id="idc-region" @bind-Value="localSettings.Region" class="form-control"
-                       placeholder="us-west-1" />
-            <div class="form-text">
+                       placeholder="us-west-1" aria-describedby="idc-region-help" />
+            <div id="idc-region-help" class="form-text">
                 The one region the instance lives in. Identity Center exists in exactly one region
-                per organisation, and this is the field worth checking twice: the wrong one reads
-                everywhere else as having no instance at all.
+                per organisation, and the wrong one reads everywhere else as having no instance at all.
             </div>
         </div>
 
-        <div class="col-md-6">
+        <div class="col-12">
             <label class="form-label" for="idc-store">Identity store ID</label>
             <InputText id="idc-store" @bind-Value="localSettings.IdentityStoreId"
-                       class="form-control font-monospace" placeholder="d-1234567890" />
-            <div class="form-text">The directory a signed-in person is resolved into.</div>
+                       class="form-control font-monospace" placeholder="d-1234567890"
+                       aria-describedby="idc-store-help" />
+            <div id="idc-store-help" class="form-text">
+                Shown on the Settings page of the
+                <a href="https://console.aws.amazon.com/singlesignon/home" target="_blank" rel="noopener">IAM Identity Center console</a>,
+                beside the instance ARN.
+            </div>
         </div>
 
         <div class="col-12">
             <label class="form-label" for="idc-arn">Instance ARN</label>
             <InputText id="idc-arn" @bind-Value="localSettings.InstanceArn"
                        class="form-control font-monospace"
-                       placeholder="arn:aws:sso:::instance/ssoins-1234567890abcdef" />
-            <div class="form-text">
+                       placeholder="arn:aws:sso:::instance/ssoins-1234567890abcdef"
+                       aria-describedby="idc-arn-help" />
+            <div id="idc-arn-help" class="form-text">
                 Shown on the Settings page of the IAM Identity Center console, or from
                 <code>aws sso-admin list-instances</code>.
             </div>
@@ -44,10 +49,10 @@
 
         <div class="col-12 mt-4">
             <button type="submit" class="btn btn-primary me-2">
-                <span class="bi-save me-1"></span> Save Changes
+                <span class="bi-save me-1" aria-hidden="true"></span> Save
             </button>
-            <button type="button" class="btn btn-secondary" @onclick="Reset">
-                <span class="bi-arrow-counterclockwise me-1"></span> Reset
+            <button type="button" class="btn btn-outline-secondary" @onclick="Reset">
+                <span class="bi-arrow-counterclockwise me-1" aria-hidden="true"></span> Reset
             </button>
         </div>
     </div>
@@ -64,9 +69,8 @@
 
     protected override void OnParametersSet()
     {
-        // A whole copy, unlike the Cognito form, which withholds the client secret. Nothing here is
-        // a credential, so round-tripping every field costs nothing and lets an edit to one value
-        // leave the other two alone.
+        // A whole copy. Nothing here is a credential, so round-tripping every field costs nothing
+        // and lets an edit to one value leave the other two alone.
         localSettings = new IdentityCenterSettings
         {
             Region = Settings.Region,

--- a/src/Connapse.Web/Components/Settings/SamlSignInSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/SamlSignInSettingsTab.razor
@@ -12,8 +12,10 @@
     at the first sign-in.
 
     Nothing here is withheld from the settings API: a signing certificate is a public key, and the
-    two Connapse values are printed for an administrator to copy. This form held a client secret
-    when it configured a Cognito pool, and that is the whole reason it needed guarding.
+    two Connapse values are printed for an administrator to copy.
+
+    Labels use the names the IAM Identity Center console shows, so a value can be matched to its
+    field without translation.
 *@
 
 @if (suggestedAcs is null)
@@ -49,19 +51,21 @@ else
         every assertion against them character for character, so they must match exactly.
     </p>
 
-    <div class="row g-3">
-        <div class="col-md-6">
-            <label class="form-label" for="saml-entity-id">Audience (entity ID)</label>
-            <InputText id="saml-entity-id" @bind-Value="localSettings.EntityId" class="form-control" />
-            <div class="form-text">
+    <div class="row g-3" style="max-width:44rem">
+        <div class="col-12">
+            <label class="form-label" for="saml-entity-id">Application SAML audience</label>
+            <InputText id="saml-entity-id" @bind-Value="localSettings.EntityId" class="form-control"
+                       aria-describedby="saml-entity-id-help" />
+            <div id="saml-entity-id-help" class="form-text">
                 Identifies Connapse. It is an identifier, not an address — nothing fetches it.
             </div>
         </div>
 
-        <div class="col-md-6">
-            <label class="form-label" for="saml-acs">Assertion consumer service URL</label>
-            <InputText id="saml-acs" @bind-Value="localSettings.AcsUrl" class="form-control" />
-            <div class="form-text">
+        <div class="col-12">
+            <label class="form-label" for="saml-acs">Application ACS URL</label>
+            <InputText id="saml-acs" @bind-Value="localSettings.AcsUrl" class="form-control"
+                       aria-describedby="saml-acs-help" />
+            <div id="saml-acs-help" class="form-text">
                 Where the browser posts the assertion. Change Connapse's address and this has to be
                 edited in AWS too, or sign-in stops with a destination mismatch.
             </div>
@@ -85,33 +89,35 @@ else
         not a sign-in outage.
     </p>
 
-    <div class="row g-3">
-        <div class="col-md-6">
-            <label class="form-label" for="saml-idp-entity">Identity Center issuer</label>
+    <div class="row g-3" style="max-width:44rem">
+        <div class="col-12">
+            <label class="form-label" for="saml-idp-entity">IAM Identity Center SAML issuer URL</label>
             <InputText id="saml-idp-entity" @bind-Value="localSettings.IdpEntityId" class="form-control"
-                       placeholder="https://portal.sso.us-west-1.amazonaws.com/saml/assertion/EXAMPLE" />
-            <div class="form-text">
+                       placeholder="https://portal.sso.us-west-1.amazonaws.com/saml/assertion/EXAMPLE"
+                       aria-describedby="saml-idp-entity-help" />
+            <div id="saml-idp-entity-help" class="form-text">
                 The <code>Issuer</code> every assertion carries. Checked so that a validly signed
                 assertion from somewhere else is still refused.
             </div>
         </div>
 
-        <div class="col-md-6">
-            <label class="form-label" for="saml-idp-sso">Sign-in URL</label>
+        <div class="col-12">
+            <label class="form-label" for="saml-idp-sso">IAM Identity Center sign-in URL</label>
             <InputText id="saml-idp-sso" @bind-Value="localSettings.IdpSingleSignOnUrl" class="form-control"
-                       placeholder="https://portal.sso.us-west-1.amazonaws.com/saml/assertion/EXAMPLE" />
-            <div class="form-text">Where Connapse sends people to sign in.</div>
+                       placeholder="https://portal.sso.us-west-1.amazonaws.com/saml/assertion/EXAMPLE"
+                       aria-describedby="saml-idp-sso-help" />
+            <div id="saml-idp-sso-help" class="form-text">Where Connapse sends people to sign in.</div>
         </div>
 
         <div class="col-12">
-            <label class="form-label" for="saml-idp-cert">Signing certificate</label>
+            <label class="form-label" for="saml-idp-cert">IAM Identity Center certificate</label>
             <InputTextArea id="saml-idp-cert" @bind-Value="localSettings.IdpSigningCertificate"
                            class="form-control font-monospace" rows="4"
-                           placeholder="MIIDBTCCAe2gAwIBAgIF…" />
-            <div class="form-text">
-                Base64, without the <code>BEGIN CERTIFICATE</code> lines. This is the whole of the
-                trust — every assertion is checked against it. Identity Center rotates it, and a
-                rotation not reflected here stops every sign-in until it is pasted again.
+                           placeholder="MIIDBTCCAe2gAwIBAgIF…"
+                           aria-describedby="saml-idp-cert-help" />
+            <div id="saml-idp-cert-help" class="form-text">
+                Base64, with or without the <code>BEGIN CERTIFICATE</code> lines. Identity Center
+                rotates it; paste the new one here when it does, or every sign-in stops.
             </div>
         </div>
     </div>

--- a/src/Connapse.Web/Components/Shared/SecretTextArea.razor
+++ b/src/Connapse.Web/Components/Shared/SecretTextArea.razor
@@ -1,0 +1,51 @@
+@*
+    The one field type for a secret: a private key, a passphrase, a token.
+
+    Masked by default and revealed on request, so a value pasted in can be checked before it is
+    saved without being readable to anyone glancing at the screen. Nothing here blocks paste or
+    a password manager: no autocomplete="off", no confirm-by-retyping.
+
+    Multiline secrets (PEM blocks) cannot use type="password", so they are masked with the
+    text-security property instead; a single-line secret toggles between password and text.
+*@
+
+@if (Multiline)
+{
+    <textarea id="@Id" class="form-control font-monospace @(revealed ? "" : "secret-masked") @CssClass"
+              rows="@Rows" placeholder="@Placeholder" aria-describedby="@DescribedBy"
+              @bind="CurrentValue"></textarea>
+}
+else
+{
+    <input id="@Id" type="@(revealed ? "text" : "password")" class="form-control @CssClass"
+           placeholder="@Placeholder" aria-describedby="@DescribedBy" @bind="CurrentValue" />
+}
+<button type="button" class="btn btn-sm btn-link px-0 mt-1" aria-controls="@Id"
+        aria-pressed="@(revealed ? "true" : "false")" @onclick="() => revealed = !revealed">
+    <span class="@(revealed ? "bi-eye-slash" : "bi-eye") me-1" aria-hidden="true"></span>
+    @(revealed ? "Hide" : "Show")
+</button>
+
+@code {
+    [Parameter, EditorRequired] public string Id { get; set; } = string.Empty;
+    [Parameter] public string? Value { get; set; }
+    [Parameter] public EventCallback<string?> ValueChanged { get; set; }
+    [Parameter] public bool Multiline { get; set; } = true;
+    [Parameter] public int Rows { get; set; } = 3;
+    [Parameter] public string? Placeholder { get; set; }
+    [Parameter] public string? DescribedBy { get; set; }
+    [Parameter] public string? CssClass { get; set; }
+
+    private bool revealed;
+
+    private string? CurrentValue
+    {
+        get => Value;
+        set
+        {
+            if (value == Value) return;
+            Value = value;
+            _ = ValueChanged.InvokeAsync(value);
+        }
+    }
+}

--- a/src/Connapse.Web/Components/_Imports.razor
+++ b/src/Connapse.Web/Components/_Imports.razor
@@ -14,3 +14,4 @@
 @using Connapse.Web.Components.Auth
 @using Connapse.Web.Components.Settings
 @using Connapse.Web.Components.Providers
+@using Connapse.Web.Components.Shared

--- a/src/Connapse.Web/Services/ProviderSetupReader.cs
+++ b/src/Connapse.Web/Services/ProviderSetupReader.cs
@@ -138,16 +138,12 @@ public class ProviderSetupReader(
     /// Whether people can connect an AWS identity of their own.
     /// </summary>
     /// <remarks>
-    /// Reports on the pool being configured, not on filtering working. Those are different claims,
-    /// and only the first is this page's to make: search is not scoped by cloud permissions yet
-    /// (#421), so a requirement worded around results would be green while every user still sees
-    /// everything.
+    /// Reports on the application being configured, not on filtering working. Those are different
+    /// claims, and only the first is this page's to make.
     /// <para>
     /// Plainly <see cref="RequirementStatus.NotConfigured"/> when unset, because that is what it
-    /// is — no part of a pool exists. Reporting it as a Warning to keep the provider's own summary
-    /// out of "Not set up" was solving the rollup's problem on the wrong object, and it put
-    /// "Partly set up" on a card for something that was not partly anything.
-    /// <see cref="ProviderSetup.Overall"/> draws that distinction now.
+    /// is — no part of the application exists. <see cref="ProviderSetup.Overall"/> decides how that
+    /// rolls up into the provider's own badge.
     /// </para>
     /// </remarks>
     private static ProviderRequirement PerUserPermissions(SamlSignInSettings settings)

--- a/src/Connapse.Web/wwwroot/app.css
+++ b/src/Connapse.Web/wwwroot/app.css
@@ -133,6 +133,11 @@ a:hover, .btn-link:hover {
     color: var(--text-muted);
 }
 
+/* Secret fields (SecretTextArea) are masked until revealed. */
+.secret-masked {
+    -webkit-text-security: disc;
+}
+
 .form-control:disabled, .form-select:disabled {
     background-color: var(--bs-tertiary-bg);
     color: var(--text-muted);


### PR DESCRIPTION
Closes #468. Runs the config-page audit rubric over `/admin/providers/aws`, the S3 branch of `/connections`, and the S3 branch of the New source dialog, and fixes what it found. Full report with per-criterion scores and evidence: `docs/plans/aws-config-page-audit-report.md`. Verdict after fixes: SHIPPABLE (was NOT SHIPPABLE on gates G2, G3, G5).

**Gates**
- New shared `SecretTextArea` (masked by default, reveal toggle, no `autocomplete="off"`), used for the Roles Anywhere private key and the SFTP key/passphrase on the same Connections page.
- Visible label on the bucket picker's search box.

**Provider page**
- Manual values collapsed behind a disclosure (open when a credential is stored), fields in the order AWS creates them, ARN/PEM placeholders, and a console link under each field.
- CloudShell permissions the runner needs are stated before the setup script; the easy guide opens by default.
- SAML form labels match the IAM Identity Center console (Application SAML audience, Application ACS URL, IAM Identity Center SAML issuer URL / sign-in URL / certificate).
- Access card: "Add a connection" once Ready; Stored / Last confirmed / Certificate expires, with an expired state and a 30-day warning; spinners on Check and save.
- Audit events: `provider.credential.setup_started|saved|removed`, `provider.identity_center.saved`, `provider.saml.saved`.

**Connections (S3)**
- Region and cross-account role move after Allowed locations (choosing a bucket fills the region); every field has `id`/`for`/`aria-describedby`; single column.
- Delete asks for confirmation; name fills from the first bucket chosen.
- S3 test messages say which layer passed or failed and what to change; raw AWS error under a "Raw error" disclosure; Troubleshooting link.

**Sources**
- Label association, dialog roles, name fills from the chosen bucket.

**Docs**
- `docs/aws-setup.md`: every field, where to obtain it, health/rotation, and a symptom → cause → fix table; linked from the page intro, the test failure alert, README, and connectors.md.

**Removed developer text** — stale Cognito/#421 narration and past-bug commentary in Sources, the two settings tabs, S3ConnectionTester, ProviderSetupReader, and Connections; listed with lines in the report.

Verified: `dotnet build` clean; 1,573 unit tests green; `ProvidersPageRenderingTests` (integration) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)