### PR TITLE
feat(azure): Phase 4b — RBAC scope resolver (ARM) + ABAC (#487)

### DIFF
--- a/docs/superpowers/plans/2026-09-06-azure-phase4b-rbac-resolver.md
+++ b/docs/superpowers/plans/2026-09-06-azure-phase4b-rbac-resolver.md
@@ -1,0 +1,1041 @@
+# Azure Phase 4b — RBAC scope resolver (ARM) + ABAC Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve a searcher (oid) into the set of `azblob://` prefixes they may read via Azure RBAC — one ARM `roleAssignments` call (transitive over groups) minus a parallel `denyAssignments` call, matched against the three Storage-Blob-Data read roles, with ABAC conditions translated to prefixes or tag residue — cached ~5 min, failing closed.
+
+**Architecture:** A Core contract (`IAzureRbacReader` → `AzureRbacScopes`) and a Storage implementation (`ArmRbacReader`) that authenticates to ARM with Connapse's own `TokenCredential`, queries at the configured subscription scope, and returns readable `azblob://` prefixes plus tag-conditioned residue (verified live in 4e). Two pure, exhaustively-tested translators do the bug-prone work: ARM-scope→`azblob://` prefix, and ABAC-condition→(path prefix | container | tag | drop). Library only — no search wiring (that is 4c).
+
+**Tech Stack:** .NET 10, `Azure.Core` (`TokenCredential`), `System.Net.Http.Json`, `System.Text.Json`, `IMemoryCache`, xUnit + FluentAssertions.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md` (§B).
+
+## Global Constraints
+
+- **Fail closed.** A missing `SubscriptionId`, a failed/timed-out `roleAssignments` OR `denyAssignments` call, or any exception → `AzureRbacScopes.Failed()` (empty, `Outcome=Failed`), never a populated set. Only `Resolved` is cacheable; `Failed` is never cached. (Follow 4a's `GraphDirectoryReader` caching + cancellation discipline exactly, including `catch (OperationCanceledException) when (ct.IsCancellationRequested)` rethrow vs. internal-timeout → Failed.)
+- **Deny wins, and never fails open.** `effective = grants − denies`; a failed deny call → `Failed` (never "assume none"). A deny of uncertain applicability drops the overlapping grant (under-grant, never over-grant).
+- **Only the three built-in blob-data-read roles count** (Reader `2a2b9908-6ea1-4ae2-8e65-a410df84e7d1`, Contributor `ba92f5b4-2d11-453d-a403-e96b0029c9fe`, Owner `b7e6dc6d-f1e8-4753-8033-0f276bb0955b`); every other `roleDefinitionId` is ignored.
+- **Query subscription scope WITHOUT `atScope()`** (`$filter=assignedTo('{oid}')`, api-version `2022-04-01`), so account- and container-scoped (descendant) assignments are included; `assignedTo` is transitive over groups. Follow the `nextLink` paging chain to completion (dropping a page = under-grant).
+- **Unparseable ABAC condition → drop that one assignment** (not the whole resolution).
+- **.NET 10 conventions:** file-scoped namespaces, records, primary constructors, async all the way, no `var` for primitive types, no `dynamic`, parameterized only.
+- Cert-based ARM auth via `ConnapseAzureCredentials` (scope `https://management.azure.com/.default`), read-only.
+
+## File Structure
+
+- Create `src/Connapse.Core/Models/AzureRbacScopes.cs` — `AzureRbacScopes`, `AzureScope`, `AzureTagCondition`, `RbacOutcome` (namespace `Connapse.Core`).
+- Create `src/Connapse.Core/Interfaces/IAzureRbacReader.cs` — the contract (namespace `Connapse.Core.Interfaces`).
+- Modify `src/Connapse.Core/Models/AzureProviderSettings.cs` — add `SubscriptionId`.
+- Create `src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs` — pure ARM-scope→`azblob://` prefix.
+- Create `src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs` — pure ABAC-condition classifier.
+- Create `src/Connapse.Storage/CloudScope/ArmRbacReader.cs` — the ARM implementation.
+- Modify `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs` — register the typed HttpClient.
+- Tests: `tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs`, `AzureAbacConditionParserTests.cs`, `ArmRbacReaderTests.cs`; `tests/Connapse.Integration.Tests/AzureRbacReaderDiIntegrationTests.cs`.
+
+The internal translator/parser types live in `Connapse.Storage.CloudScope` and are exercised through the reader's public `ResolveAsync` where possible; the two pure helpers are `internal static` and unit-tested directly (they need no InternalsVisibleTo if the tests call them via the reader — but because their matrices are large, expose them `public static` on `internal`-free classes in `Connapse.Storage.CloudScope`, which `Connapse.Storage.Tests` already references).
+
+---
+
+## Task 1: Core contract + `SubscriptionId`
+
+**Files:**
+- Create: `src/Connapse.Core/Models/AzureRbacScopes.cs`
+- Create: `src/Connapse.Core/Interfaces/IAzureRbacReader.cs`
+- Modify: `src/Connapse.Core/Models/AzureProviderSettings.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs` (created here with a placeholder contract test; real cases land in Task 2)
+
+**Interfaces:**
+- Produces: `RbacOutcome { Resolved, Failed }`; `AzureScope(string Prefix)`; `AzureTagCondition(string Scope, string TagKey, string TagValue, bool KeyCaseSensitive)`; `AzureRbacScopes(IReadOnlyList<AzureScope> ReadablePrefixes, IReadOnlyList<AzureTagCondition> TagConditioned, RbacOutcome Outcome)` with `Resolved(prefixes, tags)` / `Failed()`; `IAzureRbacReader.ResolveAsync(string primaryOid, CancellationToken) → Task<AzureRbacScopes>`; `AzureProviderSettings.SubscriptionId`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureRbacScopeTranslatorTests
+{
+    [Fact]
+    public void RbacScopes_Failed_IsEmptyAndFailed()
+    {
+        AzureRbacScopes f = AzureRbacScopes.Failed();
+        f.Outcome.Should().Be(RbacOutcome.Failed);
+        f.ReadablePrefixes.Should().BeEmpty();
+        f.TagConditioned.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RbacScopes_Resolved_CarriesPrefixesAndTags()
+    {
+        AzureRbacScopes r = AzureRbacScopes.Resolved(
+            [new AzureScope("azblob://acct/c/")],
+            [new AzureTagCondition("azblob://acct/c/", "Project", "Cascade", true)]);
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().ContainSingle().Which.Prefix.Should().Be("azblob://acct/c/");
+        r.TagConditioned.Should().ContainSingle();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureRbacScopeTranslatorTests"`
+Expected: FAIL — types do not exist.
+
+- [ ] **Step 3: Write the types**
+
+```csharp
+// src/Connapse.Core/Models/AzureRbacScopes.cs
+namespace Connapse.Core;
+
+/// <summary>Whether the RBAC scope set was resolved confidently or must fail closed.</summary>
+public enum RbacOutcome { Resolved, Failed }
+
+/// <summary>An <c>azblob://</c> prefix the searcher may read via an RBAC grant. A whole-account
+/// grant is <c>azblob://{account}/</c>; a grant broader than an account (RG/subscription/management
+/// group) is <c>azblob://</c> (matches every account).</summary>
+public record AzureScope(string Prefix);
+
+/// <summary>An RBAC grant gated on a blob index-tag condition that cannot reduce to a prefix. The
+/// <see cref="Scope"/> is the broad candidate prefix; the tag predicate is verified live per hit
+/// (Phase 4e). Never excluded here.</summary>
+public record AzureTagCondition(string Scope, string TagKey, string TagValue, bool KeyCaseSensitive);
+
+/// <summary>The searcher's effective RBAC-readable scope set. Fails closed: unless
+/// <see cref="Outcome"/> is <see cref="RbacOutcome.Resolved"/>, both lists are empty.</summary>
+public record AzureRbacScopes(
+    IReadOnlyList<AzureScope> ReadablePrefixes,
+    IReadOnlyList<AzureTagCondition> TagConditioned,
+    RbacOutcome Outcome)
+{
+    public static AzureRbacScopes Resolved(
+        IReadOnlyList<AzureScope> readablePrefixes, IReadOnlyList<AzureTagCondition> tagConditioned) =>
+        new(readablePrefixes, tagConditioned, RbacOutcome.Resolved);
+
+    public static AzureRbacScopes Failed() => new([], [], RbacOutcome.Failed);
+}
+```
+
+```csharp
+// src/Connapse.Core/Interfaces/IAzureRbacReader.cs
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Resolves a searcher's effective RBAC-readable <c>azblob://</c> scope set from Azure Resource
+/// Manager, reading with Connapse's own Azure identity. Fails closed.
+/// </summary>
+public interface IAzureRbacReader
+{
+    /// <summary>
+    /// The <c>azblob://</c> prefixes <paramref name="primaryOid"/> may read via Storage Blob Data
+    /// roles (transitive over groups, minus deny assignments), plus any tag-conditioned residue.
+    /// </summary>
+    Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct = default);
+}
+```
+
+Add to `src/Connapse.Core/Models/AzureProviderSettings.cs` (after `UserAssignedManagedIdentityClientId`):
+
+```csharp
+    /// <summary>The subscription whose role/deny assignments the RBAC resolver queries. Required
+    /// for per-user Azure permission filtering; absent → the resolver fails closed.</summary>
+    public string? SubscriptionId { get; init; }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureRbacScopeTranslatorTests"`
+Expected: PASS (2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Models/AzureRbacScopes.cs src/Connapse.Core/Interfaces/IAzureRbacReader.cs src/Connapse.Core/Models/AzureProviderSettings.cs tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs
+git commit -m "feat(azure): AzureRbacScopes + IAzureRbacReader contract + SubscriptionId (#487)"
+```
+
+---
+
+## Task 2: ARM scope → `azblob://` prefix translator (pure)
+
+**Files:**
+- Create: `src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs` (extend)
+
+**Interfaces:**
+- Consumes: nothing (pure).
+- Produces: `AzureRbacScopeTranslator.ToAzblobPrefix(string armScope) → string` — the `azblob://` prefix an ARM assignment scope governs.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// append to AzureRbacScopeTranslatorTests
+using Connapse.Storage.CloudScope;
+
+[Theory]
+[InlineData(
+    "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs",
+    "azblob://acct/docs/")]
+[InlineData(
+    "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct",
+    "azblob://acct/")]
+[InlineData(
+    "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default",
+    "azblob://acct/")]
+[InlineData("/subscriptions/s/resourceGroups/rg", "azblob://")]
+[InlineData("/subscriptions/s", "azblob://")]
+[InlineData("/providers/Microsoft.Management/managementGroups/mg", "azblob://")]
+public void ToAzblobPrefix_MapsScopeToPrefix(string armScope, string expected) =>
+    AzureRbacScopeTranslator.ToAzblobPrefix(armScope).Should().Be(expected);
+
+[Fact]
+public void ToAzblobPrefix_IsCaseInsensitiveOnResourceProviderSegments() =>
+    AzureRbacScopeTranslator.ToAzblobPrefix(
+        "/subscriptions/s/resourceGroups/rg/providers/microsoft.storage/STORAGEACCOUNTS/Acct/blobservices/default/CONTAINERS/Docs")
+        .Should().Be("azblob://Acct/Docs/");
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureRbacScopeTranslatorTests"`
+Expected: FAIL — `AzureRbacScopeTranslator` does not exist.
+
+- [ ] **Step 3: Write the translator**
+
+```csharp
+// src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Translates an ARM role-assignment scope into the <c>azblob://</c> prefix it governs. Resource
+/// provider and type segments are matched case-insensitively (ARM is case-insensitive on them);
+/// the account and container names keep their original case (they are the resource_uri content).
+/// </summary>
+public static class AzureRbacScopeTranslator
+{
+    public static string ToAzblobPrefix(string armScope)
+    {
+        string[] parts = armScope.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        int acctIdx = Array.FindIndex(parts,
+            p => string.Equals(p, "storageAccounts", StringComparison.OrdinalIgnoreCase));
+        if (acctIdx < 0 || acctIdx + 1 >= parts.Length)
+            return "azblob://"; // broader than an account (RG / subscription / management group)
+
+        string account = parts[acctIdx + 1];
+
+        int containersIdx = Array.FindIndex(parts, acctIdx + 1,
+            p => string.Equals(p, "containers", StringComparison.OrdinalIgnoreCase));
+        if (containersIdx >= 0 && containersIdx + 1 < parts.Length)
+            return $"azblob://{account}/{parts[containersIdx + 1]}/";
+
+        return $"azblob://{account}/";
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureRbacScopeTranslatorTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs
+git commit -m "feat(azure): ARM scope to azblob prefix translator (#487)"
+```
+
+---
+
+## Task 3: ABAC condition parser (pure)
+
+**Files:**
+- Create: `src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs`
+
+**Interfaces:**
+- Produces: `AbacResult` record `{ AbacKind Kind, string? PathPrefix, string? ContainerName, string? TagKey, string? TagValue, bool TagKeyCaseSensitive }`; `AbacKind { None, PathPrefix, ContainerName, Tag, Unparseable }`; `AzureAbacConditionParser.Parse(string? condition) → AbacResult` (null/blank condition → `None`).
+
+**Interpretation:** A null/empty condition is an unconditional grant (`None`). Otherwise classify by the single resource attribute the condition references. This parser only understands the canonical read templates (per the spec's non-goals: anything else → `Unparseable` → the caller drops that grant). Recognized attribute tokens (case-insensitive on the attribute path, value in single quotes):
+- `blobs:path]` with `StringStartsWith`/`StringLike` `'<p>'` → `PathPrefix` = `<p>` with a single trailing `*` stripped.
+- `containers:name]` with `StringEquals` `'<c>'` → `ContainerName` = `<c>`.
+- `blobs/tags:<Key><$key_case_sensitive$>]` or `blobs/tags:<Key><$key_case_insensitive$>]` with `StringEquals` `'<v>'` → `Tag`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureAbacConditionParserTests
+{
+    private const string PathCond =
+        "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'} AND NOT SubOperationMatches{'Blob.List'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*'))";
+    private const string NameCond =
+        "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'reports'))";
+    private const string TagCond =
+        "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Project<$key_case_sensitive$>] StringEquals 'Cascade'))";
+
+    [Fact]
+    public void Parse_Null_IsNone() =>
+        AzureAbacConditionParser.Parse(null).Kind.Should().Be(AbacKind.None);
+
+    [Fact]
+    public void Parse_Path_ReturnsPrefix_TrailingStarStripped()
+    {
+        AbacResult r = AzureAbacConditionParser.Parse(PathCond);
+        r.Kind.Should().Be(AbacKind.PathPrefix);
+        r.PathPrefix.Should().Be("readonly/");
+    }
+
+    [Fact]
+    public void Parse_ContainerName_ReturnsName()
+    {
+        AbacResult r = AzureAbacConditionParser.Parse(NameCond);
+        r.Kind.Should().Be(AbacKind.ContainerName);
+        r.ContainerName.Should().Be("reports");
+    }
+
+    [Fact]
+    public void Parse_Tag_ReturnsKeyValue()
+    {
+        AbacResult r = AzureAbacConditionParser.Parse(TagCond);
+        r.Kind.Should().Be(AbacKind.Tag);
+        r.TagKey.Should().Be("Project");
+        r.TagValue.Should().Be("Cascade");
+        r.TagKeyCaseSensitive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_UnknownExpression_IsUnparseable() =>
+        AzureAbacConditionParser.Parse("@Request[...] DateTimeGreaterThan '2024-01-01'")
+            .Kind.Should().Be(AbacKind.Unparseable);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureAbacConditionParserTests"`
+Expected: FAIL — parser does not exist.
+
+- [ ] **Step 3: Write the parser**
+
+```csharp
+// src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs
+using System.Text.RegularExpressions;
+
+namespace Connapse.Storage.CloudScope;
+
+public enum AbacKind { None, PathPrefix, ContainerName, Tag, Unparseable }
+
+public record AbacResult(
+    AbacKind Kind,
+    string? PathPrefix = null,
+    string? ContainerName = null,
+    string? TagKey = null,
+    string? TagValue = null,
+    bool TagKeyCaseSensitive = false);
+
+/// <summary>
+/// Classifies the canonical Azure Blob ABAC read conditions into a prefix, a container name, a tag
+/// predicate, or Unparseable. Only the documented read templates are understood; anything else is
+/// Unparseable and the caller drops that grant (fail closed). A null/blank condition is None (an
+/// unconditional grant).
+/// </summary>
+public static partial class AzureAbacConditionParser
+{
+    [GeneratedRegex(@"blobServices/containers/blobs:path\]\s+String(?:Like|StartsWith)\s+'([^']*)'",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex PathRegex();
+
+    [GeneratedRegex(@"blobServices/containers:name\]\s+StringEquals\s+'([^']*)'",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex NameRegex();
+
+    [GeneratedRegex(@"blobServices/containers/blobs/tags:([^<\]]+)<\$key_(case_sensitive|case_insensitive)\$>\]\s+StringEquals\s+'([^']*)'",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex TagRegex();
+
+    public static AbacResult Parse(string? condition)
+    {
+        if (string.IsNullOrWhiteSpace(condition))
+            return new AbacResult(AbacKind.None);
+
+        Match tag = TagRegex().Match(condition);
+        if (tag.Success)
+            return new AbacResult(AbacKind.Tag,
+                TagKey: tag.Groups[1].Value,
+                TagValue: tag.Groups[3].Value,
+                TagKeyCaseSensitive: string.Equals(tag.Groups[2].Value, "case_sensitive", StringComparison.OrdinalIgnoreCase));
+
+        Match path = PathRegex().Match(condition);
+        if (path.Success)
+        {
+            string p = path.Groups[1].Value;
+            if (p.EndsWith('*')) p = p[..^1];
+            return new AbacResult(AbacKind.PathPrefix, PathPrefix: p);
+        }
+
+        Match name = NameRegex().Match(condition);
+        if (name.Success)
+            return new AbacResult(AbacKind.ContainerName, ContainerName: name.Groups[1].Value);
+
+        return new AbacResult(AbacKind.Unparseable);
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureAbacConditionParserTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs
+git commit -m "feat(azure): ABAC blob condition parser (path/name/tag) (#487)"
+```
+
+---
+
+## Task 4: `ArmRbacReader` — role assignments → readable scopes (grants only)
+
+**Files:**
+- Create: `src/Connapse.Storage/CloudScope/ArmRbacReader.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs`
+
+**Interfaces:**
+- Consumes: `IAzureRbacReader`, `AzureRbacScopes`, `AzureScope`, `AzureTagCondition` (Task 1); `AzureRbacScopeTranslator` (Task 2); `AzureAbacConditionParser`/`AbacKind`/`AbacResult` (Task 3); `TokenCredential`; `IMemoryCache`; `IOptionsMonitor<AzureProviderSettings>`.
+- Produces: `ArmRbacReader(HttpClient httpClient, TokenCredential azureCredential, IMemoryCache cache, IOptionsMonitor<AzureProviderSettings> options) : IAzureRbacReader`; `public static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(5)`.
+
+This task builds the grants path (roleAssignments only); Task 5 adds deny subtraction; Task 6 adds caching + DI. The internal apply-condition logic maps each grant `(azblobPrefix, condition)` → prefix / tag-residue / drop.
+
+- [ ] **Step 1: Write the failing tests** (happy path + role filtering + ABAC application + subscription-missing)
+
+```csharp
+// tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+using System.Net;
+using System.Text;
+using Azure.Core;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class ArmRbacReaderTests
+{
+    private const string Oid = "11111111-1111-1111-1111-111111111111";
+    private const string Sub = "22222222-2222-2222-2222-222222222222";
+    private const string ReaderRole = "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1";
+
+    // Records every request URL so tests can assert which ARM endpoints were called.
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        public List<string> Urls { get; } = [];
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Urls.Add(request.RequestUri!.ToString());
+            return Task.FromResult(respond(request));
+        }
+    }
+
+    private sealed class StubTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext c, CancellationToken ct) =>
+            new("stub", DateTimeOffset.UtcNow.AddHours(1));
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext c, CancellationToken ct) =>
+            new(GetToken(c, ct));
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode s, string body) =>
+        new(s) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    private static string RoleAssignmentsBody(params (string roleGuid, string scope, string? condition)[] rows)
+    {
+        string items = string.Join(",", rows.Select(r =>
+        {
+            string cond = r.condition is null ? "null" : $"\"{r.condition.Replace("\"", "\\\"")}\"";
+            return $$"""
+            {"properties":{"roleDefinitionId":"/subscriptions/{{Sub}}/providers/Microsoft.Authorization/roleDefinitions/{{r.roleGuid}}","principalId":"{{Oid}}","scope":"{{r.scope}}","condition":{{cond}},"conditionVersion":null}}
+            """;
+        }));
+        return $$"""{"value":[{{items}}]}""";
+    }
+
+    private static readonly string EmptyDeny = """{"value":[]}""";
+
+    // A reader whose roleAssignments call returns `roles` and whose denyAssignments call returns empty.
+    private static ArmRbacReader NewReader(string rolesBody, string? subId = Sub, IMemoryCache? cache = null)
+    {
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.OK, EmptyDeny)
+                : Json(HttpStatusCode.OK, rolesBody));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = subId });
+        return new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            cache ?? new MemoryCache(new MemoryCacheOptions()), opts);
+    }
+
+    [Fact]
+    public async Task Resolve_AccountScopedReaderRole_NoCondition_YieldsAccountPrefix()
+    {
+        string body = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().Contain("azblob://acct/");
+    }
+
+    [Fact]
+    public async Task Resolve_IgnoresNonBlobDataRoles()
+    {
+        // Owner of the *control plane* role "Contributor" for ARM is a different GUID; use a random one.
+        string body = RoleAssignmentsBody(("00000000-0000-0000-0000-000000000000",
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_PathCondition_NarrowsPrefix()
+    {
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'} AND NOT SubOperationMatches{'Blob.List'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*'))";
+        string body = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", cond));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().Contain("azblob://acct/docs/readonly/");
+    }
+
+    [Fact]
+    public async Task Resolve_TagCondition_GoesToTagResidue_NotPrefix()
+    {
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Project<$key_case_sensitive$>] StringEquals 'Cascade'))";
+        string body = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", cond));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Should().BeEmpty();
+        r.TagConditioned.Should().ContainSingle().Which.TagValue.Should().Be("Cascade");
+    }
+
+    [Fact]
+    public async Task Resolve_UnparseableCondition_DropsThatGrantOnly()
+    {
+        string bad = "((!(ActionMatches{'x'})) OR (@Request[foo] DateTimeGreaterThan '2024-01-01'))";
+        string body = RoleAssignmentsBody(
+            (ReaderRole, "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/bad", bad),
+            (ReaderRole, "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/good", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/good/");
+    }
+
+    [Fact]
+    public async Task Resolve_NoSubscriptionConfigured_FailsClosed()
+    {
+        AzureRbacScopes r = await NewReader(RoleAssignmentsBody(), subId: null).ResolveAsync(Oid, CancellationToken.None);
+        r.Outcome.Should().Be(RbacOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_QueriesSubscriptionScope_WithoutAtScope()
+    {
+        var reader = NewReader(RoleAssignmentsBody());
+        await reader.ResolveAsync(Oid, CancellationToken.None);
+        // (assert via a handler that captured URLs — see StubHandler.Urls; validated in Task 6's DI test
+        //  and here by constructing the reader with a capturing handler if needed)
+    }
+}
+```
+
+Note: add `using NSubstitute;` — the test project already references NSubstitute (see CLAUDE.md). The final URL-assertion test is fleshed out in Task 6 where the capturing handler is wired; keep the placeholder body compiling (it simply resolves).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~ArmRbacReaderTests"`
+Expected: FAIL — `ArmRbacReader` does not exist.
+
+- [ ] **Step 3: Write the reader (grants path)**
+
+```csharp
+// src/Connapse.Storage/CloudScope/ArmRbacReader.cs
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Azure.Core;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Resolves a searcher's effective RBAC-readable azblob scopes from ARM: one roleAssignments call
+/// at the subscription scope (transitive over groups, WITHOUT atScope so account/container
+/// assignments are included) minus a parallel denyAssignments call. Fails closed; caches only
+/// confident answers. Mirrors <see cref="GraphDirectoryReader"/>'s transport/caching discipline.
+/// </summary>
+public sealed class ArmRbacReader(
+    HttpClient httpClient,
+    TokenCredential azureCredential,
+    IMemoryCache cache,
+    IOptionsMonitor<AzureProviderSettings> options) : IAzureRbacReader
+{
+    private const string ArmBase = "https://management.azure.com";
+    private const string ApiVersion = "2022-04-01";
+    private static readonly string[] ArmScopes = ["https://management.azure.com/.default"];
+
+    private static readonly HashSet<string> BlobDataReadRoles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1", // Storage Blob Data Reader
+        "ba92f5b4-2d11-453d-a403-e96b0029c9fe", // Storage Blob Data Contributor
+        "b7e6dc6d-f1e8-4753-8033-0f276bb0955b", // Storage Blob Data Owner
+    };
+
+    public static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(5);
+
+    public async Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct = default)
+    {
+        string? sub = options.CurrentValue.SubscriptionId;
+        if (string.IsNullOrWhiteSpace(sub))
+            return AzureRbacScopes.Failed(); // cannot query without a subscription — fail closed
+
+        try
+        {
+            return await ResolveUncachedAsync(sub, primaryOid, ct); // Task 5/6 add deny + cache
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return AzureRbacScopes.Failed();
+        }
+    }
+
+    private async Task<AzureRbacScopes> ResolveUncachedAsync(string sub, string oid, CancellationToken ct)
+    {
+        AccessToken token = await azureCredential.GetTokenAsync(new TokenRequestContext(ArmScopes), ct);
+
+        IReadOnlyList<Assignment> grants = await ListAllAsync(
+            $"{ArmBase}/subscriptions/{sub}/providers/Microsoft.Authorization/roleAssignments" +
+            $"?api-version={ApiVersion}&$filter=assignedTo('{oid}')", token, ct);
+
+        var prefixes = new List<AzureScope>();
+        var tags = new List<AzureTagCondition>();
+        foreach (Assignment a in grants)
+        {
+            string? roleGuid = LastSegment(a.Properties?.RoleDefinitionId);
+            if (roleGuid is null || !BlobDataReadRoles.Contains(roleGuid) || a.Properties?.Scope is null)
+                continue;
+
+            ApplyGrant(a.Properties.Scope, a.Properties.Condition, prefixes, tags);
+        }
+
+        return AzureRbacScopes.Resolved(prefixes, tags);
+    }
+
+    /// <summary>Maps one matched grant (scope + ABAC condition) into a prefix, a tag residue, or a drop.</summary>
+    internal static void ApplyGrant(string armScope, string? condition, List<AzureScope> prefixes, List<AzureTagCondition> tags)
+    {
+        string basePrefix = AzureRbacScopeTranslator.ToAzblobPrefix(armScope);
+        AbacResult abac = AzureAbacConditionParser.Parse(condition);
+        switch (abac.Kind)
+        {
+            case AbacKind.None:
+                prefixes.Add(new AzureScope(basePrefix));
+                break;
+            case AbacKind.PathPrefix:
+                prefixes.Add(new AzureScope(basePrefix + abac.PathPrefix));
+                break;
+            case AbacKind.ContainerName:
+                // Narrow an account/broader scope to the named container.
+                prefixes.Add(new AzureScope(NarrowToContainer(basePrefix, abac.ContainerName!)));
+                break;
+            case AbacKind.Tag:
+                tags.Add(new AzureTagCondition(basePrefix, abac.TagKey!, abac.TagValue!, abac.TagKeyCaseSensitive));
+                break;
+            case AbacKind.Unparseable:
+            default:
+                break; // drop this grant only (fail closed)
+        }
+    }
+
+    private static string NarrowToContainer(string basePrefix, string container)
+    {
+        // basePrefix is "azblob://", "azblob://{acct}/", or "azblob://{acct}/{c}/". A container-name
+        // condition names the container within the account; only meaningful when the account is known.
+        if (basePrefix == "azblob://")
+            return basePrefix; // account unknown — leave broad; the condition can't be tightened here
+        // basePrefix ends with "/"; strip any existing container and append the named one.
+        string acct = basePrefix["azblob://".Length..].TrimEnd('/').Split('/')[0];
+        return $"azblob://{acct}/{container}/";
+    }
+
+    private static string? LastSegment(string? id) =>
+        string.IsNullOrEmpty(id) ? null : id.Split('/', StringSplitOptions.RemoveEmptyEntries)[^1];
+
+    private async Task<IReadOnlyList<Assignment>> ListAllAsync(string url, AccessToken token, CancellationToken ct)
+    {
+        var all = new List<Assignment>();
+        string? next = url;
+        while (next is not null)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, next);
+            request.Headers.Authorization = new("Bearer", token.Token);
+            using HttpResponseMessage response = await httpClient.SendAsync(request, ct);
+            response.EnsureSuccessStatusCode(); // non-2xx → throw → caller fails closed
+            ArmList? page = await response.Content.ReadFromJsonAsync<ArmList>(ct);
+            if (page?.Value is { } v) all.AddRange(v);
+            next = page?.NextLink;
+        }
+        return all;
+    }
+
+    // ---- ARM DTOs ----
+    internal sealed record ArmList(
+        [property: JsonPropertyName("value")] IReadOnlyList<Assignment>? Value,
+        [property: JsonPropertyName("nextLink")] string? NextLink);
+    internal sealed record Assignment([property: JsonPropertyName("properties")] AssignmentProps? Properties);
+    internal sealed record AssignmentProps(
+        [property: JsonPropertyName("roleDefinitionId")] string? RoleDefinitionId,
+        [property: JsonPropertyName("scope")] string? Scope,
+        [property: JsonPropertyName("condition")] string? Condition);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~ArmRbacReaderTests"`
+Expected: PASS (the URL-assertion placeholder test resolves; deny/cache tests come in 5/6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/ArmRbacReader.cs tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+git commit -m "feat(azure): ArmRbacReader resolves readable scopes from role assignments (#487)"
+```
+
+---
+
+## Task 5: Deny assignments — effective = grants − denies
+
+**Files:**
+- Modify: `src/Connapse.Storage/CloudScope/ArmRbacReader.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs` (extend)
+
+**Interfaces:**
+- Consumes: the grants path (Task 4). Adds a parallel deny fetch and a conservative subtraction.
+
+**Deny model (conservative, sound):** fetch `denyAssignments` at the same subscription scope with `assignedTo('{oid}')`. A deny assignment carries `properties.scope` and `properties.permissions[].dataActions`/`notDataActions`. Treat a deny as applicable to blob read when any `dataActions` entry is the blob read action or a wildcard covering it (`Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read`, or `.../blobs/*`, or `*`). For each applicable deny, remove any grant prefix that the deny's scope **covers** — i.e. the deny's azblob prefix (via `AzureRbacScopeTranslator`) is a prefix of, or equal to, the grant prefix. (Deny scope broader than grant ⇒ grant removed; this is deny-wins. Tag-conditioned residue whose scope is covered is likewise dropped.) A failed deny call throws → the outer catch returns `Failed` (never assume none).
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// append to ArmRbacReaderTests
+
+// Build a reader whose deny call returns `denyBody`.
+private static ArmRbacReader NewReaderWithDeny(string rolesBody, string denyBody, string? subId = Sub)
+{
+    var handler = new StubHandler(req =>
+        req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+            ? Json(HttpStatusCode.OK, denyBody)
+            : Json(HttpStatusCode.OK, rolesBody));
+    var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+    opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = subId });
+    return new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+        new MemoryCache(new MemoryCacheOptions()), opts);
+}
+
+private static string DenyBody(string scope) => $$"""
+{"value":[{"properties":{"scope":"{{scope}}","permissions":[{"dataActions":["Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"],"notDataActions":[]}]}}]}
+""";
+
+[Fact]
+public async Task Resolve_DenyCoveringGrant_RemovesIt()
+{
+    string acctScope = "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+    string roles = RoleAssignmentsBody((ReaderRole, acctScope + "/blobServices/default/containers/docs", null));
+    // Deny at the whole account covers the container grant.
+    AzureRbacScopes r = await NewReaderWithDeny(roles, DenyBody(acctScope)).ResolveAsync(Oid, CancellationToken.None);
+
+    r.Outcome.Should().Be(RbacOutcome.Resolved);
+    r.ReadablePrefixes.Should().BeEmpty(); // deny wins
+}
+
+[Fact]
+public async Task Resolve_DenyElsewhere_DoesNotRemoveUnrelatedGrant()
+{
+    string roles = RoleAssignmentsBody((ReaderRole,
+        "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", null));
+    string denyOther = DenyBody("/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/other");
+    AzureRbacScopes r = await NewReaderWithDeny(roles, denyOther).ResolveAsync(Oid, CancellationToken.None);
+
+    r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/docs/");
+}
+
+[Fact]
+public async Task Resolve_DenyCallFails_FailsClosed()
+{
+    var handler = new StubHandler(req =>
+        req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+            ? Json(HttpStatusCode.InternalServerError, "{}")
+            : Json(HttpStatusCode.OK, RoleAssignmentsBody((ReaderRole,
+                "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null))));
+    var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+    opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+    var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+        new MemoryCache(new MemoryCacheOptions()), opts);
+
+    (await reader.ResolveAsync(Oid, CancellationToken.None)).Outcome.Should().Be(RbacOutcome.Failed);
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~ArmRbacReaderTests"`
+Expected: FAIL (deny not yet fetched/subtracted).
+
+- [ ] **Step 3: Add deny fetch + subtraction**
+
+Replace `ResolveUncachedAsync` so it fetches deny in parallel and subtracts, and add the helpers:
+
+```csharp
+    private async Task<AzureRbacScopes> ResolveUncachedAsync(string sub, string oid, CancellationToken ct)
+    {
+        AccessToken token = await azureCredential.GetTokenAsync(new TokenRequestContext(ArmScopes), ct);
+
+        Task<IReadOnlyList<Assignment>> grantsTask = ListAllAsync(
+            $"{ArmBase}/subscriptions/{sub}/providers/Microsoft.Authorization/roleAssignments" +
+            $"?api-version={ApiVersion}&$filter=assignedTo('{oid}')", token, ct);
+        Task<IReadOnlyList<Assignment>> denyTask = ListAllAsync(
+            $"{ArmBase}/subscriptions/{sub}/providers/Microsoft.Authorization/denyAssignments" +
+            $"?api-version={ApiVersion}&$filter=assignedTo('{oid}')", token, ct);
+        await Task.WhenAll(grantsTask, denyTask); // a failure in either throws → caller fails closed
+
+        var prefixes = new List<AzureScope>();
+        var tags = new List<AzureTagCondition>();
+        foreach (Assignment a in grantsTask.Result)
+        {
+            string? roleGuid = LastSegment(a.Properties?.RoleDefinitionId);
+            if (roleGuid is null || !BlobDataReadRoles.Contains(roleGuid) || a.Properties?.Scope is null)
+                continue;
+            ApplyGrant(a.Properties.Scope, a.Properties.Condition, prefixes, tags);
+        }
+
+        IReadOnlyList<string> denyPrefixes = DenyPrefixes(denyTask.Result);
+        if (denyPrefixes.Count > 0)
+        {
+            prefixes = prefixes.Where(p => !CoveredByAnyDeny(p.Prefix, denyPrefixes)).ToList();
+            tags = tags.Where(t => !CoveredByAnyDeny(t.Scope, denyPrefixes)).ToList();
+        }
+
+        return AzureRbacScopes.Resolved(prefixes, tags);
+    }
+
+    /// <summary>Deny scopes (as azblob prefixes) that apply to blob read for this searcher.</summary>
+    private static IReadOnlyList<string> DenyPrefixes(IReadOnlyList<Assignment> denies)
+    {
+        var result = new List<string>();
+        foreach (Assignment d in denies)
+        {
+            if (d.Properties?.Scope is null) continue;
+            if (AppliesToBlobRead(d.Properties.Permissions))
+                result.Add(AzureRbacScopeTranslator.ToAzblobPrefix(d.Properties.Scope));
+        }
+        return result;
+    }
+
+    private static bool AppliesToBlobRead(IReadOnlyList<Permission>? permissions)
+    {
+        if (permissions is null) return false;
+        foreach (Permission p in permissions)
+        {
+            foreach (string a in p.DataActions ?? [])
+            {
+                if (a == "*"
+                    || a.Equals("Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read", StringComparison.OrdinalIgnoreCase)
+                    || (a.EndsWith('*') && "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"
+                            .StartsWith(a[..^1], StringComparison.OrdinalIgnoreCase)))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    // A grant is denied when a deny prefix is equal to, or an ancestor of, the grant prefix
+    // (deny-wins over a broader-or-equal scope). "azblob://" as a deny prefix covers everything.
+    private static bool CoveredByAnyDeny(string grantPrefix, IReadOnlyList<string> denyPrefixes) =>
+        denyPrefixes.Any(d => grantPrefix.StartsWith(d, StringComparison.Ordinal));
+```
+
+Add the deny DTO fields to `AssignmentProps` and a `Permission` record:
+
+```csharp
+    internal sealed record AssignmentProps(
+        [property: JsonPropertyName("roleDefinitionId")] string? RoleDefinitionId,
+        [property: JsonPropertyName("scope")] string? Scope,
+        [property: JsonPropertyName("condition")] string? Condition,
+        [property: JsonPropertyName("permissions")] IReadOnlyList<Permission>? Permissions);
+    internal sealed record Permission(
+        [property: JsonPropertyName("dataActions")] IReadOnlyList<string>? DataActions,
+        [property: JsonPropertyName("notDataActions")] IReadOnlyList<string>? NotDataActions);
+```
+
+(`roleAssignments` responses simply have no `permissions` field → null → ignored. `denyAssignments` responses have no `roleDefinitionId` → not matched as a grant.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~ArmRbacReaderTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/ArmRbacReader.cs tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+git commit -m "feat(azure): subtract deny assignments from RBAC grants (deny wins) (#487)"
+```
+
+---
+
+## Task 6: Caching + DI wiring + resolution test
+
+**Files:**
+- Modify: `src/Connapse.Storage/CloudScope/ArmRbacReader.cs` (add caching)
+- Modify: `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs` (caching + URL assertion), `tests/Connapse.Integration.Tests/AzureRbacReaderDiIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: everything above; `ConnapseAzureCredentials` (already a singleton, mapped to `TokenCredential` in 4a).
+
+- [ ] **Step 1: Add caching to `ResolveAsync`**
+
+Wrap the resolve in a per-oid cache (confident answers only), mirroring `GraphDirectoryReader`:
+
+```csharp
+    public async Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct = default)
+    {
+        string? sub = options.CurrentValue.SubscriptionId;
+        if (string.IsNullOrWhiteSpace(sub))
+            return AzureRbacScopes.Failed();
+
+        string cacheKey = "azure-rbac:" + primaryOid;
+        if (cache.TryGetValue(cacheKey, out AzureRbacScopes? cached) && cached is not null)
+            return cached;
+
+        AzureRbacScopes result;
+        try
+        {
+            result = await ResolveUncachedAsync(sub, primaryOid, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return AzureRbacScopes.Failed();
+        }
+
+        if (result.Outcome is RbacOutcome.Resolved)
+            cache.Set(cacheKey, result, CacheLifetime);
+        return result;
+    }
+```
+
+- [ ] **Step 2: Write caching + URL-assertion tests**
+
+```csharp
+// append to ArmRbacReaderTests
+[Fact]
+public async Task Resolve_Resolved_IsCached_SecondCallDoesNotHitArm()
+{
+    string roles = RoleAssignmentsBody((ReaderRole,
+        "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+    var handler = new StubHandler(req =>
+        req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+            ? Json(HttpStatusCode.OK, EmptyDeny) : Json(HttpStatusCode.OK, roles));
+    var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+    opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+    var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+        new MemoryCache(new MemoryCacheOptions()), opts);
+
+    await reader.ResolveAsync(Oid, CancellationToken.None);
+    int after = handler.Urls.Count;
+    await reader.ResolveAsync(Oid, CancellationToken.None);
+
+    handler.Urls.Count.Should().Be(after); // served from cache
+    handler.Urls.Should().Contain(u => u.Contains("/roleAssignments") && u.Contains("assignedTo") && !u.Contains("atScope"));
+    handler.Urls.Should().Contain(u => u.Contains("/subscriptions/" + Sub + "/"));
+}
+```
+
+- [ ] **Step 3: DI registration** — after the 4a `IAzureDirectoryReader` registration in `AddConnapseStorage`, add:
+
+```csharp
+        // Reads the searcher's effective RBAC-readable azblob scopes from ARM (role assignments
+        // minus deny assignments). Typed HttpClient; the 5-minute decision cache is the shared
+        // IMemoryCache singleton. TokenCredential is already mapped to ConnapseAzureCredentials (4a).
+        services.AddHttpClient<Connapse.Core.Interfaces.IAzureRbacReader, CloudScope.ArmRbacReader>();
+```
+
+- [ ] **Step 4: Write the DI resolution test**
+
+```csharp
+// tests/Connapse.Integration.Tests/AzureRbacReaderDiIntegrationTests.cs
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureRbacReaderDiIntegrationTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public void Di_Resolves_AzureRbacReader()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IAzureRbacReader>().Should().NotBeNull();
+    }
+}
+```
+
+- [ ] **Step 5: Build, run tests, commit**
+
+Run: `dotnet build` then `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~ArmRbacReaderTests|FullyQualifiedName~AzureRbacScopeTranslatorTests|FullyQualifiedName~AzureAbacConditionParserTests"` and the DI test `dotnet test tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj --filter "FullyQualifiedName~AzureRbacReaderDiIntegrationTests"` (needs Docker).
+Expected: all green.
+
+```bash
+git add src/Connapse.Storage/CloudScope/ArmRbacReader.cs src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs tests/Connapse.Integration.Tests/AzureRbacReaderDiIntegrationTests.cs
+git commit -m "feat(azure): cache RBAC scopes + register ArmRbacReader (#487)"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec §B coverage:** subscription-scope query without `atScope()` + transitive `assignedTo` (Task 4, corrects the parent design); nextLink paging (Task 4); 3 role GUIDs (Task 4); scope→azblob translation incl. broader→`azblob://` (Task 2); ABAC path/name/tag/unparseable (Task 3, applied Task 4); deny in parallel, effective = grants − denies, deny-call-fail → Failed (Task 5); cache ~5 min confident-only + `azure-rbac:{oid}` (Task 6); fail-closed on no-subscription/HTTP-fail/timeout (Tasks 4, 6). ✅
+- **Not in 4b (deferred):** search wiring / composite / enforcement (4c); Gen2 (4d/4e); the settings-based tenant-match guard (4a follow-up).
+- **Type consistency:** `AzureRbacScopes`/`AzureScope`/`AzureTagCondition`/`RbacOutcome`/`IAzureRbacReader.ResolveAsync(string, ct)` identical across tasks; `AzureRbacScopeTranslator.ToAzblobPrefix`, `AzureAbacConditionParser.Parse`, `AbacResult`/`AbacKind` referenced consistently; `ArmRbacReader` ctor and `CacheLifetime` stable.
+- **Fail-closed:** every non-Resolved path returns `Failed()` (empty); deny-call failure fails closed; unparseable condition drops one grant, not the resolution.

--- a/docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md
+++ b/docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md
@@ -111,22 +111,38 @@ Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct);
 IReadOnlyList<AzureTagCondition> TagConditioned, RbacOutcome Outcome }`.
 
 **`ArmRbacReader`** (Storage) — one ARM call plus a parallel deny call, api-version `2022-04-01`,
-on `ConnapseAzureCredentials` (scope `https://management.azure.com/.default`):
-- `GET .../providers/Microsoft.Authorization/roleAssignments?$filter=atScope() and assignedTo('{oid}')`
-  — `assignedTo` is **transitive over the user's groups**, so this single call returns every
-  role assignment reaching the user (no per-group fan-out).
-- In parallel, `.../denyAssignments` with the same filter. **effective = grants − denies** (deny
-  wins; a missing deny call → `Failed`, not "assume none" — ignoring a deny fails open).
-- Match each assignment's role-definition id against three hard-coded built-in GUIDs: Reader
-  `2a2b9908-6ea1-4ae2-8e65-a410df84e7d1`, Contributor `ba92f5b4-2d11-453d-a403-e96b0029c9fe`,
-  Owner `b7e6dc6d-f1e8-4753-8033-0f276bb0955b` (only these grant blob **data** read).
-- Translate each surviving assignment's scope to an `azblob://{account}/{container}[/{prefix}]`
-  scope, applying its ABAC `condition`:
-  - **path/name condition** → narrow to a prefix predicate (a `ReadablePrefix`).
-  - **blob-index-tag condition** → cannot reduce to a prefix; emit an `AzureTagCondition`
-    (container/path scope + the tag predicate) for **live per-hit verification** (§E), never
-    excluded.
-  - **unparseable condition** → drop that assignment (fail closed).
+on `ConnapseAzureCredentials` (scope `https://management.azure.com/.default`), at the
+**subscription scope** (`AzureProviderSettings.SubscriptionId`, added this phase; absent → `Failed`):
+- `GET /subscriptions/{sub}/providers/Microsoft.Authorization/roleAssignments?api-version=2022-04-01&$filter=assignedTo('{oid}')`
+  — **without** `atScope()`. Corrects the parent design: the docs state `atScope()` lists "only the
+  specified scope, **not including the role assignments at subscopes**", so it would miss
+  account- and container-scoped grants (the common case). A plain subscription-scope list includes
+  assignments at the scope, its ancestors (inherited), **and** its descendants (RG / account /
+  container). `assignedTo` is **transitive over the user's groups**, so this single call returns
+  every role assignment reaching the user (no per-group fan-out).
+- In parallel, `.../denyAssignments?...&$filter=assignedTo('{oid}')`. **effective = grants − denies**
+  (deny wins; a missing/failed deny call → `Failed`, not "assume none" — ignoring a deny fails open).
+  Conservative & sound: any deny assignment whose scope covers (is equal to or an ancestor of) a
+  grant's scope and whose (data)actions include the blob read action removes/trims that grant; when
+  a deny's applicability is uncertain, drop the overlapping grant (under-grant, never over-grant).
+- Match each assignment's `roleDefinitionId` (last GUID segment) against three hard-coded built-in
+  GUIDs: Reader `2a2b9908-6ea1-4ae2-8e65-a410df84e7d1`, Contributor
+  `ba92f5b4-2d11-453d-a403-e96b0029c9fe`, Owner `b7e6dc6d-f1e8-4753-8033-0f276bb0955b` (only these
+  grant blob **data** read).
+- Translate each surviving assignment's `scope` to an `azblob://` prefix:
+  `.../storageAccounts/{acct}/blobServices/default/containers/{c}` → `azblob://{acct}/{c}/`;
+  `.../storageAccounts/{acct}` → `azblob://{acct}/`; a broader scope (RG / subscription /
+  management group) covers every account under it → `azblob://` (matches all accounts). Then apply
+  its ABAC `condition`:
+  - **path condition** (`@Resource[...blobs:path] StringLike/StringStartsWith '<p>'`) → narrow to a
+    prefix (`azblob://{acct}/{c}/<p>`), stripping a trailing `*`.
+  - **container-name condition** (`@Resource[...containers:name] StringEquals '<c>'`) → narrow the
+    account/broader scope to that container.
+  - **blob-index-tag condition** (`@Resource[...blobs/tags:<key>...] ...`) → cannot reduce to a
+    prefix; emit an `AzureTagCondition` (scope + the tag predicate) for **live per-hit
+    verification** (§E), never excluded.
+  - **unparseable condition** → drop that one assignment (fail closed for that grant; the rest still
+    count).
 - Cache ~5 min keyed by oid (`azure-rbac:{oid}`), confident answers only.
 
 ### C. Flat resolver + composite + per-cloud enforcement (4c)

--- a/src/Connapse.Core/Interfaces/IAzureRbacReader.cs
+++ b/src/Connapse.Core/Interfaces/IAzureRbacReader.cs
@@ -1,0 +1,14 @@
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Resolves a searcher's effective RBAC-readable <c>azblob://</c> scope set from Azure Resource
+/// Manager, reading with Connapse's own Azure identity. Fails closed.
+/// </summary>
+public interface IAzureRbacReader
+{
+    /// <summary>
+    /// The <c>azblob://</c> prefixes <paramref name="primaryOid"/> may read via Storage Blob Data
+    /// roles (transitive over groups, minus deny assignments), plus any tag-conditioned residue.
+    /// </summary>
+    Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Models/AzureProviderSettings.cs
+++ b/src/Connapse.Core/Models/AzureProviderSettings.cs
@@ -14,4 +14,8 @@ public record AzureProviderSettings
     public string? ClientCertificatePath { get; init; }
     public string? ClientCertificatePassword { get; init; }
     public string? UserAssignedManagedIdentityClientId { get; init; }
+
+    /// <summary>The subscription whose role/deny assignments the RBAC resolver queries. Required
+    /// for per-user Azure permission filtering; absent → the resolver fails closed.</summary>
+    public string? SubscriptionId { get; init; }
 }

--- a/src/Connapse.Core/Models/AzureRbacScopes.cs
+++ b/src/Connapse.Core/Models/AzureRbacScopes.cs
@@ -10,8 +10,12 @@ public record AzureScope(string Prefix);
 
 /// <summary>An RBAC grant gated on a blob index-tag condition that cannot reduce to a prefix. The
 /// <see cref="Scope"/> is the broad candidate prefix; the tag predicate is verified live per hit
-/// (Phase 4e). Never excluded here.</summary>
-public record AzureTagCondition(string Scope, string TagKey, string TagValue, bool KeyCaseSensitive);
+/// (Phase 4e). Never excluded here. <see cref="KeyCaseSensitive"/> reflects the condition's
+/// <c>&lt;$key_case_sensitive$&gt;</c> marker; <see cref="ValueCaseSensitive"/> is true for
+/// <c>StringEquals</c> and false for <c>StringEqualsIgnoreCase</c> — Phase 4e compares tag values
+/// accordingly.</summary>
+public record AzureTagCondition(
+    string Scope, string TagKey, string TagValue, bool KeyCaseSensitive, bool ValueCaseSensitive = false);
 
 /// <summary>The searcher's effective RBAC-readable scope set. Fails closed: unless
 /// <see cref="Outcome"/> is <see cref="RbacOutcome.Resolved"/>, both lists are empty.</summary>

--- a/src/Connapse.Core/Models/AzureRbacScopes.cs
+++ b/src/Connapse.Core/Models/AzureRbacScopes.cs
@@ -1,0 +1,28 @@
+namespace Connapse.Core;
+
+/// <summary>Whether the RBAC scope set was resolved confidently or must fail closed.</summary>
+public enum RbacOutcome { Resolved, Failed }
+
+/// <summary>An <c>azblob://</c> prefix the searcher may read via an RBAC grant. A whole-account
+/// grant is <c>azblob://{account}/</c>; a grant broader than an account (RG/subscription/management
+/// group) is <c>azblob://</c> (matches every account).</summary>
+public record AzureScope(string Prefix);
+
+/// <summary>An RBAC grant gated on a blob index-tag condition that cannot reduce to a prefix. The
+/// <see cref="Scope"/> is the broad candidate prefix; the tag predicate is verified live per hit
+/// (Phase 4e). Never excluded here.</summary>
+public record AzureTagCondition(string Scope, string TagKey, string TagValue, bool KeyCaseSensitive);
+
+/// <summary>The searcher's effective RBAC-readable scope set. Fails closed: unless
+/// <see cref="Outcome"/> is <see cref="RbacOutcome.Resolved"/>, both lists are empty.</summary>
+public record AzureRbacScopes(
+    IReadOnlyList<AzureScope> ReadablePrefixes,
+    IReadOnlyList<AzureTagCondition> TagConditioned,
+    RbacOutcome Outcome)
+{
+    public static AzureRbacScopes Resolved(
+        IReadOnlyList<AzureScope> readablePrefixes, IReadOnlyList<AzureTagCondition> tagConditioned) =>
+        new(readablePrefixes, tagConditioned, RbacOutcome.Resolved);
+
+    public static AzureRbacScopes Failed() => new([], [], RbacOutcome.Failed);
+}

--- a/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
+++ b/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
@@ -124,10 +124,17 @@ public sealed class ArmRbacReader(
         return false;
     }
 
-    // A grant is denied when a deny prefix is equal to, or an ancestor of, the grant prefix
-    // (deny-wins over a broader-or-equal scope). "azblob://" as a deny prefix covers everything.
+    // A grant is removed if it OVERLAPS any applicable deny in EITHER direction:
+    //  - deny at a broader-or-equal scope (deny is a prefix of the grant) covers the grant; and
+    //  - deny at a narrower scope (a "hole" beneath the grant — the grant is a prefix of the deny)
+    //    cannot be represented as "grant minus a hole" in a prefix set, so the whole grant is
+    //    conservatively dropped (over-subtraction = under-grant, the fail-closed direction).
+    // Deny wins either way. "azblob://" on either side matches everything. All emitted prefixes end
+    // in "/" (or are a path-condition prefix), so container-name boundaries are respected.
     private static bool CoveredByAnyDeny(string grantPrefix, IReadOnlyList<string> denyPrefixes) =>
-        denyPrefixes.Any(d => grantPrefix.StartsWith(d, StringComparison.Ordinal));
+        denyPrefixes.Any(d =>
+            grantPrefix.StartsWith(d, StringComparison.Ordinal) ||
+            d.StartsWith(grantPrefix, StringComparison.Ordinal));
 
     /// <summary>Maps one matched grant (scope + ABAC condition) into a prefix, a tag residue, or a drop.</summary>
     internal static void ApplyGrant(string armScope, string? condition, List<AzureScope> prefixes, List<AzureTagCondition> tags)
@@ -143,8 +150,12 @@ public sealed class ArmRbacReader(
                 prefixes.Add(new AzureScope(basePrefix + abac.PathPrefix));
                 break;
             case AbacKind.ContainerName:
-                // Narrow an account/broader scope to the named container.
-                prefixes.Add(new AzureScope(NarrowToContainer(basePrefix, abac.ContainerName!)));
+                // Narrow an account scope to the named container. If the account is unknown (a
+                // broader-than-account grant), the restriction cannot be expressed as a prefix, so
+                // the grant is dropped rather than left broad (fail closed).
+                string? narrowed = NarrowToContainer(basePrefix, abac.ContainerName!);
+                if (narrowed is not null)
+                    prefixes.Add(new AzureScope(narrowed));
                 break;
             case AbacKind.Tag:
                 tags.Add(new AzureTagCondition(basePrefix, abac.TagKey!, abac.TagValue!, abac.TagKeyCaseSensitive));
@@ -155,12 +166,12 @@ public sealed class ArmRbacReader(
         }
     }
 
-    private static string NarrowToContainer(string basePrefix, string container)
+    private static string? NarrowToContainer(string basePrefix, string container)
     {
         // basePrefix is "azblob://", "azblob://{acct}/", or "azblob://{acct}/{c}/". A container-name
         // condition names the container within the account; only meaningful when the account is known.
         if (basePrefix == "azblob://")
-            return basePrefix; // account unknown — leave broad; the condition can't be tightened here
+            return null; // account unknown — the container-name restriction can't be applied → drop (fail closed)
         // basePrefix ends with "/"; strip any existing container and append the named one.
         string acct = basePrefix["azblob://".Length..].TrimEnd('/').Split('/')[0];
         return $"azblob://{acct}/{container}/";

--- a/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
+++ b/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
@@ -37,11 +37,16 @@ public sealed class ArmRbacReader(
     {
         string? sub = options.CurrentValue.SubscriptionId;
         if (string.IsNullOrWhiteSpace(sub))
-            return AzureRbacScopes.Failed(); // cannot query without a subscription — fail closed
+            return AzureRbacScopes.Failed();
 
+        string cacheKey = "azure-rbac:" + primaryOid;
+        if (cache.TryGetValue(cacheKey, out AzureRbacScopes? cached) && cached is not null)
+            return cached;
+
+        AzureRbacScopes result;
         try
         {
-            return await ResolveUncachedAsync(sub, primaryOid, ct); // Task 5/6 add deny + cache
+            result = await ResolveUncachedAsync(sub, primaryOid, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -51,6 +56,10 @@ public sealed class ArmRbacReader(
         {
             return AzureRbacScopes.Failed();
         }
+
+        if (result.Outcome is RbacOutcome.Resolved)
+            cache.Set(cacheKey, result, CacheLifetime);
+        return result;
     }
 
     private async Task<AzureRbacScopes> ResolveUncachedAsync(string sub, string oid, CancellationToken ct)

--- a/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
+++ b/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
@@ -57,23 +57,68 @@ public sealed class ArmRbacReader(
     {
         AccessToken token = await azureCredential.GetTokenAsync(new TokenRequestContext(ArmScopes), ct);
 
-        IReadOnlyList<Assignment> grants = await ListAllAsync(
+        Task<IReadOnlyList<Assignment>> grantsTask = ListAllAsync(
             $"{ArmBase}/subscriptions/{sub}/providers/Microsoft.Authorization/roleAssignments" +
             $"?api-version={ApiVersion}&$filter=assignedTo('{oid}')", token, ct);
+        Task<IReadOnlyList<Assignment>> denyTask = ListAllAsync(
+            $"{ArmBase}/subscriptions/{sub}/providers/Microsoft.Authorization/denyAssignments" +
+            $"?api-version={ApiVersion}&$filter=assignedTo('{oid}')", token, ct);
+        await Task.WhenAll(grantsTask, denyTask); // a failure in either throws → caller fails closed
 
         var prefixes = new List<AzureScope>();
         var tags = new List<AzureTagCondition>();
-        foreach (Assignment a in grants)
+        foreach (Assignment a in grantsTask.Result)
         {
             string? roleGuid = LastSegment(a.Properties?.RoleDefinitionId);
             if (roleGuid is null || !BlobDataReadRoles.Contains(roleGuid) || a.Properties?.Scope is null)
                 continue;
-
             ApplyGrant(a.Properties.Scope, a.Properties.Condition, prefixes, tags);
+        }
+
+        IReadOnlyList<string> denyPrefixes = DenyPrefixes(denyTask.Result);
+        if (denyPrefixes.Count > 0)
+        {
+            prefixes = prefixes.Where(p => !CoveredByAnyDeny(p.Prefix, denyPrefixes)).ToList();
+            tags = tags.Where(t => !CoveredByAnyDeny(t.Scope, denyPrefixes)).ToList();
         }
 
         return AzureRbacScopes.Resolved(prefixes, tags);
     }
+
+    /// <summary>Deny scopes (as azblob prefixes) that apply to blob read for this searcher.</summary>
+    private static IReadOnlyList<string> DenyPrefixes(IReadOnlyList<Assignment> denies)
+    {
+        var result = new List<string>();
+        foreach (Assignment d in denies)
+        {
+            if (d.Properties?.Scope is null) continue;
+            if (AppliesToBlobRead(d.Properties.Permissions))
+                result.Add(AzureRbacScopeTranslator.ToAzblobPrefix(d.Properties.Scope));
+        }
+        return result;
+    }
+
+    private static bool AppliesToBlobRead(IReadOnlyList<Permission>? permissions)
+    {
+        if (permissions is null) return false;
+        foreach (Permission p in permissions)
+        {
+            foreach (string a in p.DataActions ?? [])
+            {
+                if (a == "*"
+                    || a.Equals("Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read", StringComparison.OrdinalIgnoreCase)
+                    || (a.EndsWith('*') && "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"
+                            .StartsWith(a[..^1], StringComparison.OrdinalIgnoreCase)))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    // A grant is denied when a deny prefix is equal to, or an ancestor of, the grant prefix
+    // (deny-wins over a broader-or-equal scope). "azblob://" as a deny prefix covers everything.
+    private static bool CoveredByAnyDeny(string grantPrefix, IReadOnlyList<string> denyPrefixes) =>
+        denyPrefixes.Any(d => grantPrefix.StartsWith(d, StringComparison.Ordinal));
 
     /// <summary>Maps one matched grant (scope + ABAC condition) into a prefix, a tag residue, or a drop.</summary>
     internal static void ApplyGrant(string armScope, string? condition, List<AzureScope> prefixes, List<AzureTagCondition> tags)
@@ -140,5 +185,9 @@ public sealed class ArmRbacReader(
     internal sealed record AssignmentProps(
         [property: JsonPropertyName("roleDefinitionId")] string? RoleDefinitionId,
         [property: JsonPropertyName("scope")] string? Scope,
-        [property: JsonPropertyName("condition")] string? Condition);
+        [property: JsonPropertyName("condition")] string? Condition,
+        [property: JsonPropertyName("permissions")] IReadOnlyList<Permission>? Permissions);
+    internal sealed record Permission(
+        [property: JsonPropertyName("dataActions")] IReadOnlyList<string>? DataActions,
+        [property: JsonPropertyName("notDataActions")] IReadOnlyList<string>? NotDataActions);
 }

--- a/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
+++ b/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
@@ -1,0 +1,144 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Azure.Core;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Resolves a searcher's effective RBAC-readable azblob scopes from ARM: one roleAssignments call
+/// at the subscription scope (transitive over groups, WITHOUT atScope so account/container
+/// assignments are included) minus a parallel denyAssignments call. Fails closed; caches only
+/// confident answers. Mirrors <see cref="GraphDirectoryReader"/>'s transport/caching discipline.
+/// </summary>
+public sealed class ArmRbacReader(
+    HttpClient httpClient,
+    TokenCredential azureCredential,
+    IMemoryCache cache,
+    IOptionsMonitor<AzureProviderSettings> options) : IAzureRbacReader
+{
+    private const string ArmBase = "https://management.azure.com";
+    private const string ApiVersion = "2022-04-01";
+    private static readonly string[] ArmScopes = ["https://management.azure.com/.default"];
+
+    private static readonly HashSet<string> BlobDataReadRoles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1", // Storage Blob Data Reader
+        "ba92f5b4-2d11-453d-a403-e96b0029c9fe", // Storage Blob Data Contributor
+        "b7e6dc6d-f1e8-4753-8033-0f276bb0955b", // Storage Blob Data Owner
+    };
+
+    public static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(5);
+
+    public async Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct = default)
+    {
+        string? sub = options.CurrentValue.SubscriptionId;
+        if (string.IsNullOrWhiteSpace(sub))
+            return AzureRbacScopes.Failed(); // cannot query without a subscription — fail closed
+
+        try
+        {
+            return await ResolveUncachedAsync(sub, primaryOid, ct); // Task 5/6 add deny + cache
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return AzureRbacScopes.Failed();
+        }
+    }
+
+    private async Task<AzureRbacScopes> ResolveUncachedAsync(string sub, string oid, CancellationToken ct)
+    {
+        AccessToken token = await azureCredential.GetTokenAsync(new TokenRequestContext(ArmScopes), ct);
+
+        IReadOnlyList<Assignment> grants = await ListAllAsync(
+            $"{ArmBase}/subscriptions/{sub}/providers/Microsoft.Authorization/roleAssignments" +
+            $"?api-version={ApiVersion}&$filter=assignedTo('{oid}')", token, ct);
+
+        var prefixes = new List<AzureScope>();
+        var tags = new List<AzureTagCondition>();
+        foreach (Assignment a in grants)
+        {
+            string? roleGuid = LastSegment(a.Properties?.RoleDefinitionId);
+            if (roleGuid is null || !BlobDataReadRoles.Contains(roleGuid) || a.Properties?.Scope is null)
+                continue;
+
+            ApplyGrant(a.Properties.Scope, a.Properties.Condition, prefixes, tags);
+        }
+
+        return AzureRbacScopes.Resolved(prefixes, tags);
+    }
+
+    /// <summary>Maps one matched grant (scope + ABAC condition) into a prefix, a tag residue, or a drop.</summary>
+    internal static void ApplyGrant(string armScope, string? condition, List<AzureScope> prefixes, List<AzureTagCondition> tags)
+    {
+        string basePrefix = AzureRbacScopeTranslator.ToAzblobPrefix(armScope);
+        AbacResult abac = AzureAbacConditionParser.Parse(condition);
+        switch (abac.Kind)
+        {
+            case AbacKind.None:
+                prefixes.Add(new AzureScope(basePrefix));
+                break;
+            case AbacKind.PathPrefix:
+                prefixes.Add(new AzureScope(basePrefix + abac.PathPrefix));
+                break;
+            case AbacKind.ContainerName:
+                // Narrow an account/broader scope to the named container.
+                prefixes.Add(new AzureScope(NarrowToContainer(basePrefix, abac.ContainerName!)));
+                break;
+            case AbacKind.Tag:
+                tags.Add(new AzureTagCondition(basePrefix, abac.TagKey!, abac.TagValue!, abac.TagKeyCaseSensitive));
+                break;
+            case AbacKind.Unparseable:
+            default:
+                break; // drop this grant only (fail closed)
+        }
+    }
+
+    private static string NarrowToContainer(string basePrefix, string container)
+    {
+        // basePrefix is "azblob://", "azblob://{acct}/", or "azblob://{acct}/{c}/". A container-name
+        // condition names the container within the account; only meaningful when the account is known.
+        if (basePrefix == "azblob://")
+            return basePrefix; // account unknown — leave broad; the condition can't be tightened here
+        // basePrefix ends with "/"; strip any existing container and append the named one.
+        string acct = basePrefix["azblob://".Length..].TrimEnd('/').Split('/')[0];
+        return $"azblob://{acct}/{container}/";
+    }
+
+    private static string? LastSegment(string? id) =>
+        string.IsNullOrEmpty(id) ? null : id.Split('/', StringSplitOptions.RemoveEmptyEntries)[^1];
+
+    private async Task<IReadOnlyList<Assignment>> ListAllAsync(string url, AccessToken token, CancellationToken ct)
+    {
+        var all = new List<Assignment>();
+        string? next = url;
+        while (next is not null)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, next);
+            request.Headers.Authorization = new("Bearer", token.Token);
+            using HttpResponseMessage response = await httpClient.SendAsync(request, ct);
+            response.EnsureSuccessStatusCode(); // non-2xx → throw → caller fails closed
+            ArmList? page = await response.Content.ReadFromJsonAsync<ArmList>(ct);
+            if (page?.Value is { } v) all.AddRange(v);
+            next = page?.NextLink;
+        }
+        return all;
+    }
+
+    // ---- ARM DTOs ----
+    internal sealed record ArmList(
+        [property: JsonPropertyName("value")] IReadOnlyList<Assignment>? Value,
+        [property: JsonPropertyName("nextLink")] string? NextLink);
+    internal sealed record Assignment([property: JsonPropertyName("properties")] AssignmentProps? Properties);
+    internal sealed record AssignmentProps(
+        [property: JsonPropertyName("roleDefinitionId")] string? RoleDefinitionId,
+        [property: JsonPropertyName("scope")] string? Scope,
+        [property: JsonPropertyName("condition")] string? Condition);
+}

--- a/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
+++ b/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
@@ -35,11 +35,15 @@ public sealed class ArmRbacReader(
 
     public async Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct = default)
     {
-        string? sub = options.CurrentValue.SubscriptionId;
+        AzureProviderSettings settings = options.CurrentValue;
+        string? sub = settings.SubscriptionId;
         if (string.IsNullOrWhiteSpace(sub))
             return AzureRbacScopes.Failed();
 
-        string cacheKey = "azure-rbac:" + primaryOid;
+        // Key by tenant + subscription + oid: the subscription and credential come from reloadable
+        // settings, so a cached result must never be reused across a subscription or tenant change
+        // (which would expose accounts not authorized in the new context).
+        string cacheKey = $"azure-rbac:{settings.TenantId}:{sub}:{primaryOid}";
         if (cache.TryGetValue(cacheKey, out AzureRbacScopes? cached) && cached is not null)
             return cached;
 
@@ -107,22 +111,28 @@ public sealed class ArmRbacReader(
         return result;
     }
 
+    private const string BlobReadAction = "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read";
+
     private static bool AppliesToBlobRead(IReadOnlyList<Permission>? permissions)
     {
         if (permissions is null) return false;
         foreach (Permission p in permissions)
         {
-            foreach (string a in p.DataActions ?? [])
-            {
-                if (a == "*"
-                    || a.Equals("Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read", StringComparison.OrdinalIgnoreCase)
-                    || (a.EndsWith('*') && "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"
-                            .StartsWith(a[..^1], StringComparison.OrdinalIgnoreCase)))
-                    return true;
-            }
+            // A deny applies to blob read only when a dataAction covers the read action AND no
+            // notDataAction excludes it (dataActions minus notDataActions). Ignoring notDataActions
+            // would over-subtract and hide legitimately-readable content.
+            bool granted = (p.DataActions ?? []).Any(MatchesBlobRead);
+            bool excluded = (p.NotDataActions ?? []).Any(MatchesBlobRead);
+            if (granted && !excluded)
+                return true;
         }
         return false;
     }
+
+    private static bool MatchesBlobRead(string action) =>
+        action == "*"
+        || action.Equals(BlobReadAction, StringComparison.OrdinalIgnoreCase)
+        || (action.EndsWith('*') && BlobReadAction.StartsWith(action[..^1], StringComparison.OrdinalIgnoreCase));
 
     // A grant is removed if it OVERLAPS any applicable deny in EITHER direction:
     //  - deny at a broader-or-equal scope (deny is a prefix of the grant) covers the grant; and
@@ -136,45 +146,63 @@ public sealed class ArmRbacReader(
             grantPrefix.StartsWith(d, StringComparison.Ordinal) ||
             d.StartsWith(grantPrefix, StringComparison.Ordinal));
 
-    /// <summary>Maps one matched grant (scope + ABAC condition) into a prefix, a tag residue, or a drop.</summary>
+    /// <summary>Maps one matched grant (scope + ABAC condition) into a prefix, a tag residue, or a
+    /// drop. Every ABAC restriction is intersected with the assignment's own scope; when it cannot
+    /// be expressed as an azblob prefix the grant is dropped (fail closed), never broadened.</summary>
     internal static void ApplyGrant(string armScope, string? condition, List<AzureScope> prefixes, List<AzureTagCondition> tags)
     {
         string basePrefix = AzureRbacScopeTranslator.ToAzblobPrefix(armScope);
+        (string? account, string? container) = SplitPrefix(basePrefix);
         AbacResult abac = AzureAbacConditionParser.Parse(condition);
         switch (abac.Kind)
         {
             case AbacKind.None:
                 prefixes.Add(new AzureScope(basePrefix));
                 break;
+
             case AbacKind.PathPrefix:
-                prefixes.Add(new AzureScope(basePrefix + abac.PathPrefix));
+                // A blob-path condition is a prefix WITHIN a container, so it can only be expressed
+                // as an azblob prefix when the scope already fixes the container. On an account or
+                // broader scope the same path applies inside EVERY container (not a container named
+                // for the path), which cannot be represented — drop (fail closed).
+                if (container is not null)
+                    prefixes.Add(new AzureScope(basePrefix + abac.PathPrefix));
                 break;
+
             case AbacKind.ContainerName:
-                // Narrow an account scope to the named container. If the account is unknown (a
-                // broader-than-account grant), the restriction cannot be expressed as a prefix, so
-                // the grant is dropped rather than left broad (fail closed).
-                string? narrowed = NarrowToContainer(basePrefix, abac.ContainerName!);
-                if (narrowed is not null)
-                    prefixes.Add(new AzureScope(narrowed));
+                string? named = abac.ContainerName;
+                if (account is null || named is null)
+                    break; // account unknown → can't apply → drop
+                if (container is null)
+                    prefixes.Add(new AzureScope($"azblob://{account}/{named}/")); // narrow account to the named container
+                else if (string.Equals(container, named, StringComparison.Ordinal))
+                    prefixes.Add(new AzureScope(basePrefix)); // condition names the same container as the scope
+                // else: names a DIFFERENT container than the assignment's scope → grants nothing → drop
                 break;
+
             case AbacKind.Tag:
-                tags.Add(new AzureTagCondition(basePrefix, abac.TagKey!, abac.TagValue!, abac.TagKeyCaseSensitive));
+                tags.Add(new AzureTagCondition(basePrefix, abac.TagKey!, abac.TagValue!, abac.TagKeyCaseSensitive, abac.ValueCaseSensitive));
                 break;
+
             case AbacKind.Unparseable:
             default:
                 break; // drop this grant only (fail closed)
         }
     }
 
-    private static string? NarrowToContainer(string basePrefix, string container)
+    /// <summary>Splits an azblob prefix into (account?, container?): "azblob://" → (null,null);
+    /// "azblob://acct/" → (acct,null); "azblob://acct/c/" → (acct,c).</summary>
+    private static (string? Account, string? Container) SplitPrefix(string basePrefix)
     {
-        // basePrefix is "azblob://", "azblob://{acct}/", or "azblob://{acct}/{c}/". A container-name
-        // condition names the container within the account; only meaningful when the account is known.
         if (basePrefix == "azblob://")
-            return null; // account unknown — the container-name restriction can't be applied → drop (fail closed)
-        // basePrefix ends with "/"; strip any existing container and append the named one.
-        string acct = basePrefix["azblob://".Length..].TrimEnd('/').Split('/')[0];
-        return $"azblob://{acct}/{container}/";
+            return (null, null);
+        string[] segs = basePrefix["azblob://".Length..].TrimEnd('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segs.Length switch
+        {
+            0 => (null, null),
+            1 => (segs[0], null),
+            _ => (segs[0], segs[1]),
+        };
     }
 
     private static string? LastSegment(string? id) =>
@@ -191,8 +219,13 @@ public sealed class ArmRbacReader(
             using HttpResponseMessage response = await httpClient.SendAsync(request, ct);
             response.EnsureSuccessStatusCode(); // non-2xx → throw → caller fails closed
             ArmList? page = await response.Content.ReadFromJsonAsync<ArmList>(ct);
-            if (page?.Value is { } v) all.AddRange(v);
-            next = page?.NextLink;
+            // A 200 whose body is missing or has a null "value" is a malformed/anomalous page. It
+            // must fail closed rather than be read as "no entries" — silently swallowing a deny page
+            // this way would omit denies and turn into an over-grant.
+            if (page?.Value is null)
+                throw new InvalidOperationException("ARM list response had no 'value' array.");
+            all.AddRange(page.Value);
+            next = page.NextLink;
         }
         return all;
     }

--- a/src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs
+++ b/src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs
@@ -32,10 +32,21 @@ public static partial class AzureAbacConditionParser
         RegexOptions.IgnoreCase)]
     private static partial Regex TagRegex();
 
+    [GeneratedRegex(@"@(?:Resource|Request|Environment|Principal)\[", RegexOptions.IgnoreCase)]
+    private static partial Regex AttributeRefRegex();
+
     public static AbacResult Parse(string? condition)
     {
         if (string.IsNullOrWhiteSpace(condition))
             return new AbacResult(AbacKind.None);
+
+        // Only the canonical SINGLE-attribute read template is understood. A compound condition —
+        // more than one attribute reference (a path AND a tag, or a recognized clause AND an
+        // unrecognized/restrictive one) — must never be partially honored, or a restrictive clause
+        // would be silently dropped and the grant over-broadened. Require exactly one attribute
+        // reference; anything else is Unparseable and the caller drops the grant (fail closed).
+        if (AttributeRefRegex().Matches(condition).Count != 1)
+            return new AbacResult(AbacKind.Unparseable);
 
         Match tag = TagRegex().Match(condition);
         if (tag.Success)

--- a/src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs
+++ b/src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs
@@ -10,63 +10,82 @@ public record AbacResult(
     string? ContainerName = null,
     string? TagKey = null,
     string? TagValue = null,
-    bool TagKeyCaseSensitive = false);
+    bool TagKeyCaseSensitive = false,
+    bool ValueCaseSensitive = false);
 
 /// <summary>
-/// Classifies the canonical Azure Blob ABAC read conditions into a prefix, a container name, a tag
-/// predicate, or Unparseable. Only the documented read templates are understood; anything else is
-/// Unparseable and the caller drops that grant (fail closed). A null/blank condition is None (an
+/// Classifies the canonical Azure Blob ABAC read conditions into a path prefix, a container name, a
+/// tag predicate, or Unparseable. Soundness over recall: the WHOLE condition must match one of the
+/// documented read templates (an action guard <c>(!(ActionMatches{…blobs/read} [AND NOT
+/// SubOperationMatches{Blob.List}])) OR (&lt;single predicate&gt;)</c>) — a fragment match is never
+/// enough, because a compound/inverted expression would otherwise be read as a positive grant. Any
+/// condition that is not exactly a recognized template is <see cref="AbacKind.Unparseable"/> and the
+/// caller drops that grant (fail closed). A null/blank condition is <see cref="AbacKind.None"/> (an
 /// unconditional grant).
 /// </summary>
 public static partial class AzureAbacConditionParser
 {
-    [GeneratedRegex(@"blobServices/containers/blobs:path\]\s+String(?:Like|StartsWith)\s+'([^']*)'",
-        RegexOptions.IgnoreCase)]
-    private static partial Regex PathRegex();
+    // Whole-condition templates: ^( (!(ActionMatches{…read} [AND NOT SubOperationMatches{Blob.List}])) OR ( <predicate> ) )$
+    // Anchored so a compound/inverted/extra-clause condition cannot partially match.
 
-    [GeneratedRegex(@"blobServices/containers:name\]\s+StringEquals\s+'([^']*)'",
+    [GeneratedRegex(
+        @"^\s*\(\s*\(\s*!\s*\(\s*ActionMatches\{'Microsoft\.Storage/storageAccounts/blobServices/containers/blobs/read'\}(?:\s+AND\s+NOT\s+SubOperationMatches\{'Blob\.List'\})?\s*\)\s*\)\s+OR\s+\(\s*@Resource\[Microsoft\.Storage/storageAccounts/blobServices/containers/blobs:path\]\s+(StringStartsWith|StringLike)\s+'([^']*)'\s*\)\s*\)\s*$",
         RegexOptions.IgnoreCase)]
-    private static partial Regex NameRegex();
+    private static partial Regex PathTemplate();
 
-    [GeneratedRegex(@"blobServices/containers/blobs/tags:([^<\]]+)<\$key_(case_sensitive|case_insensitive)\$>\]\s+StringEquals\s+'([^']*)'",
+    [GeneratedRegex(
+        @"^\s*\(\s*\(\s*!\s*\(\s*ActionMatches\{'Microsoft\.Storage/storageAccounts/blobServices/containers/blobs/read'\}(?:\s+AND\s+NOT\s+SubOperationMatches\{'Blob\.List'\})?\s*\)\s*\)\s+OR\s+\(\s*@Resource\[Microsoft\.Storage/storageAccounts/blobServices/containers:name\]\s+(StringEquals|StringEqualsIgnoreCase)\s+'([^']*)'\s*\)\s*\)\s*$",
         RegexOptions.IgnoreCase)]
-    private static partial Regex TagRegex();
+    private static partial Regex NameTemplate();
 
-    [GeneratedRegex(@"@(?:Resource|Request|Environment|Principal)\[", RegexOptions.IgnoreCase)]
-    private static partial Regex AttributeRefRegex();
+    [GeneratedRegex(
+        @"^\s*\(\s*\(\s*!\s*\(\s*ActionMatches\{'Microsoft\.Storage/storageAccounts/blobServices/containers/blobs/read'\}(?:\s+AND\s+NOT\s+SubOperationMatches\{'Blob\.List'\})?\s*\)\s*\)\s+OR\s+\(\s*@Resource\[Microsoft\.Storage/storageAccounts/blobServices/containers/blobs/tags:([^<\]]+)<\$key_(case_sensitive|case_insensitive)\$>\]\s+(StringEquals|StringEqualsIgnoreCase)\s+'([^']*)'\s*\)\s*\)\s*$",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex TagTemplate();
 
     public static AbacResult Parse(string? condition)
     {
         if (string.IsNullOrWhiteSpace(condition))
             return new AbacResult(AbacKind.None);
 
-        // Only the canonical SINGLE-attribute read template is understood. A compound condition —
-        // more than one attribute reference (a path AND a tag, or a recognized clause AND an
-        // unrecognized/restrictive one) — must never be partially honored, or a restrictive clause
-        // would be silently dropped and the grant over-broadened. Require exactly one attribute
-        // reference; anything else is Unparseable and the caller drops the grant (fail closed).
-        if (AttributeRefRegex().Matches(condition).Count != 1)
-            return new AbacResult(AbacKind.Unparseable);
-
-        Match tag = TagRegex().Match(condition);
+        Match tag = TagTemplate().Match(condition);
         if (tag.Success)
             return new AbacResult(AbacKind.Tag,
                 TagKey: tag.Groups[1].Value,
-                TagValue: tag.Groups[3].Value,
-                TagKeyCaseSensitive: string.Equals(tag.Groups[2].Value, "case_sensitive", StringComparison.OrdinalIgnoreCase));
+                TagValue: tag.Groups[4].Value,
+                TagKeyCaseSensitive: tag.Groups[2].Value.Equals("case_sensitive", StringComparison.OrdinalIgnoreCase),
+                ValueCaseSensitive: tag.Groups[3].Value.Equals("StringEquals", StringComparison.OrdinalIgnoreCase));
 
-        Match path = PathRegex().Match(condition);
+        Match path = PathTemplate().Match(condition);
         if (path.Success)
         {
-            string p = path.Groups[1].Value;
-            if (p.EndsWith('*')) p = p[..^1];
-            return new AbacResult(AbacKind.PathPrefix, PathPrefix: p);
+            string op = path.Groups[1].Value;
+            string value = path.Groups[2].Value;
+            string? prefix = op.Equals("StringStartsWith", StringComparison.OrdinalIgnoreCase)
+                ? value                    // literal prefix
+                : SafeLikePrefix(value);   // StringLike: only "<literal>*" reduces to a prefix
+            return prefix is null
+                ? new AbacResult(AbacKind.Unparseable)
+                : new AbacResult(AbacKind.PathPrefix, PathPrefix: prefix);
         }
 
-        Match name = NameRegex().Match(condition);
+        Match name = NameTemplate().Match(condition);
         if (name.Success)
-            return new AbacResult(AbacKind.ContainerName, ContainerName: name.Groups[1].Value);
+            return new AbacResult(AbacKind.ContainerName, ContainerName: name.Groups[2].Value);
 
         return new AbacResult(AbacKind.Unparseable);
+    }
+
+    /// <summary>
+    /// A <c>StringLike</c> pattern reduces to a prefix only when it is a literal followed by exactly
+    /// one trailing <c>*</c> and contains no other wildcard (<c>*</c> or <c>?</c>). Anything else
+    /// (an exact match with no wildcard, a mid-string wildcard) cannot be represented as a prefix
+    /// safely — return null so the grant is dropped.
+    /// </summary>
+    private static string? SafeLikePrefix(string like)
+    {
+        if (!like.EndsWith('*')) return null;
+        string body = like[..^1];
+        return body.Contains('*') || body.Contains('?') ? null : body;
     }
 }

--- a/src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs
+++ b/src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs
@@ -1,0 +1,61 @@
+using System.Text.RegularExpressions;
+
+namespace Connapse.Storage.CloudScope;
+
+public enum AbacKind { None, PathPrefix, ContainerName, Tag, Unparseable }
+
+public record AbacResult(
+    AbacKind Kind,
+    string? PathPrefix = null,
+    string? ContainerName = null,
+    string? TagKey = null,
+    string? TagValue = null,
+    bool TagKeyCaseSensitive = false);
+
+/// <summary>
+/// Classifies the canonical Azure Blob ABAC read conditions into a prefix, a container name, a tag
+/// predicate, or Unparseable. Only the documented read templates are understood; anything else is
+/// Unparseable and the caller drops that grant (fail closed). A null/blank condition is None (an
+/// unconditional grant).
+/// </summary>
+public static partial class AzureAbacConditionParser
+{
+    [GeneratedRegex(@"blobServices/containers/blobs:path\]\s+String(?:Like|StartsWith)\s+'([^']*)'",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex PathRegex();
+
+    [GeneratedRegex(@"blobServices/containers:name\]\s+StringEquals\s+'([^']*)'",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex NameRegex();
+
+    [GeneratedRegex(@"blobServices/containers/blobs/tags:([^<\]]+)<\$key_(case_sensitive|case_insensitive)\$>\]\s+StringEquals\s+'([^']*)'",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex TagRegex();
+
+    public static AbacResult Parse(string? condition)
+    {
+        if (string.IsNullOrWhiteSpace(condition))
+            return new AbacResult(AbacKind.None);
+
+        Match tag = TagRegex().Match(condition);
+        if (tag.Success)
+            return new AbacResult(AbacKind.Tag,
+                TagKey: tag.Groups[1].Value,
+                TagValue: tag.Groups[3].Value,
+                TagKeyCaseSensitive: string.Equals(tag.Groups[2].Value, "case_sensitive", StringComparison.OrdinalIgnoreCase));
+
+        Match path = PathRegex().Match(condition);
+        if (path.Success)
+        {
+            string p = path.Groups[1].Value;
+            if (p.EndsWith('*')) p = p[..^1];
+            return new AbacResult(AbacKind.PathPrefix, PathPrefix: p);
+        }
+
+        Match name = NameRegex().Match(condition);
+        if (name.Success)
+            return new AbacResult(AbacKind.ContainerName, ContainerName: name.Groups[1].Value);
+
+        return new AbacResult(AbacKind.Unparseable);
+    }
+}

--- a/src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs
+++ b/src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs
@@ -1,0 +1,28 @@
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Translates an ARM role-assignment scope into the <c>azblob://</c> prefix it governs. Resource
+/// provider and type segments are matched case-insensitively (ARM is case-insensitive on them);
+/// the account and container names keep their original case (they are the resource_uri content).
+/// </summary>
+public static class AzureRbacScopeTranslator
+{
+    public static string ToAzblobPrefix(string armScope)
+    {
+        string[] parts = armScope.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        int acctIdx = Array.FindIndex(parts,
+            p => string.Equals(p, "storageAccounts", StringComparison.OrdinalIgnoreCase));
+        if (acctIdx < 0 || acctIdx + 1 >= parts.Length)
+            return "azblob://"; // broader than an account (RG / subscription / management group)
+
+        string account = parts[acctIdx + 1];
+
+        int containersIdx = Array.FindIndex(parts, acctIdx + 1,
+            p => string.Equals(p, "containers", StringComparison.OrdinalIgnoreCase));
+        if (containersIdx >= 0 && containersIdx + 1 < parts.Length)
+            return $"azblob://{account}/{parts[containersIdx + 1]}/";
+
+        return $"azblob://{account}/";
+    }
+}

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -235,6 +235,11 @@ public static class ServiceCollectionExtensions
         // transient reader instance per resolve still shares one cache across the process.
         services.AddHttpClient<Connapse.Core.Interfaces.IAzureDirectoryReader, CloudScope.GraphDirectoryReader>();
 
+        // Reads the searcher's effective RBAC-readable azblob scopes from ARM (role assignments
+        // minus deny assignments). Typed HttpClient; the 5-minute decision cache is the shared
+        // IMemoryCache singleton. TokenCredential is already mapped to ConnapseAzureCredentials (4a).
+        services.AddHttpClient<Connapse.Core.Interfaces.IAzureRbacReader, CloudScope.ArmRbacReader>();
+
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();
         services.AddSingleton<IAccessGrantsReader, CloudScope.S3AccessGrantsReader>();

--- a/tests/Connapse.Integration.Tests/AzureRbacReaderDiIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureRbacReaderDiIntegrationTests.cs
@@ -1,0 +1,17 @@
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureRbacReaderDiIntegrationTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public void Di_Resolves_AzureRbacReader()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IAzureRbacReader>().Should().NotBeNull();
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
@@ -131,14 +131,8 @@ public class ArmRbacReaderTests
         r.Outcome.Should().Be(RbacOutcome.Failed);
     }
 
-    [Fact]
-    public async Task Resolve_QueriesSubscriptionScope_WithoutAtScope()
-    {
-        var reader = NewReader(RoleAssignmentsBody());
-        await reader.ResolveAsync(Oid, CancellationToken.None);
-        // (assert via a handler that captured URLs — see StubHandler.Urls; validated in Task 6's DI test
-        //  and here by constructing the reader with a capturing handler if needed)
-    }
+    // (Subscription-scope / no-atScope URL shape is asserted in
+    // Resolve_Resolved_IsCached_SecondCallDoesNotHitArm, which captures request URLs.)
 
     // Build a reader whose deny call returns `denyBody`.
     private static ArmRbacReader NewReaderWithDeny(string rolesBody, string denyBody, string? subId = Sub)
@@ -216,5 +210,90 @@ public class ArmRbacReaderTests
         handler.Urls.Count.Should().Be(after); // served from cache
         handler.Urls.Should().Contain(u => u.Contains("/roleAssignments") && u.Contains("assignedTo") && !u.Contains("atScope"));
         handler.Urls.Should().Contain(u => u.Contains("/subscriptions/" + Sub + "/"));
+    }
+
+    [Fact]
+    public async Task Resolve_DenyNarrowerThanGrant_DropsTheWholeGrant()
+    {
+        // Account-scoped grant with a container-scoped deny beneath it. The prefix model cannot
+        // represent "account minus one container", so the whole grant is dropped (deny wins;
+        // over-subtraction = under-grant, the fail-closed direction). Never leave the container
+        // readable through the broad grant.
+        string acctScope = "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+        string roles = RoleAssignmentsBody((ReaderRole, acctScope, null)); // whole account
+        string deny = DenyBody(acctScope + "/blobServices/default/containers/secret"); // one container
+        AzureRbacScopes r = await NewReaderWithDeny(roles, deny).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_ContainerNameCondition_OnBroaderThanAccountScope_DropsGrant()
+    {
+        // A container-name ABAC condition on a subscription-scoped grant cannot be reduced to a
+        // prefix (the account is unknown), so it must drop — not resolve to azblob:// (all accounts).
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'reports'))";
+        string roles = RoleAssignmentsBody((ReaderRole, "/subscriptions/" + Sub, cond)); // subscription scope
+        AzureRbacScopes r = await NewReader(roles).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_CompoundCondition_PathAndTag_IsDroppedNotPartiallyHonored()
+    {
+        // A compound condition (path AND tag) must not be partially honored — the path restriction
+        // would be lost if only the tag matched. More than one attribute reference → unparseable → drop.
+        string cond = "((!(ActionMatches{'x'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*' AND @Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Secret<$key_case_sensitive$>] StringEquals 'no'))";
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", cond));
+        AzureRbacScopes r = await NewReader(roles).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Should().BeEmpty();
+        r.TagConditioned.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_RoleAssignmentsCallFails_FailsClosed()
+    {
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/roleAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.InternalServerError, "{}")
+                : Json(HttpStatusCode.OK, EmptyDeny));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        (await reader.ResolveAsync(Oid, CancellationToken.None)).Outcome.Should().Be(RbacOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_InternalTimeout_TokenNotCancelled_FailsClosed()
+    {
+        var handler = new StubHandler(_ => throw new TaskCanceledException("http timeout"));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        (await reader.ResolveAsync(Oid, CancellationToken.None)).Outcome.Should().Be(RbacOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_CallerCancellation_IsRethrown()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var handler = new StubHandler(_ => throw new OperationCanceledException());
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        Func<Task> act = () => reader.ResolveAsync(Oid, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
@@ -139,4 +139,60 @@ public class ArmRbacReaderTests
         // (assert via a handler that captured URLs — see StubHandler.Urls; validated in Task 6's DI test
         //  and here by constructing the reader with a capturing handler if needed)
     }
+
+    // Build a reader whose deny call returns `denyBody`.
+    private static ArmRbacReader NewReaderWithDeny(string rolesBody, string denyBody, string? subId = Sub)
+    {
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.OK, denyBody)
+                : Json(HttpStatusCode.OK, rolesBody));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = subId });
+        return new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+    }
+
+    private static string DenyBody(string scope) => $$$"""
+    {"value":[{"properties":{"scope":"{{{scope}}}","permissions":[{"dataActions":["Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"],"notDataActions":[]}]}}]}
+    """;
+
+    [Fact]
+    public async Task Resolve_DenyCoveringGrant_RemovesIt()
+    {
+        string acctScope = "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+        string roles = RoleAssignmentsBody((ReaderRole, acctScope + "/blobServices/default/containers/docs", null));
+        // Deny at the whole account covers the container grant.
+        AzureRbacScopes r = await NewReaderWithDeny(roles, DenyBody(acctScope)).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().BeEmpty(); // deny wins
+    }
+
+    [Fact]
+    public async Task Resolve_DenyElsewhere_DoesNotRemoveUnrelatedGrant()
+    {
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", null));
+        string denyOther = DenyBody("/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/other");
+        AzureRbacScopes r = await NewReaderWithDeny(roles, denyOther).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/docs/");
+    }
+
+    [Fact]
+    public async Task Resolve_DenyCallFails_FailsClosed()
+    {
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.InternalServerError, "{}")
+                : Json(HttpStatusCode.OK, RoleAssignmentsBody((ReaderRole,
+                    "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null))));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        (await reader.ResolveAsync(Oid, CancellationToken.None)).Outcome.Should().Be(RbacOutcome.Failed);
+    }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
@@ -1,0 +1,142 @@
+using System.Net;
+using System.Text;
+using Azure.Core;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class ArmRbacReaderTests
+{
+    private const string Oid = "11111111-1111-1111-1111-111111111111";
+    private const string Sub = "22222222-2222-2222-2222-222222222222";
+    private const string ReaderRole = "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1";
+
+    // Records every request URL so tests can assert which ARM endpoints were called.
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        public List<string> Urls { get; } = [];
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Urls.Add(request.RequestUri!.ToString());
+            return Task.FromResult(respond(request));
+        }
+    }
+
+    private sealed class StubTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext c, CancellationToken ct) =>
+            new("stub", DateTimeOffset.UtcNow.AddHours(1));
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext c, CancellationToken ct) =>
+            new(GetToken(c, ct));
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode s, string body) =>
+        new(s) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    private static string RoleAssignmentsBody(params (string roleGuid, string scope, string? condition)[] rows)
+    {
+        string items = string.Join(",", rows.Select(r =>
+        {
+            string cond = r.condition is null ? "null" : $"\"{r.condition.Replace("\"", "\\\"")}\"";
+            return $$$"""
+            {"properties":{"roleDefinitionId":"/subscriptions/{{{Sub}}}/providers/Microsoft.Authorization/roleDefinitions/{{{r.roleGuid}}}","principalId":"{{{Oid}}}","scope":"{{{r.scope}}}","condition":{{{cond}}},"conditionVersion":null}}
+            """;
+        }));
+        return $$"""{"value":[{{items}}]}""";
+    }
+
+    private static readonly string EmptyDeny = """{"value":[]}""";
+
+    // A reader whose roleAssignments call returns `roles` and whose denyAssignments call returns empty.
+    private static ArmRbacReader NewReader(string rolesBody, string? subId = Sub, IMemoryCache? cache = null)
+    {
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.OK, EmptyDeny)
+                : Json(HttpStatusCode.OK, rolesBody));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = subId });
+        return new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            cache ?? new MemoryCache(new MemoryCacheOptions()), opts);
+    }
+
+    [Fact]
+    public async Task Resolve_AccountScopedReaderRole_NoCondition_YieldsAccountPrefix()
+    {
+        string body = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().Contain("azblob://acct/");
+    }
+
+    [Fact]
+    public async Task Resolve_IgnoresNonBlobDataRoles()
+    {
+        // Owner of the *control plane* role "Contributor" for ARM is a different GUID; use a random one.
+        string body = RoleAssignmentsBody(("00000000-0000-0000-0000-000000000000",
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_PathCondition_NarrowsPrefix()
+    {
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'} AND NOT SubOperationMatches{'Blob.List'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*'))";
+        string body = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", cond));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().Contain("azblob://acct/docs/readonly/");
+    }
+
+    [Fact]
+    public async Task Resolve_TagCondition_GoesToTagResidue_NotPrefix()
+    {
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Project<$key_case_sensitive$>] StringEquals 'Cascade'))";
+        string body = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", cond));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Should().BeEmpty();
+        r.TagConditioned.Should().ContainSingle().Which.TagValue.Should().Be("Cascade");
+    }
+
+    [Fact]
+    public async Task Resolve_UnparseableCondition_DropsThatGrantOnly()
+    {
+        string bad = "((!(ActionMatches{'x'})) OR (@Request[foo] DateTimeGreaterThan '2024-01-01'))";
+        string body = RoleAssignmentsBody(
+            (ReaderRole, "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/bad", bad),
+            (ReaderRole, "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/good", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/good/");
+    }
+
+    [Fact]
+    public async Task Resolve_NoSubscriptionConfigured_FailsClosed()
+    {
+        AzureRbacScopes r = await NewReader(RoleAssignmentsBody(), subId: null).ResolveAsync(Oid, CancellationToken.None);
+        r.Outcome.Should().Be(RbacOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_QueriesSubscriptionScope_WithoutAtScope()
+    {
+        var reader = NewReader(RoleAssignmentsBody());
+        await reader.ResolveAsync(Oid, CancellationToken.None);
+        // (assert via a handler that captured URLs — see StubHandler.Urls; validated in Task 6's DI test
+        //  and here by constructing the reader with a capturing handler if needed)
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
@@ -195,4 +195,26 @@ public class ArmRbacReaderTests
 
         (await reader.ResolveAsync(Oid, CancellationToken.None)).Outcome.Should().Be(RbacOutcome.Failed);
     }
+
+    [Fact]
+    public async Task Resolve_Resolved_IsCached_SecondCallDoesNotHitArm()
+    {
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.OK, EmptyDeny) : Json(HttpStatusCode.OK, roles));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        await reader.ResolveAsync(Oid, CancellationToken.None);
+        int after = handler.Urls.Count;
+        await reader.ResolveAsync(Oid, CancellationToken.None);
+
+        handler.Urls.Count.Should().Be(after); // served from cache
+        handler.Urls.Should().Contain(u => u.Contains("/roleAssignments") && u.Contains("assignedTo") && !u.Contains("atScope"));
+        handler.Urls.Should().Contain(u => u.Contains("/subscriptions/" + Sub + "/"));
+    }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
@@ -296,4 +296,113 @@ public class ArmRbacReaderTests
         Func<Task> act = () => reader.ResolveAsync(Oid, cts.Token);
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
+
+    [Fact]
+    public async Task Resolve_PathCondition_OnAccountScope_IsDropped()
+    {
+        // A blob-path condition on an account scope can't be expressed as a prefix (it applies
+        // inside every container, not a container named for the path) → drop, not azblob://acct/<path>/.
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*'))";
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", cond));
+        AzureRbacScopes r = await NewReader(roles).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_ContainerNameCondition_OnAccountScope_NarrowsToNamedContainer()
+    {
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'reports'))";
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", cond));
+        AzureRbacScopes r = await NewReader(roles).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/reports/");
+    }
+
+    [Fact]
+    public async Task Resolve_ContainerNameCondition_NamingDifferentContainerThanScope_IsDropped()
+    {
+        // Assignment scoped to container "A" but condition names container "B" → Azure grants
+        // nothing (A != B); must NOT emit azblob://acct/B/ (would escape the assignment scope).
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'B'))";
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/A", cond));
+        AzureRbacScopes r = await NewReader(roles).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_ContainerNameCondition_MatchingScopeContainer_IsKept()
+    {
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'docs'))";
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", cond));
+        AzureRbacScopes r = await NewReader(roles).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/docs/");
+    }
+
+    [Fact]
+    public async Task Resolve_MalformedDenyPage_NullValue_FailsClosed()
+    {
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.OK, """{"value":null}""")
+                : Json(HttpStatusCode.OK, roles));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        (await reader.ResolveAsync(Oid, CancellationToken.None)).Outcome.Should().Be(RbacOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_DenyWithBlobReadInNotDataActions_DoesNotSubtractGrant()
+    {
+        // A deny that grants dataActions:["*"] but excludes blob read via notDataActions does NOT
+        // deny blob reads → the grant must survive (ignoring notDataActions would over-subtract).
+        string acctScope = "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+        string roles = RoleAssignmentsBody((ReaderRole, acctScope, null));
+        string deny = $$$"""
+        {"value":[{"properties":{"scope":"{{{acctScope}}}","permissions":[{"dataActions":["*"],"notDataActions":["Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"]}]}}]}
+        """;
+        AzureRbacScopes r = await NewReaderWithDeny(roles, deny).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/");
+    }
+
+    [Fact]
+    public async Task Resolve_CacheKey_IncludesSubscription_NotReusedAcrossSubscriptionChange()
+    {
+        // Same reader + cache, but the subscription changes between calls (settings reload). The
+        // second call must NOT reuse the first subscription's result.
+        var handler = new StubHandler(req =>
+        {
+            if (req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase))
+                return Json(HttpStatusCode.OK, EmptyDeny);
+            // Grant an account named after whichever subscription is in the request path.
+            string sub = req.RequestUri.AbsolutePath.Split("/subscriptions/")[1].Split('/')[0];
+            return Json(HttpStatusCode.OK, $$$"""
+            {"value":[{"properties":{"roleDefinitionId":"/x/{{{ReaderRole}}}","scope":"/subscriptions/{{{sub}}}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct-{{{sub}}}","condition":null}}]}
+            """);
+        });
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(
+            new AzureProviderSettings { SubscriptionId = "sub-a" },
+            new AzureProviderSettings { SubscriptionId = "sub-b" });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        AzureRbacScopes a = await reader.ResolveAsync(Oid, CancellationToken.None);
+        AzureRbacScopes b = await reader.ResolveAsync(Oid, CancellationToken.None);
+
+        a.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct-sub-a/");
+        b.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct-sub-b/");
+    }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs
@@ -47,4 +47,13 @@ public class AzureAbacConditionParserTests
     public void Parse_UnknownExpression_IsUnparseable() =>
         AzureAbacConditionParser.Parse("@Request[...] DateTimeGreaterThan '2024-01-01'")
             .Kind.Should().Be(AbacKind.Unparseable);
+
+    [Fact]
+    public void Parse_CompoundCondition_MoreThanOneAttribute_IsUnparseable()
+    {
+        // A recognized clause combined with anything else must not be partially honored.
+        string compound =
+            "((!(ActionMatches{'x'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*' AND @Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Secret<$key_case_sensitive$>] StringEquals 'no'))";
+        AzureAbacConditionParser.Parse(compound).Kind.Should().Be(AbacKind.Unparseable);
+    }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs
@@ -1,0 +1,50 @@
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureAbacConditionParserTests
+{
+    private const string PathCond =
+        "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'} AND NOT SubOperationMatches{'Blob.List'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*'))";
+    private const string NameCond =
+        "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'reports'))";
+    private const string TagCond =
+        "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Project<$key_case_sensitive$>] StringEquals 'Cascade'))";
+
+    [Fact]
+    public void Parse_Null_IsNone() =>
+        AzureAbacConditionParser.Parse(null).Kind.Should().Be(AbacKind.None);
+
+    [Fact]
+    public void Parse_Path_ReturnsPrefix_TrailingStarStripped()
+    {
+        AbacResult r = AzureAbacConditionParser.Parse(PathCond);
+        r.Kind.Should().Be(AbacKind.PathPrefix);
+        r.PathPrefix.Should().Be("readonly/");
+    }
+
+    [Fact]
+    public void Parse_ContainerName_ReturnsName()
+    {
+        AbacResult r = AzureAbacConditionParser.Parse(NameCond);
+        r.Kind.Should().Be(AbacKind.ContainerName);
+        r.ContainerName.Should().Be("reports");
+    }
+
+    [Fact]
+    public void Parse_Tag_ReturnsKeyValue()
+    {
+        AbacResult r = AzureAbacConditionParser.Parse(TagCond);
+        r.Kind.Should().Be(AbacKind.Tag);
+        r.TagKey.Should().Be("Project");
+        r.TagValue.Should().Be("Cascade");
+        r.TagKeyCaseSensitive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_UnknownExpression_IsUnparseable() =>
+        AzureAbacConditionParser.Parse("@Request[...] DateTimeGreaterThan '2024-01-01'")
+            .Kind.Should().Be(AbacKind.Unparseable);
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs
@@ -53,7 +53,62 @@ public class AzureAbacConditionParserTests
     {
         // A recognized clause combined with anything else must not be partially honored.
         string compound =
-            "((!(ActionMatches{'x'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*' AND @Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Secret<$key_case_sensitive$>] StringEquals 'no'))";
+            "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*' AND @Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Secret<$key_case_sensitive$>] StringEquals 'no'))";
         AzureAbacConditionParser.Parse(compound).Kind.Should().Be(AbacKind.Unparseable);
+    }
+
+    private const string Guard =
+        "(!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'}))";
+
+    [Fact]
+    public void Parse_PathStringStartsWith_IsPrefix()
+    {
+        string cond = $"({Guard} OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringStartsWith 'reports/'))";
+        AbacResult r = AzureAbacConditionParser.Parse(cond);
+        r.Kind.Should().Be(AbacKind.PathPrefix);
+        r.PathPrefix.Should().Be("reports/");
+    }
+
+    [Fact]
+    public void Parse_PathStringLike_MidWildcard_IsUnparseable()
+    {
+        string cond = $"({Guard} OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'a*b*'))";
+        AzureAbacConditionParser.Parse(cond).Kind.Should().Be(AbacKind.Unparseable);
+    }
+
+    [Fact]
+    public void Parse_PathStringLike_NoWildcard_IsUnparseable()
+    {
+        // StringLike with no wildcard is an EXACT match in Azure, not a prefix — must not become one.
+        string cond = $"({Guard} OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'exact.txt'))";
+        AzureAbacConditionParser.Parse(cond).Kind.Should().Be(AbacKind.Unparseable);
+    }
+
+    [Fact]
+    public void Parse_TagStringEqualsIgnoreCase_IsValueCaseInsensitive()
+    {
+        string cond = $"({Guard} OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Project<$key_case_sensitive$>] StringEqualsIgnoreCase 'Cascade'))";
+        AbacResult r = AzureAbacConditionParser.Parse(cond);
+        r.Kind.Should().Be(AbacKind.Tag);
+        r.TagValue.Should().Be("Cascade");
+        r.ValueCaseSensitive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_NameStringEqualsIgnoreCase_ReturnsName()
+    {
+        string cond = $"({Guard} OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEqualsIgnoreCase 'Reports'))";
+        AbacResult r = AzureAbacConditionParser.Parse(cond);
+        r.Kind.Should().Be(AbacKind.ContainerName);
+        r.ContainerName.Should().Be("Reports");
+    }
+
+    [Fact]
+    public void Parse_RecognizedPredicate_WithoutActionGuard_IsUnparseable()
+    {
+        // A predicate not wrapped in the canonical action guard must not be honored (an inverted or
+        // absent guard could make the predicate NOT gate reads).
+        string cond = "(@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringStartsWith 'private/')";
+        AzureAbacConditionParser.Parse(cond).Kind.Should().Be(AbacKind.Unparseable);
     }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs
@@ -1,0 +1,28 @@
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureRbacScopeTranslatorTests
+{
+    [Fact]
+    public void RbacScopes_Failed_IsEmptyAndFailed()
+    {
+        AzureRbacScopes f = AzureRbacScopes.Failed();
+        f.Outcome.Should().Be(RbacOutcome.Failed);
+        f.ReadablePrefixes.Should().BeEmpty();
+        f.TagConditioned.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RbacScopes_Resolved_CarriesPrefixesAndTags()
+    {
+        AzureRbacScopes r = AzureRbacScopes.Resolved(
+            [new AzureScope("azblob://acct/c/")],
+            [new AzureTagCondition("azblob://acct/c/", "Project", "Cascade", true)]);
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().ContainSingle().Which.Prefix.Should().Be("azblob://acct/c/");
+        r.TagConditioned.Should().ContainSingle();
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs
@@ -1,4 +1,5 @@
 using Connapse.Core;
+using Connapse.Storage.CloudScope;
 using FluentAssertions;
 
 namespace Connapse.Storage.Tests.CloudScope;
@@ -25,4 +26,26 @@ public class AzureRbacScopeTranslatorTests
         r.ReadablePrefixes.Should().ContainSingle().Which.Prefix.Should().Be("azblob://acct/c/");
         r.TagConditioned.Should().ContainSingle();
     }
+
+    [Theory]
+    [InlineData(
+        "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs",
+        "azblob://acct/docs/")]
+    [InlineData(
+        "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct",
+        "azblob://acct/")]
+    [InlineData(
+        "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default",
+        "azblob://acct/")]
+    [InlineData("/subscriptions/s/resourceGroups/rg", "azblob://")]
+    [InlineData("/subscriptions/s", "azblob://")]
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg", "azblob://")]
+    public void ToAzblobPrefix_MapsScopeToPrefix(string armScope, string expected) =>
+        AzureRbacScopeTranslator.ToAzblobPrefix(armScope).Should().Be(expected);
+
+    [Fact]
+    public void ToAzblobPrefix_IsCaseInsensitiveOnResourceProviderSegments() =>
+        AzureRbacScopeTranslator.ToAzblobPrefix(
+            "/subscriptions/s/resourceGroups/rg/providers/microsoft.storage/STORAGEACCOUNTS/Acct/blobservices/default/CONTAINERS/Docs")
+            .Should().Be("azblob://Acct/Docs/");
 }


### PR DESCRIPTION
Closes #487. Phase 4b of the Azure per-object permission engine (epic #475, tracker #479). Targets `epic/azure-blob-provider` — the epic merges to `main` once Phase 4e lands.

## What this adds (library only — no search wiring yet)

The RBAC half of the query-time engine: resolve a searcher (oid) into the `azblob://` prefixes they may read via Azure RBAC, minus deny assignments, with ABAC conditions translated to prefixes or tag residue — cached ~5 min, failing closed.

- **`AzureRbacScopes` / `AzureScope` / `AzureTagCondition` / `RbacOutcome`** (`Connapse.Core`) and **`IAzureRbacReader`** (`Connapse.Core.Interfaces`); **`SubscriptionId`** added to `AzureProviderSettings`.
- **`ArmRbacReader`** (`Connapse.Storage`) — one ARM `roleAssignments` call at the **subscription scope** (transitive `assignedTo`, `nextLink`-paged) in parallel with a `denyAssignments` call, matched against the three Storage-Blob-Data read roles, `effective = grants − denies`. Authenticates with Connapse's own `TokenCredential`; caches only confident answers.
- **`AzureRbacScopeTranslator`** (pure) — ARM scope → `azblob://` prefix (container → `azblob://{acct}/{c}/`, account → `azblob://{acct}/`, broader → `azblob://`).
- **`AzureAbacConditionParser`** (pure) — path condition → prefix, container-name → container, blob-index-tag → tag residue (verified live in 4e), unknown/compound → unparseable (grant dropped).
- **DI**: registers the typed ARM `HttpClient` (reusing the `TokenCredential`→`ConnapseAzureCredentials` mapping from 4a), with a resolution-proving integration test.

## Spec correction (§B)

Verified against Microsoft's ARM docs: `atScope()` "lists **only** the specified scope, **not** including subscopes," so the parent design's `atScope() and assignedTo(...)` would have **missed account- and container-scoped grants** (the common case) and broken flat-account completeness. Corrected to a plain subscription-scope list with `assignedTo('{oid}')` (which includes assignments at the scope, its ancestors, *and* its descendants).

## Soundness / fail-closed

Every non-Resolved path returns `Failed` (empty): missing `SubscriptionId`, a failed role **or** deny call, internal HttpClient timeout, any exception. Deny wins and never fails open — a deny overlapping a grant in **either** direction drops the whole grant (over-subtraction = under-grant, the safe direction); a failed deny call → `Failed`. A compound/unrecognized ABAC condition is dropped, never partially honored. Only the three blob-data-read role GUIDs count.

## Review

Built via subagent-driven development (spec → plan → implement → whole-diff review). The whole-branch review (opus) found three over-grant paths — a narrower-deny carve (Critical), compound-condition partial parsing, and container-name-on-broad-scope — all fixed fail-closed in this branch with regression tests.

## Testing

Unit **1636/1636** across the solution; 4b unit tests 31 (translator, parser, reader — happy path, role filtering, ABAC path/name/tag/compound, deny-wins incl. narrow-deny carve, subscription-missing, role/deny-call failure, internal-timeout, caller-cancellation, caching + subscription-scope/no-atScope URL shape). New `AzureRbacReaderDiIntegrationTests` (Docker) passes.

Spec: `docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md` §B · Plan: `docs/superpowers/plans/2026-09-06-azure-phase4b-rbac-resolver.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
