### PR TITLE
feat: Azure app identity + read-only Blob connector (#477)

### DIFF
--- a/docs/superpowers/plans/2026-09-05-azure-phase2-app-identity-connector.md
+++ b/docs/superpowers/plans/2026-09-05-azure-phase2-app-identity-connector.md
@@ -1,0 +1,1050 @@
+# Azure Phase 2 — ConnapseAzureCredentials + Blob Connector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver Azure Blob ingestion end-to-end — Connapse's own Azure identity (ambient managed identity, or a configured service-principal certificate) plus a rebuilt read-only Azure Blob connector, creatable through the Connections/Sources UI.
+
+**Architecture:** Mirror the existing S3 path. A pure `AzureCredentialChainFactory` turns settings into a `TokenCredential` (unit-testable without Azure); `ConnapseAzureCredentials` wraps it with `IOptionsMonitor`. `AzureBlobConnector` implements `IConnector` and accepts an injectable `BlobServiceClient` so the Azurite integration test can use a shared-key client (Azurite cannot authenticate an AAD `TokenCredential`). `ConnectorFactory` recombines connection config + source scope, exactly as it does for S3.
+
+**Tech Stack:** .NET 10, `Azure.Storage.Blobs`, `Azure.Identity` (`TokenCredential`, `ChainedTokenCredential`, `ClientCertificateCredential`, `ManagedIdentityCredential`), xUnit + FluentAssertions + NSubstitute, Testcontainers.Azurite.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-azure-phase2-app-identity-connector-design.md` (parent: `docs/superpowers/specs/2026-09-05-azure-blob-provider-design.md`).
+
+## Global Constraints
+
+- **One credential story, two contexts** — configured **certificate** (off-Azure) → **ambient managed identity** (in-Azure) → **fail closed**. No client-secret, no workload-identity-federation, no credential-kind chooser.
+- **Credential config from the settings hierarchy only** (`AzureProviderSettings`), NOT `ProviderCredentialEntity`. No DB-stored/encrypted credential in this phase.
+- Use an explicit **`ChainedTokenCredential`**, never `DefaultAzureCredential`.
+- **No per-user permission logic** (Phase 4). **No guided Providers setup page.** **No live-watch** (`SupportsLiveWatch = false`).
+- Enum values: `ConnectorType.AzureBlob = 4`, `ConnectionProvider.AzureBlob = 4`, `CloudProvider.Azure = 1` — do not renumber existing members.
+- Don't touch Azure OpenAI / AI Foundry, JWT/SAML, or the AWS path.
+- .NET conventions (CLAUDE.md): file-scoped namespaces, records for DTOs/settings, primary constructors for DI, async all the way, no `var` for primitives, parameterized SQL only.
+- Build: `dotnet build`. Tests: `dotnet test --filter "Category=Unit"` (no Docker), `dotnet test --filter "Category=Integration"` (Docker). Tag tests with `[Trait("Category","Unit")]` or `[Trait("Category","Integration")]`.
+
+---
+
+### Task 1: `AzureProviderSettings` + `AzureCredentialChainFactory`
+
+The pure credential-selection logic — the novel core, unit-testable without Azure.
+
+**Files:**
+- Create: `src/Connapse.Core/Models/AzureProviderSettings.cs`
+- Create: `src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs`
+- Modify: `src/Connapse.Storage/Connapse.Storage.csproj` (add `Azure.Identity`)
+
+**Interfaces:**
+- Produces: `record AzureProviderSettings { string? TenantId; string? ClientId; string? ClientCertificatePath; string? ClientCertificatePassword; string? UserAssignedManagedIdentityClientId; const string SectionName = "Providers:Azure"; }`
+- Produces: `static class AzureCredentialChainFactory { static TokenCredential Create(AzureProviderSettings settings, Func<AzureProviderSettings, X509Certificate2?> certLoader); }` — returns a `ChainedTokenCredential`; **throws `InvalidOperationException`** when `ClientId` is set but `certLoader` returns null (misconfiguration must not silently fall through to ambient).
+
+- [ ] **Step 1: Add the `Azure.Identity` package**
+
+Add to `src/Connapse.Storage/Connapse.Storage.csproj` (version pinned to the latest 1.x the restore resolves, ≥ 1.16.0 for the resilient MI retry mode):
+```xml
+<PackageReference Include="Azure.Identity" Version="1.16.0" />
+```
+Run: `dotnet restore` — expect success.
+
+- [ ] **Step 2: Write `AzureProviderSettings`**
+
+```csharp
+namespace Connapse.Core;
+
+/// <summary>
+/// Connapse's own Azure app-credential configuration, bound from the settings hierarchy.
+/// When ClientId + a certificate are present, Connapse authenticates as that service principal;
+/// otherwise it uses the ambient managed identity. Never a client secret.
+/// </summary>
+public record AzureProviderSettings
+{
+    public const string SectionName = "Providers:Azure";
+
+    public string? TenantId { get; init; }
+    public string? ClientId { get; init; }
+    public string? ClientCertificatePath { get; init; }
+    public string? ClientCertificatePassword { get; init; }
+    public string? UserAssignedManagedIdentityClientId { get; init; }
+}
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+```csharp
+using Azure.Identity;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureCredentialChainFactoryTests
+{
+    private static X509Certificate2 SelfSigned() =>
+        new CertificateRequest("CN=connapse-test",
+            System.Security.Cryptography.ECDsa.Create(),
+            HashAlgorithmName.SHA256)
+            .CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
+
+    [Fact]
+    public void Create_WithClientIdAndCert_UsesCertificateCredential()
+    {
+        var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        cred.Should().BeOfType<ChainedTokenCredential>();
+        // First source is the cert credential when configured.
+        FirstSource(cred).Should().BeOfType<ClientCertificateCredential>();
+    }
+
+    [Fact]
+    public void Create_NoCert_SystemAssignedManagedIdentity()
+    {
+        var cred = AzureCredentialChainFactory.Create(new AzureProviderSettings(), _ => null);
+        FirstSource(cred).Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    [Fact]
+    public void Create_NoCert_UserAssignedManagedIdentity()
+    {
+        var settings = new AzureProviderSettings { UserAssignedManagedIdentityClientId = "mi-client" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => null);
+        FirstSource(cred).Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    [Fact]
+    public void Create_ClientIdSetButCertMissing_Throws()
+    {
+        var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => null);
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*certificate*");
+    }
+
+    // Reads the private _sources array ChainedTokenCredential stores, to assert ordering.
+    private static TokenCredential FirstSource(TokenCredential chain)
+    {
+        var field = typeof(ChainedTokenCredential)
+            .GetField("_sources", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var sources = (TokenCredential[])field.GetValue(chain)!;
+        return sources[0];
+    }
+}
+```
+> Note: if a future `Azure.Identity` renames the private `_sources` field, switch `FirstSource` to assert behavior via a stubbed `certLoader`/env instead. The public contract under test is "cert first when configured, else MI, else throw."
+
+- [ ] **Step 4: Run tests, verify they fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~AzureCredentialChainFactoryTests"`
+Expected: FAIL — `AzureCredentialChainFactory` does not exist.
+
+- [ ] **Step 5: Implement `AzureCredentialChainFactory`**
+
+```csharp
+using Azure.Core;
+using Azure.Identity;
+using Connapse.Core;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Pure selection of Connapse's Azure credential from settings: a configured
+/// service-principal certificate first, else the ambient managed identity, else fail closed.
+/// Deterministic (an explicit ChainedTokenCredential) — never DefaultAzureCredential.
+/// </summary>
+public static class AzureCredentialChainFactory
+{
+    public static TokenCredential Create(
+        AzureProviderSettings settings,
+        Func<AzureProviderSettings, X509Certificate2?> certLoader)
+    {
+        var sources = new List<TokenCredential>();
+
+        if (!string.IsNullOrWhiteSpace(settings.ClientId))
+        {
+            X509Certificate2 cert = certLoader(settings)
+                ?? throw new InvalidOperationException(
+                    "Azure ClientId is configured but no usable certificate was loaded "
+                    + $"(ClientCertificatePath='{settings.ClientCertificatePath}'). "
+                    + "Fix the certificate configuration; Connapse will not silently fall back to managed identity.");
+
+            sources.Add(new ClientCertificateCredential(
+                settings.TenantId, settings.ClientId, cert,
+                new ClientCertificateCredentialOptions { SendCertificateChain = true }));
+        }
+
+        sources.Add(string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+            ? new ManagedIdentityCredential()
+            : new ManagedIdentityCredential(
+                ManagedIdentityId.FromUserAssignedClientId(settings.UserAssignedManagedIdentityClientId)));
+
+        return new ChainedTokenCredential(sources.ToArray());
+    }
+}
+```
+
+- [ ] **Step 6: Run tests, verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~AzureCredentialChainFactoryTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Connapse.Core/Models/AzureProviderSettings.cs src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs src/Connapse.Storage/Connapse.Storage.csproj
+git commit -m "feat(azure): AzureProviderSettings + credential chain factory (#477)"
+```
+
+---
+
+### Task 2: `ConnapseAzureCredentials`
+
+The `TokenCredential` singleton every Azure SDK client consumes — wraps the factory with `IOptionsMonitor`, caching the chain and rebuilding on settings reload.
+
+**Files:**
+- Create: `src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs`
+
+**Interfaces:**
+- Consumes: `AzureCredentialChainFactory.Create`, `AzureProviderSettings`.
+- Produces: `class ConnapseAzureCredentials : TokenCredential { const string ProviderKey = "azure"; }` — overrides `GetToken`/`GetTokenAsync` to delegate to the current chain.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Azure.Core;
+using Azure.Identity;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class ConnapseAzureCredentialsTests
+{
+    [Fact]
+    public void ProviderKey_IsAzure() => ConnapseAzureCredentials.ProviderKey.Should().Be("azure");
+
+    [Fact]
+    public void GetToken_WithNoAzureEnvironment_FailsClosed()
+    {
+        // No cert, no managed-identity endpoint reachable in a unit-test host → the chain
+        // cannot produce a token and throws, rather than returning a bogus token.
+        var monitor = new TestOptionsMonitor<AzureProviderSettings>(new AzureProviderSettings());
+        var creds = new ConnapseAzureCredentials(monitor);
+        var act = () => creds.GetToken(
+            new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
+        act.Should().Throw<CredentialUnavailableException>();
+    }
+
+    private sealed class TestOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; private set; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}
+```
+> The fail-closed assertion runs in a host with no managed-identity endpoint; `ManagedIdentityCredential` throws `CredentialUnavailableException`, which the chain surfaces. If a CI runner ever exposes an MI endpoint, gate this test with the `AZURE_*`-absent precondition.
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~ConnapseAzureCredentialsTests"`
+Expected: FAIL — `ConnapseAzureCredentials` does not exist.
+
+- [ ] **Step 3: Implement `ConnapseAzureCredentials`**
+
+```csharp
+using Azure.Core;
+using Connapse.Core;
+using Microsoft.Extensions.Options;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Connapse's own Azure identity: an explicit certificate-or-ambient-managed-identity chain,
+/// rebuilt when settings reload. The single TokenCredential every Azure SDK client uses.
+/// </summary>
+public sealed class ConnapseAzureCredentials : TokenCredential, IDisposable
+{
+    public const string ProviderKey = "azure";
+
+    private readonly IOptionsMonitor<AzureProviderSettings> _options;
+    private readonly IDisposable? _reload;
+    private readonly object _gate = new();
+    private TokenCredential _current;
+
+    public ConnapseAzureCredentials(IOptionsMonitor<AzureProviderSettings> options)
+    {
+        _options = options;
+        _current = Build(options.CurrentValue);
+        _reload = options.OnChange(settings =>
+        {
+            lock (_gate) { _current = Build(settings); }
+        });
+    }
+
+    private TokenCredential Current { get { lock (_gate) { return _current; } } }
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken ct) =>
+        Current.GetToken(requestContext, ct);
+
+    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken ct) =>
+        Current.GetTokenAsync(requestContext, ct);
+
+    private static TokenCredential Build(AzureProviderSettings settings) =>
+        AzureCredentialChainFactory.Create(settings, LoadCertificate);
+
+    private static X509Certificate2? LoadCertificate(AzureProviderSettings s)
+    {
+        if (string.IsNullOrWhiteSpace(s.ClientCertificatePath)) return null;
+        if (!File.Exists(s.ClientCertificatePath)) return null;
+
+        string ext = Path.GetExtension(s.ClientCertificatePath).ToLowerInvariant();
+        return ext is ".pem" or ".crt"
+            ? X509Certificate2.CreateFromPemFile(s.ClientCertificatePath)
+            : X509CertificateLoader.LoadPkcs12FromFile(s.ClientCertificatePath, s.ClientCertificatePassword);
+    }
+
+    public void Dispose() => _reload?.Dispose();
+}
+```
+> `X509Certificate2.CreateFromPemFile` reads a PEM cert (with its key from the same file or a paired `.key`); `X509CertificateLoader.LoadPkcs12FromFile` is the .NET 9+ replacement for the obsolete `new X509Certificate2(path, password)` PFX ctor. If the target framework lacks `X509CertificateLoader`, use `new X509Certificate2(path, password)` and suppress the obsoletion locally.
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~ConnapseAzureCredentialsTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs
+git commit -m "feat(azure): ConnapseAzureCredentials TokenCredential singleton (#477)"
+```
+
+---
+
+### Task 3: Enum values + `ResourceUri.ForAzureBlob`
+
+Foundational identifiers the connector and factory consume.
+
+**Files:**
+- Modify: `src/Connapse.Core/Models/StorageModels.cs` (`ConnectorType`)
+- Modify: `src/Connapse.Core/Models/ConnectionModels.cs` (`ConnectionProvider`)
+- Modify: `src/Connapse.Core/Models/CloudProvider.cs`
+- Modify: `src/Connapse.Core/Utilities/ResourceUri.cs`
+- Test: `tests/Connapse.Core.Tests/Utilities/ResourceUriTests.cs`
+
+**Interfaces:**
+- Produces: `ConnectorType.AzureBlob = 4`, `ConnectionProvider.AzureBlob = 4`, `CloudProvider.Azure = 1`, `ResourceUri.ForAzureBlob(string account, string container, string path) → "azblob://{account}/{container}/{path}"`.
+
+- [ ] **Step 1: Write the failing test** (append to `ResourceUriTests.cs`)
+
+```csharp
+[Fact]
+[Trait("Category", "Unit")]
+public void ForAzureBlob_BuildsAzblobUri()
+{
+    ResourceUri.ForAzureBlob("acct", "docs", "reports/q1.pdf")
+        .Should().Be("azblob://acct/docs/reports/q1.pdf");
+}
+
+[Fact]
+[Trait("Category", "Unit")]
+public void ForAzureBlob_BlankAccount_Throws()
+{
+    var act = () => ResourceUri.ForAzureBlob("", "docs", "k");
+    act.Should().Throw<ArgumentException>();
+}
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~ResourceUriTests.ForAzureBlob"`
+Expected: FAIL — `ForAzureBlob` not defined.
+
+- [ ] **Step 3: Implement**
+
+In `ResourceUri.cs`, add beside `ForS3`:
+```csharp
+public static string ForAzureBlob(string account, string container, string path)
+{
+    ArgumentException.ThrowIfNullOrWhiteSpace(account);
+    ArgumentException.ThrowIfNullOrWhiteSpace(container);
+    return $"azblob://{account}/{container}/{path}";
+}
+```
+In the three enums, add the Azure member (do not renumber others):
+- `ConnectorType`: `... S3 = 3, AzureBlob = 4, Sftp = 5 }`
+- `ConnectionProvider`: `... S3 = 3, AzureBlob = 4, Sftp = 5 }`
+- `CloudProvider`: `{ AWS = 0, Azure = 1 }`
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~ResourceUriTests.ForAzureBlob"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Models/StorageModels.cs src/Connapse.Core/Models/ConnectionModels.cs src/Connapse.Core/Models/CloudProvider.cs src/Connapse.Core/Utilities/ResourceUri.cs tests/Connapse.Core.Tests/Utilities/ResourceUriTests.cs
+git commit -m "feat(azure): re-add AzureBlob/Azure enum values + ResourceUri.ForAzureBlob (#477)"
+```
+
+---
+
+### Task 4: `AzureBlobConnectorConfig` + `AzureBlobConnector`
+
+**Files:**
+- Create: `src/Connapse.Storage/Connectors/AzureBlobConnectorConfig.cs`
+- Create: `src/Connapse.Storage/Connectors/AzureBlobConnector.cs`
+- Modify: `src/Connapse.Storage/Connapse.Storage.csproj` (add `Azure.Storage.Blobs`)
+- Test: `tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs`
+
+**Interfaces:**
+- Consumes: `ResourceUri.ForAzureBlob`, `ConnectorType.AzureBlob`, `TokenCredential`.
+- Produces: `record AzureBlobConnectorConfig { string AccountName; string ContainerName; string? Prefix; string? BlobEndpoint; }`; `class AzureBlobConnector : IConnector, IDisposable` with a public ctor `(AzureBlobConnectorConfig config, TokenCredential credential)` and an `internal` ctor `(AzureBlobConnectorConfig config, BlobServiceClient client)` used by tests.
+
+- [ ] **Step 1: Add the `Azure.Storage.Blobs` package**
+
+Add to `Connapse.Storage.csproj`:
+```xml
+<PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
+```
+Run: `dotnet restore` — expect success.
+
+- [ ] **Step 2: Write the failing unit test** (network-free surface only: `Type`, `SupportsLiveWatch`, `ResolveJobPath`, `WatchAsync` throws)
+
+```csharp
+using Azure.Storage.Blobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Connectors;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Connectors;
+
+[Trait("Category", "Unit")]
+public class AzureBlobConnectorUnitTests
+{
+    private static AzureBlobConnector Make() =>
+        new(new AzureBlobConnectorConfig { AccountName = "acct", ContainerName = "docs", Prefix = "reports/" },
+            new BlobServiceClient(new Uri("http://127.0.0.1:10000/devstoreaccount1")));
+
+    [Fact] public void Type_IsAzureBlob() => Make().Type.Should().Be(ConnectorType.AzureBlob);
+    [Fact] public void SupportsLiveWatch_False() => Make().SupportsLiveWatch.Should().BeFalse();
+
+    [Fact]
+    public void ResolveJobPath_JoinsUnderPrefix()
+        => Make().ResolveJobPath("q1.pdf").Should().Be("reports/q1.pdf");
+
+    [Fact]
+    public async Task WatchAsync_Throws()
+    {
+        var act = async () => { await foreach (var _ in Make().WatchAsync()) { } };
+        await act.Should().ThrowAsync<NotSupportedException>();
+    }
+}
+```
+
+- [ ] **Step 3: Run test, verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~AzureBlobConnectorUnitTests"`
+Expected: FAIL — types not defined.
+
+- [ ] **Step 4: Implement config + connector**
+
+`AzureBlobConnectorConfig.cs`:
+```csharp
+namespace Connapse.Storage.Connectors;
+
+/// <summary>Recombined connection (account/endpoint) + source (container/prefix) config for the Azure Blob connector.</summary>
+public record AzureBlobConnectorConfig
+{
+    public string AccountName { get; init; } = "";
+    public string ContainerName { get; init; } = "";
+    public string? Prefix { get; init; }
+    /// <summary>Overrides https://{account}.blob.core.windows.net (Azurite/local).</summary>
+    public string? BlobEndpoint { get; init; }
+}
+```
+
+`AzureBlobConnector.cs`:
+```csharp
+using Azure.Core;
+using Azure.Storage.Blobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
+using System.Runtime.CompilerServices;
+
+namespace Connapse.Storage.Connectors;
+
+/// <summary>
+/// Read-only Azure Blob Storage connector. Builds a BlobServiceClient from the account +
+/// Connapse's TokenCredential; the internal ctor accepts a prebuilt client for tests
+/// (Azurite cannot authenticate an AAD TokenCredential). SupportsLiveWatch = false.
+/// </summary>
+public sealed class AzureBlobConnector : IConnector, IDisposable
+{
+    private readonly AzureBlobConnectorConfig _config;
+    private readonly BlobContainerClient _container;
+
+    public AzureBlobConnector(AzureBlobConnectorConfig config, TokenCredential credential)
+        : this(config, new BlobServiceClient(
+            new Uri(config.BlobEndpoint ?? $"https://{config.AccountName}.blob.core.windows.net"),
+            credential))
+    { }
+
+    internal AzureBlobConnector(AzureBlobConnectorConfig config, BlobServiceClient client)
+    {
+        _config = config;
+        _container = client.GetBlobContainerClient(config.ContainerName);
+    }
+
+    public ConnectorType Type => ConnectorType.AzureBlob;
+    public bool SupportsLiveWatch => false;
+
+    public string ResolveJobPath(string relativePath) => CombinePrefix(relativePath);
+
+    public async Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
+    {
+        string effective = CombinePrefix(prefix ?? "");
+        var files = new List<ConnectorFile>();
+        await foreach (var item in _container.GetBlobsAsync(prefix: effective, cancellationToken: ct))
+        {
+            files.Add(new ConnectorFile(
+                item.Name,
+                item.Properties.ContentLength ?? 0,
+                (item.Properties.LastModified ?? DateTimeOffset.MinValue).UtcDateTime,
+                item.Properties.ContentType,
+                ResourceUri.ForAzureBlob(_config.AccountName, _config.ContainerName, item.Name)));
+        }
+        return files;
+    }
+
+    public async Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
+    {
+        var download = await _container.GetBlobClient(path).DownloadStreamingAsync(cancellationToken: ct);
+        return download.Value.Content;
+    }
+
+    public async Task<bool> ExistsAsync(string path, CancellationToken ct = default)
+        => await _container.GetBlobClient(path).ExistsAsync(ct);
+
+    public async IAsyncEnumerable<ConnectorFileEvent> WatchAsync([EnumeratorCancellation] CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Azure Blob connector does not support live watch.");
+#pragma warning disable CS0162
+        yield break;
+#pragma warning restore CS0162
+    }
+
+    private string CombinePrefix(string tail)
+    {
+        string p = _config.Prefix?.Trim('/') ?? "";
+        string t = tail.TrimStart('/');
+        return string.IsNullOrEmpty(p) ? t : string.IsNullOrEmpty(t) ? p + "/" : $"{p}/{t}";
+    }
+
+    public void Dispose() { }
+}
+```
+> `ListFilesAsync` correctness (real enumeration, prefix scoping, streaming reads) is covered by the Azurite integration test in Task 8; this unit test covers only the network-free surface.
+
+- [ ] **Step 5: Run test, verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~AzureBlobConnectorUnitTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Connapse.Storage/Connectors/AzureBlobConnectorConfig.cs src/Connapse.Storage/Connectors/AzureBlobConnector.cs src/Connapse.Storage/Connapse.Storage.csproj tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
+git commit -m "feat(azure): AzureBlobConnector + config (#477)"
+```
+
+---
+
+### Task 5: `ConnectorFactory` Azure arm
+
+**Files:**
+- Modify: `src/Connapse.Storage/Connectors/ConnectorFactory.cs` (add `ConnapseAzureCredentials` to the primary ctor; add the `ConnectionProvider.AzureBlob` switch arm)
+- Test: `tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs` (add the Azure case)
+
+**Interfaces:**
+- Consumes: `ConnapseAzureCredentials` (as `TokenCredential`), `AzureBlobConnector`, `AzureBlobConnectorConfig`, `ConnectionProvider.AzureBlob`.
+- Produces: `IConnectorFactory.Create(source, connection, secret)` returns an `AzureBlobConnector` for `ConnectionProvider.AzureBlob`, reading `accountName`/`blobEndpoint` from the connection config and `containerName`/`prefix` from the source scope.
+
+- [ ] **Step 1: Write the failing test** (mirror the existing S3 factory test in the same file)
+
+```csharp
+[Fact]
+[Trait("Category", "Unit")]
+public void Create_AzureBlob_BuildsConnectorFromSplitConfig()
+{
+    var connection = TestConnection(ConnectionProvider.AzureBlob,
+        configJson: """{"accountName":"acct"}""");
+    var source = TestSource(connection.Id,
+        scopeJson: """{"containerName":"docs","prefix":"reports/"}""");
+
+    var connector = Factory().Create(source, connection);
+
+    connector.Should().BeOfType<AzureBlobConnector>();
+    connector.Type.Should().Be(ConnectorType.AzureBlob);
+}
+```
+> Reuse the file's existing `TestConnection`/`TestSource`/`Factory` helpers (as the S3 case does). If `Factory()` needs the new ctor arg, pass a `ConnapseAzureCredentials` built with a `TestOptionsMonitor<AzureProviderSettings>(new())` — no network is touched because `Create` does not call the connector.
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~SourceConnectorFactoryTests.Create_AzureBlob"`
+Expected: FAIL — no AzureBlob arm / ctor arg missing.
+
+- [ ] **Step 3: Implement the arm**
+
+Add `ConnapseAzureCredentials azureCredentials` to `ConnectorFactory`'s constructor (beside the existing `awsCredentials`), store it, and add the switch arm after the S3 arm:
+```csharp
+ConnectionProvider.AzureBlob => new AzureBlobConnector(new AzureBlobConnectorConfig
+{
+    AccountName = Str(credential, "accountName")
+        ?? throw new InvalidOperationException(
+            $"Connection '{connection.Name}' has no accountName."),
+    BlobEndpoint = Str(credential, "blobEndpoint"),
+    ContainerName = RequirePermittedLocation(
+        StorageLocationPolicy.ReadAllowedLocations(credential.RootElement),
+        Str(scope, "containerName")
+            ?? throw new InvalidOperationException(
+                $"Source '{source.Name}' has no containerName in its scope."),
+        Str(scope, "prefix"),
+        connection.Name, source.Name),
+    Prefix = Str(scope, "prefix"),
+}, azureCredentials),
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~SourceConnectorFactoryTests"`
+Expected: PASS (the new case + existing S3/Filesystem/Sftp cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/Connectors/ConnectorFactory.cs tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
+git commit -m "feat(azure): ConnectorFactory AzureBlob arm (#477)"
+```
+
+---
+
+### Task 6: `AzureBlobConnectionTester`
+
+**Files:**
+- Create: `src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs`
+- Test: `tests/Connapse.Core.Tests/ConnectionTesterTests.cs` (add Azure settings-shaping cases)
+
+**Interfaces:**
+- Consumes: `ConnapseAzureCredentials`, `AzureBlobConnectorConfig`, `ConnectionTestResult`.
+- Produces: `class AzureBlobConnectionTester : IConnectionTester` — `TestConnectionAsync(object settings, …)` where `settings` is an `AzureBlobConnectorConfig`; lists ≤5 blobs; returns `ConnectionTestResult.CreateSuccess`/`CreateFailure`.
+
+- [ ] **Step 1: Write the failing test** (settings-shaping + failure mapping, no network)
+
+```csharp
+[Fact]
+[Trait("Category", "Unit")]
+public async Task AzureBlobTester_WrongSettingsType_Fails()
+{
+    var tester = new AzureBlobConnectionTester(
+        new ConnapseAzureCredentials(new TestOptionsMonitor<AzureProviderSettings>(new())));
+    var result = await tester.TestConnectionAsync("not-a-config", TimeSpan.FromSeconds(1));
+    result.Success.Should().BeFalse();
+    result.Message.Should().Contain("AzureBlobConnectorConfig");
+}
+```
+> `TestOptionsMonitor<T>` is the small stub from Task 2's test; extract it to a shared test helper (`tests/Connapse.Core.Tests/TestOptionsMonitor.cs`) if both projects need it, or duplicate the 5-line stub — do not add a production seam for it.
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~ConnectionTesterTests.AzureBlobTester"`
+Expected: FAIL — `AzureBlobConnectionTester` not defined.
+
+- [ ] **Step 3: Implement** (mirror `S3ConnectionTester` structure)
+
+```csharp
+using Azure;
+using Azure.Storage.Blobs;
+using Connapse.Core.Interfaces;
+using Connapse.Core.Models;
+using Connapse.Storage.CloudScope;
+using Connapse.Storage.Connectors;
+
+namespace Connapse.Storage.ConnectionTesters;
+
+/// <summary>Validates an Azure Blob connection by listing a few blobs with Connapse's identity.</summary>
+public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentials) : IConnectionTester
+{
+    public async Task<ConnectionTestResult> TestConnectionAsync(
+        object settings, TimeSpan? timeout = null, CancellationToken ct = default)
+    {
+        if (settings is not AzureBlobConnectorConfig cfg)
+            return ConnectionTestResult.CreateFailure(
+                "Invalid settings: expected AzureBlobConnectorConfig.");
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(timeout ?? TimeSpan.FromSeconds(10));
+
+        try
+        {
+            var service = new BlobServiceClient(
+                new Uri(cfg.BlobEndpoint ?? $"https://{cfg.AccountName}.blob.core.windows.net"),
+                credentials);
+            var container = service.GetBlobContainerClient(cfg.ContainerName);
+
+            int seen = 0;
+            await foreach (var _ in container.GetBlobsAsync(prefix: cfg.Prefix, cancellationToken: cts.Token))
+                if (++seen >= 5) break;
+
+            return ConnectionTestResult.CreateSuccess(
+                $"Connected to container '{cfg.ContainerName}' on account '{cfg.AccountName}'.");
+        }
+        catch (RequestFailedException ex) when (ex.Status == 403)
+        {
+            return ConnectionTestResult.CreateFailure(
+                "Authorization failed — Connapse's identity lacks read access to this container "
+                + "(needs Storage Blob Data Reader).");
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return ConnectionTestResult.CreateFailure(
+                $"Container '{cfg.ContainerName}' or account '{cfg.AccountName}' not found.");
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return ConnectionTestResult.CreateFailure("Connection test timed out.");
+        }
+        catch (Exception ex)
+        {
+            return ConnectionTestResult.CreateFailure($"Connection test failed: {ex.Message}");
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~ConnectionTesterTests.AzureBlobTester"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs tests/Connapse.Core.Tests/ConnectionTesterTests.cs
+git commit -m "feat(azure): AzureBlobConnectionTester (#477)"
+```
+
+---
+
+### Task 7: DI + settings wiring
+
+**Files:**
+- Modify: `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs`
+- Modify: `src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs` (`CategoryPrefixMap`)
+- Modify: `src/Connapse.Web/appsettings.json` (empty `Providers:Azure` section as documentation)
+- Test: `tests/Connapse.Integration.Tests/` — add a DI-resolution assertion to an existing startup/integration fixture test (a clean container start proves the DI graph)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `ConnapseAzureCredentials` (singleton), `AzureBlobConnectionTester` (scoped), `Configure<AzureProviderSettings>` bound to `"Providers:Azure"`, and the `ConnectorFactory` ctor's new arg satisfied.
+
+- [ ] **Step 1: Write the failing test** — add to the existing DI/host integration test (find the one that resolves `IConnectorFactory`/testers; e.g. in `Connapse.Integration.Tests`):
+
+```csharp
+[Fact]
+[Trait("Category", "Integration")]
+public void Di_Resolves_AzureCredentialsAndTester()
+{
+    using var scope = _fixture.Services.CreateScope();
+    scope.ServiceProvider.GetRequiredService<ConnapseAzureCredentials>().Should().NotBeNull();
+    scope.ServiceProvider.GetServices<IConnectionTester>()
+        .Should().Contain(t => t is AzureBlobConnectionTester);
+    scope.ServiceProvider.GetRequiredService<IConnectorFactory>().Should().NotBeNull();
+}
+```
+> Use the collection's shared `SharedWebAppFixture` (per CLAUDE.md) rather than a new host. If no such DI-resolution test exists yet, add this one to the existing integration collection.
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~Di_Resolves_AzureCredentials"`
+Expected: FAIL — `ConnapseAzureCredentials`/tester not registered (or `ConnectorFactory` ctor unsatisfied).
+
+- [ ] **Step 3: Implement the registrations**
+
+In `AddConnapseStorage` (`ServiceCollectionExtensions.cs`), beside the AWS credential + S3 tester registrations:
+```csharp
+services.Configure<AzureProviderSettings>(configuration.GetSection(AzureProviderSettings.SectionName));
+services.AddSingleton<ConnapseAzureCredentials>();
+services.AddScoped<IConnectionTester, AzureBlobConnectionTester>();
+```
+In `DatabaseSettingsProvider.CategoryPrefixMap`, add:
+```csharp
+["azure"] = "Providers:Azure",
+```
+In `appsettings.json`, add a documented empty section:
+```json
+"Providers": { "Azure": { "TenantId": "", "ClientId": "", "ClientCertificatePath": "", "UserAssignedManagedIdentityClientId": "" } }
+```
+(If `ConnectorFactory` is a singleton consuming `ConnapseAzureCredentials`, the new ctor arg is satisfied automatically once the singleton is registered.)
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~Di_Resolves_AzureCredentials"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs src/Connapse.Web/appsettings.json tests/Connapse.Integration.Tests/
+git commit -m "feat(azure): DI + settings wiring for Azure provider (#477)"
+```
+
+---
+
+### Task 8: Azurite integration tests
+
+**Files:**
+- Modify: `tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj` (add `Testcontainers.Azurite`)
+- Create: `tests/Connapse.Integration.Tests/AzuriteFixture.cs`
+- Create: `tests/Connapse.Integration.Tests/AzureBlobConnectorIntegrationTests.cs`
+- Modify: `tests/Connapse.Integration.Tests/CloudConnectorTestCollection.cs` (add `AzureBlobConnectorTestCollection`)
+
+**Interfaces:**
+- Consumes: `AzureBlobConnector` (internal `BlobServiceClient` ctor), `AzureBlobConnectorConfig`.
+- Produces: end-to-end coverage of list/read/exists/prefix/ResourceUri against Azurite.
+
+- [ ] **Step 1: Add the package**
+
+```xml
+<PackageReference Include="Testcontainers.Azurite" Version="4.3.0" />
+```
+Run: `dotnet restore` — expect success.
+
+- [ ] **Step 2: Write `AzuriteFixture`**
+
+```csharp
+using Testcontainers.Azurite;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+public sealed class AzuriteFixture : IAsyncLifetime
+{
+    private readonly AzuriteContainer _container = new AzuriteBuilder().Build();
+    public string ConnectionString => _container.GetConnectionString();
+    public Task InitializeAsync() => _container.StartAsync();
+    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+}
+```
+
+- [ ] **Step 3: Write the failing integration test** (drives the connector via the shared-key client — Azurite can't auth AAD)
+
+```csharp
+using Azure.Storage.Blobs;
+using Connapse.Storage.Connectors;
+using FluentAssertions;
+using System.Text;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("AzureBlobConnector")]
+public class AzureBlobConnectorIntegrationTests(AzuriteFixture fixture)
+{
+    [Fact]
+    public async Task ListAndRead_ScopedToPrefix()
+    {
+        var service = new BlobServiceClient(fixture.ConnectionString); // shared-key, Azurite
+        var container = service.GetBlobContainerClient("docs");
+        await container.CreateIfNotExistsAsync();
+        await container.UploadBlobAsync("reports/q1.pdf", new BinaryData("hello"));
+        await container.UploadBlobAsync("other/skip.txt", new BinaryData("nope"));
+
+        var connector = new AzureBlobConnector(
+            new AzureBlobConnectorConfig { AccountName = "devstoreaccount1", ContainerName = "docs", Prefix = "reports/" },
+            service); // internal test ctor
+
+        var files = await connector.ListFilesAsync();
+        files.Should().ContainSingle();
+        files[0].Path.Should().Be("reports/q1.pdf");
+        files[0].ResourceUri.Should().Be("azblob://devstoreaccount1/docs/reports/q1.pdf");
+
+        (await connector.ExistsAsync("reports/q1.pdf")).Should().BeTrue();
+        using var stream = await connector.ReadFileAsync("reports/q1.pdf");
+        (await new StreamReader(stream).ReadToEndAsync()).Should().Be("hello");
+    }
+}
+```
+> The internal ctor requires `[assembly: InternalsVisibleTo("Connapse.Integration.Tests")]` on `Connapse.Storage` — add it to that project's `AssemblyInfo`/csproj if not already present (the S3 tests' access pattern shows whether it is).
+
+- [ ] **Step 4: Add the test collection** in `CloudConnectorTestCollection.cs`:
+```csharp
+[CollectionDefinition("AzureBlobConnector")]
+public class AzureBlobConnectorTestCollection : ICollectionFixture<AzuriteFixture> { }
+```
+
+- [ ] **Step 5: Run test, verify it fails then passes**
+
+Run (fails first if run before Task 4 wiring, else drives real behavior): `dotnet test --filter "FullyQualifiedName~AzureBlobConnectorIntegrationTests"`
+Expected: PASS (needs Docker).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/Connapse.Integration.Tests/
+git commit -m "test(azure): Azurite integration tests for AzureBlobConnector (#477)"
+```
+
+---
+
+### Task 9: Connection/Source form UI
+
+**Files:**
+- Modify: `src/Connapse.Web/Components/Settings/ConnectionForm.cs`
+- Modify: `src/Connapse.Web/Components/Settings/SourceForm.cs`
+- Modify: `src/Connapse.Web/Components/Pages/Connections.razor`
+- Modify: `src/Connapse.Web/Components/Pages/Sources.razor`
+- Test: `tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs`, `tests/Connapse.Core.Tests/Sources/SourceFormTests.cs`
+
+**Interfaces:**
+- Consumes: `ConnectionProvider.AzureBlob`, `AzureBlobConnectionTester`.
+- Produces: `ConnectionForm` emits `{"accountName":...,"blobEndpoint"?:...}` for AzureBlob; `SourceForm` emits `{"containerName":...,"prefix"?:...}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`ConnectionFormTests.cs`:
+```csharp
+[Fact]
+[Trait("Category", "Unit")]
+public void ConnectionForm_AzureBlob_BuildsConfigJson()
+{
+    var form = new ConnectionForm { Provider = ConnectionProvider.AzureBlob, StorageAccountName = "acct" };
+    form.Validate().Should().BeNull();               // valid
+    form.ToConfigJson().Should().Contain("\"accountName\":\"acct\"");
+}
+
+[Fact]
+[Trait("Category", "Unit")]
+public void ConnectionForm_AzureBlob_MissingAccount_FailsValidation()
+{
+    var form = new ConnectionForm { Provider = ConnectionProvider.AzureBlob };
+    form.Validate().Should().NotBeNull();
+}
+```
+`SourceFormTests.cs`:
+```csharp
+[Fact]
+[Trait("Category", "Unit")]
+public void SourceForm_AzureBlob_BuildsScopeJson()
+{
+    var form = new SourceForm { Container = "docs", Prefix = "reports/" };
+    form.ToScopeJson(ConnectionProvider.AzureBlob)
+        .Should().Contain("\"containerName\":\"docs\"").And.Contain("\"prefix\":\"reports/\"");
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~ConnectionForm_AzureBlob|FullyQualifiedName~SourceForm_AzureBlob"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the form logic**
+
+`ConnectionForm.cs`:
+- Add `public string? StorageAccountName { get; set; }` and `public string? BlobEndpoint { get; set; }`.
+- In `IsCloudProvider` (or the cloud-branching property), include `ConnectionProvider.AzureBlob`.
+- In `ToConfigJson()`, add the case: for `AzureBlob`, serialize `{ accountName = StorageAccountName, blobEndpoint = string.IsNullOrWhiteSpace(BlobEndpoint) ? null : BlobEndpoint }` (omit null endpoint).
+- In `Validate()`, add: `AzureBlob` requires non-blank `StorageAccountName` (else return a message).
+
+`SourceForm.cs`:
+- In `ToScopeJson(provider)`, add the `ConnectionProvider.AzureBlob` case building `{ containerName = Container, prefix = Prefix (if non-blank) }` (mirror the S3 case that uses `Container` as bucketName).
+- In `Validate()`, require `Container` for `AzureBlob`.
+
+`Connections.razor`:
+- Add `@inject AzureBlobConnectionTester AzureBlobTester`.
+- Add `<option value="AzureBlob">Azure Blob Storage</option>` to the provider select.
+- Add the Azure form branch (Storage Account Name input, optional Blob Endpoint).
+- Wire the test button for AzureBlob to call `AzureBlobTester.TestConnectionAsync(new AzureBlobConnectorConfig { AccountName = form.StorageAccountName, BlobEndpoint = form.BlobEndpoint, ContainerName = "$root" })` — test at account level; use a probe container name only if the form has one, else test service-level reachability.
+- Add the summary/`DescribeScope` arm for AzureBlob.
+
+`Sources.razor`:
+- Add the `ConnectionProvider.AzureBlob` branch rendering the container + prefix fields (mirror S3's bucket + prefix).
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~ConnectionForm_AzureBlob|FullyQualifiedName~SourceForm_AzureBlob"`
+Expected: PASS.
+
+- [ ] **Step 5: Build (Blazor components compile)**
+
+Run: `dotnet build`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Connapse.Web/Components/Settings/ConnectionForm.cs src/Connapse.Web/Components/Settings/SourceForm.cs src/Connapse.Web/Components/Pages/Connections.razor src/Connapse.Web/Components/Pages/Sources.razor tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
+git commit -m "feat(azure): connection/source form UI for Azure Blob (#477)"
+```
+
+---
+
+### Task 10: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full build**
+
+Run: `dotnet build`
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 2: Unit tests**
+
+Run: `dotnet test --filter "Category=Unit"`
+Expected: PASS (all, including the new Azure unit tests).
+
+- [ ] **Step 3: Integration tests (Docker)**
+
+Run: `dotnet test --filter "Category=Integration"`
+Expected: the Azure integration + DI-resolution tests PASS. (Pre-existing Ollama-dependent ingestion tests may fail if no local Ollama — that is the known environmental gap from Phase 1, not introduced here; confirm any failures are only those.)
+
+- [ ] **Step 4: Confirm Azure OpenAI untouched**
+
+Run: `rg -ln "AzureOpenAi|AzureAIFoundry" src/`
+Expected: the AI-provider files still present.
+
+- [ ] **Step 5: Push + open PR**
+
+```bash
+git push -u origin feature/477-azure-app-identity-connector
+gh pr create --repo Destrayon/Connapse --base main \
+  --title "feat: Azure Blob connector + ConnapseAzureCredentials (#477)" \
+  --body "Closes #477. Part of epic #475. Adds Connapse's Azure identity (ambient managed identity, or a configured service-principal certificate) and a read-only Azure Blob connector, creatable via the Connections/Sources UI. No per-user permission filtering (Phase 4); no guided Providers page or DB-stored credentials (deferred). See docs/superpowers/specs/2026-09-05-azure-phase2-app-identity-connector-design.md."
+```
+(Push/PR is an outward action — perform in the finishing step after the whole-branch review, with the user's go-ahead.)
+
+---
+
+## Self-Review
+
+**Spec coverage:** §A credential (Tasks 1–2, chain factory + wrapper, cert-or-MI-or-fail-closed, `AzureProviderSettings` from config), §B connector (Tasks 3–4, `ResourceUri.ForAzureBlob`, config, connector with injectable client), §C enums + factory (Tasks 3, 5), §D UI (Task 9, forms only), §E DI/packages/settings (Tasks 1/4/7/8 add the three packages; Task 7 DI + category map), testing (Tasks 1–2 unit chain, 8 Azurite seam, 7 DI-resolution). Non-goals (Providers page, DB creds, federation/secret, per-user perms, live-watch) are respected — no task implements them.
+
+**Placeholder scan:** UI Task 9's razor steps describe exact fields/JSON/validation rather than pasting full markup — that is the one place the plan gives precise instructions over verbatim code, because Blazor markup mirrors the existing S3 branch in the same files; every data shape (`accountName`/`blobEndpoint`/`containerName`/`prefix`) and validation rule is stated explicitly. No "TBD"/"handle edge cases"/"similar to Task N" remain.
+
+**Type consistency:** `AzureProviderSettings` fields, `AzureBlobConnectorConfig { AccountName, ContainerName, Prefix, BlobEndpoint }`, `AzureCredentialChainFactory.Create(settings, certLoader)`, `ConnapseAzureCredentials.ProviderKey = "azure"`, and `ResourceUri.ForAzureBlob(account, container, path)` are used identically across tasks. The connection-config keys (`accountName`/`blobEndpoint`) and source-scope keys (`containerName`/`prefix`) match between the factory (Task 5), the forms (Task 9), and the integration test (Task 8).

--- a/docs/superpowers/specs/2026-09-05-azure-phase2-app-identity-connector-design.md
+++ b/docs/superpowers/specs/2026-09-05-azure-phase2-app-identity-connector-design.md
@@ -1,0 +1,91 @@
+# Azure Phase 2 — ConnapseAzureCredentials + Azure Blob connector
+
+**Status:** Design — approved in brainstorming, pending spec review
+**Date:** 2026-09-05
+**Milestone:** v0.4.0 · Issue #477 · Epic #475
+**Parent design:** `docs/superpowers/specs/2026-09-05-azure-blob-provider-design.md` (§A credentials, §E data plane). This phase spec refines that section with the phase-specific decisions; where they differ, this document governs Phase 2.
+
+## Goal
+
+Deliver Azure Blob ingestion end-to-end: Connapse's own Azure identity plus a rebuilt read-only Azure Blob data-plane connector, creatable through the existing Connections/Sources UI. **No per-user permission filtering** (that is Phase 4). Independently shippable — a green increment that ingests Azure blobs.
+
+## Scope decisions (from brainstorming)
+
+1. **One credential story, two runtime contexts** — not a chooser among kinds. Ambient **managed identity** in Azure; a configured service-principal **certificate** off-Azure. No client-secret, no workload-identity-federation, no UI toggle among kinds.
+2. **Credential config comes from the settings hierarchy**, not `ProviderCredentialEntity`. DataProtection-encrypted DB storage of the cert (written by a guided Providers page) is a **deferred** follow-up. Reading a cert by path/config keeps this phase decoupled from that UI.
+3. **UI is connection/source forms only.** The guided Azure Providers setup page (credential status cards) is deferred.
+
+## Components
+
+### A. `ConnapseAzureCredentials` (Connapse.Storage/CloudScope)
+
+Mirror of [`ConnapseAwsCredentials`](../../../src/Connapse.Storage/CloudScope/ConnapseAwsCredentials.cs); `ProviderKey = "azure"`. Exposes an `Azure.Core.TokenCredential` consumed by every Azure SDK client. Built as an explicit `ChainedTokenCredential` (never `DefaultAzureCredential` — deterministic, no silent fall-through):
+
+1. **Configured certificate** — when `AzureProviderSettings` supplies `TenantId` + `ClientId` + a certificate: `new ClientCertificateCredential(tenantId, clientId, cert, new ClientCertificateCredentialOptions { SendCertificateChain = true })`.
+2. **Ambient managed identity** — `new ManagedIdentityCredential(ManagedIdentityId.FromUserAssignedClientId(id))` when `UserAssignedManagedIdentityClientId` is set, else `new ManagedIdentityCredential()`.
+3. **Fail closed** — if neither branch can produce a credential object, the chain has no usable entry; a `GetToken` failure propagates and callers deny. No developer-tool credentials in the chain.
+
+Registered **singleton**. Reads `IOptionsMonitor<AzureProviderSettings>` at token time so config reload (settings table) takes effect without restart. The Azure SDK honors `AccessToken.RefreshOn` for SDK-client calls, so **no manual refresh timer** (unlike the AWS design). Uses `Task.Run` where a synchronous credential path could deadlock the Blazor sync context, matching the AWS credential's precaution.
+
+**`AzureProviderSettings`** (`Connapse.Core/Models`), bound from configuration only:
+- `TenantId : string?`
+- `ClientId : string?`
+- `ClientCertificatePath : string?` (PEM or PFX path; the private key stays on disk under file permissions — the `AZURE_CLIENT_CERTIFICATE_PATH` pattern)
+- `ClientCertificatePassword : string?` (for PFX; optional)
+- `UserAssignedManagedIdentityClientId : string?`
+- `SectionName = "Providers:Azure"`; a `DatabaseSettingsProvider.CategoryPrefixMap` entry maps DB category `azure` → `Providers:Azure`.
+
+Cert loading is a small helper: PEM (`X509Certificate2.CreateFromPemFile`) or PFX (`new X509Certificate2(path, password)`), selected by extension/content. A missing/invalid cert file when `ClientId` is set is a **configuration error surfaced at credential build**, not a silent fall-through to ambient (that would mask a misconfiguration).
+
+### B. Data-plane connector (Connapse.Storage/Connectors)
+
+- **`AzureBlobConnectorConfig`** record: `{ AccountName, ContainerName, Prefix?, BlobEndpoint? }`. `BlobEndpoint` overrides the default `https://{account}.blob.core.windows.net` (Azurite/local).
+- **`AzureBlobConnector : IConnector, IDisposable`** — ctor `(AzureBlobConnectorConfig config, TokenCredential credential)`. Builds one `BlobServiceClient` (per instance) from `BlobEndpoint ?? https://{account}.blob.core.windows.net` + credential; `GetBlobContainerClient(ContainerName)`. `Type => ConnectorType.AzureBlob`; `SupportsLiveWatch => false`.
+  - `ListFilesAsync(prefix)` → `container.GetBlobsAsync(prefix: Combine(Prefix, prefix))`, paged, mapping each to `ConnectorFile` with `ResourceUri.ForAzureBlob(AccountName, ContainerName, blobName)`.
+  - `ReadFileAsync(path)` → `GetBlobClient(path).DownloadStreamingAsync()`.
+  - `ExistsAsync(path)` → `GetBlobClient(path).ExistsAsync()`.
+  - `ResolveJobPath(relative)` → prefix-joined blob key.
+  - `WatchAsync` → not supported (mirrors S3).
+- **`ResourceUri.ForAzureBlob(account, container, path)`** → `azblob://{account}/{container}/{path}` (re-added; mirror `ForS3`).
+- **`AzureBlobConnectionTester : IConnectionTester`** — `TestConnectionAsync` lists up to ~5 blobs via the credential; rich per-status error messages (auth failure, container missing, account not found), mirroring `S3ConnectionTester`.
+
+### C. Enum re-add + factory recombination
+
+- `ConnectorType.AzureBlob = 4`, `ConnectionProvider.AzureBlob = 4`, `CloudProvider.Azure = 1` (values match, per the enum comment's cast-backfill convention).
+- `ConnectorFactory` gains the `ConnectionProvider.AzureBlob` arm: read `accountName`/`blobEndpoint` from the **connection** config, `containerName`/`prefix` from the **source** scope, run `RequirePermittedLocation` (same as S3), pass the singleton `ConnapseAzureCredentials`' `TokenCredential`. Throws if `source.ConnectionId != connection.Id` (existing invariant).
+
+**JSON shapes:**
+- Connection config: `{ "accountName": "...", "blobEndpoint"?: "..." }`
+- Source scope: `{ "containerName": "...", "prefix"?: "..." }`
+
+### D. UI (forms only)
+
+- `ConnectionForm` — add `StorageAccountName` (and optional `BlobEndpoint`) fields; add `AzureBlob` to the `IsCloudProvider` arm, the build case (`ToConfigJson` → `{accountName, blobEndpoint?}`), and validation (account name required, DNS-name shape).
+- `SourceForm` — add the `AzureBlob` case to `ToScopeJson` (`{containerName, prefix?}`) and validation (container required).
+- `Connections.razor` — provider `<option>`, the Azure form branch, the `AzureBlobConnectionTester` test call, and the summary/`DescribeScope` arm.
+- `Sources.razor` — the `ConnectionProvider.AzureBlob` branch for the container/prefix fields.
+
+### E. DI, packages, settings
+
+- Re-add NuGet to `Connapse.Storage.csproj`: `Azure.Storage.Blobs`, `Azure.Identity`.
+- `Connapse.Storage/Extensions/ServiceCollectionExtensions.cs`: register `ConnapseAzureCredentials` (singleton), `AzureBlobConnectionTester` (scoped), and `Configure<AzureProviderSettings>` from the `"Providers:Azure"` section; `ConnectorFactory` picks up the new arm.
+- `DatabaseSettingsProvider.CategoryPrefixMap`: add `["azure"] = "Providers:Azure"`.
+
+## Testing
+
+- **Unit — `ConnapseAzureCredentialsTests`** (no Docker): cert-configured → a `ClientCertificateCredential` is composed; no cert but MI configured → `ManagedIdentityCredential` (system vs user-assigned by settings); neither → fail-closed (a token request throws / yields no token); an invalid cert path with `ClientId` set → surfaces a configuration error rather than silently using ambient. Assert on the composed chain / a seam that exposes which branch was chosen (extract a small pure `AzureCredentialChainFactory` so the composition is unit-testable without real Azure).
+- **Unit** — `ResourceUri.ForAzureBlob` round-trips (clone the S3 cases); `ConnectorFactory` builds the Azure arm from split config/scope; `ConnectionForm`/`SourceForm` Azure build+validation cases.
+- **Integration — `AzureBlobConnectorIntegrationTests`** (Testcontainers **Azurite**): re-add `Testcontainers.Azurite` + an `AzuriteFixture`. **Azurite cannot authenticate an AAD `TokenCredential`**, so the test drives the connector's list/read/`ResourceUri` logic through a blob client built with Azurite's **shared-key/connection-string** (a test-only construction path — the `TestableAzureBlobConnector` pattern that Phase 1 deleted). This proves blob enumeration, prefix scoping, streaming reads, and URI minting; the `TokenCredential` wiring is covered by the unit tests above, not against Azurite.
+- Add the `AzureBlobConnectorTestCollection` back to `CloudConnectorTestCollection.cs`.
+
+## Testable seams (design-for-isolation)
+
+- `AzureCredentialChainFactory` (pure): `(AzureProviderSettings, certLoader) → TokenCredential` — the branch logic, unit-testable without Azure. `ConnapseAzureCredentials` wraps it + `IOptionsMonitor`.
+- `AzureBlobConnector` takes an already-built `BlobServiceClient` via an internal ctor (or a client-factory delegate) so the integration test can inject the Azurite shared-key client while production uses the account+credential path.
+
+## Non-goals (deferred)
+
+- Guided Azure Providers setup page + DataProtection-encrypted `ProviderCredentialEntity` storage of the cert.
+- Workload-identity-federation and client-secret credential kinds.
+- Per-user permission resolution / search filtering (Phase 4, #479).
+- Live-watch for Azure Blob.

--- a/src/Connapse.Core/Models/AzureProviderSettings.cs
+++ b/src/Connapse.Core/Models/AzureProviderSettings.cs
@@ -1,0 +1,17 @@
+namespace Connapse.Core;
+
+/// <summary>
+/// Connapse's own Azure app-credential configuration, bound from the settings hierarchy.
+/// When ClientId + a certificate are present, Connapse authenticates as that service principal;
+/// otherwise it uses the ambient managed identity. Never a client secret.
+/// </summary>
+public record AzureProviderSettings
+{
+    public const string SectionName = "Providers:Azure";
+
+    public string? TenantId { get; init; }
+    public string? ClientId { get; init; }
+    public string? ClientCertificatePath { get; init; }
+    public string? ClientCertificatePassword { get; init; }
+    public string? UserAssignedManagedIdentityClientId { get; init; }
+}

--- a/src/Connapse.Core/Models/CloudProvider.cs
+++ b/src/Connapse.Core/Models/CloudProvider.cs
@@ -2,5 +2,6 @@ namespace Connapse.Core;
 
 public enum CloudProvider
 {
-    AWS = 0
+    AWS = 0,
+    Azure = 1
 }

--- a/src/Connapse.Core/Models/ConnectionModels.cs
+++ b/src/Connapse.Core/Models/ConnectionModels.cs
@@ -6,7 +6,7 @@ namespace Connapse.Core;
 /// ManagedStorage is deliberately absent: it is Connapse's own backend, not an
 /// external system requiring credentials.
 /// </summary>
-public enum ConnectionProvider { Filesystem = 1, S3 = 3, Sftp = 5 }
+public enum ConnectionProvider { Filesystem = 1, S3 = 3, AzureBlob = 4, Sftp = 5 }
 
 public record Connection(
     Guid Id,

--- a/src/Connapse.Core/Models/StorageModels.cs
+++ b/src/Connapse.Core/Models/StorageModels.cs
@@ -1,6 +1,6 @@
 ﻿namespace Connapse.Core;
 
-public enum ConnectorType { ManagedStorage = 0, Filesystem = 1, S3 = 3, Sftp = 5 }
+public enum ConnectorType { ManagedStorage = 0, Filesystem = 1, S3 = 3, AzureBlob = 4, Sftp = 5 }
 
 public record ContainerSettingsOverrides
 {

--- a/src/Connapse.Core/Utilities/ResourceUri.cs
+++ b/src/Connapse.Core/Utilities/ResourceUri.cs
@@ -28,4 +28,12 @@ public static class ResourceUri
         ArgumentException.ThrowIfNullOrWhiteSpace(bucket);
         return $"s3://{bucket}/{key}";
     }
+
+    /// <summary>An Azure Blob Storage object, as <c>azblob://account/container/path</c>.</summary>
+    public static string ForAzureBlob(string account, string container, string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(account);
+        ArgumentException.ThrowIfNullOrWhiteSpace(container);
+        return $"azblob://{account}/{container}/{path}";
+    }
 }

--- a/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
@@ -1,0 +1,41 @@
+using Azure.Core;
+using Azure.Identity;
+using Connapse.Core;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Pure selection of Connapse's Azure credential from settings: a configured
+/// service-principal certificate first, else the ambient managed identity, else fail closed.
+/// Deterministic (an explicit ChainedTokenCredential) — never DefaultAzureCredential.
+/// </summary>
+public static class AzureCredentialChainFactory
+{
+    public static TokenCredential Create(
+        AzureProviderSettings settings,
+        Func<AzureProviderSettings, X509Certificate2?> certLoader)
+    {
+        var sources = new List<TokenCredential>();
+
+        if (!string.IsNullOrWhiteSpace(settings.ClientId))
+        {
+            X509Certificate2 cert = certLoader(settings)
+                ?? throw new InvalidOperationException(
+                    "Azure ClientId is configured but no usable certificate was loaded "
+                    + $"(ClientCertificatePath='{settings.ClientCertificatePath}'). "
+                    + "Fix the certificate configuration; Connapse will not silently fall back to managed identity.");
+
+            sources.Add(new ClientCertificateCredential(
+                settings.TenantId, settings.ClientId, cert,
+                new ClientCertificateCredentialOptions { SendCertificateChain = true }));
+        }
+
+        sources.Add(string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+            ? new ManagedIdentityCredential()
+            : new ManagedIdentityCredential(
+                ManagedIdentityId.FromUserAssignedClientId(settings.UserAssignedManagedIdentityClientId)));
+
+        return new ChainedTokenCredential(sources.ToArray());
+    }
+}

--- a/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
@@ -16,26 +16,43 @@ public static class AzureCredentialChainFactory
         AzureProviderSettings settings,
         Func<AzureProviderSettings, X509Certificate2?> certLoader)
     {
-        var sources = new List<TokenCredential>();
+        bool anyServicePrincipalFieldSet =
+            !string.IsNullOrWhiteSpace(settings.TenantId)
+            || !string.IsNullOrWhiteSpace(settings.ClientId)
+            || !string.IsNullOrWhiteSpace(settings.ClientCertificatePath)
+            || !string.IsNullOrWhiteSpace(settings.ClientCertificatePassword);
 
-        if (!string.IsNullOrWhiteSpace(settings.ClientId))
+        if (!anyServicePrincipalFieldSet)
         {
-            X509Certificate2 cert = certLoader(settings)
-                ?? throw new InvalidOperationException(
-                    "Azure ClientId is configured but no usable certificate was loaded "
-                    + $"(ClientCertificatePath='{settings.ClientCertificatePath}'). "
-                    + "Fix the certificate configuration; Connapse will not silently fall back to managed identity.");
+            // No service-principal intent at all: managed-identity-only chain.
+            TokenCredential managedIdentity = string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+                ? new ManagedIdentityCredential()
+                : new ManagedIdentityCredential(
+                    ManagedIdentityId.FromUserAssignedClientId(settings.UserAssignedManagedIdentityClientId));
 
-            sources.Add(new ClientCertificateCredential(
-                settings.TenantId, settings.ClientId, cert,
-                new ClientCertificateCredentialOptions { SendCertificateChain = true }));
+            return new ChainedTokenCredential(managedIdentity);
         }
 
-        sources.Add(string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
-            ? new ManagedIdentityCredential()
-            : new ManagedIdentityCredential(
-                ManagedIdentityId.FromUserAssignedClientId(settings.UserAssignedManagedIdentityClientId)));
+        // Any populated service-principal field is intent to use certificate auth.
+        // Require a complete, usable set — never fall through to managed identity
+        // (a broader, ambient identity) on a partial or broken configuration.
+        if (string.IsNullOrWhiteSpace(settings.TenantId) || string.IsNullOrWhiteSpace(settings.ClientId))
+        {
+            throw new InvalidOperationException(
+                "Azure service-principal fields are partially configured (some of TenantId, ClientId, "
+                + "ClientCertificatePath, ClientCertificatePassword are set) but TenantId and ClientId are "
+                + "both required. Fix the certificate configuration; Connapse will not silently fall back "
+                + "to managed identity.");
+        }
 
-        return new ChainedTokenCredential(sources.ToArray());
+        X509Certificate2 cert = certLoader(settings)
+            ?? throw new InvalidOperationException(
+                "Azure ClientId is configured but no usable certificate was loaded "
+                + $"(ClientCertificatePath='{settings.ClientCertificatePath}'). "
+                + "Fix the certificate configuration; Connapse will not silently fall back to managed identity.");
+
+        return new ChainedTokenCredential(new ClientCertificateCredential(
+            settings.TenantId, settings.ClientId, cert,
+            new ClientCertificateCredentialOptions { SendCertificateChain = true }));
     }
 }

--- a/src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs
+++ b/src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs
@@ -1,0 +1,54 @@
+using Azure.Core;
+using Connapse.Core;
+using Microsoft.Extensions.Options;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Connapse's own Azure identity: an explicit certificate-or-ambient-managed-identity chain,
+/// rebuilt when settings reload. The single TokenCredential every Azure SDK client uses.
+/// </summary>
+public sealed class ConnapseAzureCredentials : TokenCredential, IDisposable
+{
+    public const string ProviderKey = "azure";
+
+    private readonly IOptionsMonitor<AzureProviderSettings> _options;
+    private readonly IDisposable? _reload;
+    private readonly object _gate = new();
+    private TokenCredential _current;
+
+    public ConnapseAzureCredentials(IOptionsMonitor<AzureProviderSettings> options)
+    {
+        _options = options;
+        _current = Build(options.CurrentValue);
+        _reload = options.OnChange(settings =>
+        {
+            lock (_gate) { _current = Build(settings); }
+        });
+    }
+
+    private TokenCredential Current { get { lock (_gate) { return _current; } } }
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken ct) =>
+        Current.GetToken(requestContext, ct);
+
+    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken ct) =>
+        Current.GetTokenAsync(requestContext, ct);
+
+    private static TokenCredential Build(AzureProviderSettings settings) =>
+        AzureCredentialChainFactory.Create(settings, LoadCertificate);
+
+    private static X509Certificate2? LoadCertificate(AzureProviderSettings s)
+    {
+        if (string.IsNullOrWhiteSpace(s.ClientCertificatePath)) return null;
+        if (!File.Exists(s.ClientCertificatePath)) return null;
+
+        string ext = Path.GetExtension(s.ClientCertificatePath).ToLowerInvariant();
+        return ext is ".pem" or ".crt"
+            ? X509Certificate2.CreateFromPemFile(s.ClientCertificatePath)
+            : X509CertificateLoader.LoadPkcs12FromFile(s.ClientCertificatePath, s.ClientCertificatePassword);
+    }
+
+    public void Dispose() => _reload?.Dispose();
+}

--- a/src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs
+++ b/src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs
@@ -16,19 +16,32 @@ public sealed class ConnapseAzureCredentials : TokenCredential, IDisposable
     private readonly IOptionsMonitor<AzureProviderSettings> _options;
     private readonly IDisposable? _reload;
     private readonly object _gate = new();
-    private TokenCredential _current;
+    private TokenCredential? _current;
 
     public ConnapseAzureCredentials(IOptionsMonitor<AzureProviderSettings> options)
     {
         _options = options;
-        _current = Build(options.CurrentValue);
-        _reload = options.OnChange(settings =>
+        // Deliberately do NOT build here: a missing/unreadable cert or incomplete config
+        // must not throw during DI construction and take down unrelated (non-Azure) hosts.
+        // The credential is built lazily on first GetToken/GetTokenAsync call.
+        _reload = options.OnChange(_ =>
         {
-            lock (_gate) { _current = Build(settings); }
+            // Invalidate only — never build (and never let a build failure throw) from
+            // the reload callback. The next token request rebuilds from fresh settings.
+            lock (_gate) { _current = null; }
         });
     }
 
-    private TokenCredential Current { get { lock (_gate) { return _current; } } }
+    private TokenCredential Current
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _current ??= Build(_options.CurrentValue);
+            }
+        }
+    }
 
     public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken ct) =>
         Current.GetToken(requestContext, ct);

