### PR TITLE
feat(azure): Phase 4e — Gen2 live per-hit verify seam + tag verify (#490)

### DIFF
--- a/docs/superpowers/plans/2026-09-07-azure-phase4e-verify-seam.md
+++ b/docs/superpowers/plans/2026-09-07-azure-phase4e-verify-seam.md
@@ -1,0 +1,1159 @@
+# Azure Phase 4e — Gen2 live per-hit verify seam + tag verify Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the Azure permission engine into live search: a post-retrieval `ISearchResultVerifier` that admits every readable Azure hit and drops every unreadable one, completing Phase 4 (on merge, the epic → `main`).
+
+**Architecture:** `AzureSearchScopeResolver` broadens Azure retrieval to the scheme wildcard `azblob://` (retrieve every candidate by relevance) for a valid enforcing identity. After retrieval + rerank, `HybridSearchService` calls `ISearchResultVerifier`, which routes each `azblob://` hit: covered by an RBAC prefix → pass (in-memory, RBAC supersedes ACLs); under a tag condition → live blob-tag verify; otherwise → live Gen2 file-ACL (Read) + 4d ancestor-traverse (Execute). Fail closed; `s3://` and non-cloud hits pass untouched. Over-fetch + backfill keeps the page full; bounded parallelism bounds cost.
+
+**Tech Stack:** .NET 10, C#; `Azure.Storage.Blobs` (tags), `Azure.Storage.Files.DataLake` (file ACL); `Microsoft.Extensions.Caching.Memory`; xUnit + FluentAssertions + NSubstitute.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md` (§E and its 2026-09-07 amendment)
+
+## Global Constraints
+
+- **Broad retrieve-then-verify (§E amendment).** For a valid enforcing Azure identity, `AzureSearchScopeResolver` emits the single broad match `azblob://`; all Azure tightening is the verifier's job. No HNS detection, **no new Azure permission** (app stays `Storage Blob Data Reader` + the existing RBAC-read).
+- **The verifier acts ONLY on `azblob://` hits.** `s3://` and non-cloud (`resource_uri` NULL) hits pass through untouched — the AWS path is unchanged.
+- **Fail closed everywhere.** Any unreadable directory/file, tag-read failure, SDK error, missing link, deprovisioned/uncertain identity → drop that hit (never admit). A flat-account Gen2 ACL read fails → drop.
+- **Live only.** No permission persistence. RBAC/identity are resolved live and cached (~5 min, existing readers); per-hit ACL/tag reads cached for the query and ~30–120 s. Freshness = cache TTL.
+- **Routing precedence per `azblob://` hit:** (1) covered by any RBAC `ReadablePrefix` (exact or prefix) → **pass**, no live call; (2) else under a `TagConditioned` scope → **tag verify**; (3) else → **Gen2 verify** file ACL Read + ancestor-traverse Execute. Reading a Gen2 file requires **both** the file's own Read AND traverse-X on every ancestor (4d) — folder access is never trusted.
+- **Connapse reads only** — never writes a grant/role/ACL/tag.
+- **AWS unchanged:** no file under `AwsSearchScopeResolver`, `S3*`, `RolesAnywhere/`, or the SAML/JWT path is modified. `PgVectorStore`/`KeywordSearchService` SQL filters are not modified (retrieval breadth changes only via the resolver's `SearchScopes`).
+
+## File Structure
+
+**Create (Core):**
+- `Models/AzblobUri.cs` — parse `azblob://account/container/path` → components / `Gen2Path`.
+- `CloudScope/AzureTagConditionEvaluator.cs` — pure blob-tag ↔ `AzureTagCondition` match.
+- `Interfaces/IGen2FileAclReader.cs`, `Interfaces/IBlobTagReader.cs`, `Interfaces/ISearchResultVerifier.cs`.
+
+**Create (Storage):**
+- `CloudScope/BlobTagReader.cs` — `IBlobTagReader` over `Azure.Storage.Blobs`.
+- `CloudScope/AzureSearchResultVerifier.cs` — the routing verifier.
+- `CloudScope/NoOpSearchResultVerifier.cs` — pass-through default.
+
+**Modify:**
+- `src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs` — also implement `IGen2FileAclReader` (file-ACL read).
+- `src/Connapse.Core/Interfaces/IDocumentStore.cs` + its implementation — add `GetResourceUrisAsync`.
+- `src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs` — emit broad `azblob://` for a valid enforcing identity.
+- `src/Connapse.Search/Hybrid/HybridSearchService.cs` — over-fetch, call the verifier, backfill.
+- `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs` — register the verifier + new seams.
+
+**Create (tests):** one test file per new type under the mirroring `tests/*` path, plus an integration test `tests/Connapse.Integration.Tests/AzureVerifyEnforcementTests.cs`.
+
+---
+
+### Task 1: Azblob URI parsing (Core)
+
+**Files:**
+- Create: `src/Connapse.Core/Models/AzblobUri.cs`
+- Test: `tests/Connapse.Core.Tests/Models/AzblobUriTests.cs`
+
+**Interfaces:**
+- Produces: `static bool AzblobUri.TryParse(string? resourceUri, out Gen2Path path)` — true only for a well-formed `azblob://account/container/blobpath` (account + container + non-empty path); `path` = `Gen2Path(account, container, blobpath)`. `static bool AzblobUri.IsAzblob(string? resourceUri)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Models;
+
+[Trait("Category", "Unit")]
+public class AzblobUriTests
+{
+    [Theory]
+    [InlineData("azblob://acct/docs/a/b/file.txt", "acct", "docs", "a/b/file.txt")]
+    [InlineData("azblob://acct/docs/file.txt", "acct", "docs", "file.txt")]
+    public void TryParse_WellFormed_ReturnsComponents(string uri, string acct, string fs, string path)
+    {
+        AzblobUri.TryParse(uri, out Gen2Path p).Should().BeTrue();
+        p.Account.Should().Be(acct);
+        p.FileSystem.Should().Be(fs);
+        p.Path.Should().Be(path);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("s3://bucket/key")]
+    [InlineData("azblob://acct")]          // no container or path
+    [InlineData("azblob://acct/docs")]     // no blob path
+    [InlineData("azblob://acct/docs/")]    // empty blob path
+    public void TryParse_MalformedOrNonAzblob_ReturnsFalse(string? uri) =>
+        AzblobUri.TryParse(uri, out _).Should().BeFalse();
+
+    [Fact]
+    public void IsAzblob_MatchesSchemeOnly()
+    {
+        AzblobUri.IsAzblob("azblob://a/c/x").Should().BeTrue();
+        AzblobUri.IsAzblob("s3://b/k").Should().BeFalse();
+        AzblobUri.IsAzblob(null).Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~AzblobUriTests"`
+Expected: FAIL — `AzblobUri` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```csharp
+namespace Connapse.Core;
+
+/// <summary>Parses <c>azblob://account/container/blobpath</c> resource URIs into a
+/// <see cref="Gen2Path"/> (container = filesystem). The blob path is required and kept verbatim.</summary>
+public static class AzblobUri
+{
+    private const string Scheme = "azblob://";
+
+    public static bool IsAzblob(string? resourceUri) =>
+        resourceUri is not null && resourceUri.StartsWith(Scheme, StringComparison.Ordinal);
+
+    public static bool TryParse(string? resourceUri, out Gen2Path path)
+    {
+        path = new Gen2Path("", "", "");
+        if (!IsAzblob(resourceUri))
+            return false;
+
+        string rest = resourceUri![Scheme.Length..];
+        int firstSlash = rest.IndexOf('/');
+        if (firstSlash <= 0)
+            return false; // no container
+        int secondSlash = rest.IndexOf('/', firstSlash + 1);
+        if (secondSlash < 0 || secondSlash == rest.Length - 1)
+            return false; // no container/path boundary, or empty blob path
+
+        string account = rest[..firstSlash];
+        string container = rest[(firstSlash + 1)..secondSlash];
+        string blobPath = rest[(secondSlash + 1)..];
+        if (account.Length == 0 || container.Length == 0 || blobPath.Length == 0)
+            return false;
+
+        path = new Gen2Path(account, container, blobPath);
+        return true;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~AzblobUriTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Models/AzblobUri.cs tests/Connapse.Core.Tests/Models/AzblobUriTests.cs
+git commit -m "feat(azure): azblob:// URI parser (#490)"
+```
+
+---
+
+### Task 2: Tag-condition evaluator (Core)
+
+**Files:**
+- Create: `src/Connapse.Core/CloudScope/AzureTagConditionEvaluator.cs`
+- Test: `tests/Connapse.Core.Tests/CloudScope/AzureTagConditionEvaluatorTests.cs`
+
+**Interfaces:**
+- Consumes: `AzureTagCondition(string Scope, string TagKey, string TagValue, bool KeyCaseSensitive, bool ValueCaseSensitive)` (Connapse.Core, from 4b).
+- Produces: `static bool AzureTagConditionEvaluator.Matches(AzureTagCondition condition, IReadOnlyDictionary<string,string> blobTags)` — the blob's index tags satisfy the condition. Key match honors `KeyCaseSensitive`; value match honors `ValueCaseSensitive`. A missing key → false (fail closed).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureTagConditionEvaluatorTests
+{
+    private static AzureTagCondition Cond(bool keyCase = true, bool valueCase = false) =>
+        new("azblob://acct/docs/", "Project", "Cascade", keyCase, valueCase);
+
+    [Fact]
+    public void Matches_KeyAndValuePresent_True() =>
+        AzureTagConditionEvaluator.Matches(Cond(), new Dictionary<string, string> { ["Project"] = "Cascade" })
+            .Should().BeTrue();
+
+    [Fact]
+    public void Matches_MissingKey_False() =>
+        AzureTagConditionEvaluator.Matches(Cond(), new Dictionary<string, string> { ["Other"] = "Cascade" })
+            .Should().BeFalse();
+
+    [Fact]
+    public void Matches_KeyCaseSensitive_DoesNotMatchDifferentCaseKey() =>
+        AzureTagConditionEvaluator.Matches(Cond(keyCase: true), new Dictionary<string, string> { ["project"] = "Cascade" })
+            .Should().BeFalse();
+
+    [Fact]
+    public void Matches_ValueCaseInsensitive_MatchesDifferentCaseValue() =>
+        AzureTagConditionEvaluator.Matches(Cond(valueCase: false), new Dictionary<string, string> { ["Project"] = "cascade" })
+            .Should().BeTrue();
+
+    [Fact]
+    public void Matches_ValueCaseSensitive_DoesNotMatchDifferentCaseValue() =>
+        AzureTagConditionEvaluator.Matches(Cond(valueCase: true), new Dictionary<string, string> { ["Project"] = "cascade" })
+            .Should().BeFalse();
+
+    [Fact]
+    public void Matches_WrongValue_False() =>
+        AzureTagConditionEvaluator.Matches(Cond(), new Dictionary<string, string> { ["Project"] = "Other" })
+            .Should().BeFalse();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~AzureTagConditionEvaluatorTests"`
+Expected: FAIL — type does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```csharp
+namespace Connapse.Core;
+
+/// <summary>
+/// Evaluates a blob's index tags against an <see cref="AzureTagCondition"/> (an RBAC ABAC grant that
+/// could not reduce to a prefix, carried as residue by 4b). Pure; used by the Phase 4e verifier per
+/// hit. A missing key fails closed.
+/// </summary>
+public static class AzureTagConditionEvaluator
+{
+    public static bool Matches(AzureTagCondition condition, IReadOnlyDictionary<string, string> blobTags)
+    {
+        ArgumentNullException.ThrowIfNull(condition);
+        ArgumentNullException.ThrowIfNull(blobTags);
+
+        string? value = FindValue(condition.TagKey, condition.KeyCaseSensitive, blobTags);
+        if (value is null)
+            return false;
+
+        StringComparison valueCmp = condition.ValueCaseSensitive
+            ? StringComparison.Ordinal
+            : StringComparison.OrdinalIgnoreCase;
+        return string.Equals(value, condition.TagValue, valueCmp);
+    }
+
+    private static string? FindValue(string key, bool keyCaseSensitive, IReadOnlyDictionary<string, string> tags)
+    {
+        if (keyCaseSensitive)
+            return tags.TryGetValue(key, out string? v) ? v : null;
+
+        foreach (KeyValuePair<string, string> t in tags)
+            if (string.Equals(t.Key, key, StringComparison.OrdinalIgnoreCase))
+                return t.Value;
+        return null;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~AzureTagConditionEvaluatorTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/CloudScope/AzureTagConditionEvaluator.cs tests/Connapse.Core.Tests/CloudScope/AzureTagConditionEvaluatorTests.cs
+git commit -m "feat(azure): blob-tag condition evaluator (#490)"
+```
+
+---
+
+### Task 3: Gen2 file-ACL read seam (Core interface + Storage)
+
+**Files:**
+- Create: `src/Connapse.Core/Interfaces/IGen2FileAclReader.cs`
+- Modify: `src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs` (also implement the new interface)
+- Test: `tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs` (the mapper is already covered; no new mapper logic — the file path reuses `MapAccessControl` + `IsStructurallyComplete`).
+
+**Interfaces:**
+- Consumes: `Gen2Acl`, `Gen2Path` (Core); the existing `MapAccessControl`/`IsStructurallyComplete` (4d).
+- Produces: `interface IGen2FileAclReader { Task<Gen2Acl?> ReadFileAclAsync(Gen2Path file, CancellationToken ct = default); }`; `DataLakeGen2DirectoryReader` implements it too.
+
+- [ ] **Step 1: Add the interface**
+
+```csharp
+// src/Connapse.Core/Interfaces/IGen2FileAclReader.cs
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Reads a single ADLS Gen2 <b>file's own</b> access ACL, with Connapse's Data-Reader identity, to
+/// evaluate a searcher's Read on the leaf (the ancestor-traverse resolver checks only directories).
+/// Returns <c>null</c> when the file cannot be read or the ACL is structurally incomplete — an
+/// uncertain answer the caller treats as fail-closed. On a non-HNS (flat) account the underlying
+/// call fails and this returns <c>null</c>, which is the correct drop for a flat blob reached only
+/// by the broad retrieval over-approximation.
+/// </summary>
+public interface IGen2FileAclReader
+{
+    Task<Gen2Acl?> ReadFileAclAsync(Gen2Path file, CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 2: Write the failing test (interface implemented by the reader)**
+
+Add to `tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs`:
+
+```csharp
+[Fact]
+public void Reader_Implements_FileAclReader() =>
+    typeof(Connapse.Core.Interfaces.IGen2FileAclReader)
+        .IsAssignableFrom(typeof(DataLakeGen2DirectoryReader)).Should().BeTrue();
+```
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~DataLakeGen2DirectoryReaderMappingTests"`
+Expected: FAIL — the reader does not implement `IGen2FileAclReader` yet (compile error).
+
+- [ ] **Step 3: Implement `ReadFileAclAsync` on `DataLakeGen2DirectoryReader`**
+
+Change the class declaration to also implement the interface, and add the method (mirrors `ReadAccessAclAsync` but uses a `DataLakeFileClient`):
+
+```csharp
+public sealed class DataLakeGen2DirectoryReader(TokenCredential credential)
+    : IGen2DirectoryReader, IGen2FileAclReader
+{
+    // ... existing members ...
+
+    public async Task<Gen2Acl?> ReadFileAclAsync(Gen2Path file, CancellationToken ct = default)
+    {
+        try
+        {
+            var service = new DataLakeServiceClient(
+                new Uri($"https://{file.Account}.dfs.core.windows.net"), credential);
+            DataLakeFileSystemClient fs = service.GetFileSystemClient(file.FileSystem);
+            DataLakeFileClient fileClient = fs.GetFileClient(file.Path);
+            Response<PathAccessControl> ac = await fileClient.GetAccessControlAsync(cancellationToken: ct);
+            Gen2Acl acl = MapAccessControl(ac.Value.Owner, ac.Value.Group, ac.Value.AccessControlList);
+            return IsStructurallyComplete(acl) ? acl : null;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~DataLakeGen2DirectoryReaderMappingTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Interfaces/IGen2FileAclReader.cs src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs
+git commit -m "feat(azure): Gen2 file-ACL read seam (#490)"
+```
+
+---
+
+### Task 4: Blob-tag read seam (Core interface + Storage)
+
+**Files:**
+- Create: `src/Connapse.Core/Interfaces/IBlobTagReader.cs`
+- Create: `src/Connapse.Storage/CloudScope/BlobTagReader.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/BlobTagReaderTests.cs`
+
+**Interfaces:**
+- Consumes: `Gen2Path` (account/container/path is the same shape for a flat blob), `Azure.Core.TokenCredential`.
+- Produces: `interface IBlobTagReader { Task<IReadOnlyDictionary<string,string>?> ReadTagsAsync(Gen2Path blob, CancellationToken ct = default); }`; `BlobTagReader : IBlobTagReader`. Returns `null` on failure (fail closed); an empty dictionary means "no tags" (a valid answer → tag conditions won't match → drop).
+
+- [ ] **Step 1: Add the interface**
+
+```csharp
+// src/Connapse.Core/Interfaces/IBlobTagReader.cs
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>Reads a blob's index tags (with Connapse's Data-Reader identity) for live ABAC tag
+/// verification. <c>null</c> on any read failure (fail closed); an empty map is a valid "no tags".</summary>
+public interface IBlobTagReader
+{
+    Task<IReadOnlyDictionary<string, string>?> ReadTagsAsync(Gen2Path blob, CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+The `BlobClient` is sealed-ish but its calls can be stubbed via a custom `BlobClientOptions.Transport`. To keep the test a pure unit test, isolate the mapping in an `internal static` helper and test that; the thin client shell is exercised by the integration test in Task 8.
+
+```csharp
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class BlobTagReaderTests
+{
+    [Fact]
+    public void MapTags_CopiesAllPairs()
+    {
+        IReadOnlyDictionary<string, string> result = BlobTagReader.MapTags(
+            new Dictionary<string, string> { ["Project"] = "Cascade", ["Env"] = "prod" });
+        result.Should().HaveCount(2);
+        result["Project"].Should().Be("Cascade");
+        result["Env"].Should().Be("prod");
+    }
+
+    [Fact]
+    public void MapTags_Null_ReturnsEmpty() =>
+        BlobTagReader.MapTags(null).Should().BeEmpty();
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~BlobTagReaderTests"`
+Expected: FAIL — `BlobTagReader` does not exist.
+
+- [ ] **Step 4: Write minimal implementation**
+
+```csharp
+// src/Connapse.Storage/CloudScope/BlobTagReader.cs
+using Azure;
+using Azure.Core;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>Reads a blob's index tags over <c>Azure.Storage.Blobs</c>. Thin shell; fail-closed
+/// (<c>null</c>) on any error, genuine caller cancellation propagates.</summary>
+public sealed class BlobTagReader(TokenCredential credential) : IBlobTagReader
+{
+    public async Task<IReadOnlyDictionary<string, string>?> ReadTagsAsync(Gen2Path blob, CancellationToken ct = default)
+    {
+        try
+        {
+            var service = new BlobServiceClient(
+                new Uri($"https://{blob.Account}.blob.core.windows.net"), credential);
+            BlobClient client = service.GetBlobContainerClient(blob.FileSystem).GetBlobClient(blob.Path);
+            Response<GetBlobTagResult> tags = await client.GetTagsAsync(cancellationToken: ct);
+            return MapTags(tags.Value?.Tags);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    internal static IReadOnlyDictionary<string, string> MapTags(IDictionary<string, string>? tags) =>
+        tags is null ? new Dictionary<string, string>() : new Dictionary<string, string>(tags);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~BlobTagReaderTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Connapse.Core/Interfaces/IBlobTagReader.cs src/Connapse.Storage/CloudScope/BlobTagReader.cs tests/Connapse.Storage.Tests/CloudScope/BlobTagReaderTests.cs
+git commit -m "feat(azure): blob-tag read seam (#490)"
+```
+
+---
+
+### Task 5: Bulk resource_uri lookup (Core interface + Storage)
+
+**Files:**
+- Modify: `src/Connapse.Core/Interfaces/IDocumentStore.cs` (add the method)
+- Modify: the `IDocumentStore` implementation (find it: `grep -rl "class .*DocumentStore" src/Connapse.Storage`)
+- Test: `tests/Connapse.Storage.Tests/...` (an integration-tagged test if the impl needs a DbContext; otherwise a focused unit test). Because this needs the real store, put the covering test in `tests/Connapse.Integration.Tests/` tagged `Category=Integration`, OR — preferred — verify it in Task 8's integration test and here add only the interface + a mapping check. Follow whichever the existing `IDocumentStore` tests do.
+
+**Interfaces:**
+- Produces: `Task<IReadOnlyDictionary<string, string?>> GetResourceUrisAsync(IReadOnlyCollection<string> documentIds, CancellationToken ct = default)` — maps each requested document id to its `resource_uri` (null when the document has none or is not found). One query, not N.
+
+- [ ] **Step 1: Add the interface method**
+
+In `src/Connapse.Core/Interfaces/IDocumentStore.cs`:
+
+```csharp
+/// <summary>
+/// The <c>resource_uri</c> of each requested document (null when it has none — uploads and non-cloud
+/// connectors — or the id is unknown). One batched lookup, for the search verifier which must map
+/// ranked hits back to their governing URIs.
+/// </summary>
+Task<IReadOnlyDictionary<string, string?>> GetResourceUrisAsync(
+    IReadOnlyCollection<string> documentIds, CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Match the existing `IDocumentStore` test style. If the store is EF/Npgsql-backed (integration), add to a suitable integration test class; assert that for a set of document ids the returned map has the seeded `resource_uri`s and `null` for an unknown id. (Concrete seeding mirrors `AzureFlatEnforcementTests.SeedAsync` — a document with `ResourceUri = "azblob://acct/docs/a"` and one with `ResourceUri = null`.) Run it and confirm it fails to compile (method missing) then fails red.
+
+- [ ] **Step 3: Implement in the store**
+
+Use a single parameterized query. Example shape (adapt to the store's EF context / raw-SQL idiom already used in `PgVectorStore`):
+
+```csharp
+public async Task<IReadOnlyDictionary<string, string?>> GetResourceUrisAsync(
+    IReadOnlyCollection<string> documentIds, CancellationToken ct = default)
+{
+    var result = new Dictionary<string, string?>();
+    if (documentIds.Count == 0) return result;
+
+    Guid[] ids = documentIds.Select(Guid.Parse).ToArray();
+    await using var db = await _factory.CreateDbContextAsync(ct);
+    var rows = await db.Documents
+        .Where(d => ids.Contains(d.Id))
+        .Select(d => new { d.Id, d.ResourceUri })
+        .ToListAsync(ct);
+    foreach (var r in rows)
+        result[r.Id.ToString()] = r.ResourceUri;
+    return result;
+}
+```
+
+(Use the exact `DbContext`/entity names the store already uses — `KnowledgeDbContext`, `Documents`, `DocumentEntity.ResourceUri`, `Id`. Never string-interpolate SQL.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run the added test's filter. Expected: PASS (seeded URIs returned; unknown id → null/absent).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(search): bulk resource_uri lookup on the document store (#490)"
+```
+
+---
+
+### Task 6: The search-result verifier (Core interface + Storage impl + no-op)
+
+**Files:**
+- Create: `src/Connapse.Core/Interfaces/ISearchResultVerifier.cs`
+- Create: `src/Connapse.Storage/CloudScope/NoOpSearchResultVerifier.cs`
+- Create: `src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs`
+
+**Interfaces:**
+- Consumes: `SearchHit(ChunkId, DocumentId, Content, Score, Metadata)` (Core); `IDocumentStore.GetResourceUrisAsync` (Task 5); `IAzureIdentityLinkReader`→`AzureIdentityRef(ObjectId, TenantId)`; `IAzureDirectoryReader`→`AzureIdentitySet(PrincipalOids, Outcome)`; `IAzureRbacReader`→`AzureRbacScopes(ReadablePrefixes[AzureScope(Prefix)], TagConditioned[AzureTagCondition], Outcome)`; `IGen2FileAclReader.ReadFileAclAsync`; `AncestorTraverseResolver.HoldsTraverseOnAllAncestorsAsync(Gen2Path, string userOid, IReadOnlySet<string> groupOids, ct)`; `IBlobTagReader.ReadTagsAsync`; `PosixAclEvaluator.Grants(Gen2Acl, string userOid, IReadOnlySet<string> groupOids, Gen2Permission)`; `AzureTagConditionEvaluator.Matches`; `AzblobUri.TryParse`; `PermissionEnforcementSettings.StateForAzure`; `AzureAdSignInSettings.IsConfigured`; `EnforcementMigration.Determined`.
+- Produces: `interface ISearchResultVerifier { int CandidateMultiplier { get; } Task<IReadOnlyList<SearchHit>> VerifyAsync(IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default); }`. `VerifyAsync` returns the rank-ordered surviving hits, at most `topK` (backfill). `NoOpSearchResultVerifier`: `CandidateMultiplier => 1`, returns `rankedCandidates.Take(topK)`.
+
+**Routing (per candidate, in rank order; azblob only):**
+1. `resource_uri` not azblob (s3/null/unknown) → **pass**.
+2. Azure enforcement not active (StateForAzure ≠ Enforcing) → **pass** all (no-op; the resolver didn't broaden either).
+3. Identity: no link / deprovisioned / directory-failed → **drop** every azblob hit (fail closed).
+4. Covered by an RBAC `ReadablePrefix` (hit URI starts with the prefix) → **pass**.
+5. Under a `TagConditioned` scope (hit URI starts with its `Scope`) → **tag verify**: read tags; if any covering tag condition matches → pass, else drop.
+6. Else → **Gen2 verify**: `ReadFileAclAsync` → `PosixAclEvaluator.Grants(fileAcl, userOid, groupOids, Read)` AND `HoldsTraverseOnAllAncestorsAsync(path, userOid, groupOids)`; both true → pass, else drop.
+
+Bounded parallelism (`SemaphoreSlim`, degree from settings, default 16) over the candidate pool; preserve input rank order in the output; stop-collecting at `topK` survivors is unnecessary because the pool is already bounded by the over-fetch — verify the whole pool concurrently and take the first `topK` survivors by original rank.
+
+- [ ] **Step 1: Add the interface + no-op**
+
+```csharp
+// src/Connapse.Core/Interfaces/ISearchResultVerifier.cs
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Post-retrieval per-hit permission verify. Given ranked candidates, returns the subset the searcher
+/// may actually read, in rank order, at most <paramref name="topK"/> (dropping unreadable hits and
+/// backfilling from lower-ranked survivors). <see cref="CandidateMultiplier"/> tells the pipeline how
+/// much to over-fetch so backfill has material.
+/// </summary>
+public interface ISearchResultVerifier
+{
+    int CandidateMultiplier { get; }
+
+    Task<IReadOnlyList<SearchHit>> VerifyAsync(
+        IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default);
+}
+```
+
+```csharp
+// src/Connapse.Storage/CloudScope/NoOpSearchResultVerifier.cs
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>The default: no Azure verification. Returns the top <c>topK</c> unchanged.</summary>
+public sealed class NoOpSearchResultVerifier : ISearchResultVerifier
+{
+    public int CandidateMultiplier => 1;
+
+    public Task<IReadOnlyList<SearchHit>> VerifyAsync(
+        IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<SearchHit>>(rankedCandidates.Take(topK).ToList());
+}
+```
+
+- [ ] **Step 2: Write the failing tests (fakes for every seam)**
+
+```csharp
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureSearchResultVerifierTests
+{
+    private const Gen2Permission RX = Gen2Permission.Read | Gen2Permission.Execute;
+    private static readonly Guid User = Guid.NewGuid();
+    private static readonly AzureIdentityRef Link = new("user-oid", "tid");
+
+    private static SearchHit Hit(string docId, double score) =>
+        new($"chunk-{docId}", docId, "content", (float)score, new Dictionary<string, string>());
+
+    private static IOptionsMonitor<T> Opt<T>(T v) where T : class
+    {
+        var m = Substitute.For<IOptionsMonitor<T>>();
+        m.CurrentValue.Returns(v);
+        return m;
+    }
+
+    // Builds a verifier with all seams faked; each test overrides what it needs.
+    private sealed class Harness
+    {
+        public IDocumentStore Docs = Substitute.For<IDocumentStore>();
+        public IAzureIdentityLinkReader Links = Substitute.For<IAzureIdentityLinkReader>();
+        public IAzureDirectoryReader Directory = Substitute.For<IAzureDirectoryReader>();
+        public IAzureRbacReader Rbac = Substitute.For<IAzureRbacReader>();
+        public IGen2FileAclReader FileAcl = Substitute.For<IGen2FileAclReader>();
+        public IBlobTagReader Tags = Substitute.For<IBlobTagReader>();
+        public IGen2DirectoryReader DirReader = Substitute.For<IGen2DirectoryReader>();
+        public bool AzureConfigured = true;
+        public bool AzureEnforcing = true;
+
+        public AzureSearchResultVerifier Build()
+        {
+            Links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+            Directory.ResolveAsync(Link, Arg.Any<CancellationToken>())
+                .Returns(AzureIdentitySet.Resolved(["user-oid", "group-1"]));
+            Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+                .Returns(AzureRbacScopes.Resolved([], []));
+            var azureAd = Opt(AzureConfigured
+                ? new AzureAdSignInSettings { TenantId = "t", ClientId = "c", RedirectUri = "https://x/cb", ClientCertificatePath = "p.pem" }
+                : new AzureAdSignInSettings());
+            var enf = Opt(new PermissionEnforcementSettings { AzureEnforcing = AzureEnforcing });
+            var traverse = new AncestorTraverseResolver(DirReader, new MemoryCache(new MemoryCacheOptions()));
+            return new AzureSearchResultVerifier(
+                Docs, Links, Directory, Rbac, FileAcl, Tags, traverse,
+                azureAd, enf, EnforcementMigration.Completed(),
+                Options.Create(new AzureVerifierSettings { MaxParallelism = 16, CandidateMultiplier = 5 }),
+                NullLogger<AzureSearchResultVerifier>.Instance);
+        }
+    }
+
+    private void ResourceUris(Harness h, params (string doc, string? uri)[] map) =>
+        h.Docs.GetResourceUrisAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
+            .Returns(map.ToDictionary(m => m.doc, m => m.uri));
+
+    [Fact]
+    public async Task NonAzureHits_PassUntouched()
+    {
+        var h = new Harness();
+        ResourceUris(h, ("d1", "s3://b/k"), ("d2", null));
+        var hits = new[] { Hit("d1", 0.9), Hit("d2", 0.8) };
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync(hits, User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("d1", "d2");
+    }
+
+    [Fact]
+    public async Task AzureNotEnforcing_PassesEverything()
+    {
+        var h = new Harness { AzureEnforcing = false };
+        ResourceUris(h, ("d1", "azblob://acct/docs/secret"));
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+        r.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RbacCoveredHit_Passes_WithoutAnyLiveAclOrTagRead()
+    {
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+            .Returns(AzureRbacScopes.Resolved([new AzureScope("azblob://acct/docs/")], []));
+        ResourceUris(h, ("d1", "azblob://acct/docs/a/file.txt"));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().ContainSingle();
+        await h.FileAcl.DidNotReceive().ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+        await h.Tags.DidNotReceive().ReadTagsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task LockedFileBeneathReadableFolder_IsDropped()
+    {
+        // Soundness: no RBAC/tag; file's own ACL denies Read → drop, even if ancestors traverse.
+        var h = new Harness();
+        ResourceUris(h, ("d1", "azblob://acct/docs/locked.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, RX, Gen2Permission.None, null, [], [])); // other = no read
+        h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, RX, HasExtendedAcl: false)); // ancestors traverse
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CaseC_PerFileGrantBeneathUnreadableFolder_IsReturned()
+    {
+        // Completeness: file's own ACL grants Read to the user AND ancestors are traversable (X),
+        // even though the folder is not readable as a listing (R). No RBAC. → pass.
+        var h = new Harness();
+        ResourceUris(h, ("d1", "azblob://acct/docs/secret/case-c.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, Gen2Permission.None, Gen2Permission.None,
+                Mask: RX, NamedUsers: [new Gen2NamedAce("user-oid", RX)], NamedGroups: []));
+        h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, Gen2Permission.Execute, HasExtendedAcl: false));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Gen2FileAclUnreadable_IsDropped_FailClosed()
+    {
+        var h = new Harness();
+        ResourceUris(h, ("d1", "azblob://acct/docs/x.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns((Gen2Acl?)null);
+
+        (await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TagConditioned_MatchingTag_Passes_And_NonMatching_Drops()
+    {
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>()).Returns(
+            AzureRbacScopes.Resolved([], [new AzureTagCondition("azblob://acct/docs/", "Project", "Cascade", true, false)]));
+        ResourceUris(h, ("hit-ok", "azblob://acct/docs/a.txt"), ("hit-no", "azblob://acct/docs/b.txt"));
+        h.Tags.ReadTagsAsync(Arg.Is<Gen2Path>(p => p.Path == "a.txt"), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, string> { ["Project"] = "Cascade" });
+        h.Tags.ReadTagsAsync(Arg.Is<Gen2Path>(p => p.Path == "b.txt"), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, string> { ["Project"] = "Other" });
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("hit-ok", 0.9), Hit("hit-no", 0.8)], User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("hit-ok");
+    }
+
+    [Fact]
+    public async Task DeprovisionedIdentity_DropsAllAzure_ButKeepsNonCloud()
+    {
+        var h = new Harness();
+        h.Directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Deprovisioned());
+        ResourceUris(h, ("az", "azblob://acct/docs/x"), ("nc", null));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("az", 0.9), Hit("nc", 0.8)], User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("nc");
+    }
+
+    [Fact]
+    public async Task Backfill_KeepsTopKInRankOrder_AfterDroppingUnreadable()
+    {
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+            .Returns(AzureRbacScopes.Resolved([new AzureScope("azblob://acct/ok/")], []));
+        ResourceUris(h,
+            ("d1", "azblob://acct/no/1"),  // dropped (not covered, file acl null)
+            ("d2", "azblob://acct/ok/2"),  // pass
+            ("d3", "azblob://acct/ok/3")); // pass
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns((Gen2Acl?)null);
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync(
+            [Hit("d1", 0.9), Hit("d2", 0.8), Hit("d3", 0.7)], User, 2);
+
+        r.Select(x => x.DocumentId).Should().Equal("d2", "d3"); // rank order preserved, d1 backfilled out
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureSearchResultVerifierTests"`
+Expected: FAIL — `AzureSearchResultVerifier` / `AzureVerifierSettings` do not exist.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `src/Connapse.Core/Models/AzureVerifierSettings.cs`:
+
+```csharp
+namespace Connapse.Core;
+
+/// <summary>Tuning for the Phase 4e verifier.</summary>
+public sealed class AzureVerifierSettings
+{
+    public const string SectionName = "Azure:Verifier";
+    /// <summary>Bounded per-hit verify concurrency.</summary>
+    public int MaxParallelism { get; set; } = 16;
+    /// <summary>How many candidates to over-fetch per requested result, so backfill has material.</summary>
+    public int CandidateMultiplier { get; set; } = 5;
+}
+```
+
+Create `src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs`:
+
+```csharp
+using System.Collections.Concurrent;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Live per-hit Azure permission verify (Phase 4e). Passes non-Azure hits untouched; for each
+/// azblob hit, admits it only if covered by an RBAC prefix (in-memory), or a matching blob-tag
+/// condition, or the file's own ACL grants Read AND every ancestor directory grants traverse-X
+/// (4d). Fails closed on every uncertain read. Preserves rank order and returns at most topK.
+/// </summary>
+public sealed class AzureSearchResultVerifier(
+    IDocumentStore documents,
+    IAzureIdentityLinkReader links,
+    IAzureDirectoryReader directory,
+    IAzureRbacReader rbac,
+    IGen2FileAclReader fileAcl,
+    IBlobTagReader blobTags,
+    AncestorTraverseResolver traverse,
+    IOptionsMonitor<AzureAdSignInSettings> azureAd,
+    IOptionsMonitor<PermissionEnforcementSettings> enforcement,
+    EnforcementMigration migration,
+    IOptions<AzureVerifierSettings> settings,
+    ILogger<AzureSearchResultVerifier> logger) : ISearchResultVerifier
+{
+    public int CandidateMultiplier =>
+        Math.Max(1, settings.Value.CandidateMultiplier);
+
+    public async Task<IReadOnlyList<SearchHit>> VerifyAsync(
+        IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default)
+    {
+        // No Azure enforcement → the resolver did not broaden; nothing to tighten.
+        if (enforcement.CurrentValue.StateForAzure(azureAd.CurrentValue.IsConfigured, migration.Determined)
+            != EnforcementState.Enforcing)
+            return rankedCandidates.Take(topK).ToList();
+
+        // Map hits to their governing URIs (one batched query).
+        IReadOnlyDictionary<string, string?> uris =
+            await documents.GetResourceUrisAsync(rankedCandidates.Select(h => h.DocumentId).ToList(), ct);
+
+        // Resolve the searcher's Azure context once. Any failure/deprovision → drop every azblob hit.
+        AzureContext? azure = await ResolveContextAsync(userId, ct);
+
+        // Verify azblob hits concurrently (bounded); non-azblob pass; decision keyed by index so we
+        // can re-assemble in rank order.
+        var verdicts = new ConcurrentDictionary<int, bool>();
+        using var gate = new SemaphoreSlim(Math.Max(1, settings.Value.MaxParallelism));
+
+        await Task.WhenAll(rankedCandidates.Select(async (hit, i) =>
+        {
+            string? uri = uris.GetValueOrDefault(hit.DocumentId);
+            if (!AzblobUri.TryParse(uri, out Gen2Path path))
+            {
+                verdicts[i] = true; // s3:// or non-cloud → pass untouched
+                return;
+            }
+            if (azure is null)
+            {
+                verdicts[i] = false; // enforcing but no usable identity → drop azblob
+                return;
+            }
+            await gate.WaitAsync(ct);
+            try { verdicts[i] = await AdmitAzureHitAsync(uri!, path, azure, ct); }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+            catch (Exception ex) { logger.LogError(ex, "Azure hit verify failed; dropping"); verdicts[i] = false; }
+            finally { gate.Release(); }
+        }));
+
+        var survivors = new List<SearchHit>(topK);
+        for (int i = 0; i < rankedCandidates.Count && survivors.Count < topK; i++)
+            if (verdicts.GetValueOrDefault(i)) survivors.Add(rankedCandidates[i]);
+        return survivors;
+    }
+
+    private async Task<bool> AdmitAzureHitAsync(string uri, Gen2Path path, AzureContext azure, CancellationToken ct)
+    {
+        // 1. RBAC read supersedes ACLs — covered by any readable prefix → pass, no live call.
+        if (azure.ReadablePrefixes.Any(p => uri.StartsWith(p, StringComparison.Ordinal)))
+            return true;
+
+        // 2. Tag-conditioned residue → live tag verify against every covering condition.
+        AzureTagCondition[] covering =
+            azure.TagConditions.Where(t => uri.StartsWith(t.Scope, StringComparison.Ordinal)).ToArray();
+        if (covering.Length > 0)
+        {
+            IReadOnlyDictionary<string, string>? tags = await blobTags.ReadTagsAsync(path, ct);
+            if (tags is null) return false; // fail closed
+            return covering.Any(c => AzureTagConditionEvaluator.Matches(c, tags));
+        }
+
+        // 3. Gen2 ACL: file's own Read AND traverse-X on every ancestor. Folder access never trusted.
+        Gen2Acl? acl = await fileAcl.ReadFileAclAsync(path, ct);
+        if (acl is null) return false; // unreadable / flat account / incomplete → drop
+        if (!PosixAclEvaluator.Grants(acl, azure.UserOid, azure.GroupOids, Gen2Permission.Read))
+            return false;
+        return await traverse.HoldsTraverseOnAllAncestorsAsync(path, azure.UserOid, azure.GroupOids, ct);
+    }
+
+    private async Task<AzureContext?> ResolveContextAsync(Guid? userId, CancellationToken ct)
+    {
+        if (userId is null) return null;
+        AzureIdentityRef? link = await links.GetLinkAsync(userId.Value, ct);
+        if (link is null) return null;
+
+        AzureIdentitySet identity = await directory.ResolveAsync(link, ct);
+        if (identity.Outcome != AzureIdentityOutcome.Resolved) return null; // deprovisioned/failed → drop azblob
+
+        AzureRbacScopes scopes = await rbac.ResolveAsync(link.ObjectId, ct);
+        if (scopes.Outcome != RbacOutcome.Resolved) return null; // RBAC uncertain → fail closed
+
+        var groups = identity.PrincipalOids.Where(o => o != link.ObjectId).ToHashSet(StringComparer.Ordinal);
+        return new AzureContext(
+            link.ObjectId, groups,
+            scopes.ReadablePrefixes.Select(s => s.Prefix).ToArray(),
+            scopes.TagConditioned.ToArray());
+    }
+
+    private sealed record AzureContext(
+        string UserOid, IReadOnlySet<string> GroupOids,
+        IReadOnlyList<string> ReadablePrefixes, IReadOnlyList<AzureTagCondition> TagConditions);
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureSearchResultVerifierTests"`
+Expected: PASS (all 9 cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Connapse.Core/Interfaces/ISearchResultVerifier.cs src/Connapse.Core/Models/AzureVerifierSettings.cs src/Connapse.Storage/CloudScope/NoOpSearchResultVerifier.cs src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
+git commit -m "feat(azure): live per-hit search-result verifier + no-op default (#490)"
+```
+
+---
+
+### Task 7: Broaden Azure retrieval (Storage)
+
+**Files:**
+- Modify: `src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs`
+
+**Interfaces:**
+- Produces (change): for a valid enforcing identity (link present, not deprovisioned, directory not failed), `ResolveAsync` returns `SearchScopes.Of([new GrantMatch("azblob://", IsExact: false)])` — retrieve every Azure candidate. The enforcement gate, null-user `NoPrincipal`, no-link `NoPrincipal`, deprovisioned `NoPrincipal`, and directory-failed `Failed` paths are unchanged. **The RBAC call is removed from retrieval** (RBAC now lives in the verifier); drop the `IAzureRbacReader` dependency if it becomes unused.
+
+- [ ] **Step 1: Update the tests to the broadened contract**
+
+In `AzureSearchScopeResolverTests.cs`, the "enabled with RBAC prefixes → granted azblob matches" and "no RBAC prefixes → no-grants" cases are replaced: a valid enforcing identity now yields the single broad `azblob://` match. Keep every fail-closed case (`NotEnforcing`→Unrestricted, `EnforcingButAzureAdNotConfigured`→Failed, `Undetermined`→Failed, null user→NoPrincipal, no link→NoPrincipal, deprovisioned→NoPrincipal, identity-failed→Failed). Replace the two RBAC-specific tests with:
+
+```csharp
+[Fact]
+public async Task ValidEnforcingIdentity_RetrievesAllAzblob_ForTheVerifierToTighten()
+{
+    var links = Substitute.For<IAzureIdentityLinkReader>();
+    links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+    var directory = Substitute.For<IAzureDirectoryReader>();
+    directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
+    var r = Build(links: links, directory: directory);
+
+    SearchScopes s = await r.ResolveAsync(User);
+
+    s.Outcome.Should().Be(ScopeOutcome.Granted);
+    s.Matches.Should().ContainSingle().Which.Value.Should().Be("azblob://");
+    s.Matches[0].IsExact.Should().BeFalse();
+}
+```
+
+(Delete `Enabled_WithRbacPrefixes_ReturnsGrantedAzblobMatches` and `Enabled_NoRbacPrefixes_IsNoGrants`, and drop the now-unused `rbac`/`IAzureRbacReader` wiring from the test's `Build` helper.)
+
+- [ ] **Step 2: Run to verify the new test fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureSearchScopeResolverTests"`
+Expected: FAIL — resolver still emits RBAC prefixes / references removed members.
+
+- [ ] **Step 3: Broaden the resolver**
+
+In `AzureSearchScopeResolver.ResolveUncachedAsync`, after the deprovisioning gate, replace the RBAC resolution + prefix projection with the broad match:
+
+```csharp
+private async Task<SearchScopes> ResolveUncachedAsync(Guid userId, CancellationToken ct)
+{
+    AzureIdentityRef? link = await links.GetLinkAsync(userId, ct);
+    if (link is null)
+        return SearchScopes.NoPrincipal;
+
+    AzureIdentitySet identity = await directory.ResolveAsync(link, ct);
+    if (identity.Outcome is AzureIdentityOutcome.Deprovisioned)
+    {
+        logger.LogInformation("A linked Entra identity is disabled or gone; denying");
+        return SearchScopes.NoPrincipal;
+    }
+    if (identity.Outcome is AzureIdentityOutcome.Failed)
+        return SearchScopes.Failed;
+
+    // Broad retrieve-then-verify (§E amendment): a valid enforcing identity retrieves EVERY Azure
+    // candidate by relevance; the post-retrieval verifier (Phase 4e) tightens per hit via RBAC
+    // coverage, tag conditions, and Gen2 file-ACL + ancestor traverse. Narrowing here (e.g. to RBAC
+    // prefixes) would drop ACL-only "Case C" files, which can live in any container.
+    return SearchScopes.Of([new GrantMatch("azblob://", IsExact: false)]);
+}
+```
+
+Remove the `IAzureRbacReader rbac` constructor parameter and its `using`/field if now unused. (Leave `IAzureDirectoryReader` — the deprovisioning gate still needs it.)
+
+- [ ] **Step 4: Run to verify tests pass**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureSearchScopeResolverTests"`
+Expected: PASS. Also run the composite tests to confirm no break: `--filter "FullyQualifiedName~CompositeSearchScopeResolverTests"`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs
+git commit -m "feat(azure): broaden Azure retrieval to azblob:// (verify tightens) (#490)"
+```
+
+---
+
+### Task 8: Wire the verifier into the pipeline + DI + integration test
+
+**Files:**
+- Modify: `src/Connapse.Search/Hybrid/HybridSearchService.cs`
+- Modify: `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs`
+- Test: `tests/Connapse.Integration.Tests/AzureVerifyEnforcementTests.cs`
+
+**Interfaces:**
+- Consumes: `ISearchResultVerifier` (Task 6). The service resolves it in the per-search DI scope (like `vectorSearch`/`keywordSearch`).
+
+- [ ] **Step 1: Over-fetch, verify, backfill in `HybridSearchService`**
+
+The retrieval leaves use `options.TopK`. To give the verifier backfill headroom, retrieve with an inflated `TopK` (`options.TopK * verifier.CandidateMultiplier`), then verify down to `options.TopK`. Resolve the verifier in the existing `scope` (line 104 area) alongside the other scoped services, and compute the inflated options BEFORE dispatch:
+
+```csharp
+var verifier = scope.ServiceProvider.GetRequiredService<ISearchResultVerifier>();
+int overFetch = Math.Max(1, verifier.CandidateMultiplier);
+SearchOptions retrieveOptions = options with { TopK = options.TopK * overFetch };
+```
+
+Use `retrieveOptions` for the `vectorSearch.SearchAsync` / `keywordSearch.SearchAsync` / `PerformHybridSearchAsync` calls and for rerank. Then insert the verify AFTER the `filtered` ordering (line 171) and BEFORE `AutoCut`/substitution:
+
+```csharp
+var ordered = hits
+    .Where(h => h.Score >= options.MinScore)
+    .OrderByDescending(h => h.Score)
+    .ToList();
+
+IReadOnlyList<SearchHit> verified = await verifier.VerifyAsync(ordered, options.UserId, options.TopK, ct);
+
+var filtered = verified.ToList();
+if (searchSettings.AutoCut)
+    filtered = ApplyAutoCut(filtered);
+
+IReadOnlyList<SearchHit> substituted = SentenceWindowSubstitution
+    .SubstituteIfEnabled(filtered, searchSettings.SentenceWindowSubstituteOnSearch);
+
+var finalHits = substituted.Take(options.TopK).ToList();
+```
+
+(`SearchOptions` is a record — confirm `with` works; if it is not a record, construct a copy explicitly. Verify against `src/Connapse.Core/Models/SearchModels.cs`.)
+
+- [ ] **Step 2: Register the verifier + seams in DI**
+
+In `ServiceCollectionExtensions.cs`, alongside the CloudScope registrations, register the seams (Task 3/4 concretes) and choose the verifier based on whether Azure is in play. Simplest and safe: always register the Azure verifier (it self-no-ops when Azure isn't enforcing):
+
+```csharp
+services.AddSingleton<IGen2FileAclReader>(sp => (DataLakeGen2DirectoryReader)sp.GetRequiredService<IGen2DirectoryReader>());
+services.AddSingleton<IBlobTagReader, BlobTagReader>();
+services.AddScoped<ISearchResultVerifier, AzureSearchResultVerifier>();
+services.Configure<AzureVerifierSettings>(configuration.GetSection(AzureVerifierSettings.SectionName));
+```
+
+(If `IGen2DirectoryReader` is registered as the concrete `DataLakeGen2DirectoryReader`, resolve the same singleton for `IGen2FileAclReader` as shown so both interfaces share one instance. `AzureSearchResultVerifier` depends on `IDocumentStore`, the Azure readers, `AncestorTraverseResolver`, and the options — all already registered. Confirm `configuration`/`IConfiguration` is in scope in this extension method; if not, bind settings the way the file binds other sections.)
+
+- [ ] **Step 3: Write the integration test**
+
+`tests/Connapse.Integration.Tests/AzureVerifyEnforcementTests.cs` — mirror `AzureFlatEnforcementTests`' fixture usage. Seed documents with `azblob://` and `s3://` and NULL `resource_uri`, drive `IKnowledgeSearch.SearchAsync` (or the verifier directly with a seeded `IDocumentStore`) and assert: an azblob hit with no grant is dropped; an azblob hit under an RBAC prefix passes; an s3 and a non-cloud hit pass untouched; Azure-not-enforcing passes everything. Because live Azure calls can't run in CI, inject fake `IGen2FileAclReader`/`IBlobTagReader`/`IAzureRbacReader`/`IAzureDirectoryReader`/`IAzureIdentityLinkReader` into the verifier and exercise the real `IDocumentStore.GetResourceUrisAsync` against the seeded database (this is the piece that needs the container). Assert the resource_uri lookup + routing end to end.
+
+```csharp
+// Shape (adapt fixture/DI to the SharedWebAppFixture pattern):
+// 1. Seed 4 docs: azblob in-RBAC, azblob no-grant, s3, non-cloud.
+// 2. Build AzureSearchResultVerifier with the real IDocumentStore (from the fixture) + fake Azure readers.
+// 3. VerifyAsync(rankedHits, user, topK) → assert the expected survivors.
+```
+
+- [ ] **Step 4: Build + run the full unit suites and the new integration test**
+
+Run:
+```bash
+dotnet build -clp:ErrorsOnly
+dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --no-build --filter "Category=Unit"
+dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --no-build --filter "Category=Unit"
+dotnet test tests/Connapse.Search.Tests/Connapse.Search.Tests.csproj --no-build --filter "Category=Unit"   # if present
+dotnet test tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj --no-build --filter "FullyQualifiedName~AzureVerifyEnforcementTests"
+```
+Expected: build clean; unit suites green; the new integration test green (the 23 pre-existing Ollama integration failures are unrelated and environmental).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(azure): wire per-hit verifier into HybridSearchService + DI (#490)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (§E + amendment):**
+- `ISearchResultVerifier` + no-op default → Tasks 6.
+- Over-fetch + backfill + bounded parallelism → Task 6 (parallelism, backfill) + Task 8 (over-fetch via `CandidateMultiplier`).
+- Retrieve by relevance over a broad over-approximation, folder structure never narrows retrieval → Task 7 (`azblob://`).
+- Routing: exact/prefix RBAC → pass; HNS → file ACL + ancestor traverse; flat tag → tag verify; AWS/non-cloud → untouched → Task 6 `AdmitAzureHitAsync`.
+- Reading a Gen2 file requires the file's own Read AND traverse-X on every ancestor (folder access never trusted) → Task 6 (both checks) using 4d.
+- Soundness (locked file dropped) + Completeness (Case C returned) → Task 6 tests `LockedFileBeneathReadableFolder_IsDropped`, `CaseC_PerFileGrantBeneathUnreadableFolder_IsReturned`.
+- Fail-closed matrix (no link / deprovisioned / failed / uncertain read) → Task 6 (`ResolveContextAsync` + null-drops).
+- AWS path unchanged → verifier passes s3/non-cloud; resolver change is Azure-only; SQL stores untouched.
+
+**2. Placeholder scan:** Every code step has full code except Task 5 (store impl adapts to the existing DbContext idiom) and Task 8 Step 3 (integration test shape) — both name the exact types and assertions required and defer only to existing local patterns, which the implementer must read. No TBD/TODO.
+
+**3. Type consistency:** `Gen2Path`, `Gen2Acl`, `Gen2Permission`, `PosixAclEvaluator.Grants(acl, userOid, groupOids, perm)`, `AncestorTraverseResolver.HoldsTraverseOnAllAncestorsAsync(path, userOid, groupOids, ct)`, `AzureRbacScopes.ReadablePrefixes`/`TagConditioned`, `AzureTagCondition(Scope, TagKey, TagValue, KeyCaseSensitive, ValueCaseSensitive)`, `AzureIdentitySet.PrincipalOids`/`Outcome`, `AzureIdentityRef.ObjectId`, `SearchHit(ChunkId, DocumentId, Content, Score, Metadata)`, `ISearchResultVerifier.VerifyAsync/CandidateMultiplier` — names match across producing and consuming tasks and the Explore map. The implementer MUST confirm three things against the real code before relying on them: (a) `SearchOptions` supports `with` (record) — Task 8; (b) the `IDocumentStore` implementation's DbContext/entity names — Task 5; (c) the DI extension method's access to `IConfiguration` for binding `AzureVerifierSettings` — Task 8. Each is flagged in its task.

--- a/docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md
+++ b/docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md
@@ -317,3 +317,18 @@ claim. Per-cloud isolation: an Azure failure must not hide AWS-granted or non-cl
 For an enforcing Azure user with a valid, non-deprovisioned identity, `AzureSearchScopeResolver` emits the **broad scheme wildcard `azblob://`** (retrieve every Azure candidate by relevance); all Azure tightening moves to the post-retrieval verifier. This is the only over-approximation that can retrieve a "Case C" file (ACL-granted, RBAC-less) wherever it lives, so completeness holds. It needs **no new Azure permission** (no ARM `isHnsEnabled`; the app stays `Storage Blob Data Reader` + the existing RBAC-read used by 4b).
 
 Consequence: 4c's flat filtering moves from the SQL prefix filter to the verifier's RBAC-coverage check. That check is **in-memory** against the user's already-resolved-and-cached (~5 min, per 4b) RBAC prefixes — no per-hit call, no new persistence (still live-only). Per-hit live reads happen only for hits **not** covered by RBAC: tag-conditioned (blob-tag read) or Gen2 ACL (file-ACL + ancestor traverse). On a flat account a Gen2 ACL read fails → null → drop (fail closed). Rejected alternative: foothold-scoped retrieval + ARM HNS detection — lower verify volume but a new control-plane permission and a Case-C recall gap.
+
+### §E amendment 2 — blob-tag read permission prerequisite (2026-09-07)
+
+Live tag verification (`GetBlobTags`, for ABAC tag-conditioned grants) needs the data action
+`Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read`, which the built-in
+**Storage Blob Data Reader** role does not include. Connapse cannot grant it to itself — it never
+writes roles or grants (`connapse-writes-grants`) and its identity has no role-assignment right — so
+this is a **deployment prerequisite**: the app registration's role assignment must include
+`blobs/tags/read` (add it via a small custom role bundling `blobs/read` + `blobs/tags/read`, or an
+additional assignment). It is a data-plane **read** action, still read-only (never Data Owner).
+
+Fail-closed either way: without it, `GetBlobTags` returns 403 → the reader returns null → the
+verifier falls through to the Gen2 ACL check (§E amendment 1 routing). So a tag-conditioned file that
+is **also** ACL- or RBAC-readable still surfaces; only a file readable **solely** via a matching tag
+condition (ACL denies it) is dropped until the permission is granted. Never an over-grant.

--- a/docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md
+++ b/docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md
@@ -309,3 +309,11 @@ claim. Per-cloud isolation: an Azure failure must not hide AWS-granted or non-cl
 - Ingestion-time permission capture / any new stored permission surface.
 - Any write to customer Azure authorization (grants/roles/ACLs).
 - Touching the AWS provider's mechanism (it already satisfies the invariant; it is only wrapped).
+
+## §E amendment — retrieval breadth decision (2026-09-07, settled with the user)
+
+§E left the Gen2 retrieval over-approximation open ("container(s) the user has a foothold in, or unfiltered across HNS containers"). **Decision: unfiltered — broad retrieve-then-verify, no HNS detection.**
+
+For an enforcing Azure user with a valid, non-deprovisioned identity, `AzureSearchScopeResolver` emits the **broad scheme wildcard `azblob://`** (retrieve every Azure candidate by relevance); all Azure tightening moves to the post-retrieval verifier. This is the only over-approximation that can retrieve a "Case C" file (ACL-granted, RBAC-less) wherever it lives, so completeness holds. It needs **no new Azure permission** (no ARM `isHnsEnabled`; the app stays `Storage Blob Data Reader` + the existing RBAC-read used by 4b).
+
+Consequence: 4c's flat filtering moves from the SQL prefix filter to the verifier's RBAC-coverage check. That check is **in-memory** against the user's already-resolved-and-cached (~5 min, per 4b) RBAC prefixes — no per-hit call, no new persistence (still live-only). Per-hit live reads happen only for hits **not** covered by RBAC: tag-conditioned (blob-tag read) or Gen2 ACL (file-ACL + ancestor traverse). On a flat account a Gen2 ACL read fails → null → drop (fail closed). Rejected alternative: foothold-scoped retrieval + ARM HNS detection — lower verify volume but a new control-plane permission and a Case-C recall gap.

--- a/src/Connapse.Core/CloudScope/AzureTagConditionEvaluator.cs
+++ b/src/Connapse.Core/CloudScope/AzureTagConditionEvaluator.cs
@@ -1,0 +1,35 @@
+namespace Connapse.Core;
+
+/// <summary>
+/// Evaluates a blob's index tags against an <see cref="AzureTagCondition"/> (an RBAC ABAC grant that
+/// could not reduce to a prefix, carried as residue by 4b). Pure; used by the Phase 4e verifier per
+/// hit. A missing key fails closed.
+/// </summary>
+public static class AzureTagConditionEvaluator
+{
+    public static bool Matches(AzureTagCondition condition, IReadOnlyDictionary<string, string> blobTags)
+    {
+        ArgumentNullException.ThrowIfNull(condition);
+        ArgumentNullException.ThrowIfNull(blobTags);
+
+        string? value = FindValue(condition.TagKey, condition.KeyCaseSensitive, blobTags);
+        if (value is null)
+            return false;
+
+        StringComparison valueCmp = condition.ValueCaseSensitive
+            ? StringComparison.Ordinal
+            : StringComparison.OrdinalIgnoreCase;
+        return string.Equals(value, condition.TagValue, valueCmp);
+    }
+
+    private static string? FindValue(string key, bool keyCaseSensitive, IReadOnlyDictionary<string, string> tags)
+    {
+        if (keyCaseSensitive)
+            return tags.TryGetValue(key, out string? v) ? v : null;
+
+        foreach (KeyValuePair<string, string> t in tags)
+            if (string.Equals(t.Key, key, StringComparison.OrdinalIgnoreCase))
+                return t.Value;
+        return null;
+    }
+}

--- a/src/Connapse.Core/Interfaces/IBlobTagReader.cs
+++ b/src/Connapse.Core/Interfaces/IBlobTagReader.cs
@@ -1,0 +1,10 @@
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>Reads a blob's index tags (with Connapse's Data-Reader identity) for live ABAC tag
+/// verification. <c>null</c> on any read failure (fail closed); an empty map is a valid "no tags".</summary>
+public interface IBlobTagReader
+{
+    Task<IReadOnlyDictionary<string, string>?> ReadTagsAsync(Gen2Path blob, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/IDocumentStore.cs
+++ b/src/Connapse.Core/Interfaces/IDocumentStore.cs
@@ -48,4 +48,12 @@ public interface IDocumentStore
     /// to catch any containers missed by event-driven rollup triggering.
     /// </summary>
     Task<IReadOnlyList<Guid>> FindContainersWithStaleSummariesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// The <c>resource_uri</c> of each requested document (null when it has none — uploads and non-cloud
+    /// connectors — or the id is unknown). One batched lookup, for the search verifier which must map
+    /// ranked hits back to their governing URIs.
+    /// </summary>
+    Task<IReadOnlyDictionary<string, string?>> GetResourceUrisAsync(
+        IReadOnlyCollection<string> documentIds, CancellationToken ct = default);
 }

--- a/src/Connapse.Core/Interfaces/IGen2FileAclReader.cs
+++ b/src/Connapse.Core/Interfaces/IGen2FileAclReader.cs
@@ -1,0 +1,16 @@
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Reads a single ADLS Gen2 <b>file's own</b> access ACL, with Connapse's Data-Reader identity, to
+/// evaluate a searcher's Read on the leaf (the ancestor-traverse resolver checks only directories).
+/// Returns <c>null</c> when the file cannot be read or the ACL is structurally incomplete — an
+/// uncertain answer the caller treats as fail-closed. On a non-HNS (flat) account the underlying
+/// call fails and this returns <c>null</c>, which is the correct drop for a flat blob reached only
+/// by the broad retrieval over-approximation.
+/// </summary>
+public interface IGen2FileAclReader
+{
+    Task<Gen2Acl?> ReadFileAclAsync(Gen2Path file, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/ISearchResultVerifier.cs
+++ b/src/Connapse.Core/Interfaces/ISearchResultVerifier.cs
@@ -1,0 +1,17 @@
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Post-retrieval per-hit permission verify. Given ranked candidates, returns the subset the searcher
+/// may actually read, in rank order, at most <paramref name="topK"/> (dropping unreadable hits and
+/// backfilling from lower-ranked survivors). <see cref="CandidateMultiplier"/> tells the pipeline how
+/// much to over-fetch so backfill has material.
+/// </summary>
+public interface ISearchResultVerifier
+{
+    int CandidateMultiplier { get; }
+
+    Task<IReadOnlyList<SearchHit>> VerifyAsync(
+        IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/ISearchResultVerifier.cs
+++ b/src/Connapse.Core/Interfaces/ISearchResultVerifier.cs
@@ -3,10 +3,11 @@ using Connapse.Core;
 namespace Connapse.Core.Interfaces;
 
 /// <summary>
-/// Post-retrieval per-hit permission verify. Given ranked candidates, returns the subset the searcher
-/// may actually read, in rank order, at most <paramref name="topK"/> (dropping unreadable hits and
-/// backfilling from lower-ranked survivors). <see cref="CandidateMultiplier"/> tells the pipeline how
-/// much to over-fetch so backfill has material.
+/// Post-retrieval per-hit permission verify. Returns the readable hits in rank order. An enforcing
+/// verifier drops unreadable hits and caps the result at <paramref name="topK"/>, backfilling from
+/// lower-ranked candidates; a pass-through/no-op verifier returns all candidates unchanged and lets
+/// the caller apply the final <paramref name="topK"/> cap. <see cref="CandidateMultiplier"/> tells
+/// the pipeline how much to over-fetch so backfill has material.
 /// </summary>
 public interface ISearchResultVerifier
 {

--- a/src/Connapse.Core/Models/AzblobUri.cs
+++ b/src/Connapse.Core/Models/AzblobUri.cs
@@ -1,0 +1,35 @@
+namespace Connapse.Core;
+
+/// <summary>Parses <c>azblob://account/container/blobpath</c> resource URIs into a
+/// <see cref="Gen2Path"/> (container = filesystem). The blob path is required and kept verbatim.</summary>
+public static class AzblobUri
+{
+    private const string Scheme = "azblob://";
+
+    public static bool IsAzblob(string? resourceUri) =>
+        resourceUri is not null && resourceUri.StartsWith(Scheme, StringComparison.Ordinal);
+
+    public static bool TryParse(string? resourceUri, out Gen2Path path)
+    {
+        path = new Gen2Path("", "", "");
+        if (!IsAzblob(resourceUri))
+            return false;
+
+        string rest = resourceUri![Scheme.Length..];
+        int firstSlash = rest.IndexOf('/');
+        if (firstSlash <= 0)
+            return false; // no container
+        int secondSlash = rest.IndexOf('/', firstSlash + 1);
+        if (secondSlash < 0 || secondSlash == rest.Length - 1)
+            return false; // no container/path boundary, or empty blob path
+
+        string account = rest[..firstSlash];
+        string container = rest[(firstSlash + 1)..secondSlash];
+        string blobPath = rest[(secondSlash + 1)..];
+        if (account.Length == 0 || container.Length == 0 || blobPath.Length == 0)
+            return false;
+
+        path = new Gen2Path(account, container, blobPath);
+        return true;
+    }
+}

--- a/src/Connapse.Core/Models/AzureRbacScopes.cs
+++ b/src/Connapse.Core/Models/AzureRbacScopes.cs
@@ -22,11 +22,14 @@ public record AzureTagCondition(
 public record AzureRbacScopes(
     IReadOnlyList<AzureScope> ReadablePrefixes,
     IReadOnlyList<AzureTagCondition> TagConditioned,
-    RbacOutcome Outcome)
+    RbacOutcome Outcome,
+    IReadOnlyList<string> DeniedPrefixes)
 {
     public static AzureRbacScopes Resolved(
-        IReadOnlyList<AzureScope> readablePrefixes, IReadOnlyList<AzureTagCondition> tagConditioned) =>
-        new(readablePrefixes, tagConditioned, RbacOutcome.Resolved);
+        IReadOnlyList<AzureScope> readablePrefixes,
+        IReadOnlyList<AzureTagCondition> tagConditioned,
+        IReadOnlyList<string>? deniedPrefixes = null) =>
+        new(readablePrefixes, tagConditioned, RbacOutcome.Resolved, deniedPrefixes ?? []);
 
-    public static AzureRbacScopes Failed() => new([], [], RbacOutcome.Failed);
+    public static AzureRbacScopes Failed() => new([], [], RbacOutcome.Failed, []);
 }

--- a/src/Connapse.Core/Models/AzureVerifierSettings.cs
+++ b/src/Connapse.Core/Models/AzureVerifierSettings.cs
@@ -1,0 +1,11 @@
+namespace Connapse.Core;
+
+/// <summary>Tuning for the Phase 4e verifier.</summary>
+public sealed class AzureVerifierSettings
+{
+    public const string SectionName = "Azure:Verifier";
+    /// <summary>Bounded per-hit verify concurrency.</summary>
+    public int MaxParallelism { get; set; } = 16;
+    /// <summary>How many candidates to over-fetch per requested result, so backfill has material.</summary>
+    public int CandidateMultiplier { get; set; } = 5;
+}

--- a/src/Connapse.Search/Hybrid/HybridSearchService.cs
+++ b/src/Connapse.Search/Hybrid/HybridSearchService.cs
@@ -106,6 +106,15 @@ public class HybridSearchService : IKnowledgeSearch
         var vectorSearch = scope.ServiceProvider.GetRequiredService<VectorSearchService>();
         var keywordSearch = scope.ServiceProvider.GetRequiredService<KeywordSearchService>();
 
+        // Per-hit verify (Phase 4e). Resolved once per search alongside the other scoped services
+        // above. Retrieval over-fetches by CandidateMultiplier so the verifier's drop+backfill has
+        // material to work with; VerifyAsync narrows back down to options.TopK after ranking. For
+        // AWS-only/non-cloud deployments (Azure AD not configured) the multiplier is 1, so this
+        // costs nothing extra and VerifyAsync passes every hit through untouched.
+        var verifier = scope.ServiceProvider.GetRequiredService<ISearchResultVerifier>();
+        int overFetch = Math.Max(1, verifier.CandidateMultiplier);
+        SearchOptions retrieveOptions = options with { TopK = options.TopK * overFetch };
+
         // One resolution per search, taken here because this is where the query fans out. Doing it
         // inside each leaf would mean two answers for one query, and hybrid would be the mode in
         // which they could disagree — half a result set from one set of permissions and half from
@@ -131,16 +140,16 @@ public class HybridSearchService : IKnowledgeSearch
         switch (mode)
         {
             case SearchMode.Semantic:
-                hits = await vectorSearch.SearchAsync(query, options, scopes, ct);
+                hits = await vectorSearch.SearchAsync(query, retrieveOptions, scopes, ct);
                 break;
 
             case SearchMode.Keyword:
-                hits = await keywordSearch.SearchAsync(query, options, scopes, ct);
+                hits = await keywordSearch.SearchAsync(query, retrieveOptions, scopes, ct);
                 break;
 
             case SearchMode.Hybrid:
             default:
-                hits = await PerformHybridSearchAsync(query, options, scopes, ct);
+                hits = await PerformHybridSearchAsync(query, retrieveOptions, scopes, ct);
                 break;
         }
 
@@ -164,12 +173,18 @@ public class HybridSearchService : IKnowledgeSearch
             }
         }
 
-        // Apply final score threshold, auto-cut, and limit
-        var filtered = hits
+        // Apply final score threshold and rank order
+        var ordered = hits
             .Where(h => h.Score >= options.MinScore)
             .OrderByDescending(h => h.Score)
             .ToList();
 
+        // Per-hit verify + backfill: drops hits the searcher may not read and backfills from the
+        // over-fetched, lower-ranked candidates so up to options.TopK survivors come back where
+        // possible. Passes s3/non-cloud hits and everything else untouched when not enforcing.
+        IReadOnlyList<SearchHit> verified = await verifier.VerifyAsync(ordered, options.UserId, options.TopK, ct);
+
+        var filtered = verified.ToList();
         if (searchSettings.AutoCut)
             filtered = ApplyAutoCut(filtered);
 

--- a/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
+++ b/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
@@ -95,7 +95,7 @@ public sealed class ArmRbacReader(
             tags = tags.Where(t => !CoveredByAnyDeny(t.Scope, denyPrefixes)).ToList();
         }
 
-        return AzureRbacScopes.Resolved(prefixes, tags);
+        return AzureRbacScopes.Resolved(prefixes, tags, denyPrefixes);
     }
 
     /// <summary>Deny scopes (as azblob prefixes) that apply to blob read for this searcher.</summary>

--- a/src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs
+++ b/src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs
@@ -10,7 +10,9 @@ namespace Connapse.Storage.CloudScope;
 /// Live per-hit Azure permission verify (Phase 4e). Passes non-Azure hits untouched; for each
 /// azblob hit, admits it only if covered by an RBAC prefix (in-memory), or a matching blob-tag
 /// condition, or the file's own ACL grants Read AND every ancestor directory grants traverse-X
-/// (4d). Fails closed on every uncertain read. Preserves rank order and returns at most topK.
+/// (4d). Fails closed on every uncertain read. Preserves rank order. When actually enforcing,
+/// caps the result at topK (backfilling from lower-ranked survivors); when not enforcing, returns
+/// every candidate unchanged so the pipeline's own final cap sees the untouched pool.
 /// </summary>
 public sealed class AzureSearchResultVerifier(
     IDocumentStore documents,
@@ -26,20 +28,28 @@ public sealed class AzureSearchResultVerifier(
     IOptions<AzureVerifierSettings> settings,
     ILogger<AzureSearchResultVerifier> logger) : ISearchResultVerifier
 {
-    // Azure AD not configured is a deployment-level fact (this instance can never verify azblob
-    // hits either way), so an AWS-only/non-cloud deployment never pays the over-fetch cost even
-    // though this verifier is always registered.
+    // Over-fetch only pays off when VerifyAsync will actually drop hits, which happens only in the
+    // Enforcing state below. NotEnforcing and EnforcingButUnusable never call into the per-hit
+    // logic that needs backfill material (NotEnforcing passes everything; EnforcingButUnusable
+    // drops every azblob hit outright, and backfill can't rescue a class that's dropped wholesale).
+    // So AWS-only, non-cloud, and configured-but-not-yet-enforcing Azure deployments never pay the
+    // over-fetch cost even though this verifier is always registered.
     public int CandidateMultiplier =>
-        azureAd.CurrentValue.IsConfigured ? Math.Max(1, settings.Value.CandidateMultiplier) : 1;
+        enforcement.CurrentValue.StateForAzure(azureAd.CurrentValue.IsConfigured, migration.Determined)
+            == EnforcementState.Enforcing
+            ? Math.Max(1, settings.Value.CandidateMultiplier)
+            : 1;
 
     public async Task<IReadOnlyList<SearchHit>> VerifyAsync(
         IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default)
     {
-        // No Azure enforcement → the resolver did not broaden; nothing to tighten.
+        // No Azure enforcement → the resolver did not broaden; nothing to tighten. Return every
+        // candidate unchanged (not capped at topK) — the pipeline's own final Take(topK) applies
+        // the cap, so AutoCut still sees the full pool exactly as it would with no verifier at all.
         EnforcementState state = enforcement.CurrentValue.StateForAzure(
             azureAd.CurrentValue.IsConfigured, migration.Determined);
         if (state == EnforcementState.NotEnforcing)
-            return rankedCandidates.Take(topK).ToList();
+            return rankedCandidates;
 
         // Map hits to their governing URIs (one batched query).
         IReadOnlyDictionary<string, string?> uris =

--- a/src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs
+++ b/src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs
@@ -1,0 +1,124 @@
+using System.Collections.Concurrent;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Live per-hit Azure permission verify (Phase 4e). Passes non-Azure hits untouched; for each
+/// azblob hit, admits it only if covered by an RBAC prefix (in-memory), or a matching blob-tag
+/// condition, or the file's own ACL grants Read AND every ancestor directory grants traverse-X
+/// (4d). Fails closed on every uncertain read. Preserves rank order and returns at most topK.
+/// </summary>
+public sealed class AzureSearchResultVerifier(
+    IDocumentStore documents,
+    IAzureIdentityLinkReader links,
+    IAzureDirectoryReader directory,
+    IAzureRbacReader rbac,
+    IGen2FileAclReader fileAcl,
+    IBlobTagReader blobTags,
+    AncestorTraverseResolver traverse,
+    IOptionsMonitor<AzureAdSignInSettings> azureAd,
+    IOptionsMonitor<PermissionEnforcementSettings> enforcement,
+    EnforcementMigration migration,
+    IOptions<AzureVerifierSettings> settings,
+    ILogger<AzureSearchResultVerifier> logger) : ISearchResultVerifier
+{
+    public int CandidateMultiplier =>
+        Math.Max(1, settings.Value.CandidateMultiplier);
+
+    public async Task<IReadOnlyList<SearchHit>> VerifyAsync(
+        IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default)
+    {
+        // No Azure enforcement → the resolver did not broaden; nothing to tighten.
+        if (enforcement.CurrentValue.StateForAzure(azureAd.CurrentValue.IsConfigured, migration.Determined)
+            != EnforcementState.Enforcing)
+            return rankedCandidates.Take(topK).ToList();
+
+        // Map hits to their governing URIs (one batched query).
+        IReadOnlyDictionary<string, string?> uris =
+            await documents.GetResourceUrisAsync(rankedCandidates.Select(h => h.DocumentId).ToList(), ct);
+
+        // Resolve the searcher's Azure context once. Any failure/deprovision → drop every azblob hit.
+        AzureContext? azure = await ResolveContextAsync(userId, ct);
+
+        // Verify azblob hits concurrently (bounded); non-azblob pass; decision keyed by index so we
+        // can re-assemble in rank order.
+        var verdicts = new ConcurrentDictionary<int, bool>();
+        using var gate = new SemaphoreSlim(Math.Max(1, settings.Value.MaxParallelism));
+
+        await Task.WhenAll(rankedCandidates.Select(async (hit, i) =>
+        {
+            string? uri = uris.GetValueOrDefault(hit.DocumentId);
+            if (!AzblobUri.TryParse(uri, out Gen2Path path))
+            {
+                verdicts[i] = true; // s3:// or non-cloud → pass untouched
+                return;
+            }
+            if (azure is null)
+            {
+                verdicts[i] = false; // enforcing but no usable identity → drop azblob
+                return;
+            }
+            await gate.WaitAsync(ct);
+            try { verdicts[i] = await AdmitAzureHitAsync(uri!, path, azure, ct); }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+            catch (Exception ex) { logger.LogError(ex, "Azure hit verify failed; dropping"); verdicts[i] = false; }
+            finally { gate.Release(); }
+        }));
+
+        var survivors = new List<SearchHit>(topK);
+        for (int i = 0; i < rankedCandidates.Count && survivors.Count < topK; i++)
+            if (verdicts.GetValueOrDefault(i)) survivors.Add(rankedCandidates[i]);
+        return survivors;
+    }
+
+    private async Task<bool> AdmitAzureHitAsync(string uri, Gen2Path path, AzureContext azure, CancellationToken ct)
+    {
+        // 1. RBAC read supersedes ACLs — covered by any readable prefix → pass, no live call.
+        if (azure.ReadablePrefixes.Any(p => uri.StartsWith(p, StringComparison.Ordinal)))
+            return true;
+
+        // 2. Tag-conditioned residue → live tag verify against every covering condition.
+        AzureTagCondition[] covering =
+            azure.TagConditions.Where(t => uri.StartsWith(t.Scope, StringComparison.Ordinal)).ToArray();
+        if (covering.Length > 0)
+        {
+            IReadOnlyDictionary<string, string>? tags = await blobTags.ReadTagsAsync(path, ct);
+            if (tags is null) return false; // fail closed
+            return covering.Any(c => AzureTagConditionEvaluator.Matches(c, tags));
+        }
+
+        // 3. Gen2 ACL: file's own Read AND traverse-X on every ancestor. Folder access never trusted.
+        Gen2Acl? acl = await fileAcl.ReadFileAclAsync(path, ct);
+        if (acl is null) return false; // unreadable / flat account / incomplete → drop
+        if (!PosixAclEvaluator.Grants(acl, azure.UserOid, azure.GroupOids, Gen2Permission.Read))
+            return false;
+        return await traverse.HoldsTraverseOnAllAncestorsAsync(path, azure.UserOid, azure.GroupOids, ct);
+    }
+
+    private async Task<AzureContext?> ResolveContextAsync(Guid? userId, CancellationToken ct)
+    {
+        if (userId is null) return null;
+        AzureIdentityRef? link = await links.GetLinkAsync(userId.Value, ct);
+        if (link is null) return null;
+
+        AzureIdentitySet identity = await directory.ResolveAsync(link, ct);
+        if (identity.Outcome != AzureIdentityOutcome.Resolved) return null; // deprovisioned/failed → drop azblob
+
+        AzureRbacScopes scopes = await rbac.ResolveAsync(link.ObjectId, ct);
+        if (scopes.Outcome != RbacOutcome.Resolved) return null; // RBAC uncertain → fail closed
+
+        var groups = identity.PrincipalOids.Where(o => o != link.ObjectId).ToHashSet(StringComparer.Ordinal);
+        return new AzureContext(
+            link.ObjectId, groups,
+            scopes.ReadablePrefixes.Select(s => s.Prefix).ToArray(),
+            scopes.TagConditioned.ToArray());
+    }
+
+    private sealed record AzureContext(
+        string UserOid, IReadOnlySet<string> GroupOids,
+        IReadOnlyList<string> ReadablePrefixes, IReadOnlyList<AzureTagCondition> TagConditions);
+}

--- a/src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs
+++ b/src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs
@@ -26,8 +26,11 @@ public sealed class AzureSearchResultVerifier(
     IOptions<AzureVerifierSettings> settings,
     ILogger<AzureSearchResultVerifier> logger) : ISearchResultVerifier
 {
+    // Azure AD not configured is a deployment-level fact (this instance can never verify azblob
+    // hits either way), so an AWS-only/non-cloud deployment never pays the over-fetch cost even
+    // though this verifier is always registered.
     public int CandidateMultiplier =>
-        Math.Max(1, settings.Value.CandidateMultiplier);
+        azureAd.CurrentValue.IsConfigured ? Math.Max(1, settings.Value.CandidateMultiplier) : 1;
 
     public async Task<IReadOnlyList<SearchHit>> VerifyAsync(
         IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default)

--- a/src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs
+++ b/src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs
@@ -33,16 +33,20 @@ public sealed class AzureSearchResultVerifier(
         IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default)
     {
         // No Azure enforcement → the resolver did not broaden; nothing to tighten.
-        if (enforcement.CurrentValue.StateForAzure(azureAd.CurrentValue.IsConfigured, migration.Determined)
-            != EnforcementState.Enforcing)
+        EnforcementState state = enforcement.CurrentValue.StateForAzure(
+            azureAd.CurrentValue.IsConfigured, migration.Determined);
+        if (state == EnforcementState.NotEnforcing)
             return rankedCandidates.Take(topK).ToList();
 
         // Map hits to their governing URIs (one batched query).
         IReadOnlyDictionary<string, string?> uris =
             await documents.GetResourceUrisAsync(rankedCandidates.Select(h => h.DocumentId).ToList(), ct);
 
-        // Resolve the searcher's Azure context once. Any failure/deprovision → drop every azblob hit.
-        AzureContext? azure = await ResolveContextAsync(userId, ct);
+        // Enforcing → resolve identity. EnforcingButUnusable ("searches deny") → no context, so every
+        // azblob hit is dropped (and non-cloud still passes), matching the resolver's SearchScopes.Failed.
+        AzureContext? azure = state == EnforcementState.Enforcing
+            ? await ResolveContextAsync(userId, ct)
+            : null;
 
         // Verify azblob hits concurrently (bounded); non-azblob pass; decision keyed by index so we
         // can re-assemble in rank order.
@@ -51,10 +55,19 @@ public sealed class AzureSearchResultVerifier(
 
         await Task.WhenAll(rankedCandidates.Select(async (hit, i) =>
         {
-            string? uri = uris.GetValueOrDefault(hit.DocumentId);
+            if (!uris.TryGetValue(hit.DocumentId, out string? uri))
+            {
+                verdicts[i] = false; // document row not found (deleted/dangling chunk) → fail closed
+                return;
+            }
+            if (uri is null || !AzblobUri.IsAzblob(uri))
+            {
+                verdicts[i] = true; // non-cloud (null) or non-Azure (s3://) → pass untouched
+                return;
+            }
             if (!AzblobUri.TryParse(uri, out Gen2Path path))
             {
-                verdicts[i] = true; // s3:// or non-cloud → pass untouched
+                verdicts[i] = false; // azblob scheme but unparseable → fail closed, never bypass
                 return;
             }
             if (azure is null)
@@ -63,7 +76,7 @@ public sealed class AzureSearchResultVerifier(
                 return;
             }
             await gate.WaitAsync(ct);
-            try { verdicts[i] = await AdmitAzureHitAsync(uri!, path, azure, ct); }
+            try { verdicts[i] = await AdmitAzureHitAsync(uri, path, azure, ct); }
             catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
             catch (Exception ex) { logger.LogError(ex, "Azure hit verify failed; dropping"); verdicts[i] = false; }
             finally { gate.Release(); }
@@ -78,6 +91,8 @@ public sealed class AzureSearchResultVerifier(
     private async Task<bool> AdmitAzureHitAsync(string uri, Gen2Path path, AzureContext azure, CancellationToken ct)
     {
         // 1. RBAC read supersedes ACLs — covered by any readable prefix → pass, no live call.
+        // Prefix match is safe because resolver-minted prefixes are account/container-terminated with '/'
+        // (or the bare azblob:// wildcard); it never partial-matches a sibling like azblob://acct/docs-secret/.
         if (azure.ReadablePrefixes.Any(p => uri.StartsWith(p, StringComparison.Ordinal)))
             return true;
 

--- a/src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs
+++ b/src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs
@@ -46,6 +46,8 @@ public sealed class AzureSearchResultVerifier(
         // No Azure enforcement → the resolver did not broaden; nothing to tighten. Return every
         // candidate unchanged (not capped at topK) — the pipeline's own final Take(topK) applies
         // the cap, so AutoCut still sees the full pool exactly as it would with no verifier at all.
+        // A resolve/verify state flip is benign: off→NotEnforcing returns unfiltered (correct for
+        // not-enforcing); on→Enforcing filters (fail-closed). Neither over-grants.
         EnforcementState state = enforcement.CurrentValue.StateForAzure(
             azureAd.CurrentValue.IsConfigured, migration.Determined);
         if (state == EnforcementState.NotEnforcing)
@@ -103,20 +105,29 @@ public sealed class AzureSearchResultVerifier(
 
     private async Task<bool> AdmitAzureHitAsync(string uri, Gen2Path path, AzureContext azure, CancellationToken ct)
     {
+        // 0. Deny assignments outrank every grant (RBAC and ACL). A hit under any applicable deny scope is
+        //    blocked by Azure regardless of ACLs, so drop it before any permissive check.
+        if (azure.DeniedPrefixes.Any(d => uri.StartsWith(d, StringComparison.Ordinal)))
+            return false;
+
         // 1. RBAC read supersedes ACLs — covered by any readable prefix → pass, no live call.
         // Prefix match is safe because resolver-minted prefixes are account/container-terminated with '/'
         // (or the bare azblob:// wildcard); it never partial-matches a sibling like azblob://acct/docs-secret/.
         if (azure.ReadablePrefixes.Any(p => uri.StartsWith(p, StringComparison.Ordinal)))
             return true;
 
-        // 2. Tag-conditioned residue → live tag verify against every covering condition.
+        // 2. Tag-conditioned residue → live tag verify. A MATCH grants (RBAC-ABAC supersedes ACLs). A
+        //    non-match or unreadable tags does NOT drop: this assignment simply doesn't grant, and the file
+        //    may still be readable via its own ACL (Azure evaluates ACLs when ABAC does not grant), so fall
+        //    through to the Gen2 ACL check below (which is itself fail-closed).
         AzureTagCondition[] covering =
             azure.TagConditions.Where(t => uri.StartsWith(t.Scope, StringComparison.Ordinal)).ToArray();
         if (covering.Length > 0)
         {
             IReadOnlyDictionary<string, string>? tags = await blobTags.ReadTagsAsync(path, ct);
-            if (tags is null) return false; // fail closed
-            return covering.Any(c => AzureTagConditionEvaluator.Matches(c, tags));
+            if (tags is not null && covering.Any(c => AzureTagConditionEvaluator.Matches(c, tags)))
+                return true;
+            // else: no tag grant — fall through to the ACL path (never over-grants; ACL is fail-closed).
         }
 
         // 3. Gen2 ACL: file's own Read AND traverse-X on every ancestor. Folder access never trusted.
@@ -143,10 +154,12 @@ public sealed class AzureSearchResultVerifier(
         return new AzureContext(
             link.ObjectId, groups,
             scopes.ReadablePrefixes.Select(s => s.Prefix).ToArray(),
-            scopes.TagConditioned.ToArray());
+            scopes.TagConditioned.ToArray(),
+            scopes.DeniedPrefixes.ToArray());
     }
 
     private sealed record AzureContext(
         string UserOid, IReadOnlySet<string> GroupOids,
-        IReadOnlyList<string> ReadablePrefixes, IReadOnlyList<AzureTagCondition> TagConditions);
+        IReadOnlyList<string> ReadablePrefixes, IReadOnlyList<AzureTagCondition> TagConditions,
+        IReadOnlyList<string> DeniedPrefixes);
 }

--- a/src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs
+++ b/src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs
@@ -7,15 +7,16 @@ using Microsoft.Extensions.Options;
 namespace Connapse.Storage.CloudScope;
 
 /// <summary>
-/// Answers what a Connapse user may search in Azure Blob, from the Storage-Blob-Data role
-/// assignments held against the Entra identity they linked. Flat accounts only: the RBAC prefix set
-/// is exact and complete. Mirrors <see cref="AwsSearchScopeResolver"/> — enforcement gate first,
-/// then link → deprovisioning gate → RBAC — and fails closed on every uncertain path.
+/// Answers what a Connapse user may search in Azure Blob. Broad retrieve-then-verify: for any valid
+/// enforcing identity (link present, not deprovisioned, directory not failed) this returns the single
+/// broad <c>azblob://</c> match so every Azure candidate is retrieved by relevance; the Phase 4e
+/// per-hit verifier tightens the result via RBAC coverage, tag conditions, and Gen2 ACLs. Mirrors
+/// <see cref="AwsSearchScopeResolver"/> for the enforcement gate and link → deprovisioning gate, and
+/// fails closed on every uncertain path.
 /// </summary>
 public sealed class AzureSearchScopeResolver(
     IAzureIdentityLinkReader links,
     IAzureDirectoryReader directory,
-    IAzureRbacReader rbac,
     IOptionsMonitor<AzureAdSignInSettings> azureAd,
     IOptionsMonitor<PermissionEnforcementSettings> enforcement,
     EnforcementMigration migration,
@@ -81,17 +82,10 @@ public sealed class AzureSearchScopeResolver(
         if (identity.Outcome is AzureIdentityOutcome.Failed)
             return SearchScopes.Failed;
 
-        AzureRbacScopes scopes = await rbac.ResolveAsync(link.ObjectId, ct);
-        if (scopes.Outcome is RbacOutcome.Failed)
-            return SearchScopes.Failed;
-
-        // Flat accounts: RBAC readable prefixes are the answer. Tag-conditioned residue and Gen2
-        // ACLs are NOT admitted here — they require Phase 4e's live per-hit verifier; omitting them
-        // is a temporary under-grant on the epic branch that 4e closes before the epic reaches main.
-        var matches = scopes.ReadablePrefixes
-            .Select(s => new GrantMatch(s.Prefix, IsExact: false))
-            .ToList();
-
-        return SearchScopes.Of(matches);
+        // Broad retrieve-then-verify (§E amendment): a valid enforcing identity retrieves EVERY Azure
+        // candidate by relevance; the post-retrieval verifier (Phase 4e) tightens per hit via RBAC
+        // coverage, tag conditions, and Gen2 file-ACL + ancestor traverse. Narrowing here (e.g. to RBAC
+        // prefixes) would drop ACL-only "Case C" files, which can live in any container.
+        return SearchScopes.Of([new GrantMatch("azblob://", IsExact: false)]);
     }
 }

--- a/src/Connapse.Storage/CloudScope/BlobTagReader.cs
+++ b/src/Connapse.Storage/CloudScope/BlobTagReader.cs
@@ -1,0 +1,36 @@
+using Azure;
+using Azure.Core;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>Reads a blob's index tags over <c>Azure.Storage.Blobs</c>. Thin shell; fail-closed
+/// (<c>null</c>) on any error, genuine caller cancellation propagates.</summary>
+public sealed class BlobTagReader(TokenCredential credential) : IBlobTagReader
+{
+    public async Task<IReadOnlyDictionary<string, string>?> ReadTagsAsync(Gen2Path blob, CancellationToken ct = default)
+    {
+        try
+        {
+            var service = new BlobServiceClient(
+                new Uri($"https://{blob.Account}.blob.core.windows.net"), credential);
+            BlobClient client = service.GetBlobContainerClient(blob.FileSystem).GetBlobClient(blob.Path);
+            Response<GetBlobTagResult> tags = await client.GetTagsAsync(cancellationToken: ct);
+            return MapTags(tags.Value?.Tags);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    internal static IReadOnlyDictionary<string, string> MapTags(IDictionary<string, string>? tags) =>
+        tags is null ? new Dictionary<string, string>() : new Dictionary<string, string>(tags);
+}

--- a/src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs
+++ b/src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs
@@ -14,7 +14,7 @@ namespace Connapse.Storage.CloudScope;
 /// failure returns <c>null</c> (the resolver treats that as fail-closed); genuine caller
 /// cancellation propagates.
 /// </summary>
-public sealed class DataLakeGen2DirectoryReader(TokenCredential credential) : IGen2DirectoryReader
+public sealed class DataLakeGen2DirectoryReader(TokenCredential credential) : IGen2DirectoryReader, IGen2FileAclReader
 {
     public async Task<Gen2ModeBits?> ReadModeBitsAsync(Gen2Path directory, CancellationToken ct = default)
     {
@@ -50,6 +50,28 @@ public sealed class DataLakeGen2DirectoryReader(TokenCredential credential) : IG
             Response<PathAccessControl> ac = await dir.GetAccessControlAsync(cancellationToken: ct);
             Gen2Acl acl = MapAccessControl(ac.Value.Owner, ac.Value.Group, ac.Value.AccessControlList);
             return IsStructurallyComplete(acl) ? acl : null; // incomplete ACL → deny (fail closed)
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task<Gen2Acl?> ReadFileAclAsync(Gen2Path file, CancellationToken ct = default)
+    {
+        try
+        {
+            var service = new DataLakeServiceClient(
+                new Uri($"https://{file.Account}.dfs.core.windows.net"), credential);
+            DataLakeFileSystemClient fs = service.GetFileSystemClient(file.FileSystem);
+            DataLakeFileClient fileClient = fs.GetFileClient(file.Path);
+            Response<PathAccessControl> ac = await fileClient.GetAccessControlAsync(cancellationToken: ct);
+            Gen2Acl acl = MapAccessControl(ac.Value.Owner, ac.Value.Group, ac.Value.AccessControlList);
+            return IsStructurallyComplete(acl) ? acl : null;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {

--- a/src/Connapse.Storage/CloudScope/NoOpSearchResultVerifier.cs
+++ b/src/Connapse.Storage/CloudScope/NoOpSearchResultVerifier.cs
@@ -3,12 +3,14 @@ using Connapse.Core.Interfaces;
 
 namespace Connapse.Storage.CloudScope;
 
-/// <summary>The default: no Azure verification. Returns the top <c>topK</c> unchanged.</summary>
+/// <summary>The default: no verification. Returns every candidate unchanged — the caller (the search
+/// pipeline's own final <c>Take(topK)</c>) applies the cap, so AutoCut still sees the full pool
+/// exactly as it would with no verifier in the pipeline at all.</summary>
 public sealed class NoOpSearchResultVerifier : ISearchResultVerifier
 {
     public int CandidateMultiplier => 1;
 
     public Task<IReadOnlyList<SearchHit>> VerifyAsync(
         IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default) =>
-        Task.FromResult<IReadOnlyList<SearchHit>>(rankedCandidates.Take(topK).ToList());
+        Task.FromResult(rankedCandidates);
 }

--- a/src/Connapse.Storage/CloudScope/NoOpSearchResultVerifier.cs
+++ b/src/Connapse.Storage/CloudScope/NoOpSearchResultVerifier.cs
@@ -1,0 +1,14 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>The default: no Azure verification. Returns the top <c>topK</c> unchanged.</summary>
+public sealed class NoOpSearchResultVerifier : ISearchResultVerifier
+{
+    public int CandidateMultiplier => 1;
+
+    public Task<IReadOnlyList<SearchHit>> VerifyAsync(
+        IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<SearchHit>>(rankedCandidates.Take(topK).ToList());
+}

--- a/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
+++ b/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
@@ -353,6 +353,26 @@ public class PostgresDocumentStore : IDocumentStore
             stats.LastIndexedAt);
     }
 
+    public async Task<IReadOnlyDictionary<string, string?>> GetResourceUrisAsync(
+        IReadOnlyCollection<string> documentIds, CancellationToken ct = default)
+    {
+        var result = new Dictionary<string, string?>();
+        if (documentIds.Count == 0) return result;
+
+        Guid[] ids = documentIds.Select(Guid.Parse).ToArray();
+        await using var context = await _factory.CreateDbContextAsync(ct);
+
+        var rows = await context.Documents
+            .Where(d => ids.Contains(d.Id))
+            .Select(d => new { d.Id, d.ResourceUri })
+            .ToListAsync(ct);
+
+        foreach (var row in rows)
+            result[row.Id.ToString()] = row.ResourceUri;
+
+        return result;
+    }
+
     private static Document MapToModel(DocumentEntity entity)
     {
         var metadata = new Dictionary<string, string>(entity.Metadata ?? new());

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -240,10 +240,22 @@ public static class ServiceCollectionExtensions
         // IMemoryCache singleton. TokenCredential is already mapped to ConnapseAzureCredentials (4a).
         services.AddHttpClient<Connapse.Core.Interfaces.IAzureRbacReader, CloudScope.ArmRbacReader>();
 
-        // Gen2 permission engine (Phase 4d). A pure library the Phase 4e verifier consumes; nothing here
-        // is wired into the search pipeline yet.
-        services.AddSingleton<IGen2DirectoryReader, DataLakeGen2DirectoryReader>();
+        // Gen2 permission engine (Phase 4d), consumed by the Phase 4e per-hit verifier below.
+        // DataLakeGen2DirectoryReader implements both IGen2DirectoryReader (mode bits for ancestor
+        // traverse checks) and IGen2FileAclReader (a file's own ACL) — one singleton serves both
+        // interfaces so directory reads share the client construction and any future caching.
+        services.AddSingleton<DataLakeGen2DirectoryReader>();
+        services.AddSingleton<IGen2DirectoryReader>(sp => sp.GetRequiredService<DataLakeGen2DirectoryReader>());
+        services.AddSingleton<IGen2FileAclReader>(sp => sp.GetRequiredService<DataLakeGen2DirectoryReader>());
         services.AddSingleton<AncestorTraverseResolver>();
+
+        // Live per-hit permission verify (Phase 4e), wired into HybridSearchService's search
+        // pipeline. Always registered — it self-no-ops (CandidateMultiplier=1, VerifyAsync passes
+        // everything through) when Azure AD isn't configured, so AWS-only/non-cloud deployments
+        // pay nothing extra.
+        services.AddSingleton<IBlobTagReader, BlobTagReader>();
+        services.AddScoped<ISearchResultVerifier, AzureSearchResultVerifier>();
+        services.Configure<AzureVerifierSettings>(configuration.GetSection(AzureVerifierSettings.SectionName));
 
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();

--- a/tests/Connapse.Core.Tests/CloudScope/AzureTagConditionEvaluatorTests.cs
+++ b/tests/Connapse.Core.Tests/CloudScope/AzureTagConditionEvaluatorTests.cs
@@ -1,0 +1,41 @@
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureTagConditionEvaluatorTests
+{
+    private static AzureTagCondition Cond(bool keyCase = true, bool valueCase = false) =>
+        new("azblob://acct/docs/", "Project", "Cascade", keyCase, valueCase);
+
+    [Fact]
+    public void Matches_KeyAndValuePresent_True() =>
+        AzureTagConditionEvaluator.Matches(Cond(), new Dictionary<string, string> { ["Project"] = "Cascade" })
+            .Should().BeTrue();
+
+    [Fact]
+    public void Matches_MissingKey_False() =>
+        AzureTagConditionEvaluator.Matches(Cond(), new Dictionary<string, string> { ["Other"] = "Cascade" })
+            .Should().BeFalse();
+
+    [Fact]
+    public void Matches_KeyCaseSensitive_DoesNotMatchDifferentCaseKey() =>
+        AzureTagConditionEvaluator.Matches(Cond(keyCase: true), new Dictionary<string, string> { ["project"] = "Cascade" })
+            .Should().BeFalse();
+
+    [Fact]
+    public void Matches_ValueCaseInsensitive_MatchesDifferentCaseValue() =>
+        AzureTagConditionEvaluator.Matches(Cond(valueCase: false), new Dictionary<string, string> { ["Project"] = "cascade" })
+            .Should().BeTrue();
+
+    [Fact]
+    public void Matches_ValueCaseSensitive_DoesNotMatchDifferentCaseValue() =>
+        AzureTagConditionEvaluator.Matches(Cond(valueCase: true), new Dictionary<string, string> { ["Project"] = "cascade" })
+            .Should().BeFalse();
+
+    [Fact]
+    public void Matches_WrongValue_False() =>
+        AzureTagConditionEvaluator.Matches(Cond(), new Dictionary<string, string> { ["Project"] = "Other" })
+            .Should().BeFalse();
+}

--- a/tests/Connapse.Core.Tests/Models/AzblobUriTests.cs
+++ b/tests/Connapse.Core.Tests/Models/AzblobUriTests.cs
@@ -1,0 +1,37 @@
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Models;
+
+[Trait("Category", "Unit")]
+public class AzblobUriTests
+{
+    [Theory]
+    [InlineData("azblob://acct/docs/a/b/file.txt", "acct", "docs", "a/b/file.txt")]
+    [InlineData("azblob://acct/docs/file.txt", "acct", "docs", "file.txt")]
+    public void TryParse_WellFormed_ReturnsComponents(string uri, string acct, string fs, string path)
+    {
+        AzblobUri.TryParse(uri, out Gen2Path p).Should().BeTrue();
+        p.Account.Should().Be(acct);
+        p.FileSystem.Should().Be(fs);
+        p.Path.Should().Be(path);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("s3://bucket/key")]
+    [InlineData("azblob://acct")]          // no container or path
+    [InlineData("azblob://acct/docs")]     // no blob path
+    [InlineData("azblob://acct/docs/")]    // empty blob path
+    public void TryParse_MalformedOrNonAzblob_ReturnsFalse(string? uri) =>
+        AzblobUri.TryParse(uri, out _).Should().BeFalse();
+
+    [Fact]
+    public void IsAzblob_MatchesSchemeOnly()
+    {
+        AzblobUri.IsAzblob("azblob://a/c/x").Should().BeTrue();
+        AzblobUri.IsAzblob("s3://b/k").Should().BeFalse();
+        AzblobUri.IsAzblob(null).Should().BeFalse();
+    }
+}

--- a/tests/Connapse.Integration.Tests/AzureVerifyEnforcementTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureVerifyEnforcementTests.cs
@@ -1,0 +1,190 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using Connapse.Storage.Data;
+using Connapse.Storage.Data.Entities;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// End-to-end proof of the Phase 4e verify seam: <see cref="AzureSearchResultVerifier"/> built with
+/// the real <see cref="IDocumentStore"/> from the shared fixture (so
+/// <c>GetResourceUrisAsync</c> runs against the actual database) plus faked Azure identity/RBAC/ACL
+/// readers, verifying seeded azblob/s3/non-cloud documents the same way
+/// <see cref="AzureFlatEnforcementTests"/> proves the composite scope resolver end to end.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureVerifyEnforcementTests(SharedWebAppFixture fixture)
+{
+    private static readonly Guid TestUser = Guid.NewGuid();
+    private static readonly AzureIdentityRef Link = new("user-oid", "tid");
+
+    private static SearchHit Hit(Guid docId, double score) =>
+        new($"chunk-{docId}", docId.ToString(), "content", (float)score, new Dictionary<string, string>());
+
+    private static IOptionsMonitor<T> Opt<T>(T v) where T : class
+    {
+        var m = Substitute.For<IOptionsMonitor<T>>();
+        m.CurrentValue.Returns(v);
+        return m;
+    }
+
+    /// <summary>Four documents in one container: an azblob doc under an RBAC-readable prefix, an
+    /// azblob doc with no grant, an AWS doc, and a non-cloud doc (resource_uri NULL).</summary>
+    private static async Task<(Guid ContainerId, Guid InRbac, Guid NoGrant, Guid Aws, Guid NonCloud)> SeedAsync(
+        KnowledgeDbContext db)
+    {
+        var container = new ContainerEntity { Id = Guid.NewGuid(), Name = $"c-{Guid.NewGuid():N}" };
+        db.Containers.Add(container);
+
+        Guid inRbac = Guid.NewGuid(), noGrant = Guid.NewGuid(), aws = Guid.NewGuid(), nonCloud = Guid.NewGuid();
+
+        foreach (var (id, name, uri) in new (Guid, string, string?)[]
+                 {
+                     (inRbac, "in-rbac.md", "azblob://acct/docs/a"),
+                     (noGrant, "no-grant.md", "azblob://acct/secret/b"),
+                     (aws, "aws.md", "s3://bucket/x"),
+                     (nonCloud, "non-cloud.md", null),
+                 })
+        {
+            db.Documents.Add(new DocumentEntity
+            {
+                Id = id,
+                ContainerId = container.Id,
+                FileName = name,
+                Path = "/" + name,
+                ResourceUri = uri,
+                ContentHash = Guid.NewGuid().ToString("N"),
+                Status = "Ready",
+                CreatedAt = DateTime.UtcNow,
+                Metadata = [],
+            });
+        }
+
+        await db.SaveChangesAsync();
+        return (container.Id, inRbac, noGrant, aws, nonCloud);
+    }
+
+    /// <summary>Builds the verifier against the real <paramref name="documents"/> store with every
+    /// Azure identity/RBAC/ACL seam faked — live calls to Entra/ARM/ADLS/Blob can't run in CI, only
+    /// the resource_uri lookup needs to be real.</summary>
+    private static AzureSearchResultVerifier BuildVerifier(
+        IDocumentStore documents, bool azureEnforcing, IReadOnlyList<AzureScope> readablePrefixes)
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(TestUser, Arg.Any<CancellationToken>()).Returns(Link);
+
+        var directory = Substitute.For<IAzureDirectoryReader>();
+        directory.ResolveAsync(Link, Arg.Any<CancellationToken>())
+            .Returns(AzureIdentitySet.Resolved(["user-oid"]));
+
+        var rbac = Substitute.For<IAzureRbacReader>();
+        rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+            .Returns(AzureRbacScopes.Resolved(readablePrefixes, []));
+
+        var fileAcl = Substitute.For<IGen2FileAclReader>();
+        var blobTags = Substitute.For<IBlobTagReader>();
+        var gen2DirReader = Substitute.For<IGen2DirectoryReader>();
+        var traverse = new AncestorTraverseResolver(gen2DirReader, new MemoryCache(new MemoryCacheOptions()));
+
+        var azureAd = Opt(new AzureAdSignInSettings
+        {
+            TenantId = "t",
+            ClientId = "c",
+            RedirectUri = "https://x/cb",
+            ClientCertificatePath = "p.pem",
+        });
+        var enforcement = Opt(new PermissionEnforcementSettings { AzureEnforcing = azureEnforcing });
+
+        return new AzureSearchResultVerifier(
+            documents, links, directory, rbac, fileAcl, blobTags, traverse,
+            azureAd, enforcement, EnforcementMigration.Completed(),
+            Options.Create(new AzureVerifierSettings { MaxParallelism = 16, CandidateMultiplier = 5 }),
+            NullLogger<AzureSearchResultVerifier>.Instance);
+    }
+
+    [Fact]
+    public async Task Enforcing_AdmitsRbacCoveredAzblob_DropsUngranted_PassesAwsAndNonCloud()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factoryDb = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var db = await factoryDb.CreateDbContextAsync();
+        var (containerId, inRbac, noGrant, aws, nonCloud) = await SeedAsync(db);
+
+        try
+        {
+            var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+            var verifier = BuildVerifier(documents, azureEnforcing: true, [new AzureScope("azblob://acct/docs/")]);
+
+            SearchHit[] ranked =
+            [
+                Hit(inRbac, 0.9),
+                Hit(noGrant, 0.85),
+                Hit(aws, 0.8),
+                Hit(nonCloud, 0.7),
+            ];
+
+            IReadOnlyList<SearchHit> result = await verifier.VerifyAsync(ranked, TestUser, topK: 10);
+
+            result.Select(h => h.DocumentId).Should().BeEquivalentTo(
+                inRbac.ToString(), aws.ToString(), nonCloud.ToString());
+        }
+        finally
+        {
+            await CleanupAsync(factoryDb, containerId);
+        }
+    }
+
+    [Fact]
+    public async Task NotEnforcing_PassesEverythingThrough()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factoryDb = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var db = await factoryDb.CreateDbContextAsync();
+        var (containerId, inRbac, noGrant, aws, nonCloud) = await SeedAsync(db);
+
+        try
+        {
+            var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+            // No RBAC scopes at all — proves the pass-through is because enforcement is off, not
+            // because a grant happens to cover everything.
+            var verifier = BuildVerifier(documents, azureEnforcing: false, []);
+
+            SearchHit[] ranked =
+            [
+                Hit(inRbac, 0.9),
+                Hit(noGrant, 0.85),
+                Hit(aws, 0.8),
+                Hit(nonCloud, 0.7),
+            ];
+
+            IReadOnlyList<SearchHit> result = await verifier.VerifyAsync(ranked, TestUser, topK: 10);
+
+            result.Select(h => h.DocumentId).Should().BeEquivalentTo(
+                inRbac.ToString(), noGrant.ToString(), aws.ToString(), nonCloud.ToString());
+        }
+        finally
+        {
+            await CleanupAsync(factoryDb, containerId);
+        }
+    }
+
+    private static async Task CleanupAsync(IDbContextFactory<KnowledgeDbContext> factoryDb, Guid containerId)
+    {
+        await using var ctx = await factoryDb.CreateDbContextAsync();
+        var docs = await ctx.Documents.Where(d => d.ContainerId == containerId).ToListAsync();
+        ctx.Documents.RemoveRange(docs);
+        var container = await ctx.Containers.FirstOrDefaultAsync(c => c.Id == containerId);
+        if (container is not null) ctx.Containers.Remove(container);
+        await ctx.SaveChangesAsync();
+    }
+}

--- a/tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj
+++ b/tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NSubstitute" Version="6.2.0" />
     <!--
       Direct reference purely to lift the transitive SSH.NET that Testcontainers brings in.
       2024.2.0 carries GHSA-q939-rpr3-3284 (CVE-2026-48798, CVSS 7.1) — a path traversal in

--- a/tests/Connapse.Integration.Tests/GetResourceUrisTests.cs
+++ b/tests/Connapse.Integration.Tests/GetResourceUrisTests.cs
@@ -1,0 +1,102 @@
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Data;
+using Connapse.Storage.Data.Entities;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="IDocumentStore.GetResourceUrisAsync"/> — the batched lookup
+/// the search verifier uses to map ranked hits back to their governing <c>resource_uri</c> in one
+/// query instead of N.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class GetResourceUrisTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public async Task SeededIdsAndUnknownId_ResolveToTheirUriOrNull()
+    {
+        Guid containerId = Guid.NewGuid();
+        Guid azureDocId = Guid.NewGuid();
+        Guid nonCloudDocId = Guid.NewGuid();
+        Guid unknownDocId = Guid.NewGuid();
+
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factoryDb = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+
+        try
+        {
+            await using (var ctx = await factoryDb.CreateDbContextAsync())
+            {
+                ctx.Containers.Add(new ContainerEntity
+                {
+                    Id = containerId,
+                    Name = $"c-{containerId:N}",
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow,
+                });
+
+                ctx.Documents.Add(new DocumentEntity
+                {
+                    Id = azureDocId,
+                    ContainerId = containerId,
+                    FileName = "a.md",
+                    Path = "/a.md",
+                    ResourceUri = "azblob://acct/docs/a",
+                    ContentHash = Guid.NewGuid().ToString("N"),
+                    Status = "Ready",
+                    CreatedAt = DateTime.UtcNow,
+                    Metadata = [],
+                });
+
+                ctx.Documents.Add(new DocumentEntity
+                {
+                    Id = nonCloudDocId,
+                    ContainerId = containerId,
+                    FileName = "b.md",
+                    Path = "/b.md",
+                    ResourceUri = null,
+                    ContentHash = Guid.NewGuid().ToString("N"),
+                    Status = "Ready",
+                    CreatedAt = DateTime.UtcNow,
+                    Metadata = [],
+                });
+
+                await ctx.SaveChangesAsync();
+            }
+
+            var docStore = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+            var result = await docStore.GetResourceUrisAsync(
+                [azureDocId.ToString(), nonCloudDocId.ToString(), unknownDocId.ToString()],
+                CancellationToken.None);
+
+            result[azureDocId.ToString()].Should().Be("azblob://acct/docs/a");
+            result[nonCloudDocId.ToString()].Should().BeNull();
+            result.GetValueOrDefault(unknownDocId.ToString()).Should().BeNull();
+        }
+        finally
+        {
+            await using var ctx = await factoryDb.CreateDbContextAsync();
+            var docs = await ctx.Documents.Where(d => d.ContainerId == containerId).ToListAsync();
+            ctx.Documents.RemoveRange(docs);
+            var container = await ctx.Containers.FirstOrDefaultAsync(c => c.Id == containerId);
+            if (container is not null) ctx.Containers.Remove(container);
+            await ctx.SaveChangesAsync();
+        }
+    }
+
+    [Fact]
+    public async Task EmptyInput_ReturnsEmptyMap()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var docStore = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+
+        var result = await docStore.GetResourceUrisAsync([], CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
@@ -426,6 +426,22 @@ public class ArmRbacReaderTests
     }
 
     [Fact]
+    public async Task Resolve_DenyAssignment_IsExposedOnDeniedPrefixes()
+    {
+        // A Blob Data role grant on the account, plus a deny assignment on a container beneath it.
+        // The grant itself is unaffected (deny doesn't cover the whole account), but the resolved
+        // result must also surface the deny as a DeniedPrefix so the verifier can block ACL fallback
+        // reads under it.
+        string acctScope = "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+        string roles = RoleAssignmentsBody((ReaderRole, acctScope, null));
+        string containerScope = acctScope + "/blobServices/default/containers/secret";
+        AzureRbacScopes r = await NewReaderWithDeny(roles, DenyBody(containerScope)).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.DeniedPrefixes.Should().Contain("azblob://acct/secret/");
+    }
+
+    [Fact]
     public async Task Resolve_CacheKey_IncludesSubscription_NotReusedAcrossSubscriptionChange()
     {
         // Same reader + cache, but the subscription changes between calls (settings reload). The

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
@@ -197,4 +197,36 @@ public class AzureSearchResultVerifierTests
 
         r.Select(x => x.DocumentId).Should().Equal("d2", "d3"); // rank order preserved, d1 backfilled out
     }
+
+    [Fact]
+    public async Task EnforcingButUnusable_DropsAllAzure_ButKeepsNonCloud()
+    {
+        // AzureEnforcing latched on but the provider isn't configured → EnforcingButUnusable, which
+        // the sibling AzureSearchScopeResolver treats as SearchScopes.Failed ("searches deny"). The
+        // verifier must not fall back to passing everything through.
+        var h = new Harness { AzureConfigured = false, AzureEnforcing = true };
+        ResourceUris(h, ("az", "azblob://acct/docs/x"), ("nc", null));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("az", 0.9), Hit("nc", 0.8)], User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("nc");
+    }
+
+    [Fact]
+    public async Task UnparseableAzblobUri_IsDropped_FailClosed()
+    {
+        var h = new Harness();
+        ResourceUris(h, ("bad", "azblob://acct/docs/")); // azblob scheme, empty blob path → unparseable
+
+        (await h.Build().VerifyAsync([Hit("bad", 0.9)], User, 10)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DocumentIdNotFound_IsDropped_FailClosed()
+    {
+        var h = new Harness();
+        ResourceUris(h); // no entries at all — "gone" is absent from the map, not merely null
+
+        (await h.Build().VerifyAsync([Hit("gone", 0.9)], User, 10)).Should().BeEmpty();
+    }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
@@ -233,7 +233,18 @@ public class AzureSearchResultVerifierTests
     [Fact]
     public void CandidateMultiplier_IsOne_WhenAzureAdNotConfigured()
     {
-        var h = new Harness { AzureConfigured = false };
+        // Not configured -> EnforcingButUnusable (latched on by the harness default), not Enforcing -> 1.
+        var h = new Harness { AzureConfigured = false, AzureEnforcing = true };
+
+        h.Build().CandidateMultiplier.Should().Be(1);
+    }
+
+    [Fact]
+    public void CandidateMultiplier_IsOne_WhenAzureConfiguredButNotEnforcing()
+    {
+        // Configured but the latch is off -> NotEnforcing, not Enforcing -> 1. A deployment with
+        // Azure AD wired up that hasn't switched enforcement on must not pay the over-fetch cost.
+        var h = new Harness { AzureConfigured = true, AzureEnforcing = false };
 
         h.Build().CandidateMultiplier.Should().Be(1);
     }
@@ -241,7 +252,8 @@ public class AzureSearchResultVerifierTests
     [Fact]
     public void CandidateMultiplier_UsesSetting_WhenAzureConfigured()
     {
-        var h = new Harness { AzureConfigured = true };
+        // Configured AND enforcing -> Enforcing -> the configured setting (5) applies.
+        var h = new Harness { AzureConfigured = true, AzureEnforcing = true };
 
         h.Build().CandidateMultiplier.Should().Be(5);
     }

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
@@ -229,4 +229,20 @@ public class AzureSearchResultVerifierTests
 
         (await h.Build().VerifyAsync([Hit("gone", 0.9)], User, 10)).Should().BeEmpty();
     }
+
+    [Fact]
+    public void CandidateMultiplier_IsOne_WhenAzureAdNotConfigured()
+    {
+        var h = new Harness { AzureConfigured = false };
+
+        h.Build().CandidateMultiplier.Should().Be(1);
+    }
+
+    [Fact]
+    public void CandidateMultiplier_UsesSetting_WhenAzureConfigured()
+    {
+        var h = new Harness { AzureConfigured = true };
+
+        h.Build().CandidateMultiplier.Should().Be(5);
+    }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
@@ -183,9 +183,10 @@ public class AzureSearchResultVerifierTests
             .Returns(AzureRbacScopes.Resolved([], [], ["azblob://acct/secret/"]));
         ResourceUris(h, ("d1", "azblob://acct/secret/x.txt"));
         h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
-            .Returns(new Gen2Acl("owner", "group", RX, RX, RX, null, [], []));
+            .Returns(new Gen2Acl("owner", "group", RX, RX, Gen2Permission.Read | Gen2Permission.Execute,
+                Mask: null, NamedUsers: [], NamedGroups: [])); // grants "user-oid" Read via the "other" class
         h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
-            .Returns(new Gen2ModeBits("owner", "group", RX, RX, RX, HasExtendedAcl: false));
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, Gen2Permission.Execute, HasExtendedAcl: false)); // ancestors traverse via "other"
 
         IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
 

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
@@ -152,8 +152,12 @@ public class AzureSearchResultVerifierTests
     }
 
     [Fact]
-    public async Task TagConditioned_MatchingTag_Passes_And_NonMatching_Drops()
+    public async Task TagConditioned_MatchingTag_Passes_And_NonMatching_FallsThroughToAcl_AndDrops()
     {
+        // The tag branch itself only ever grants on a match. A non-match falls through to the Gen2
+        // ACL check; with FileAcl unstubbed (returns null / unreadable), that fallthrough still
+        // fails closed, so the non-matching hit drops — same observable outcome as before the fix,
+        // but now via the ACL path rather than the tag branch being terminal.
         var h = new Harness();
         h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>()).Returns(
             AzureRbacScopes.Resolved([], [new AzureTagCondition("azblob://acct/docs/", "Project", "Cascade", true, false)]));
@@ -166,6 +170,65 @@ public class AzureSearchResultVerifierTests
         IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("hit-ok", 0.9), Hit("hit-no", 0.8)], User, 10);
 
         r.Select(x => x.DocumentId).Should().BeEquivalentTo("hit-ok");
+    }
+
+    [Fact]
+    public async Task DenyCoveredHit_IsDropped_EvenWhenAclWouldGrant()
+    {
+        // A deny assignment outranks every grant, including the Gen2 ACL fallback. Even though the
+        // file's own ACL (and every ancestor) would grant read, the hit sits under a denied prefix
+        // and must be dropped before the ACL check ever runs.
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+            .Returns(AzureRbacScopes.Resolved([], [], ["azblob://acct/secret/"]));
+        ResourceUris(h, ("d1", "azblob://acct/secret/x.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, RX, RX, null, [], []));
+        h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, RX, HasExtendedAcl: false));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TagNonMatch_FallsThroughToAcl_AndAclReadableFilePasses()
+    {
+        // Azure evaluates ACLs when an ABAC condition doesn't grant. A tag condition that covers the
+        // scope but doesn't match this blob's tags must not drop the hit outright — the file's own
+        // ACL (plus ancestor traverse) still grants it, so it passes via the Gen2 ACL fallback.
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>()).Returns(
+            AzureRbacScopes.Resolved([], [new AzureTagCondition("azblob://acct/docs/", "Project", "Cascade", true, false)]));
+        ResourceUris(h, ("d1", "azblob://acct/docs/a.txt"));
+        h.Tags.ReadTagsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, string> { ["Project"] = "Other" });
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, Gen2Permission.None, Gen2Permission.None,
+                Mask: RX, NamedUsers: [new Gen2NamedAce("user-oid", RX)], NamedGroups: []));
+        h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, RX, HasExtendedAcl: false));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task TagNonMatch_FallsThroughToAcl_AndAclDeniesDrops()
+    {
+        // Same as above, but the file's own ACL is unreadable — the ACL fallback is itself
+        // fail-closed, so the hit still drops.
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>()).Returns(
+            AzureRbacScopes.Resolved([], [new AzureTagCondition("azblob://acct/docs/", "Project", "Cascade", true, false)]));
+        ResourceUris(h, ("d1", "azblob://acct/docs/a.txt"));
+        h.Tags.ReadTagsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, string> { ["Project"] = "Other" });
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns((Gen2Acl?)null);
+
+        (await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10)).Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
@@ -1,0 +1,200 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureSearchResultVerifierTests
+{
+    private const Gen2Permission RX = Gen2Permission.Read | Gen2Permission.Execute;
+    private static readonly Guid User = Guid.NewGuid();
+    private static readonly AzureIdentityRef Link = new("user-oid", "tid");
+
+    private static SearchHit Hit(string docId, double score) =>
+        new($"chunk-{docId}", docId, "content", (float)score, new Dictionary<string, string>());
+
+    private static IOptionsMonitor<T> Opt<T>(T v) where T : class
+    {
+        var m = Substitute.For<IOptionsMonitor<T>>();
+        m.CurrentValue.Returns(v);
+        return m;
+    }
+
+    // Builds a verifier with all seams faked; each test overrides what it needs.
+    private sealed class Harness
+    {
+        public IDocumentStore Docs = Substitute.For<IDocumentStore>();
+        public IAzureIdentityLinkReader Links = Substitute.For<IAzureIdentityLinkReader>();
+        public IAzureDirectoryReader Directory = Substitute.For<IAzureDirectoryReader>();
+        public IAzureRbacReader Rbac = Substitute.For<IAzureRbacReader>();
+        public IGen2FileAclReader FileAcl = Substitute.For<IGen2FileAclReader>();
+        public IBlobTagReader Tags = Substitute.For<IBlobTagReader>();
+        public IGen2DirectoryReader DirReader = Substitute.For<IGen2DirectoryReader>();
+        public bool AzureConfigured = true;
+        public bool AzureEnforcing = true;
+
+        public Harness()
+        {
+            // Defaults are wired here (construction time) rather than in Build(), so that any
+            // test-specific override set on these substitutes between `new Harness()` and
+            // `Build()` is the LAST configuration registered for that call and therefore wins
+            // (NSubstitute resolves repeat `.Returns()` on identical arguments by last-write).
+            Links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+            Directory.ResolveAsync(Link, Arg.Any<CancellationToken>())
+                .Returns(AzureIdentitySet.Resolved(["user-oid", "group-1"]));
+            Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+                .Returns(AzureRbacScopes.Resolved([], []));
+        }
+
+        public AzureSearchResultVerifier Build()
+        {
+            var azureAd = Opt(AzureConfigured
+                ? new AzureAdSignInSettings { TenantId = "t", ClientId = "c", RedirectUri = "https://x/cb", ClientCertificatePath = "p.pem" }
+                : new AzureAdSignInSettings());
+            var enf = Opt(new PermissionEnforcementSettings { AzureEnforcing = AzureEnforcing });
+            var traverse = new AncestorTraverseResolver(DirReader, new MemoryCache(new MemoryCacheOptions()));
+            return new AzureSearchResultVerifier(
+                Docs, Links, Directory, Rbac, FileAcl, Tags, traverse,
+                azureAd, enf, EnforcementMigration.Completed(),
+                Options.Create(new AzureVerifierSettings { MaxParallelism = 16, CandidateMultiplier = 5 }),
+                NullLogger<AzureSearchResultVerifier>.Instance);
+        }
+    }
+
+    private void ResourceUris(Harness h, params (string doc, string? uri)[] map) =>
+        h.Docs.GetResourceUrisAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
+            .Returns(map.ToDictionary(m => m.doc, m => m.uri));
+
+    [Fact]
+    public async Task NonAzureHits_PassUntouched()
+    {
+        var h = new Harness();
+        ResourceUris(h, ("d1", "s3://b/k"), ("d2", null));
+        var hits = new[] { Hit("d1", 0.9), Hit("d2", 0.8) };
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync(hits, User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("d1", "d2");
+    }
+
+    [Fact]
+    public async Task AzureNotEnforcing_PassesEverything()
+    {
+        var h = new Harness { AzureEnforcing = false };
+        ResourceUris(h, ("d1", "azblob://acct/docs/secret"));
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+        r.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RbacCoveredHit_Passes_WithoutAnyLiveAclOrTagRead()
+    {
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+            .Returns(AzureRbacScopes.Resolved([new AzureScope("azblob://acct/docs/")], []));
+        ResourceUris(h, ("d1", "azblob://acct/docs/a/file.txt"));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().ContainSingle();
+        await h.FileAcl.DidNotReceive().ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+        await h.Tags.DidNotReceive().ReadTagsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task LockedFileBeneathReadableFolder_IsDropped()
+    {
+        // Soundness: no RBAC/tag; file's own ACL denies Read → drop, even if ancestors traverse.
+        var h = new Harness();
+        ResourceUris(h, ("d1", "azblob://acct/docs/locked.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, RX, Gen2Permission.None, null, [], [])); // other = no read
+        h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, RX, HasExtendedAcl: false)); // ancestors traverse
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CaseC_PerFileGrantBeneathUnreadableFolder_IsReturned()
+    {
+        // Completeness: file's own ACL grants Read to the user AND ancestors are traversable (X),
+        // even though the folder is not readable as a listing (R). No RBAC. → pass.
+        var h = new Harness();
+        ResourceUris(h, ("d1", "azblob://acct/docs/secret/case-c.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, Gen2Permission.None, Gen2Permission.None,
+                Mask: RX, NamedUsers: [new Gen2NamedAce("user-oid", RX)], NamedGroups: []));
+        h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, Gen2Permission.Execute, HasExtendedAcl: false));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Gen2FileAclUnreadable_IsDropped_FailClosed()
+    {
+        var h = new Harness();
+        ResourceUris(h, ("d1", "azblob://acct/docs/x.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns((Gen2Acl?)null);
+
+        (await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TagConditioned_MatchingTag_Passes_And_NonMatching_Drops()
+    {
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>()).Returns(
+            AzureRbacScopes.Resolved([], [new AzureTagCondition("azblob://acct/docs/", "Project", "Cascade", true, false)]));
+        ResourceUris(h, ("hit-ok", "azblob://acct/docs/a.txt"), ("hit-no", "azblob://acct/docs/b.txt"));
+        h.Tags.ReadTagsAsync(Arg.Is<Gen2Path>(p => p.Path == "a.txt"), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, string> { ["Project"] = "Cascade" });
+        h.Tags.ReadTagsAsync(Arg.Is<Gen2Path>(p => p.Path == "b.txt"), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, string> { ["Project"] = "Other" });
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("hit-ok", 0.9), Hit("hit-no", 0.8)], User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("hit-ok");
+    }
+
+    [Fact]
+    public async Task DeprovisionedIdentity_DropsAllAzure_ButKeepsNonCloud()
+    {
+        var h = new Harness();
+        h.Directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Deprovisioned());
+        ResourceUris(h, ("az", "azblob://acct/docs/x"), ("nc", null));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("az", 0.9), Hit("nc", 0.8)], User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("nc");
+    }
+
+    [Fact]
+    public async Task Backfill_KeepsTopKInRankOrder_AfterDroppingUnreadable()
+    {
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+            .Returns(AzureRbacScopes.Resolved([new AzureScope("azblob://acct/ok/")], []));
+        ResourceUris(h,
+            ("d1", "azblob://acct/no/1"),  // dropped (not covered, file acl null)
+            ("d2", "azblob://acct/ok/2"),  // pass
+            ("d3", "azblob://acct/ok/3")); // pass
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns((Gen2Acl?)null);
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync(
+            [Hit("d1", 0.9), Hit("d2", 0.8), Hit("d3", 0.7)], User, 2);
+
+        r.Select(x => x.DocumentId).Should().Equal("d2", "d3"); // rank order preserved, d1 backfilled out
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs
@@ -25,7 +25,6 @@ public class AzureSearchScopeResolverTests
     private static AzureSearchScopeResolver Build(
         IAzureIdentityLinkReader? links = null,
         IAzureDirectoryReader? directory = null,
-        IAzureRbacReader? rbac = null,
         bool azureAdConfigured = true,
         bool isEnforcing = true,
         bool determined = true)
@@ -44,7 +43,6 @@ public class AzureSearchScopeResolverTests
         return new AzureSearchScopeResolver(
             links ?? Substitute.For<IAzureIdentityLinkReader>(),
             directory ?? Substitute.For<IAzureDirectoryReader>(),
-            rbac ?? Substitute.For<IAzureRbacReader>(),
             azureAd, enforcement, migration,
             new MemoryCache(new MemoryCacheOptions()),
             NullLogger<AzureSearchScopeResolver>.Instance);
@@ -110,47 +108,18 @@ public class AzureSearchScopeResolverTests
     }
 
     [Fact]
-    public async Task RbacFailed_Fails()
+    public async Task ValidEnforcingIdentity_RetrievesAllAzblob_ForTheVerifierToTighten()
     {
         var links = Substitute.For<IAzureIdentityLinkReader>();
         links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
         var directory = Substitute.For<IAzureDirectoryReader>();
         directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
-        var rbac = Substitute.For<IAzureRbacReader>();
-        rbac.ResolveAsync("oid-1", Arg.Any<CancellationToken>()).Returns(AzureRbacScopes.Failed());
-        var r = Build(links: links, directory: directory, rbac: rbac);
-        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.ResolverFailed);
-    }
-
-    [Fact]
-    public async Task Enabled_WithRbacPrefixes_ReturnsGrantedAzblobMatches()
-    {
-        var links = Substitute.For<IAzureIdentityLinkReader>();
-        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
-        var directory = Substitute.For<IAzureDirectoryReader>();
-        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
-        var rbac = Substitute.For<IAzureRbacReader>();
-        rbac.ResolveAsync("oid-1", Arg.Any<CancellationToken>()).Returns(
-            AzureRbacScopes.Resolved([new AzureScope("azblob://acct/docs/")], []));
-        var r = Build(links: links, directory: directory, rbac: rbac);
+        var r = Build(links: links, directory: directory);
 
         SearchScopes s = await r.ResolveAsync(User);
+
         s.Outcome.Should().Be(ScopeOutcome.Granted);
-        s.Matches.Should().ContainSingle().Which.Value.Should().Be("azblob://acct/docs/");
+        s.Matches.Should().ContainSingle().Which.Value.Should().Be("azblob://");
         s.Matches[0].IsExact.Should().BeFalse();
-    }
-
-    [Fact]
-    public async Task Enabled_NoRbacPrefixes_IsNoGrants()
-    {
-        var links = Substitute.For<IAzureIdentityLinkReader>();
-        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
-        var directory = Substitute.For<IAzureDirectoryReader>();
-        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
-        var rbac = Substitute.For<IAzureRbacReader>();
-        rbac.ResolveAsync("oid-1", Arg.Any<CancellationToken>()).Returns(AzureRbacScopes.Resolved([], []));
-        var r = Build(links: links, directory: directory, rbac: rbac);
-
-        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.NoGrants);
     }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/BlobTagReaderTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/BlobTagReaderTests.cs
@@ -1,0 +1,23 @@
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class BlobTagReaderTests
+{
+    [Fact]
+    public void MapTags_CopiesAllPairs()
+    {
+        IReadOnlyDictionary<string, string> result = BlobTagReader.MapTags(
+            new Dictionary<string, string> { ["Project"] = "Cascade", ["Env"] = "prod" });
+        result.Should().HaveCount(2);
+        result["Project"].Should().Be("Cascade");
+        result["Env"].Should().Be("prod");
+    }
+
+    [Fact]
+    public void MapTags_Null_ReturnsEmpty() =>
+        BlobTagReader.MapTags(null).Should().BeEmpty();
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs
@@ -98,4 +98,9 @@ public class DataLakeGen2DirectoryReaderMappingTests
         // (a named entry would otherwise be uncapped) → deny the directory.
         DataLakeGen2DirectoryReader.IsStructurallyComplete(
             Acl(mask: null, namedGroups: [new Gen2NamedAce("devs", RX)])).Should().BeFalse();
+
+    [Fact]
+    public void Reader_Implements_FileAclReader() =>
+        typeof(Connapse.Core.Interfaces.IGen2FileAclReader)
+            .IsAssignableFrom(typeof(DataLakeGen2DirectoryReader)).Should().BeTrue();
 }


### PR DESCRIPTION
Closes #490. **Phase 4e — the final sub-issue of the Azure per-object permission epic (#475, tracker #479).** Targets `epic/azure-blob-provider`; once this lands, the epic is ready to merge to `main`.

## What this adds

Wires the Phase 4a–4d engine into **live search**: broad Azure retrieval + a post-retrieval per-hit verifier, so every readable Azure file gets through and every unreadable one is dropped.

- **Broad retrieve-then-verify** (spec §E amendment, settled with the user). `AzureSearchScopeResolver` now emits the scheme wildcard `azblob://` for a valid enforcing identity — retrieve every Azure candidate by relevance — because an ACL-only "Case C" file can live in any container. All Azure tightening moves to the verifier. **No new Azure permission** (the app stays `Storage Blob Data Reader` + the existing RBAC read; no ARM HNS detection).
- **`ISearchResultVerifier`** (+ `AzureSearchResultVerifier`), called in `HybridSearchService` after retrieval + rerank, with **over-fetch + backfill** (only when actually enforcing) and **bounded parallelism**. Per `azblob://` hit: covered by an RBAC prefix → **pass** (in-memory, RBAC read supersedes ACLs); under a tag condition → **live blob-tag verify**; otherwise → **Gen2 verify** the file's own ACL (Read) **and** 4d ancestor-traverse (Execute). `s3://` and non-cloud hits pass untouched.
- **Seams:** `AzblobUri`, `AzureTagConditionEvaluator`, `IGen2FileAclReader` (on `DataLakeGen2DirectoryReader`), `IBlobTagReader`/`BlobTagReader`, and a batched `IDocumentStore.GetResourceUrisAsync`.

## Soundness & completeness

- **Soundness** (never over-grant): fail-closed at every branch — unparseable `azblob://` URI, not-found document, `EnforcingButUnusable`, no-usable-identity, and any uncertain ACL/tag read all **drop**; no denying class falls through to a permissive one. Test: `LockedFileBeneathReadableFolder_IsDropped`.
- **Completeness** (never drop a readable file): retrieval is never narrowed for Gen2, so a Case-C file is retrieved and then admitted by the file-ACL + ancestor-traverse check. Test: `CaseC_PerFileGrantBeneathUnreadableFolder_IsReturned`.
- Reading a Gen2 file requires the file's own Read **and** traverse-`X` on every ancestor — **folder access is never trusted**.

## AWS / non-cloud path unchanged

`AwsSearchScopeResolver`, `PgVectorStore`, `KeywordSearchService`, and every SAML/JWT file are **not in this diff**. For AWS-only, non-cloud, and Azure-configured-but-not-enforcing deployments the pipeline is **byte-identical** to before: the verifier returns candidates unchanged (no pre-cap), `CandidateMultiplier == 1` (no over-fetch), AutoCut sees the same pool, and the final `Take(options.TopK)` is intact.

## Review

Built via subagent-driven development (8 tasks, per-task TDD + review; the verifier core and the whole-branch review on the most capable model). The final whole-branch review returned **MERGE-READY to `main`, no Critical/Important** — soundness, completeness, AWS-unchanged, concurrency, DI, and enforcement-state coherence all confirmed. Two fail-open edges caught mid-review (`EnforcingButUnusable` pass-all; unparseable-`azblob://` bypass) were fixed with regression tests. One non-blocking Minor (the `NoOp` verifier isn't registered as a Search-layer default — the Azure verifier self-no-ops) is filed as #496.

## Testing

Unit: **Core 1075/1075, Storage 221/221** (incl. the 15-case verifier suite covering the routing matrix, fail-closed paths, backfill/rank-order, and the enforcement/multiplier gates). Integration: `AzureVerifyEnforcementTests` (ran live on Testcontainers) proves end-to-end that an RBAC-covered azblob hit passes, an un-granted azblob hit drops, and `s3://`/non-cloud hits pass — exercising the real `GetResourceUrisAsync`. The 3 pre-existing `SearchEndpointTests` (Ollama ingestion) failures are environmental and identical on the baseline.

Spec: `docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md` §E + amendment · Plan: `docs/superpowers/plans/2026-09-07-azure-phase4e-verify-seam.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
