### PR TITLE
fix: adversarial-review findings — enforcement fail-open, stale AWS session, REST AWS disconnect (#473)

### DIFF
--- a/src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs
+++ b/src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Connapse.Storage.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -31,8 +31,21 @@ public class DatabaseSettingsProvider : ConfigurationProvider
         _optionsAction = optionsAction;
     }
 
+    /// <summary>
+    /// Whether the most recent <see cref="Load"/> read the settings table.
+    /// </summary>
+    /// <remarks>
+    /// False after a load that could not connect or whose query failed. Those loads leave the
+    /// configuration at whatever it held before — appsettings defaults on the first load — which
+    /// is indistinguishable from "nothing stored" to every reader of IOptionsMonitor. Anything that
+    /// treats "not configured" as a safe answer must check this first.
+    /// </remarks>
+    public bool LastLoadSucceeded { get; private set; }
+
     public override void Load()
     {
+        LastLoadSucceeded = false;
+
         var builder = new DbContextOptionsBuilder<KnowledgeDbContext>();
         _optionsAction(builder);
 
@@ -59,6 +72,8 @@ public class DatabaseSettingsProvider : ConfigurationProvider
                     : $"Knowledge:{setting.Category}";
                 FlattenJsonDocument(prefix, setting.Values);
             }
+
+            LastLoadSucceeded = true;
         }
         catch (Exception)
         {
@@ -119,9 +134,10 @@ public class DatabaseSettingsProvider : ConfigurationProvider
     /// Reloads settings from the database and triggers change tokens.
     /// Call this after updating settings to propagate changes to IOptionsMonitor.
     /// </summary>
-    public void Reload()
+    public bool Reload()
     {
         Load();
         OnReload();
+        return LastLoadSucceeded;
     }
 }

--- a/src/Connapse.Storage/Settings/ISettingsReloader.cs
+++ b/src/Connapse.Storage/Settings/ISettingsReloader.cs
@@ -10,5 +10,10 @@ public interface ISettingsReloader
     /// Reloads settings from the database and triggers change notifications.
     /// Call this after updating settings to propagate changes to IOptionsMonitor.
     /// </summary>
-    void Reload();
+    /// <returns>
+    /// True when the database was read. False when it could not be reached or the read failed, in
+    /// which case the merged configuration still holds whatever was loaded before — possibly only
+    /// appsettings defaults — and must not be trusted as the authoritative stored state.
+    /// </returns>
+    bool Reload();
 }

--- a/src/Connapse.Storage/Settings/SettingsReloader.cs
+++ b/src/Connapse.Storage/Settings/SettingsReloader.cs
@@ -13,10 +13,10 @@ public class SettingsReloader : ISettingsReloader
         _provider = provider;
     }
 
-    public void Reload()
+    public bool Reload()
     {
         // Reload database settings and trigger change token
         // This will notify IOptionsMonitor subscribers
-        _provider.Reload();
+        return _provider.Reload();
     }
 }

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -20,6 +20,7 @@
 @inject IProviderSetupReader SetupReader
 @inject IProviderCredentialStore CredentialStore
 @inject IRolesAnywhereSetupValidator RaValidator
+@inject Connapse.Storage.CloudScope.ConnapseAwsCredentials AwsCredentials
 @inject IJSRuntime JS
 @inject NavigationManager Navigation
 @inject ILogger<Providers> Logger
@@ -1622,6 +1623,11 @@
             }
 
             await CredentialStore.SaveRolesAnywhereAsync("aws", config, privateKeyPem, principal, null);
+
+            // Drop the session the runtime is holding, so the next AWS call resolves the credential
+            // just stored rather than finishing out the previous one's refresh window.
+            AwsCredentials.ClearCredentials();
+
             await AuditLogger.LogAsync("provider.credential.saved", "provider", "aws",
                 new { Method = "RolesAnywhere", config.RoleArn, config.Region });
 
@@ -1657,11 +1663,16 @@
     /// Clears this instance's Roles Anywhere credential, then offers to remove the AWS-side resources.
     /// </summary>
     /// <remarks>