--- a/src/Connapse.Storage/Connapse.Storage.csproj
+++ b/src/Connapse.Storage/Connapse.Storage.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.15" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
     <PackageReference Include="Azure.Identity" Version="1.16.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -39,6 +40,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Connapse.Core.Tests" />
     <InternalsVisibleTo Include="Connapse.Storage.Tests" />
+    <InternalsVisibleTo Include="Connapse.Integration.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Connapse.Storage/Connapse.Storage.csproj
+++ b/src/Connapse.Storage/Connapse.Storage.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="AWSSDK.SSO" Version="4.0.2.14" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.15" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.Identity" Version="1.16.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
@@ -1,0 +1,57 @@
+using Azure;
+using Azure.Storage.Blobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using Connapse.Storage.Connectors;
+
+namespace Connapse.Storage.ConnectionTesters;
+
+/// <summary>Validates an Azure Blob connection by listing a few blobs with Connapse's identity.</summary>
+public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentials) : IConnectionTester
+{
+    public async Task<ConnectionTestResult> TestConnectionAsync(
+        object settings, TimeSpan? timeout = null, CancellationToken ct = default)
+    {
+        if (settings is not AzureBlobConnectorConfig cfg)
+            return ConnectionTestResult.CreateFailure(
+                "Invalid settings: expected AzureBlobConnectorConfig.");
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(timeout ?? TimeSpan.FromSeconds(10));
+
+        try
+        {
+            var service = new BlobServiceClient(
+                new Uri(cfg.BlobEndpoint ?? $"https://{cfg.AccountName}.blob.core.windows.net"),
+                credentials);
+            var container = service.GetBlobContainerClient(cfg.ContainerName);
+
+            int seen = 0;
+            await foreach (var _ in container.GetBlobsAsync(prefix: cfg.Prefix, cancellationToken: cts.Token))
+                if (++seen >= 5) break;
+
+            return ConnectionTestResult.CreateSuccess(
+                $"Connected to container '{cfg.ContainerName}' on account '{cfg.AccountName}'.");
+        }
+        catch (RequestFailedException ex) when (ex.Status == 403)
+        {
+            return ConnectionTestResult.CreateFailure(
+                "Authorization failed — Connapse's identity lacks read access to this container "
+                + "(needs Storage Blob Data Reader).");
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return ConnectionTestResult.CreateFailure(
+                $"Container '{cfg.ContainerName}' or account '{cfg.AccountName}' not found.");
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return ConnectionTestResult.CreateFailure("Connection test timed out.");
+        }
+        catch (Exception ex)
+        {
+            return ConnectionTestResult.CreateFailure($"Connection test failed: {ex.Message}");
+        }
+    }
+}

--- a/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
+++ b/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
@@ -1,0 +1,78 @@
+using Azure.Core;
+using Azure.Storage.Blobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
+using System.Runtime.CompilerServices;
+
+namespace Connapse.Storage.Connectors;
+
+/// <summary>
+/// Read-only Azure Blob Storage connector. Builds a BlobServiceClient from the account +
+/// Connapse's TokenCredential; the internal ctor accepts a prebuilt client for tests
+/// (Azurite cannot authenticate an AAD TokenCredential). SupportsLiveWatch = false.
+/// </summary>
+public sealed class AzureBlobConnector : IConnector, IDisposable
+{
+    private readonly AzureBlobConnectorConfig _config;
+    private readonly BlobContainerClient _container;
+
+    public AzureBlobConnector(AzureBlobConnectorConfig config, TokenCredential credential)
+        : this(config, new BlobServiceClient(
+            new Uri(config.BlobEndpoint ?? $"https://{config.AccountName}.blob.core.windows.net"),
+            credential))
+    { }
+
+    internal AzureBlobConnector(AzureBlobConnectorConfig config, BlobServiceClient client)
+    {
+        _config = config;
+        _container = client.GetBlobContainerClient(config.ContainerName);
+    }
+
+    public ConnectorType Type => ConnectorType.AzureBlob;
+    public bool SupportsLiveWatch => false;
+
+    public string ResolveJobPath(string relativePath) => CombinePrefix(relativePath);
+
+    public async Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
+    {
+        string effective = CombinePrefix(prefix ?? "");
+        var files = new List<ConnectorFile>();
+        await foreach (var item in _container.GetBlobsAsync(prefix: effective, cancellationToken: ct))
+        {
+            files.Add(new ConnectorFile(
+                item.Name,
+                item.Properties.ContentLength ?? 0,
+                (item.Properties.LastModified ?? DateTimeOffset.MinValue).UtcDateTime,
+                item.Properties.ContentType,
+                ResourceUri.ForAzureBlob(_config.AccountName, _config.ContainerName, item.Name)));
+        }
+        return files;
+    }
+
+    public async Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
+    {
+        var download = await _container.GetBlobClient(path).DownloadStreamingAsync(cancellationToken: ct);
+        return download.Value.Content;
+    }
+
+    public async Task<bool> ExistsAsync(string path, CancellationToken ct = default)
+        => await _container.GetBlobClient(path).ExistsAsync(ct);
+
+    public async IAsyncEnumerable<ConnectorFileEvent> WatchAsync([EnumeratorCancellation] CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Azure Blob connector does not support live watch.");
+#pragma warning disable CS0162
+        yield break;
+#pragma warning restore CS0162
+    }
+
+    private string CombinePrefix(string tail)
+    {
+        string p = _config.Prefix?.Trim('/') ?? "";
+        string t = tail.TrimStart('/');
+        return string.IsNullOrEmpty(p) ? t : string.IsNullOrEmpty(t) ? p + "/" : $"{p}/{t}";
+    }
+
+    public void Dispose() { }
+}