-    /// The local wipe comes first and is what actually protects the operator: it stops this instance
-    /// authenticating immediately, independent of any AWS call. The AWS trust anchor, role, and
-    /// profile are per-instance, so a CloudShell cleanup snippet is shown afterwards to remove them —
-    /// Connapse's own read-only identity cannot delete them directly. Nothing shared is ever touched,
-    /// because in the per-instance design nothing is shared.
+    /// The local wipe comes first: the row goes, and the session the runtime was holding is dropped
+    /// with it, so the next AWS call cannot reuse the removed credential. The AWS trust anchor,
+    /// role, and profile are per-instance, so a CloudShell cleanup snippet is shown afterwards to
+    /// remove them — Connapse's own read-only identity cannot delete them directly. Nothing shared
+    /// is ever touched, because in the per-instance design nothing is shared.
+    /// <para>
+    /// With no stored credential the runtime falls back to whatever the environment provides, by
+    /// design (an instance or task role is the ordinary way to run without one). The outcome says
+    /// so when that is the case, because "removed" would otherwise read as "no longer reading S3".
+    /// </para>
     /// </remarks>
     private async Task ResetAccessIdentity()
     {
@@ -1672,6 +1683,7 @@
             RolesAnywhereConfig? config = await CredentialStore.GetRolesAnywhereAsync("aws");
 
             await CredentialStore.DeleteAsync("aws");
+            AwsCredentials.ClearCredentials();
             await AuditLogger.LogAsync("provider.credential.removed", "provider", "aws",
                 new { Method = "RolesAnywhere", config?.RoleArn, config?.Region });
 
@@ -1689,6 +1701,12 @@
                 : "Connapse's stored AWS credential was removed. It is still valid in AWS until you "
                   + "run the cleanup command shown below, or it expires.";
             await RefreshSetups();
+
+            if (EnvironmentCredentialResolves)
+            {
+                saveMessage += " Connapse is now reading S3 with credentials from its environment "
+                    + "instead; remove those from the server if that is not what you want.";
+            }
         }
         catch (Exception ex)
         {

--- a/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Claims;
+using System.Security.Claims;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Identity.Services;
@@ -309,6 +309,7 @@ public static class CloudIdentityEndpoints
             string provider,
             HttpContext httpContext,
             [FromServices] ICloudIdentityService service,
+            [FromServices] IAwsIdentityLinkService awsLinks,
             [FromServices] IConnectorScopeCache scopeCache,
             [FromServices] ISourceStore sourceStore,
             [FromServices] IConnectionStore connectionStore,
@@ -320,7 +321,28 @@ public static class CloudIdentityEndpoints
             if (!Enum.TryParse<CloudProvider>(provider, ignoreCase: true, out var cloudProvider))
                 return Results.BadRequest(new { error = "invalid_provider", message = $"Unknown provider: {provider}. Valid values: AWS, Azure." });
 
-            var deleted = await service.DisconnectAsync(userId.Value, cloudProvider, ct);
+            bool deleted;
+            if (cloudProvider == CloudProvider.AWS)
+            {
+                // AWS links live in their own store, the one the integrations page reads and
+                // deletes through; the cloud-identity table this route used to consult never holds
+                // a SAML link, so deleting there answered 404 and left the link in force.
+                var result = await awsLinks.DisconnectAsync(userId.Value, ct);
+                if (result.LinkChangedDuringDisconnect)
+                {
+                    return Results.Conflict(new
+                    {
+                        error = "link_changed",
+                        message = "The AWS identity link changed while disconnecting. Try again."
+                    });
+                }
+
+                deleted = result.Deleted;
+            }
+            else
+            {
+                deleted = await service.DisconnectAsync(userId.Value, cloudProvider, ct);
+            }
 
             // Evict cached scope entries for this user + provider
             if (deleted)

--- a/src/Connapse.Web/Services/SamlEnforcementLatch.cs
+++ b/src/Connapse.Web/Services/SamlEnforcementLatch.cs
@@ -1,5 +1,6 @@
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Storage.Settings;
 using Microsoft.Extensions.Options;
 
 namespace Connapse.Web.Services;
@@ -40,12 +41,27 @@ public sealed class SamlEnforcementLatch(
     IOptionsMonitor<SamlSignInSettings> signIn,
     IOptionsMonitor<PermissionEnforcementSettings> enforcement,
     EnforcementMigration migration,
+    ISettingsReloader settingsReloader,
     ILogger<SamlEnforcementLatch> logger) : IHostedService
 {
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         try
         {
+            // Read the stored settings again, now that migrations have run, and refuse to decide
+            // from a load that did not reach the database. The configuration is first loaded before
+            // the host starts, and a database that is briefly unreachable at that moment leaves
+            // every stored value at its default without any error: a deployment that had been
+            // enforcing then looks exactly like one that never set sign-in up, and the branch below
+            // would record it as unrestricted. Left undetermined instead, searches are refused
+            // until the next successful reload -- the same posture as the catch below.
+            if (!settingsReloader.Reload())
+            {
+                logger.LogError(
+                    "Could not read the stored settings, so whether per-user permissions are enforced is unknown; searches will be refused until the database can be read");
+                return;
+            }
+
             // Already recorded, by a previous boot or by an administrator saving the settings.
             if (enforcement.CurrentValue.IsEnforcing)
             {

--- a/tests/Connapse.Integration.Tests/CloudIdentityEndpointTests.cs
+++ b/tests/Connapse.Integration.Tests/CloudIdentityEndpointTests.cs
@@ -1,7 +1,10 @@
+using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Connapse.Identity.Services;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Connapse.Integration.Tests;
 
@@ -69,6 +72,55 @@ public class CloudIdentityEndpointTests(SharedWebAppFixture fixture)
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DisconnectAws_WithASamlLink_DeletesTheLinkAndReturns204()
+    {
+        // The route used to delete from the cloud-identity table, which never holds a SAML link,
+        // so a user with a real link got 404 and stayed eligible for AWS-derived search scopes.
+        Guid admin = AdminUserId();
+        string directoryUserId = $"dir-{Guid.NewGuid():N}";
+
+        await using (var scope = fixture.Factory.Services.CreateAsyncScope())
+        {
+            var store = scope.ServiceProvider.GetRequiredService<AwsIdentityLinkStore>();
+            await store.SaveAsync(admin, directoryUserId, "admin-person", "admin@example.com");
+        }
+
+        try
+        {
+            var response = await fixture.AdminClient.DeleteAsync("/api/v1/auth/cloud/AWS");
+
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            (await LinkedDirectoryUserIdAsync(admin)).Should().BeNull("the link was deleted");
+        }
+        finally
+        {
+            // Leave the shared admin as the other tests expect to find them: unlinked.
+            await using var scope = fixture.Factory.Services.CreateAsyncScope();
+            var store = scope.ServiceProvider.GetRequiredService<AwsIdentityLinkStore>();
+            await store.DeleteAsync(admin);
+        }
+    }
+
+    /// <summary>The admin's own user id, read from the token the fixture signed in with.</summary>
+    private Guid AdminUserId()
+    {
+        var token = new JwtSecurityTokenHandler().ReadJwtToken(fixture.AdminToken);
+        string? sub = token.Claims.FirstOrDefault(c =>
+            c.Type is "sub" or "nameid"
+                   or "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")?.Value;
+
+        Guid.TryParse(sub, out Guid id).Should().BeTrue("the token identifies the signed-in user");
+        return id;
+    }
+
+    private async Task<string?> LinkedDirectoryUserIdAsync(Guid userId)
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<AwsIdentityLinkStore>();
+        return await store.GetDirectoryUserIdAsync(userId);
     }
 
     // ── DTOs ──────────────────────────────────────────────────────────

--- a/tests/Connapse.Web.Tests/Services/SamlEnforcementLatchTests.cs
+++ b/tests/Connapse.Web.Tests/Services/SamlEnforcementLatchTests.cs
@@ -1,5 +1,6 @@
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Storage.Settings;
 using Connapse.Web.Services;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,6 +26,9 @@ public class SamlEnforcementLatchTests
 {
     private readonly ISettingsStore store = Substitute.For<ISettingsStore>();
 
+    /// <summary>Reads the database successfully unless a test says otherwise.</summary>
+    private readonly ISettingsReloader reloader = Substitute.For<ISettingsReloader>();
+
     private static SamlSignInSettings Complete() => new()
     {
         EntityId = "https://connapse.example.com/saml/connapse",
@@ -42,18 +46,20 @@ public class SamlEnforcementLatchTests
     }
 
     private (SamlEnforcementLatch Latch, EnforcementMigration Migration) Build(
-        SamlSignInSettings signIn, bool alreadyEnforcing = false)
+        SamlSignInSettings signIn, bool alreadyEnforcing = false, bool settingsReadable = true)
     {
         var services = new ServiceCollection();
         services.AddSingleton(store);
 
         var migration = new EnforcementMigration();
+        reloader.Reload().Returns(settingsReadable);
 
         return (new SamlEnforcementLatch(
             services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
             Monitor(signIn),
             Monitor(new PermissionEnforcementSettings { IsEnforcing = alreadyEnforcing }),
             migration,
+            reloader,
             NullLogger<SamlEnforcementLatch>.Instance), migration);
     }
 
@@ -93,6 +99,31 @@ public class SamlEnforcementLatchTests
 
         (await SavedMarker()).Should().BeNull();
         migration.Determined.Should().BeTrue("a fresh install's state is known, not unknown");
+    }
+
+    [Fact]
+    public async Task WhenTheSettingsCannotBeRead_LeavesTheStateUndetermined()
+    {
+        // The configuration is first loaded before the host starts, and a database that is
+        // unreachable at that moment leaves every stored value at its default without an error. A
+        // deployment that had been enforcing then reads as "never configured", which the branch for
+        // fresh installs would have recorded as unrestricted. Undetermined denies instead.
+        var (latch, migration) = Build(new SamlSignInSettings(), settingsReadable: false);
+        await latch.StartAsync(CancellationToken.None);
+
+        migration.Determined.Should().BeFalse();
+        (await SavedMarker()).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ReadsTheStoredSettingsAgainBeforeDeciding()
+    {
+        // Migrations run between the first configuration load and this service, so the values
+        // it decides from must come from a load that happened after them.
+        var (latch, _) = Build(Complete());
+        await latch.StartAsync(CancellationToken.None);
+
+        reloader.Received(1).Reload();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #473. Fixes the three verified findings from the Codex adversarial review of #472; the fourth (the credential-column migration) was checked against the tagged releases and left as is, since no release ever contained the access-key shape it deletes.

**1. Enforcement no longer fails open on an unreadable settings load (critical)**
`DatabaseSettingsProvider` now records `LastLoadSucceeded`, and `ISettingsReloader.Reload()` returns it. `SamlEnforcementLatch` reloads the stored settings after migrations and, if the database could not be read, leaves the migration undetermined, which the resolver already treats as deny. Previously a database that was briefly unreachable at configuration time made an enforcing deployment look unconfigured, and the latch recorded it as unrestricted.

**2. Credential changes take effect immediately (high)**
The Providers page calls `ClearCredentials()` on the singleton `ConnapseAwsCredentials` after saving or removing the Roles Anywhere credential, so the held session is not reused for the rest of its refresh window. The misleading "stops authenticating immediately" comment is corrected, and when environment credentials take over after a reset the outcome message says so. Fallback to the environment stays as designed.

**3. REST AWS disconnect deletes the real link (medium)**
`DELETE /api/v1/auth/cloud/AWS` now goes through `IAwsIdentityLinkService`, the store the integrations page uses; it answers 409 if the link changed during the call. Azure keeps the cloud-identity path.

**Tests**
- `SamlEnforcementLatchTests`: undetermined on an unreadable load; reloads before deciding.
- `CloudIdentityEndpointTests`: seeds a SAML link and proves the route deletes it with 204.
- 1,575 unit tests and 13 integration tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)