--- a/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
+++ b/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
@@ -52,12 +52,33 @@ public sealed class AzureBlobConnector : IConnector, IDisposable
 
     public async Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
     {
+        if (!IsInPrefixScope(path))
+        {
+            throw new UnauthorizedAccessException(
+                $"Blob '{path}' is outside the source's configured prefix scope.");
+        }
         var download = await _container.GetBlobClient(path).DownloadStreamingAsync(cancellationToken: ct);
         return download.Value.Content;
     }
 
     public async Task<bool> ExistsAsync(string path, CancellationToken ct = default)
-        => await _container.GetBlobClient(path).ExistsAsync(ct);
+        => IsInPrefixScope(path) && await _container.GetBlobClient(path).ExistsAsync(ct);
+
+    /// <summary>
+    /// Enforces the configured prefix as an exact-subtree boundary: a path is in scope only if
+    /// the prefix is empty (whole container), equals the path exactly, or is followed by '/'.
+    /// Prevents a sibling prefix (e.g. "team-archive/") from matching "team/" via a raw StartsWith.
+    /// </summary>
+    internal bool IsInPrefixScope(string path)
+    {
+        string normalizedPrefix = _config.Prefix?.Trim('/') ?? "";
+        if (string.IsNullOrEmpty(normalizedPrefix))
+        {
+            return true;
+        }
+        return path.Equals(normalizedPrefix, StringComparison.Ordinal)
+            || path.StartsWith(normalizedPrefix + "/", StringComparison.Ordinal);
+    }
 
     public async IAsyncEnumerable<ConnectorFileEvent> WatchAsync([EnumeratorCancellation] CancellationToken ct = default)
     {

--- a/src/Connapse.Storage/Connectors/AzureBlobConnectorConfig.cs
+++ b/src/Connapse.Storage/Connectors/AzureBlobConnectorConfig.cs
@@ -1,0 +1,11 @@
+namespace Connapse.Storage.Connectors;
+
+/// <summary>Recombined connection (account/endpoint) + source (container/prefix) config for the Azure Blob connector.</summary>
+public record AzureBlobConnectorConfig
+{
+    public string AccountName { get; init; } = "";
+    public string ContainerName { get; init; } = "";
+    public string? Prefix { get; init; }
+    /// <summary>Overrides https://{account}.blob.core.windows.net (Azurite/local).</summary>
+    public string? BlobEndpoint { get; init; }
+}

--- a/src/Connapse.Storage/Connectors/ConnectorFactory.cs
+++ b/src/Connapse.Storage/Connectors/ConnectorFactory.cs
@@ -14,6 +14,7 @@ public class ConnectorFactory(
     IOptionsMonitor<SourceSecuritySettings> sourceSecurity,
     ISshHostKeyStore hostKeyStore,
     CloudScope.ConnapseAwsCredentials awsCredentials,
+    CloudScope.ConnapseAzureCredentials azureCredentials,
     ILogger<ConnectorFactory> logger) : IConnectorFactory
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -69,6 +70,22 @@ public class ConnectorFactory(
             // The identity an administrator configured, so a sync runs as whatever the
             // Providers page reports rather than as whatever the container is carrying.
             awsCredentials),
+
+            ConnectionProvider.AzureBlob => new AzureBlobConnector(new AzureBlobConnectorConfig
+            {
+                AccountName = Str(credential, "accountName")
+                    ?? throw new InvalidOperationException(
+                        $"Connection '{connection.Name}' has no accountName."),
+                BlobEndpoint = Str(credential, "blobEndpoint"),
+                ContainerName = RequirePermittedLocation(
+                    StorageLocationPolicy.ReadAllowedLocations(credential.RootElement),
+                    Str(scope, "containerName")
+                        ?? throw new InvalidOperationException(
+                            $"Source '{source.Name}' has no containerName in its scope."),
+                    Str(scope, "prefix"),
+                    connection.Name, source.Name),
+                Prefix = Str(scope, "prefix"),
+            }, azureCredentials),
 
             ConnectionProvider.Filesystem => new FilesystemConnector(new FilesystemConnectorConfig
             {

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -189,7 +189,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<OllamaConnectionTester>();
         services.AddScoped<MinioConnectionTester>();
         services.AddScoped<S3ConnectionTester>();
-        services.AddScoped<IConnectionTester, AzureBlobConnectionTester>();
+        services.AddScoped<AzureBlobConnectionTester>();
 
         // Singleton: it holds no per-request state, and the SDK caches and refreshes the resolved
         // credential itself, so a new instance per scope would discard that cache each time.

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -189,6 +189,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<OllamaConnectionTester>();
         services.AddScoped<MinioConnectionTester>();
         services.AddScoped<S3ConnectionTester>();
+        services.AddScoped<IConnectionTester, AzureBlobConnectionTester>();
 
         // Singleton: it holds no per-request state, and the SDK caches and refreshes the resolved
         // credential itself, so a new instance per scope would discard that cache each time.
@@ -214,6 +215,15 @@ public static class ServiceCollectionExtensions
         // credential provider therefore takes IServiceScopeFactory and opens a scope per refresh
         // rather than holding the store.
         services.AddSingleton<CloudScope.ConnapseAwsCredentials>();
+
+        // Connapse's own Azure app identity — bound from Providers:Azure, consumed by
+        // ConnectorFactory and AzureBlobConnectionTester. Singleton for the same reason as
+        // ConnapseAwsCredentials: it caches/rebuilds its own credential chain on settings
+        // reload, so one instance per process is the correct shape, not one per scope.
+        services.Configure<AzureProviderSettings>(
+            configuration.GetSection(AzureProviderSettings.SectionName));
+        services.AddSingleton<CloudScope.ConnapseAzureCredentials>();
+
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();
         services.AddSingleton<IAccessGrantsReader, CloudScope.S3AccessGrantsReader>();

--- a/src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs
+++ b/src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs
@@ -23,6 +23,7 @@ public class DatabaseSettingsProvider : ConfigurationProvider
         ["samlsignin"] = "Identity:SamlSignIn",
         ["identitycenter"] = "Identity:IdentityCenter",
         ["permissionenforcement"] = "Identity:PermissionEnforcement",
+        ["azure"] = "Providers:Azure",
     };
 
     public DatabaseSettingsProvider(Action<DbContextOptionsBuilder> optionsAction)

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -1687,20 +1687,23 @@
 
             if (form.Provider == ConnectionProvider.AzureBlob)
             {
-                // Unlike S3, a missing probe target is not refused: an Azure storage account
-                // always has a root container to check against, so this tests service-level
-                // reachability instead of demanding a container nobody has chosen yet.
-                string? azureTarget = NullIfBlank(probeTarget) ?? form.FirstAllowedLocation();
-                var (azureContainer, azurePrefix) = azureTarget is null
-                    ? ("$root", null)
-                    : ConnectionForm.SplitLocation(azureTarget);
+                // Unlike a bucket name, "$root" is not a safe default: Azure storage accounts
+                // do not auto-create a root container, so probing it when nobody has chosen a
+                // container yet would report a perfectly valid account as unreachable.
+                var azureProbe = form.ResolveProbeTarget(probeTarget);
+                if (azureProbe is null)
+                {
+                    testSuccess = false;
+                    testMessage = "Enter a container name (or configure an allowed location) to test this Azure connection.";
+                    return;
+                }
 
                 ConnectionTestResult azureResult = await AzureBlobTester.TestConnectionAsync(new AzureBlobConnectorConfig
                 {
                     AccountName = form.StorageAccountName?.Trim() ?? "",
                     BlobEndpoint = NullIfBlank(form.BlobEndpoint),
-                    ContainerName = azureContainer,
-                    Prefix = azurePrefix,
+                    ContainerName = azureProbe.Value.Container,
+                    Prefix = azureProbe.Value.Prefix,
                 }, TimeSpan.FromSeconds(15));
 
                 testSuccess = azureResult.Success;

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -15,6 +15,7 @@
 @inject IOptionsMonitor<SourceSecuritySettings> SourceSecurity
 @inject IContainerHostResolver HostResolver
 @inject S3ConnectionTester S3Tester
+@inject AzureBlobConnectionTester AzureBlobTester
 @inject SftpConnectionTester SftpTester
 @inject IS3Discovery S3Discovery
 @inject IProviderSetupReader SetupReader
@@ -475,6 +476,7 @@
             <label class="form-label" for="connection-provider">Provider</label>
             <select id="connection-provider" class="form-select" @bind="form.Provider" disabled="@(!isNew)">
                 <option value="@ConnectionProvider.S3">Amazon S3</option>
+                <option value="@ConnectionProvider.AzureBlob">Azure Blob Storage</option>
                 <option value="@ConnectionProvider.Filesystem">Local filesystem</option>
                 <option value="@ConnectionProvider.Sftp">SFTP</option>
             </select>
@@ -519,6 +521,31 @@
                 </div>
             }
 
+        }
+        else if (form.Provider == ConnectionProvider.AzureBlob)
+        {
+            <div class="col-12" style="max-width:32rem">
+                <label class="form-label" for="azure-account-name">Storage account name</label>
+                <input id="azure-account-name" class="form-control font-monospace" @bind="form.StorageAccountName"
+                       placeholder="mystorageaccount" aria-describedby="azure-account-name-help" />
+                <div id="azure-account-name-help" class="form-text">
+                    Connapse reaches it as its own Azure identity — no key or connection string is
+                    entered here.
+                </div>
+            </div>
+
+            <div class="col-12" style="max-width:32rem">
+                <label class="form-label" for="azure-blob-endpoint">
+                    Blob endpoint <span class="text-muted">(optional)</span>
+                </label>
+                <input id="azure-blob-endpoint" class="form-control font-monospace" @bind="form.BlobEndpoint"
+                       placeholder="@($"https://{(string.IsNullOrWhiteSpace(form.StorageAccountName) ? "account" : form.StorageAccountName)}.blob.core.windows.net")"
+                       aria-describedby="azure-blob-endpoint-help" />
+                <div id="azure-blob-endpoint-help" class="form-text">
+                    Set only to override the default endpoint above — for example, to point at
+                    Azurite or another local emulator.
+                </div>
+            </div>
         }
         else if (form.Provider == ConnectionProvider.Sftp)
         {
@@ -1658,6 +1685,30 @@
                 return;
             }
 
+            if (form.Provider == ConnectionProvider.AzureBlob)
+            {
+                // Unlike S3, a missing probe target is not refused: an Azure storage account
+                // always has a root container to check against, so this tests service-level
+                // reachability instead of demanding a container nobody has chosen yet.
+                string? azureTarget = NullIfBlank(probeTarget) ?? form.FirstAllowedLocation();
+                var (azureContainer, azurePrefix) = azureTarget is null
+                    ? ("$root", null)
+                    : ConnectionForm.SplitLocation(azureTarget);
+
+                ConnectionTestResult azureResult = await AzureBlobTester.TestConnectionAsync(new AzureBlobConnectorConfig
+                {
+                    AccountName = form.StorageAccountName?.Trim() ?? "",
+                    BlobEndpoint = NullIfBlank(form.BlobEndpoint),
+                    ContainerName = azureContainer,
+                    Prefix = azurePrefix,
+                }, TimeSpan.FromSeconds(15));
+
+                testSuccess = azureResult.Success;
+                testMessage = azureResult.Message;
+                testDetail = RawError(azureResult);
+                return;
+            }
+
             string? target = NullIfBlank(probeTarget) ?? form.FirstAllowedLocation();
             if (target is null)
             {
@@ -1700,6 +1751,7 @@
         {
             ConnectionProvider.Filesystem => form.AllowedRoot ?? "—",
             ConnectionProvider.S3 => form.Region ?? "—",
+            ConnectionProvider.AzureBlob => form.StorageAccountName ?? "—",
             ConnectionProvider.Sftp => $"{form.Username}@{form.Host}:{form.AllowedRoot}",
             _ => "—"
         };

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -294,15 +294,21 @@
                     @* Which scope fields exist is decided by the connection's provider, because
                        the keys ConnectorFactory reads differ per provider and writing the wrong
                        one produces a source that silently syncs nothing. *@
-                    @if (selectedProvider is ConnectionProvider.S3)
+                    @if (selectedProvider is ConnectionProvider.S3 or ConnectionProvider.AzureBlob)
                     {
-                        @* The connection already names which buckets it permits, so asking for
-                           one in free text made the reader supply a fact Connapse was holding —
-                           and a name typed from memory saves cleanly, then fails at the first
-                           sync or is refused by the scope preflight afterwards. *@
+                        @* AzureBlob shares this branch with S3 rather than getting its own: both
+                           are bounded by the same allowedLocations allowlist on the connection,
+                           read through the same StorageLocationPolicy, and differ only in what
+                           the container-like scope is called. *@
+                        string containerNoun = selectedProvider is ConnectionProvider.S3 ? "bucket" : "container";
+
+                        @* The connection already names which buckets/containers it permits, so
+                           asking for one in free text made the reader supply a fact Connapse was
+                           holding — and a name typed from memory saves cleanly, then fails at the
+                           first sync or is refused by the scope preflight afterwards. *@
                         <div class="mb-3">
                             <label class="form-label" for="source-container">
-                                Bucket
+                                @(selectedProvider is ConnectionProvider.S3 ? "Bucket" : "Container")
                             </label>
 
                             @{ var choices = AllowedScopes(); }
@@ -317,7 +323,7 @@
                                     <span class="bi-exclamation-triangle me-1"></span>
                                     This connection's allowed locations cannot be read, so Connapse
                                     cannot say which
-                                    buckets
+                                    @(containerNoun)s
                                     it permits. Fix them on the Connections page before adding a
                                     source — a source saved now would be refused at sync time.
                                 </div>
@@ -345,7 +351,7 @@
                                    count to accommodate two help links would cost more than the
                                    links are worth. *@
                                 <div id="source-container-help" class="form-text">
-                                    Buckets
+                                    @(containerNoun)s
                                     this connection is allowed to read. To use another, add it to
                                     that connection's allowed locations on the Connections page.
                                 </div>
@@ -357,7 +363,7 @@
                                        placeholder="company-knowledge" />
                                 <div id="source-container-help" class="form-text">
                                     Which
-                                    bucket
+                                    @(containerNoun)
                                     inside this connection the source reads. This connection lists
                                     no allowed locations, so it permits any its credential can
                                     reach — naming them on the Connections page bounds that.

--- a/src/Connapse.Web/Components/Settings/ConnectionForm.cs
+++ b/src/Connapse.Web/Components/Settings/ConnectionForm.cs
@@ -315,6 +315,24 @@ public sealed record ConnectionForm
     }
 
     /// <summary>
+    /// The container (and optional prefix) to test a cloud connection against: the
+    /// operator-entered probe target when there is one, otherwise the first allowed location,
+    /// and null when neither is available.
+    /// <para>
+    /// Extracted so "nothing to test against" can be told apart from "test some
+    /// account-wide default container" by the caller. Azure storage accounts do not
+    /// auto-create a root container the way S3 always has a bucket once one is named, so a
+    /// caller that turned a null here into a guessed container name would report a perfectly
+    /// valid account as unreachable.
+    /// </para>
+    /// </summary>
+    public (string Container, string? Prefix)? ResolveProbeTarget(string? probeTarget)
+    {
+        string? target = string.IsNullOrWhiteSpace(probeTarget) ? FirstAllowedLocation() : probeTarget.Trim();
+        return target is null ? null : SplitLocation(target);
+    }
+
+    /// <summary>
     /// The credential to store, or null to leave any existing one untouched.
     /// </summary>
     /// <remarks>

--- a/src/Connapse.Web/Components/Settings/ConnectionForm.cs
+++ b/src/Connapse.Web/Components/Settings/ConnectionForm.cs
@@ -23,6 +23,12 @@ public sealed record ConnectionForm
     public string? Region { get; set; }
     public string? RoleArn { get; set; }
 
+    // AzureBlob
+    public string? StorageAccountName { get; set; }
+
+    /// <summary>Overrides https://{account}.blob.core.windows.net — Azurite or another local emulator.</summary>
+    public string? BlobEndpoint { get; set; }
+
     // Filesystem and SFTP both bound a source with a root, so this is shared.
     public string? AllowedRoot { get; set; }
 
@@ -66,7 +72,7 @@ public sealed record ConnectionForm
     /// </para>
     /// </summary>
     public bool IsCloudProvider =>
-        Provider is ConnectionProvider.S3;
+        Provider is ConnectionProvider.S3 or ConnectionProvider.AzureBlob;
 
 
     /// <summary>
@@ -187,6 +193,8 @@ public sealed record ConnectionForm
 
         form.Region = Str(node, "region");
         form.RoleArn = Str(node, "roleArn");
+        form.StorageAccountName = Str(node, "accountName");
+        form.BlobEndpoint = Str(node, "blobEndpoint");
         form.AllowedRoot = Str(node, "allowedRoot");
         form.Host = Str(node, "host");
         form.Username = Str(node, "username");
@@ -236,6 +244,11 @@ public sealed record ConnectionForm
             case ConnectionProvider.S3:
                 node["region"] = Blank(Region) ? "us-east-1" : Region!.Trim();
                 if (!Blank(RoleArn)) node["roleArn"] = RoleArn!.Trim();
+                break;
+
+            case ConnectionProvider.AzureBlob:
+                node["accountName"] = StorageAccountName?.Trim() ?? "";
+                if (!Blank(BlobEndpoint)) node["blobEndpoint"] = BlobEndpoint!.Trim();
                 break;
 
             case ConnectionProvider.Filesystem:
@@ -332,6 +345,8 @@ public sealed record ConnectionForm
 
         return Provider switch
         {
+            ConnectionProvider.AzureBlob when Blank(StorageAccountName) => "A storage account name is required.",
+
             ConnectionProvider.Filesystem when Blank(AllowedRoot) => "Choose an allowed root.",
 
             ConnectionProvider.Sftp when Blank(Host) => "A host is required.",

--- a/src/Connapse.Web/Components/Settings/SourceForm.cs
+++ b/src/Connapse.Web/Components/Settings/SourceForm.cs
@@ -55,6 +55,11 @@ public sealed record SourceForm
                 if (!Blank(Prefix)) node["prefix"] = Prefix!.Trim();
                 break;
 
+            case ConnectionProvider.AzureBlob:
+                node["containerName"] = Container?.Trim() ?? "";
+                if (!Blank(Prefix)) node["prefix"] = Prefix!.Trim();
+                break;
+
             // One case for both. The SFTP scope was deliberately given the same shape as the
             // filesystem one so that this form, the preflight and the scope summary each gained
             // a provider here rather than a parallel implementation to keep in step.
@@ -93,6 +98,9 @@ public sealed record SourceForm
 
         if (provider is ConnectionProvider.S3 && Blank(Container))
             return "A bucket name is required.";
+
+        if (provider is ConnectionProvider.AzureBlob && Blank(Container))
+            return "A container name is required.";
 
         if (SyncIntervalSeconds is { } interval && interval < 60)
             return "Sync interval must be at least 60 seconds.";

--- a/src/Connapse.Web/Services/SourceScopePreflight.cs
+++ b/src/Connapse.Web/Services/SourceScopePreflight.cs
@@ -53,6 +53,7 @@ public class SourceScopePreflight(IOptionsMonitor<SourceSecuritySettings> source
         return connection.Provider switch
         {
             ConnectionProvider.S3 => CheckLocation(credential, scope, "bucketName", "bucket", connection.Name),
+            ConnectionProvider.AzureBlob => CheckLocation(credential, scope, "containerName", "container", connection.Name),
             ConnectionProvider.Filesystem => CheckRoot(credential, scope, connection.Name),
             ConnectionProvider.Sftp => CheckSftpScope(credential, scope, connection.Name),
             _ => ScopePreflightResult.Refuse(

--- a/src/Connapse.Web/appsettings.json
+++ b/src/Connapse.Web/appsettings.json
@@ -31,6 +31,15 @@
       "Audience": "Connapse"
     }
   },
+  "Providers": {
+    "Azure": {
+      "//": "Connapse's own Azure app identity, used by the Azure Blob connector and its connection tester. When ClientId + ClientCertificatePath are set, Connapse authenticates as that service principal; otherwise it falls back to the ambient managed identity (optionally pinned via UserAssignedManagedIdentityClientId). Never a client secret.",
+      "TenantId": "",
+      "ClientId": "",
+      "ClientCertificatePath": "",
+      "UserAssignedManagedIdentityClientId": ""
+    }
+  },
   "Sources": {
     "Security": {
       "//AllowedFilesystemRoots": "Directories a filesystem connection's allowedRoot may name; a root must equal one of these or sit beneath it. Empty means unrestricted, which is retained for one release so upgrades keep working, and logs a warning naming each root in use. Configuration only — never settable through the API or the settings table, because the authority a root confers is the same class of thing as a cloud credential.",

--- a/src/Connapse.Web/appsettings.json
+++ b/src/Connapse.Web/appsettings.json
@@ -37,6 +37,7 @@
       "TenantId": "",
       "ClientId": "",
       "ClientCertificatePath": "",
+      "ClientCertificatePassword": "",
       "UserAssignedManagedIdentityClientId": ""
     }
   },

--- a/tests/Connapse.Core.Tests/ConnectionTesterTests.cs
+++ b/tests/Connapse.Core.Tests/ConnectionTesterTests.cs
@@ -1,9 +1,11 @@
 using System.Net;
 using System.Text.Json;
 using Connapse.Core;
+using Connapse.Storage.CloudScope;
 using Connapse.Storage.ConnectionTesters;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
 
@@ -195,6 +197,27 @@ public class MinioConnectionTesterTests
     }
 
     // Note: Full MinIO integration tests require real service and are covered in Integration.Tests
+}
+
+[Trait("Category", "Unit")]
+public class AzureBlobConnectionTesterTests
+{
+    [Fact]
+    public async Task AzureBlobTester_WrongSettingsType_Fails()
+    {
+        var tester = new AzureBlobConnectionTester(
+            new ConnapseAzureCredentials(new TestOptionsMonitor<AzureProviderSettings>(new())));
+        var result = await tester.TestConnectionAsync("not-a-config", TimeSpan.FromSeconds(1));
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("AzureBlobConnectorConfig");
+    }
+
+    private sealed class TestOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; private set; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
 }
 
 /// <summary>

--- a/tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
@@ -1,0 +1,30 @@
+using Azure.Storage.Blobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Connectors;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Connectors;
+
+[Trait("Category", "Unit")]
+public class AzureBlobConnectorUnitTests
+{
+    private static AzureBlobConnector Make() =>
+        new(new AzureBlobConnectorConfig { AccountName = "acct", ContainerName = "docs", Prefix = "reports/" },
+            new BlobServiceClient(new Uri("http://127.0.0.1:10000/devstoreaccount1")));
+
+    [Fact] public void Type_IsAzureBlob() => Make().Type.Should().Be(ConnectorType.AzureBlob);
+    [Fact] public void SupportsLiveWatch_False() => Make().SupportsLiveWatch.Should().BeFalse();
+
+    [Fact]
+    public void ResolveJobPath_JoinsUnderPrefix()
+        => Make().ResolveJobPath("q1.pdf").Should().Be("reports/q1.pdf");
+
+    [Fact]
+    public async Task WatchAsync_Throws()
+    {
+        var act = async () => { await foreach (var _ in Make().WatchAsync()) { } };
+        await act.Should().ThrowAsync<NotSupportedException>();
+    }
+}

--- a/tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
@@ -27,4 +27,42 @@ public class AzureBlobConnectorUnitTests
         var act = async () => { await foreach (var _ in Make().WatchAsync()) { } };
         await act.Should().ThrowAsync<NotSupportedException>();
     }
+
+    [Fact]
+    public async Task ReadFileAsync_OutOfPrefixPath_ThrowsUnauthorizedAccessException()
+    {
+        var act = async () => await Make().ReadFileAsync("hr/secret.pdf");
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_OutOfPrefixPath_ReturnsFalse()
+        => (await Make().ExistsAsync("hr/secret.pdf")).Should().BeFalse();
+
+    private static AzureBlobConnector MakeWithPrefix(string? prefix) =>
+        new(new AzureBlobConnectorConfig { AccountName = "acct", ContainerName = "docs", Prefix = prefix },
+            new BlobServiceClient(new Uri("http://127.0.0.1:10000/devstoreaccount1")));
+
+    [Fact]
+    public void IsInPrefixScope_SiblingPrefix_IsRejected()
+        => MakeWithPrefix("team/").IsInPrefixScope("team-archive/secret.txt").Should().BeFalse();
+
+    [Fact]
+    public void IsInPrefixScope_MatchingSubtree_IsAllowed()
+        => MakeWithPrefix("team/").IsInPrefixScope("team/ok.txt").Should().BeTrue();
+
+    [Fact]
+    public async Task ReadFileAsync_SiblingPrefixPath_ThrowsUnauthorizedAccessException()
+    {
+        var act = async () => await MakeWithPrefix("team/").ReadFileAsync("team-archive/secret.txt");
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_SiblingPrefixPath_ReturnsFalse()
+        => (await MakeWithPrefix("team/").ExistsAsync("team-archive/secret.txt")).Should().BeFalse();
+
+    [Fact]
+    public void IsInPrefixScope_EmptyPrefix_AllowsAnyPath()
+        => MakeWithPrefix(null).IsInPrefixScope("anything/at/all.txt").Should().BeTrue();
 }

--- a/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
@@ -67,10 +67,16 @@ public class SourceConnectorFactoryTests
         services.AddSingleton(credentialStore);
         var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
+        // No network is touched: Create() never calls GetToken, so a default,
+        // unconfigured AzureProviderSettings is enough to construct the credential.
+        var azureOptions = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        azureOptions.CurrentValue.Returns(new AzureProviderSettings());
+
         return new ConnectorFactory(
             monitor,
             hostKeyStore ?? Substitute.For<ISshHostKeyStore>(),
             new ConnapseAwsCredentials(scopeFactory, NullLogger<ConnapseAwsCredentials>.Instance),
+            new ConnapseAzureCredentials(azureOptions),
             logger ?? NullLogger<ConnectorFactory>.Instance);
     }
 
@@ -109,6 +115,18 @@ public class SourceConnectorFactoryTests
         connector.Config.Region.Should().Be("eu-west-1", "the region comes from the connection");
         connector.Config.BucketName.Should().Be("my-bucket", "the bucket comes from the source scope");
         connector.Config.Prefix.Should().Be("docs/");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Create_AzureBlob_BuildsConnectorFromSplitConfig()
+    {
+        var connection = MakeConnection(ConnectionProvider.AzureBlob, """{"accountName":"acct"}""");
+        var source = MakeSource(connection.Id, """{"containerName":"docs","prefix":"reports/"}""");
+
+        var connector = (AzureBlobConnector)_factory.Create(source, connection);
+
+        connector.Type.Should().Be(ConnectorType.AzureBlob);
     }
 
     [Fact]

--- a/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
+++ b/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
@@ -268,6 +268,38 @@ public class ConnectionFormTests
         new ConnectionForm { Provider = ConnectionProvider.AzureBlob }.IsCloudProvider.Should().BeTrue();
     }
 
+    // ── ResolveProbeTarget, for the test-connection probe ───────────────
+
+    [Fact]
+    public void ResolveProbeTarget_PrefersTheOperatorEnteredTarget()
+    {
+        var form = new ConnectionForm { AllowedLocations = "allowlisted-container" };
+
+        form.ResolveProbeTarget("typed-container/docs")
+            .Should().Be(("typed-container", "docs"));
+    }
+
+    [Fact]
+    public void ResolveProbeTarget_FallsBackToTheFirstAllowedLocation()
+    {
+        var form = new ConnectionForm { AllowedLocations = "first-container\nsecond-container" };
+
+        form.ResolveProbeTarget(null).Should().Be(("first-container", (string?)null));
+        form.ResolveProbeTarget("   ").Should().Be(("first-container", (string?)null));
+    }
+
+    /// <summary>
+    /// This is the regression this test guards: with nothing typed and nothing allow-listed,
+    /// there is no container to test that is known to exist. "$root" is not auto-created by
+    /// Azure, so a caller that guessed it here would report a valid account as unreachable.
+    /// </summary>
+    [Fact]
+    public void ResolveProbeTarget_NoTargetAndNoAllowlist_IsNullRatherThanAGuessedContainer()
+    {
+        new ConnectionForm().ResolveProbeTarget(null).Should().BeNull();
+        new ConnectionForm().ResolveProbeTarget("  ").Should().BeNull();
+    }
+
     // ── SFTP ───────────────────────────────────────────────────────────────
 
     private static ConnectionForm SftpForm() => new()

--- a/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
+++ b/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
@@ -215,6 +215,59 @@ public class ConnectionFormTests
             .Validate().Should().BeNull();
     }
 
+    // ── AzureBlob ────────────────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ConnectionForm_AzureBlob_BuildsConfigJson()
+    {
+        // Name is required for every provider (see Validate_RequiresAName above), so it is set
+        // here even though the brief's test body omitted it — otherwise this can never pass.
+        var form = new ConnectionForm { Name = "c", Provider = ConnectionProvider.AzureBlob, StorageAccountName = "acct" };
+        form.Validate().Should().BeNull();               // valid
+        form.ToConfigJson().Should().Contain("\"accountName\":\"acct\"");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ConnectionForm_AzureBlob_MissingAccount_FailsValidation()
+    {
+        var form = new ConnectionForm { Provider = ConnectionProvider.AzureBlob };
+        form.Validate().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AzureBlobConnection_RoundTripsEveryField()
+    {
+        var stored = Stored(ConnectionProvider.AzureBlob,
+            """{"accountName":"acct","blobEndpoint":"http://azurite:10000/acct","allowedLocations":["docs"]}""");
+
+        var form = ConnectionForm.FromConnection(stored);
+
+        form.StorageAccountName.Should().Be("acct");
+        form.BlobEndpoint.Should().Be("http://azurite:10000/acct");
+        form.AllowedLocations.Should().Be("docs");
+
+        var reserialized = JsonNode.Parse(form.ToConfigJson())!.AsObject();
+        reserialized["accountName"]!.GetValue<string>().Should().Be("acct");
+        reserialized["blobEndpoint"]!.GetValue<string>().Should().Be("http://azurite:10000/acct");
+    }
+
+    [Fact]
+    public void ToConfigJson_AzureBlob_OmitsBlankBlobEndpoint()
+    {
+        var form = new ConnectionForm { Name = "c", Provider = ConnectionProvider.AzureBlob, StorageAccountName = "acct" };
+
+        JsonNode.Parse(form.ToConfigJson())!.AsObject()
+            .ContainsKey("blobEndpoint").Should().BeFalse();
+    }
+
+    [Fact]
+    public void AzureBlob_IsACloudProvider()
+    {
+        new ConnectionForm { Provider = ConnectionProvider.AzureBlob }.IsCloudProvider.Should().BeTrue();
+    }
+
     // ── SFTP ───────────────────────────────────────────────────────────────
 
     private static ConnectionForm SftpForm() => new()

--- a/tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
@@ -117,10 +117,45 @@ public class SourceFormTests
 
     [Theory]
     [InlineData(ConnectionProvider.S3, "bucket")]
+    [InlineData(ConnectionProvider.AzureBlob, "container")]
     public void Validate_CloudProviderWithoutAContainer_IsRejected(ConnectionProvider provider, string noun)
     {
         var form = new SourceForm { Name = "n", ConnectionId = Guid.NewGuid() };
         form.Validate(provider).Should().Contain(noun);
+    }
+
+    // ── AzureBlob ────────────────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void SourceForm_AzureBlob_BuildsScopeJson()
+    {
+        var form = new SourceForm { Container = "docs", Prefix = "reports/" };
+        form.ToScopeJson(ConnectionProvider.AzureBlob)
+            .Should().Contain("\"containerName\":\"docs\"").And.Contain("\"prefix\":\"reports/\"");
+    }
+
+    [Fact]
+    public void ToScopeJson_AzureBlob_WritesContainerNameNotBucketName()
+    {
+        var scope = Parse(Filled().ToScopeJson(ConnectionProvider.AzureBlob));
+
+        scope.GetProperty("containerName").GetString().Should().Be("company-knowledge");
+        scope.GetProperty("prefix").GetString().Should().Be("docs/");
+
+        // The S3 key must not leak into an Azure scope: the connector reads one or the other,
+        // so a stray key is silently ignored rather than rejected.
+        scope.TryGetProperty("bucketName", out _).Should().BeFalse();
+        scope.TryGetProperty("subPath", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToScopeJson_AzureBlobBlankPrefix_IsOmittedRatherThanWrittenEmpty()
+    {
+        var form = new SourceForm { Name = "n", Container = "c", Prefix = "   " };
+
+        Parse(form.ToScopeJson(ConnectionProvider.AzureBlob))
+            .TryGetProperty("prefix", out _).Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
@@ -258,6 +258,50 @@ public class SourceScopePreflightTests
 
         result.IsRefused.Should().BeFalse();
     }
+    // ── Azure Blob ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Check_AzureContainerInsideAllowedLocations_IsAllowed()
+    {
+        var connection = Conn(ConnectionProvider.AzureBlob, """{"allowedLocations":["company-knowledge"]}""");
+
+        var result = Build().Check(connection, """{"containerName":"company-knowledge"}""");
+
+        result.IsRefused.Should().BeFalse();
+        result.Warning.Should().BeNull();
+    }
+
+    [Fact]
+    public void Check_AzureContainerOutsideAllowedLocations_IsRefusedNamingTheScope()
+    {
+        var connection = Conn(ConnectionProvider.AzureBlob, """{"allowedLocations":["company-knowledge"]}""");
+
+        var result = Build().Check(connection, """{"containerName":"payroll-data"}""");
+
+        result.IsRefused.Should().BeTrue();
+        result.Error.Should().Contain("payroll-data").And.Contain("conn");
+    }
+
+    [Fact]
+    public void Check_AzureMissingContainerName_IsRefusedBeforeThePolicyRuns()
+    {
+        var connection = Conn(ConnectionProvider.AzureBlob, """{"allowedLocations":["c"]}""");
+
+        Build().Check(connection, "{}").IsRefused.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Check_AzureNoAllowedLocations_IsAcceptedWithAWarning()
+    {
+        // Matches ConnectorFactory, which warns and proceeds for Azure exactly as it does for S3.
+        var connection = Conn(ConnectionProvider.AzureBlob, """{"accountName":"acct"}""");
+
+        var result = Build().Check(connection, """{"containerName":"anything"}""");
+
+        result.IsRefused.Should().BeFalse();
+        result.Warning.Should().NotBeNullOrEmpty();
+    }
+
     // ── SFTP ───────────────────────────────────────────────────────────────
 
     private const string SftpConn = """{"host":"h","port":22,"username":"u","allowedRoot":"/D:/CodeProjects"}""";

--- a/tests/Connapse.Core.Tests/Utilities/ResourceUriTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/ResourceUriTests.cs
@@ -54,4 +54,20 @@ public class ResourceUriTests
             .Should().Throw<ArgumentException>();
     }
 
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ForAzureBlob_BuildsAzblobUri()
+    {
+        ResourceUri.ForAzureBlob("acct", "docs", "reports/q1.pdf")
+            .Should().Be("azblob://acct/docs/reports/q1.pdf");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ForAzureBlob_BlankAccount_Throws()
+    {
+        var act = () => ResourceUri.ForAzureBlob("", "docs", "k");
+        act.Should().Throw<ArgumentException>();
+    }
+
 }

--- a/tests/Connapse.Integration.Tests/AzureBlobConnectorIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureBlobConnectorIntegrationTests.cs
@@ -1,0 +1,38 @@
+using Azure.Storage.Blobs;
+using Connapse.Storage.Connectors;
+using FluentAssertions;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Integration tests for AzureBlobConnector against Azurite. Azurite cannot authenticate an
+/// AAD TokenCredential, so the connector is constructed via its internal ctor with a
+/// shared-key BlobServiceClient pointed at the emulator.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("AzureBlobConnector")]
+public class AzureBlobConnectorIntegrationTests(AzuriteFixture fixture)
+{
+    [Fact]
+    public async Task ListAndRead_ScopedToPrefix()
+    {
+        var service = new BlobServiceClient(fixture.ConnectionString); // shared-key, Azurite
+        var container = service.GetBlobContainerClient("docs");
+        await container.CreateIfNotExistsAsync();
+        await container.UploadBlobAsync("reports/q1.pdf", new BinaryData("hello"));
+        await container.UploadBlobAsync("other/skip.txt", new BinaryData("nope"));
+
+        var connector = new AzureBlobConnector(
+            new AzureBlobConnectorConfig { AccountName = "devstoreaccount1", ContainerName = "docs", Prefix = "reports/" },
+            service); // internal test ctor
+
+        var files = await connector.ListFilesAsync();
+        files.Should().ContainSingle();
+        files[0].Path.Should().Be("reports/q1.pdf");
+        files[0].ResourceUri.Should().Be("azblob://devstoreaccount1/docs/reports/q1.pdf");
+
+        (await connector.ExistsAsync("reports/q1.pdf")).Should().BeTrue();
+        using var stream = await connector.ReadFileAsync("reports/q1.pdf");
+        (await new StreamReader(stream).ReadToEndAsync()).Should().Be("hello");
+    }
+}

--- a/tests/Connapse.Integration.Tests/AzureBlobConnectorIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureBlobConnectorIntegrationTests.cs
@@ -35,4 +35,29 @@ public class AzureBlobConnectorIntegrationTests(AzuriteFixture fixture)
         using var stream = await connector.ReadFileAsync("reports/q1.pdf");
         (await new StreamReader(stream).ReadToEndAsync()).Should().Be("hello");
     }
+
+    [Fact]
+    public async Task ReadFileAsync_BlobOutsideConfiguredPrefix_IsConfined()
+    {
+        var service = new BlobServiceClient(fixture.ConnectionString); // shared-key, Azurite
+        var container = service.GetBlobContainerClient("docs-confinement");
+        await container.CreateIfNotExistsAsync();
+        await container.UploadBlobAsync("reports/q1.pdf", new BinaryData("hello"));
+        await container.UploadBlobAsync("hr/secret.pdf", new BinaryData("confidential"));
+
+        var connector = new AzureBlobConnector(
+            new AzureBlobConnectorConfig { AccountName = "devstoreaccount1", ContainerName = "docs-confinement", Prefix = "reports/" },
+            service); // internal test ctor
+
+        // In-scope blob still reads fine.
+        using var stream = await connector.ReadFileAsync("reports/q1.pdf");
+        (await new StreamReader(stream).ReadToEndAsync()).Should().Be("hello");
+
+        // A blob that exists in the SAME container but outside the source's configured
+        // prefix must not be reachable via this connector, even though the underlying
+        // Azure SDK client has no such restriction.
+        var act = async () => await connector.ReadFileAsync("hr/secret.pdf");
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+        (await connector.ExistsAsync("hr/secret.pdf")).Should().BeFalse();
+    }
 }

--- a/tests/Connapse.Integration.Tests/AzureProviderDiIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureProviderDiIntegrationTests.cs
@@ -1,0 +1,30 @@
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using Connapse.Storage.ConnectionTesters;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Proves the Azure provider's DI graph actually resolves from a real host — a clean container
+/// start does not catch a missing registration, only constructing the services does. Covers the
+/// gap left when <see cref="Connapse.Storage.Connectors.ConnectorFactory"/> gained a
+/// <see cref="ConnapseAzureCredentials"/> constructor parameter before that type (and the Azure
+/// connection tester) were registered.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureProviderDiIntegrationTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public void Di_Resolves_AzureCredentialsAndTester()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+
+        scope.ServiceProvider.GetRequiredService<ConnapseAzureCredentials>().Should().NotBeNull();
+        scope.ServiceProvider.GetServices<IConnectionTester>()
+            .Should().Contain(t => t is AzureBlobConnectionTester);
+        scope.ServiceProvider.GetRequiredService<IConnectorFactory>().Should().NotBeNull();
+    }
+}

--- a/tests/Connapse.Integration.Tests/AzureProviderDiIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureProviderDiIntegrationTests.cs
@@ -23,8 +23,13 @@ public class AzureProviderDiIntegrationTests(SharedWebAppFixture fixture)
         using var scope = fixture.Factory.Services.CreateScope();
 
         scope.ServiceProvider.GetRequiredService<ConnapseAzureCredentials>().Should().NotBeNull();
-        scope.ServiceProvider.GetServices<IConnectionTester>()
-            .Should().Contain(t => t is AzureBlobConnectionTester);
+
+        // Registered concrete-only, matching S3ConnectionTester/SftpConnectionTester — this is
+        // the exact path Connections.razor's `@inject AzureBlobConnectionTester` resolves
+        // through. A prior interface-only registration (AddScoped<IConnectionTester,
+        // AzureBlobConnectionTester>) satisfied GetServices<IConnectionTester>() but left the
+        // concrete type unresolvable, which threw InvalidOperationException at component init.
+        scope.ServiceProvider.GetRequiredService<AzureBlobConnectionTester>().Should().NotBeNull();
         scope.ServiceProvider.GetRequiredService<IConnectorFactory>().Should().NotBeNull();
     }
 }

--- a/tests/Connapse.Integration.Tests/AzuriteFixture.cs
+++ b/tests/Connapse.Integration.Tests/AzuriteFixture.cs
@@ -13,10 +13,13 @@ public sealed class AzuriteFixture : IAsyncLifetime
 {
     // Testcontainers.Azurite 4.3.0's default image (3.28.0) rejects the x-ms-version header
     // sent by Azure.Storage.Blobs 12.24.0 (the version Connapse.Storage references) with
-    // "The API version 2025-05-05 is not supported by Azurite" on every request. Pin to
-    // :latest so the emulator's supported API surface keeps pace with the client SDK.
+    // "The API version 2025-05-05 is not supported by Azurite" on every request. Pin to a
+    // concrete newer version (not :latest, which floats) whose supported API surface keeps
+    // pace with the client SDK. 3.37.0 is confirmed via `docker manifest inspect` to be the
+    // exact version :latest resolved to at the time this was verified working
+    // (manifest-list digest sha256:830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5).
     private readonly AzuriteContainer _container = new AzuriteBuilder()
-        .WithImage("mcr.microsoft.com/azure-storage/azurite:latest")
+        .WithImage("mcr.microsoft.com/azure-storage/azurite:3.37.0")
         .Build();
     public string ConnectionString => _container.GetConnectionString();
     public Task InitializeAsync() => _container.StartAsync();

--- a/tests/Connapse.Integration.Tests/AzuriteFixture.cs
+++ b/tests/Connapse.Integration.Tests/AzuriteFixture.cs
@@ -1,0 +1,24 @@
+using Testcontainers.Azurite;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Shared fixture that starts an Azurite container for Azure Blob connector testing.
+/// Azurite cannot authenticate an AAD TokenCredential, so tests drive the connector
+/// through its internal ctor with a shared-key BlobServiceClient built from
+/// <see cref="ConnectionString"/>.
+/// </summary>
+public sealed class AzuriteFixture : IAsyncLifetime
+{
+    // Testcontainers.Azurite 4.3.0's default image (3.28.0) rejects the x-ms-version header
+    // sent by Azure.Storage.Blobs 12.24.0 (the version Connapse.Storage references) with
+    // "The API version 2025-05-05 is not supported by Azurite" on every request. Pin to
+    // :latest so the emulator's supported API surface keeps pace with the client SDK.
+    private readonly AzuriteContainer _container = new AzuriteBuilder()
+        .WithImage("mcr.microsoft.com/azure-storage/azurite:latest")
+        .Build();
+    public string ConnectionString => _container.GetConnectionString();
+    public Task InitializeAsync() => _container.StartAsync();
+    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+}

--- a/tests/Connapse.Integration.Tests/CloudConnectorTestCollection.cs
+++ b/tests/Connapse.Integration.Tests/CloudConnectorTestCollection.cs
@@ -4,3 +4,8 @@ namespace Connapse.Integration.Tests;
 public class S3ConnectorTestCollection : ICollectionFixture<LocalStackFixture>
 {
 }
+
+[CollectionDefinition("AzureBlobConnector")]
+public class AzureBlobConnectorTestCollection : ICollectionFixture<AzuriteFixture>
+{
+}

--- a/tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj
+++ b/tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj
@@ -27,6 +27,7 @@
     -->
     <PackageReference Include="SSH.NET" Version="2026.0.0" />
     <PackageReference Include="Testcontainers" Version="4.3.0" />
+    <PackageReference Include="Testcontainers.Azurite" Version="4.3.0" />
     <PackageReference Include="Testcontainers.LocalStack" Version="4.3.0" />
     <PackageReference Include="Testcontainers.Minio" Version="4.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.3.0" />

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
@@ -52,12 +52,66 @@ public class AzureCredentialChainFactoryTests
            .WithMessage("*certificate*");
     }
 
-    // Reads the private _sources array ChainedTokenCredential stores, to assert ordering.
-    private static TokenCredential FirstSource(TokenCredential chain)
+    [Fact]
+    public void Create_TenantIdAndCertPathSetButClientIdBlank_Throws()
+    {
+        // Partial service-principal config: ClientId lost/blank must not silently
+        // fall through to managed identity (a broader, ambient identity).
+        var settings = new AzureProviderSettings { TenantId = "t", ClientCertificatePath = "cert.pfx" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Create_ClientIdAndTenantIdSetButCertPathBlank_Throws()
+    {
+        var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => null);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Create_OnlyClientCertificatePasswordSet_Throws()
+    {
+        // A lone SP field is still "intent to use certificate auth" and must fail
+        // closed rather than silently becoming managed-identity-only.
+        var settings = new AzureProviderSettings { ClientCertificatePassword = "pw" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Create_OnlyClientIdSetButTenantIdBlank_Throws()
+    {
+        var settings = new AzureProviderSettings { ClientId = "c", ClientCertificatePath = "cert.pfx" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Create_FullServicePrincipalSet_UsesCertificateCredentialOnly()
+    {
+        // When the SP set is complete, the chain must not also carry a managed-identity
+        // fallback source — that fallback is exactly the broader-identity fall-open path.
+        var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c", ClientCertificatePath = "cert.pfx" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        Sources(cred).Should().ContainSingle().Which.Should().BeOfType<ClientCertificateCredential>();
+    }
+
+    [Fact]
+    public void Create_NoServicePrincipalFields_ManagedIdentityOnlyChain()
+    {
+        var cred = AzureCredentialChainFactory.Create(new AzureProviderSettings(), _ => null);
+        Sources(cred).Should().ContainSingle().Which.Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    // Reads the private _sources array ChainedTokenCredential stores, to assert ordering/contents.
+    private static TokenCredential FirstSource(TokenCredential chain) => Sources(chain)[0];
+
+    private static TokenCredential[] Sources(TokenCredential chain)
     {
         var field = typeof(ChainedTokenCredential)
             .GetField("_sources", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        var sources = (TokenCredential[])field.GetValue(chain)!;
-        return sources[0];
+        return (TokenCredential[])field.GetValue(chain)!;
     }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
@@ -1,0 +1,63 @@
+using Azure.Core;
+using Azure.Identity;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureCredentialChainFactoryTests
+{
+    private static X509Certificate2 SelfSigned() =>
+        new CertificateRequest("CN=connapse-test",
+            System.Security.Cryptography.ECDsa.Create(),
+            HashAlgorithmName.SHA256)
+            .CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
+
+    [Fact]
+    public void Create_WithClientIdAndCert_UsesCertificateCredential()
+    {
+        var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        cred.Should().BeOfType<ChainedTokenCredential>();
+        // First source is the cert credential when configured.
+        FirstSource(cred).Should().BeOfType<ClientCertificateCredential>();
+    }
+
+    [Fact]
+    public void Create_NoCert_SystemAssignedManagedIdentity()
+    {
+        var cred = AzureCredentialChainFactory.Create(new AzureProviderSettings(), _ => null);
+        FirstSource(cred).Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    [Fact]
+    public void Create_NoCert_UserAssignedManagedIdentity()
+    {
+        var settings = new AzureProviderSettings { UserAssignedManagedIdentityClientId = "mi-client" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => null);
+        FirstSource(cred).Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    [Fact]
+    public void Create_ClientIdSetButCertMissing_Throws()
+    {
+        var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => null);
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*certificate*");
+    }
+
+    // Reads the private _sources array ChainedTokenCredential stores, to assert ordering.
+    private static TokenCredential FirstSource(TokenCredential chain)
+    {
+        var field = typeof(ChainedTokenCredential)
+            .GetField("_sources", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var sources = (TokenCredential[])field.GetValue(chain)!;
+        return sources[0];
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs
@@ -1,0 +1,35 @@
+using Azure.Core;
+using Azure.Identity;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class ConnapseAzureCredentialsTests
+{
+    [Fact]
+    public void ProviderKey_IsAzure() => ConnapseAzureCredentials.ProviderKey.Should().Be("azure");
+
+    [Fact]
+    public void GetToken_WithNoAzureEnvironment_FailsClosed()
+    {
+        // No cert, no managed-identity endpoint reachable in a unit-test host → the chain
+        // cannot produce a token and throws, rather than returning a bogus token.
+        var monitor = new TestOptionsMonitor<AzureProviderSettings>(new AzureProviderSettings());
+        var creds = new ConnapseAzureCredentials(monitor);
+        var act = () => creds.GetToken(
+            new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
+        act.Should().Throw<CredentialUnavailableException>();
+    }
+
+    private sealed class TestOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; private set; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs
@@ -26,10 +26,72 @@ public class ConnapseAzureCredentialsTests
         act.Should().Throw<CredentialUnavailableException>();
     }
 
+    [Fact]
+    public void Constructor_WithInvalidPartialServicePrincipalSettings_DoesNotThrow()
+    {
+        // Host-safety: a broken/partial Azure config must not take down DI construction
+        // for installs that don't even use Azure (filesystem/S3/SFTP-only hosts share
+        // this singleton via ConnectorFactory -> SourceSyncService).
+        var settings = new AzureProviderSettings { TenantId = "t", ClientCertificatePath = "missing.pfx" };
+        var monitor = new TestOptionsMonitor<AzureProviderSettings>(settings);
+        var act = () => new ConnapseAzureCredentials(monitor);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void GetToken_WithInvalidPartialServicePrincipalSettings_Throws()
+    {
+        // The failure surfaces lazily, on first actual token request, and fails closed
+        // rather than falling through to managed identity.
+        var settings = new AzureProviderSettings { TenantId = "t", ClientCertificatePath = "missing.pfx" };
+        var monitor = new TestOptionsMonitor<AzureProviderSettings>(settings);
+        var creds = new ConnapseAzureCredentials(monitor);
+        var act = () => creds.GetToken(
+            new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void OnChange_AfterInvalidatingSettings_DoesNotThrowFromCallback()
+    {
+        // Settings reload must invalidate the cache without building/throwing inline.
+        var settings = new AzureProviderSettings();
+        var monitor = new TestOptionsMonitor<AzureProviderSettings>(settings);
+        var creds = new ConnapseAzureCredentials(monitor);
+
+        // Prime the cache with a valid (managed-identity-only) build.
+        var act1 = () => creds.GetToken(
+            new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
+        act1.Should().Throw<CredentialUnavailableException>();
+
+        // Reload into a broken partial config; the callback itself must not throw.
+        var broken = new AzureProviderSettings { TenantId = "t", ClientCertificatePath = "missing.pfx" };
+        var raiseChange = () => monitor.Set(broken);
+        raiseChange.Should().NotThrow();
+
+        // The next token request rebuilds and now fails closed on the bad config.
+        var act2 = () => creds.GetToken(
+            new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
+        act2.Should().Throw<InvalidOperationException>();
+    }
+
     private sealed class TestOptionsMonitor<T>(T value) : IOptionsMonitor<T>
     {
+        private Action<T, string?>? _listener;
+
         public T CurrentValue { get; private set; } = value;
         public T Get(string? name) => CurrentValue;
-        public IDisposable? OnChange(Action<T, string?> listener) => null;
+
+        public IDisposable? OnChange(Action<T, string?> listener)
+        {
+            _listener += listener;
+            return null;
+        }
+
+        public void Set(T newValue)
+        {
+            CurrentValue = newValue;
+            _listener?.Invoke(newValue, null);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Phase 2 of the Azure Blob provider rebuild (epic #475). Adds Connapse's own Azure identity and a read-only Azure Blob data-plane connector, creatable via the existing Connections/Sources UI.

Closes #477. **Targets the `epic/azure-blob-provider` branch** (not main) — Phases 3–4 stack here; the whole feature merges to main once per-user permission filtering (Phase 4) lands, so partial/unfiltered Azure ingestion isn't exposed on main in the interim.

Spec: `docs/superpowers/specs/2026-09-05-azure-phase2-app-identity-connector-design.md`.

## What's added
- **`ConnapseAzureCredentials`** — one credential story, two contexts: a configured service-principal **certificate** (off-Azure), else the ambient **managed identity** (in-Azure), else **fail closed**. Explicit `ChainedTokenCredential` (never `DefaultAzureCredential`); a configured `ClientId` with no loadable cert **throws** rather than falling through. Config from the settings hierarchy (`AzureProviderSettings`, `Providers:Azure`) — not the DB.
- **`AzureBlobConnector`** (read-only `IConnector`) + config + `AzureBlobConnectionTester` + `ResourceUri.ForAzureBlob` (`azblob://account/container/path`); re-added `AzureBlob`/`Azure` enum values + `ConnectorFactory` arm.
- **DI** wiring, and **Connections/Sources form UI** to create an Azure connection/source.

## What's explicitly deferred (not in this PR)
Per-user permission filtering (Phase 4, #479), the guided Providers setup page, DB-stored/encrypted credentials, and workload-identity-federation / client-secret credential kinds.

## Verification
- Build: 0 errors. Unit: 1540/1540 pass. DI + Azurite integration tests pass against real Docker (Azurite pinned to `3.37.0`). The 23 Ollama-dependent integration failures are a pre-existing environmental gap, unrelated.
- Azure OpenAI / AI Foundry, JWT/SAML, and the AWS path are untouched.
- Whole-branch review (opus) passed merge-ready after fixing one DI-registration bug (tester now resolvable by concrete type, matching the S3/Sftp pattern; DI test asserts the concrete path).

> Note: CI runs only on PRs to `main`, so automated checks won't run on this epic-targeted PR — verification above was run locally against Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)