### PR TITLE
Azure provider: guided setup, connector parity, and fixes from live testing

### DIFF
--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -1,0 +1,70 @@
+# Azure setup
+
+Connapse reads Azure Blob Storage (including Data Lake Gen2 accounts) as its own Entra app
+identity, authenticated with a certificate it generates on its host, or as a managed identity.
+No account keys, SAS tokens, client secrets, or connection strings are ever entered or stored.
+It only reads: it never writes a blob, a role assignment, an ACL, or a tag.
+
+## Setup
+
+Admin → Providers → Azure. Two steps, each with an **Easy setup** guide and **Manual values**.
+
+1. **Access.** Copy the script, run it in [Azure Cloud Shell](https://shell.azure.com) (Bash),
+   paste back what it prints, Save. It uses the subscription Cloud Shell is signed in to, creates
+   two custom roles and the access app, and uploads only the public certificate:
+   - *Connapse Blob Data + Tags Reader* — read blobs and blob index tags, list containers.
+   - *Connapse RBAC Authorization Reader* — read role and deny assignments and storage-account
+     metadata at subscription scope.
+   Whoever runs it needs Owner or User Access Administrator on the subscription and permission
+   to register applications. The script is safe to re-run: it finds existing apps by name and
+   updates the roles in place.
+2. **Per-user permissions.** A second script registers the sign-in app people link their Entra
+   identity through, grants the access app the two Microsoft Graph permissions
+   (`User.Read.All`, `GroupMember.Read.All`) it looks people and groups up with, and attempts
+   admin consent. Consent needs a Global Administrator or Privileged Role Administrator; if the
+   person running the script is not one, the page shows a consent link to send them. When
+   consent succeeds the script also pre-consents the sign-in app for everyone, so nobody sees a
+   consent prompt when linking.
+
+Then Admin → Connections → New → Azure Blob Storage: choose the storage account and containers
+from the lists (or type them), Test connection, Save. People link their Entra identity under
+Integrations → Microsoft Entra ID; their search results are then limited to what that identity
+may read.
+
+## Troubleshooting
+
+**`AADSTS700027: The certificate ... is not registered on application`** — the certificate
+Connapse signs with is not the one uploaded to that app. Open the step's guide on the Azure
+provider page (it embeds the certificate Connapse actually holds), re-run the script, paste back,
+Save. Use **New certificate** only if you want to replace the key.
+
+**`AADSTS500113: No reply address is registered`** on the admin-consent link — the access app
+had no reply URL. Re-run the Per-user permissions script; it registers the Providers page as
+the reply URL and the link works.
+
+**`AADSTS65001` / "admin consent pending"** — the Graph permissions have not been approved.
+Send the consent link from the Per-user permissions card to a Global Administrator.
+
+**"This identity may not list storage accounts / containers"** in the connection form — the
+access identity lacks a listing role. Roles created before container/account listing was added
+are upgraded by re-running the Access script; otherwise assign *Connapse Blob Data + Tags Reader*
+on the account and *Connapse RBAC Authorization Reader* on the subscription. Typing the names
+still works without the lists.
+
+**Test connection fails with 403 / `AuthorizationPermissionMismatch`** — the access app has no
+blob-read role on that account or container. Use the "Role assignments granting exactly this
+access" snippet on the connection form, or assign *Connapse Blob Data + Tags Reader* at the
+account scope. Role assignments can take a few minutes to propagate.
+
+**Test connection fails with 404** — the container name is wrong, or the account is not the one
+you think (check the resource group in the account picker). Azure accounts have no default
+container; the test needs one that exists.
+
+**Search returns nothing for a linked user** — per-user filtering is on and the identity lookup
+failed closed. Check that admin consent was granted, that the subscription is set on the Access
+step (the RBAC resolver needs it), and that the user still exists and is enabled in Entra. For
+Data Lake Gen2 accounts, the user also needs Read on the file and Execute on every ancestor
+directory in the POSIX ACLs.
+
+**"Could not connect your Entra identity"** — the container log names the cause:
+`docker logs connapse-web-1 | grep -A5 "Entra sign-in callback failed"`.

--- a/docs/research/azure-blob-connector-parity-2026-09-08.md
+++ b/docs/research/azure-blob-connector-parity-2026-09-08.md
@@ -1,0 +1,111 @@
+# Can the Azure Blob connector be as guided as the S3 one?
+**Date:** 2026-09-08
+**Status:** Reviewed
+**Built on:** azure-easy-setup-2026-09-08.md (the app-identity and custom-role design this extends)
+
+## Executive summary
+Yes — everything the S3 connection form automates has an Azure equivalent reachable with the
+certificate-authenticated access app Connapse already has, using only read-only operations:
+storage-account discovery (ARM), container discovery (blob data plane), hierarchical-namespace
+detection (ARM `isHnsEnabled`), and a real test-connection call. The one cost is two small
+control-plane **read** permissions the least-privilege custom roles currently omit
+(`Microsoft.Storage/storageAccounts/read` and `.../blobServices/containers/read`). Neither exposes
+keys or data; both are part of the built-in Storage Blob Data Reader / Reader roles. Microsoft's
+own Data Factory presents exactly this shape: "From Azure subscription" pickers or "Enter manually",
+plus Test connection.
+
+## Research brief
+**Question:** What can the Azure Blob connection form automate to match the S3 form, under
+Connapse's identity model (certificate app or managed identity; no keys, SAS, or connection strings)?
+
+**Sub-questions:** (1) What does the S3 form automate and how? (2) What does the Azure form have?
+(3) Which Azure operations and RBAC actions give account/container discovery and a test?
+(4) How do Microsoft's products present this?
+
+**Out of scope:** account keys / SAS / connection strings; write operations of any kind; changing
+the per-object permission engine.
+
+## Findings
+
+### What S3 automates today (Connections.razor, S3Discovery, S3ConnectionTester)
+Readiness banner from `IProviderSetupReader` (links to the AWS provider page when access is not set
+up); bucket picker ("Choose from buckets Connapse can see", `IS3Discovery.ListBucketsAsync`) that
+adds to the allowed-locations list and auto-fills the connection name; region auto-detect on pick
+(`GetBucketRegionAsync`); cross-account Role ARN behind a disclosure; a generated least-privilege IAM
+policy for exactly the chosen buckets (`S3SetupPolicy`); Test connection (lists ≤5 objects) with a
+troubleshooting link on failure. Discovery is a server-side service injected into the page, not a
+REST endpoint.
+
+### What Azure has today
+Two text fields (storage account name; optional blob endpoint for emulators), the shared
+allowed-locations list, and Test connection (`AzureBlobConnectionTester`, lists ≤5 blobs). No
+readiness banner, no account or container picker, no name auto-fill, no RBAC snippet, no
+troubleshooting link, and no discovery service at all (`ConnapseAzureCredentials` is only a
+`TokenCredential`).
+
+### Azure operations and the permissions they need (learn.microsoft.com, high confidence)
+| Need | Call | RBAC operation | In our roles today? |
+|---|---|---|---|
+| List storage accounts in the subscription | `Azure.ResourceManager.Storage` `SubscriptionResource.GetStorageAccountsAsync()` → `PrimaryEndpoints.BlobUri`, `IsHnsEnabled` | `Microsoft.Storage/storageAccounts/read` (Action) | **No** |
+| List containers in an account | `BlobServiceClient.GetBlobContainersAsync()` | `Microsoft.Storage/storageAccounts/blobServices/containers/read` (control-plane **Action**, even though the call is data-plane) | **No** → 403 today |
+| List blobs with a prefix / read blobs | `BlobContainerClient.GetBlobsAsync` | `.../containers/blobs/read` (DataAction) | Yes |
+| Read blob index tags | | `.../blobs/tags/read` (DataAction) | Yes |
+
+Storage Blob Data Reader's definition is Actions `containers/read` + `generateUserDelegationKey`,
+DataActions `blobs/read`; our blob role is that minus `containers/read` plus `tags/read`. The
+subscription-wide Reader role would also work for account listing but exposes every resource type,
+so a targeted action on our existing subscription-scoped role is tighter. `listKeys/action` is not
+needed for anything here and must stay out.
+
+There is no Azure "GetCallerIdentity" for an app. Token acquisition alone proves only that the
+certificate is valid, not that any role is assigned; the meaningful readiness probe is a scoped
+read that exercises the real permission (e.g. `GetBlobContainersAsync` on the chosen account, or
+`GET /subscriptions/{id}` for ARM reachability).
+
+### How Microsoft's products present it
+Azure Data Factory: "Account selection method" toggle — **From Azure subscription** (subscription →
+storage account dropdown, auto-fills the endpoint) or **Enter manually** (type the URL) — with a
+**Test connection** button; service-principal auth stores the service endpoint URL. Purview browses
+subscription → storage account and tests with the chosen identity (needs Storage Blob Data
+Reader). Fabric and Databricks take a URL (`https://…dfs.core.windows.net` / `abfss://`). All store
+a URL or endpoint, never a bare account name; HNS is implied by endpoint choice rather than shown,
+though ARM exposes `isHnsEnabled` directly — Connapse can do better by showing it.
+
+## Recommendation
+1. **Roles (needs the operator's OK — two read-only additions):** add
+   `Microsoft.Storage/storageAccounts/blobServices/containers/read` to the blob data role's
+   Actions, and `Microsoft.Storage/storageAccounts/read` to the subscription-scoped authorization
+   reader role. Both are read-only listing rights; no data or key access changes. The Access script
+   should create-or-update the role definitions so re-running upgrades existing roles.
+2. **`IAzureBlobDiscovery`** (Core interface, Storage implementation, mirroring `IS3Discovery`
+   with an `AzureProbe<T>` outcome type: not-configured / denied / failed / ok):
+   `ListStorageAccountsAsync` (name, blob endpoint, resource group, `IsHnsEnabled`),
+   `ListContainersAsync(accountName | endpoint)`, `ProbeAccessAsync`.
+3. **Connections form, Azure block, mirroring S3 line for line:** readiness banner (Azure Access
+   status, link to the Azure provider page); "From your subscription" account picker with an
+   "Enter manually" fallback (auto-fills account + endpoint; shows a "Data Lake Gen2 (hierarchical
+   namespace)" badge, which matters because Gen2 accounts are enforced via POSIX ACLs); container
+   picker feeding allowed locations and auto-filling the name; a generated `az role assignment`
+   snippet scoping the blob role to exactly the chosen account(s)/container(s); troubleshooting
+   link to `docs/azure-setup.md` on test failure.
+4. Package: `Azure.ResourceManager.Storage` (new, Storage project). Sovereign clouds: construct
+   `ArmClient` with the environment matching the credential's authority host.
+
+## Conflicts and uncertainties
+- The List Containers REST doc names Storage Blob Data Contributor as least-privileged although
+  Reader carries the same `containers/read` Action — treated as a docs inconsistency; Reader-level
+  rights suffice. Verify live after the role change.
+- `PrimaryEndpoints.BlobUri` vs `.Blob` depends on the SDK version; check the installed package.
+- ADF's exact Test-connection operation is not documented (community claim: a lightweight list).
+
+## Gaps
+No product documents surfacing `isHnsEnabled` in a picker; Connapse would be doing something the
+references don't. Managed-identity deployments get discovery the same way, but the Providers page
+still cannot see a system-assigned identity (known limitation).
+
+## Sources
+Primary: learn.microsoft.com — Azure built-in roles (Storage); List Containers and List Blobs REST
+authorization sections; `StorageAccountData.PrimaryEndpoints`; storage-blob-query-endpoint-srp;
+hierarchical-namespace (isHnsEnabled); Data Factory Azure Blob connector; Purview register/scan
+Azure Blob; Fabric ADLS shortcuts; Databricks external locations (ADLS). Secondary: Airbyte Azure
+Blob source docs; RBACMap role listing; a community Q&A on ADF test connection (410 Gone at fetch).

--- a/docs/research/azure-easy-setup-2026-09-08.md
+++ b/docs/research/azure-easy-setup-2026-09-08.md
@@ -1,0 +1,161 @@
+# Best "easy setup" (guided) flow for connecting Connapse to Azure
+**Date:** 2026-09-08
+**Status:** Reviewed
+**Built on:** no prior corpus material (Connapse knowledge MCP not available this session)
+
+## Executive summary
+The recommended Azure "easy setup" is the direct analog of Connapse's AWS CloudShell flow: **Connapse generates keypairs locally, emits an `az`-CLI Bash script the operator pastes into Azure Cloud Shell, and parses a delimited block the script prints back** (tenant, subscription, and two client IDs). Use **two separate Entra app registrations** (a low-privilege OIDC *sign-in* app and a certificate-authenticated *access* app) and **two least-privilege custom RBAC roles** (blob+tags data reader; authorization reader) rather than the over-broad built-ins. The one step that **cannot be guaranteed automatable** is granting admin consent to the access app's Microsoft Graph *application* permissions (`User.Read.All`, `GroupMember.Read.All`): **only Global Administrator or Privileged Role Administrator can do it**. The flow must therefore attempt consent, treat "insufficient privileges" as an expected branch, and fall back to surfacing a ready-to-send v1 `adminconsent` URL while marking per-user permissions "pending admin consent." Bicep/ARM is a non-starter (it cannot create Entra apps, service principals, or Graph grants).
+
+## Research brief
+**Question:** What is the best way to implement a low-friction guided ("easy") Azure setup for Connapse (self-hosted .NET), analogous to its AWS CloudShell + IAM Roles Anywhere flow, and what genuinely cannot be automated?
+
+**Sub-questions investigated:**
+1. Scripting approach & host (`az`/Cloud Shell vs Bicep vs Graph PowerShell vs portal) + the exact command sequence.
+2. The admin-consent constraint: exact role requirements, the out-of-band consent URL, graceful degradation.
+3. Identity & Azure RBAC model: one app vs two; built-in vs custom roles for blob+tags and for the RBAC read.
+4. Certificate handling, the paste-back handshake values, and common tenant blockers.
+
+**Out of scope:** the Blazor UI implementation itself; AWS specifics; non-Azure clouds.
+
+**Success criteria:** a concrete, implementable recommendation — approach + actual scripts/commands + how to handle the non-automatable admin-consent step + the recommended UX — grounded in current (2026) Azure/Entra behavior with citations.
+
+## Findings by sub-question
+
+### Sub-question 1 — Scripting approach & host: Azure Cloud Shell + discrete `az` commands
+**Claim:** Emit an `az`-CLI Bash script for Azure Cloud Shell; do not use Bicep, and do not use the `create-for-rbac` combo command.
+
+Azure Cloud Shell is the correct AWS-CloudShell analog: it is **pre-authenticated** ("Cloud Shell automatically securely authenticates for instant access to your resources through the Azure CLI" — [Cloud Shell overview](https://learn.microsoft.com/en-us/azure/cloud-shell/overview)) and runs **as the signed-in operator**, so its permissions match whatever rights the operator already holds — the same trust model as AWS CloudShell. **Bicep/ARM cannot create Entra app registrations, service principals, or Graph permission grants at all** — those are Microsoft Graph/Entra objects, not ARM resources — so Bicep is disqualified. `az ad sp create-for-rbac` can bundle app+SP+cert+role in one call but **cannot add Graph API permissions**, so the discrete command sequence is required regardless. Microsoft Graph PowerShell is workable but more verbose; portal click-through fails the "scriptable/low-friction" bar.
+
+Cloud Shell limitations to design around: it requires a one-time Azure Files (5 GB) mount prompt on first use, and times out after ~20 min of inactivity.
+
+**Verified command sequence** (current `az` syntax, Microsoft Learn CLI reference):
+```bash
+APP_ID=$(az ad app create --display-name "Connapse-Azure-Access" --query appId -o tsv)
+az ad app credential reset --id "$APP_ID" --cert "@connapse-access.pem" --append   # PUBLIC cert only
+az ad sp create --id "$APP_ID"
+az role assignment create --assignee "$APP_ID" --role "<data role>"  --scope "<storage account scope>"
+az role assignment create --assignee "$APP_ID" --role "<rbac-read role>" --scope "/subscriptions/<sub>"
+az ad app permission add --id "$APP_ID" --api 00000003-0000-0000-c000-000000000000 \
+  --api-permissions a154be20-db9c-4678-8ab7-66f6cc099a59=Role   # User.Read.All
+az ad app permission add --id "$APP_ID" --api 00000003-0000-0000-c000-000000000000 \
+  --api-permissions 98830695-27a2-44f7-8c18-0c3ebc9698f6=Role   # GroupMember.Read.All
+az ad app permission admin-consent --id "$APP_ID"               # may fail — see sub-question 2
+```
+**Corrections vs. common/older guidance** ([az ad app credential](https://learn.microsoft.com/en-us/cli/azure/ad/app/credential)): `az ad app credential add` does not exist — `az ad app credential reset` (with `--append`) is the unified command. `az ad app permission grant` activates **delegated** (`Scope`) permissions only; **application** (`Role`) permissions like these require `az ad app permission admin-consent`, a different command.
+
+*Confidence:* Commands and Cloud Shell pre-auth are **primary-source (Microsoft Learn)**. The two Graph app-role GUIDs were confirmed via a widely-cited third-party reference (graphpermissions.merill.net), **not** Microsoft directly — **verify live at build time** with `az ad sp show --id 00000003-0000-0000-c000-000000000000 --query "appRoles[?value=='User.Read.All'||value=='GroupMember.Read.All'].{v:value,id:id}"`.
+
+### Sub-question 2 — Admin consent is the one hard, non-automatable gate
+**Claim:** Only Global Administrator or Privileged Role Administrator can consent to the access app's Microsoft Graph *application* permissions; the flow must degrade gracefully.
+
+Per Microsoft's Graph permissions doc, **"Only Privileged Role Administrator and Global Administrator can consent to application permissions"** ([Permissions overview](https://learn.microsoft.com/en-us/graph/permissions-overview)). The Entra "Grant tenant-wide admin consent" prerequisites make the split explicit: **Privileged Role Administrator** can consent to any permission for any API; **Application Administrator / Cloud Application Administrator** can consent to any permission **except Microsoft Graph app roles (application permissions)** ([Grant tenant-wide admin consent](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent)). Global Administrator is a superset. So an operator who can *create* the app (Application/Cloud App Admin, or any member if the tenant allows self-service registration) **still cannot consent** to `User.Read.All`/`GroupMember.Read.All` unless they are Global Admin or Privileged Role Admin.
+
+Adjacent role requirements: **assigning Azure RBAC roles** (`Microsoft.Authorization/roleAssignments/write`) needs **Owner, User Access Administrator, or Role Based Access Control Administrator** at the target scope ([RBAC troubleshooting](https://learn.microsoft.com/en-us/azure/role-based-access-control/troubleshooting)) — Azure RBAC, distinct from Entra roles. **Creating custom roles** (`roleDefinitions/write`) needs the same Owner/User Access Admin level.
+
+**Out-of-band consent URL (verified, v1):**
+```
+https://login.microsoftonline.com/{tenant}/adminconsent?client_id={access-app-id}
+```
+`{tenant}` = tenant ID / a verified domain / the literal `organizations`. This grants **all permissions already configured** on the app's API-permissions blade — no scope enumeration, no redirect URI required ([Grant tenant-wide admin consent](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent)). The v2 form (`/v2.0/adminconsent?...&scope=https://graph.microsoft.com/.default&redirect_uri=...`) requires a registered redirect URI and is unnecessary here.
+
+**Recommended graceful degradation:** the script attempts `az ad app permission admin-consent` right after adding the permissions; treat `AADSTS650052`/"Insufficient privileges" as a **non-fatal expected branch**. On that branch: finish everything else (app + SP + RBAC assignments + emit the paste-back block), and have Connapse render the v1 consent URL with plain instructions ("send this to a Global Administrator or Privileged Role Administrator; they click Accept"). Connapse marks per-user Azure permissions **"pending admin consent"** (not "failed") with a re-check button, since consent completes out-of-band and takes a few minutes to propagate. This mirrors Microsoft's own SaaS deferred-admin-consent onboarding pattern.
+
+*Confidence:* **Primary-source (Microsoft Learn)** for the role split, the URL, and propagation delay.
+
+### Sub-question 3 — Two apps, and two custom least-privilege roles
+**Claim:** Use separate sign-in and access app registrations; build custom RBAC roles rather than the over-broad built-ins.
+
+**Two app registrations, not one.** Microsoft's Zero Trust guidance is explicit: "Use separate app registrations for apps that sign in users and apps that expose data and operations via API," to keep high-privilege API permissions and credentials "at a distance from user-facing components" ([Register applications – Zero Trust](https://learn.microsoft.com/en-us/security/zero-trust/develop/app-registration)). A combined app would make the public, every-user OIDC sign-in flow carry the same identity that holds subscription-wide reads and Graph app permissions. Separate apps also give independent credential rotation, independent consent, and clean audit separation (sign-ins vs. service reads under different app IDs).
+
+**Blob + tags data role — the built-in is insufficient; use a custom role.** `Microsoft.Storage/.../blobs/read` and `Microsoft.Storage/.../blobs/tags/read` are **distinct** actions in the Azure permissions reference, and **Storage Blob Data Reader's `dataActions` contains only `blobs/read`, not `blobs/tags/read`** ([storage permissions](https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/storage)). Storage Blob Data Owner/Contributor would add write/delete (far broader). A custom data role is the least-privilege fit — and it directly closes the `blobs/tags/read` prerequisite that Connapse's tag-ABAC verification needs (repo issue #498):
+```json
+{
+  "Name": "Connapse Blob Data + Tags Reader",
+  "IsCustom": true,
+  "Description": "Read blob content and blob index tags for ABAC-conditioned access verification.",
+  "Actions": [], "NotActions": [], "NotDataActions": [],
+  "DataActions": [
+    "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
+    "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read"
+  ],
+  "AssignableScopes": ["/subscriptions/{subscriptionId}"]
+}
+```
+Assign it at the storage-account (or container) scope; `AssignableScopes` can be narrowed to the specific account(s) if that fits Connapse's per-container model.
+
+**RBAC-read role — custom is more correct than built-in Reader.** Both `Microsoft.Authorization/roleAssignments/read` and `Microsoft.Authorization/denyAssignments/read` are confirmed read-only control-plane actions. Built-in **Reader** grants `*/read` across *every* resource type in scope (VMs, networking, SQL metadata, …) — far more than Connapse needs. Least-privilege custom role:
+```json
+{
+  "Name": "Connapse RBAC Authorization Reader",
+  "IsCustom": true,
+  "Description": "Read role and deny assignments at subscription scope for per-user permission filtering.",
+  "Actions": [
+    "Microsoft.Authorization/roleAssignments/read",
+    "Microsoft.Authorization/denyAssignments/read"
+  ],
+  "NotActions": [], "DataActions": [], "NotDataActions": [],
+  "AssignableScopes": ["/subscriptions/{subscriptionId}"]
+}
+```
+(Custom-role schema per [custom roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles).) **`Microsoft.Authorization/roleDefinitions/read` is NOT needed** — a research worker raised it as a possible dependency, but Connapse's `ArmRbacReader` matches assignments by the hard-coded Storage-Blob-Data role GUIDs (the last segment of `RoleDefinitionId`) and never fetches role *definitions*, so `roleAssignments/read` + `denyAssignments/read` suffice (resolved against this repo's code, not an external source). Built-in Reader remains a defensible one-line fallback if custom-role creation is undesirable.
+
+**Managed identity vs certificate app — split by topology.** A managed identity **cannot be used outside Azure** ("a managed identity can only be used by the Azure resource for which it was created"), so Connapse's self-hosted/Docker deployments **must** use a certificate-authenticated app registration + service principal — not optional, a hard platform constraint. On an Azure VM/AKS a managed identity is preferable (no cert to store/rotate), **but** its auto-created service principal still needs the same Graph application permissions granted and admin-consented and the same RBAC roles assigned — MI only removes credential management, not the permission grants. Design the access identity around the certificate app as the baseline; treat MI as an optional enhancement, applying the identical roles/consent to whichever service principal represents the access identity.
+
+*Confidence:* **Primary-source** for the built-in-role facts, the two-app guidance, and the MI constraint. The two custom-role recommendations are a least-privilege synthesis (well-documented principle) applied to confirmed read-only actions, not copied from a named MS example.
+
+### Sub-question 4 — Certificates, the paste-back handshake, and tenant blockers
+**Claim:** Upload only the public cert; return four values in a delimited block; detect the common tenant blockers.
+
+**Certificate (public only).** Entra accepts `.cer`/`.pem`/`.crt` public certificates; you upload the public key and sign the client-assertion JWT locally with the private key — the private key never leaves the host, matching the AWS flow ([Add and manage app credentials](https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials)). `az ad app credential reset --cert @cert.pem` takes a PEM/DER public cert (docs: "Do not include the private key"); **without `--append` it wipes existing credentials** (destructive default), so rotation and multi-cert use must pass `--append`. Known gotcha: re-running the same `--append` isn't idempotent (it imports a duplicate keyCredential) — the script should `az ad app credential list` first. **Rotation:** append the new cert before the old expires, switch local config to the new thumbprint, verify, then `az ad app credential delete --key-id <old>`. Some hardened tenants enforce an `appManagementPolicy` capping cert lifetime (e.g., `maxLifetime P180D`) — **disabled by default** but, when on, will reject a longer-lived cert; catch and surface that error ([Enforce secret/certificate standards](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/tutorial-enforce-secret-standards)).
+
+**Paste-back handshake — four values suffice:**
+```
+-----BEGIN CONNAPSE AZURE SETUP-----
+TENANT_ID=<guid>            # az account show --query tenantId -o tsv
+SUBSCRIPTION_ID=<guid>      # az account show --query id -o tsv
+ACCESS_APP_CLIENT_ID=<guid> # az ad app create (access) --query appId -o tsv
+SIGNIN_APP_CLIENT_ID=<guid> # az ad app create (sign-in) --query appId -o tsv
+-----END CONNAPSE AZURE SETUP-----
+```
+`appId` (client ID) is shared by an app and its SP; the separate *object* IDs aren't needed at paste-back (Connapse can derive the SP object id later via `az ad sp show --id <appId> --query id` if required). The delimited-block format is a **design recommendation** (mirroring Connapse's AWS `-----BEGIN…-----` marker), not an MS-documented convention.
+
+**Common tenant blockers** (script should detect the error and instruct):
+- **"Users can register applications" = No** (default is Yes): app creation then needs Application Developer / Application Administrator / Cloud Application Administrator / Global Administrator ([Delegate app roles](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/delegate-app-roles)).
+- **Guest (B2B) operator**: guests get restricted directory permissions by default and typically cannot register apps ([Default user permissions](https://learn.microsoft.com/en-us/entra/fundamentals/users-default-permissions)).
+- **PIM / Conditional Access / MFA**: a PIM-eligible privileged role must be *activated* (MFA/justification) before privileged `az` calls succeed — instruct the operator to activate then re-run. *(Inferred from PIM/CA docs, not a single Cloud-Shell-specific statement — lower confidence.)*
+- **Sovereign/national clouds** (Azure Government, China): different ARM/Graph/login endpoints — the script must `az cloud set --name <cloud>` and target the matching Graph endpoint. *(General pattern; needs a dedicated endpoint citation if launch targets these.)*
+
+## Conflicts and uncertainties
+- **No material conflicts** between workers. Both the admin-consent and blockers workers independently confirmed default self-service app registration is **Yes** and that consent is the gated step.
+- **Load-bearing single-source:** the Graph app-role GUIDs came from a third-party reference, not Microsoft directly. Mitigation: the script/Connapse should resolve them live via `az ad sp show` on the Graph SP at build/run time rather than hard-coding.
+- **Lower-confidence, inferred (not single-source MS):** the PIM→Cloud-Shell failure mode; sovereign-cloud endpoint specifics; the paste-back delimiter format (our design, not an MS convention).
+- **Resolved against this repo (not external):** the custom RBAC-read role does not need `roleDefinitions/read` (Connapse hard-codes the role GUIDs).
+
+## Gaps — what we did not find
+- No official Microsoft guidance on a "handshake" output format (expected — it's an app-specific design choice).
+- No single canonical Learn page enumerating all sovereign-cloud ARM/Graph/login endpoints was captured this pass.
+- Whether a client *secret* is acceptable in non-production self-host (vs. mandatory certificate) was out of scope; Connapse's design already mandates certificate/MI, so this doesn't block.
+- Not verified live: that the exact Graph app-role GUIDs above are current in every cloud — flagged for build-time verification.
+
+## Source quality assessment
+The load-bearing conclusions — Cloud Shell pre-auth and command semantics, the admin-consent role split, the v1 consent URL, the built-in-role dataActions, the certificate-public-key/`--append` behavior, and the MI-cannot-run-off-Azure constraint — rest on **primary sources (Microsoft Learn / Entra / Graph docs)**. The custom-role JSON recommendations are a **synthesis** of the (documented) least-privilege principle over confirmed read-only actions. Three items are explicitly lower-confidence/inferred (Graph GUIDs' provenance, PIM-in-Cloud-Shell, sovereign endpoints, and the handshake format) and are flagged inline.
+
+## Sources
+**Primary (Microsoft Learn / Entra / Graph):**
+- Cloud Shell overview — https://learn.microsoft.com/en-us/azure/cloud-shell/overview
+- az ad app credential — https://learn.microsoft.com/en-us/cli/azure/ad/app/credential
+- Add and manage app credentials — https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials
+- Permissions overview (who can consent) — https://learn.microsoft.com/en-us/graph/permissions-overview
+- Grant tenant-wide admin consent (role split + v1 URL) — https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent
+- v2 admin consent protocol — https://learn.microsoft.com/en-us/entra/identity-platform/v2-admin-consent
+- Azure RBAC troubleshooting (roleAssignments/write roles) — https://learn.microsoft.com/en-us/azure/role-based-access-control/troubleshooting
+- Storage permissions reference (blobs/read vs blobs/tags/read) — https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/storage
+- Azure custom roles — https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles
+- Register applications – Zero Trust (separate apps) — https://learn.microsoft.com/en-us/security/zero-trust/develop/app-registration
+- Delegate app registration permissions — https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/delegate-app-roles
+- Default user permissions (guest limits) — https://learn.microsoft.com/en-us/entra/fundamentals/users-default-permissions
+- Enforce secret/certificate standards (cert lifetime policy) — https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/tutorial-enforce-secret-standards
+
+**Secondary/tertiary (flagged, verify at build):**
+- graphpermissions.merill.net — Graph app-role GUIDs (User.Read.All, GroupMember.Read.All)
+- azure-cli GitHub issue #12797 — admin-consent propagation/failure modes

--- a/src/Connapse.Core/Interfaces/IAzureBlobDiscovery.cs
+++ b/src/Connapse.Core/Interfaces/IAzureBlobDiscovery.cs
@@ -1,0 +1,70 @@
+namespace Connapse.Core.Interfaces;
+
+/// <summary>A storage account Connapse's identity can see, with what the connection form needs.</summary>
+/// <param name="Name">The account name.</param>
+/// <param name="BlobEndpoint">The primary blob endpoint, e.g. <c>https://name.blob.core.windows.net</c>.</param>
+/// <param name="ResourceGroup">The resource group it lives in, for telling same-named accounts apart.</param>
+/// <param name="ResourceId">The ARM resource id — the scope a role assignment is written against.</param>
+/// <param name="IsHnsEnabled">Whether the account is Data Lake Gen2 (hierarchical namespace), whose
+/// per-user permissions are POSIX ACLs rather than RBAC alone.</param>
+public record AzureStorageAccountInfo(
+    string Name,
+    string BlobEndpoint,
+    string ResourceGroup,
+    string ResourceId,
+    bool IsHnsEnabled);
+
+/// <summary>
+/// The outcome of asking Azure something, separating the cases that need different advice: it
+/// worked, Connapse has no Azure identity configured, or it has one and Azure refused.
+/// </summary>
+/// <remarks>Mirrors <see cref="AwsProbe{T}"/>; the same three-way split matters for the same reason —
+/// "set up the identity" and "grant the identity a role" send the operator to different places.</remarks>
+public record AzureProbe<T>(T? Value, AzureProbeOutcome Outcome, string? Detail = null)
+{
+    public bool Succeeded => Outcome == AzureProbeOutcome.Succeeded;
+
+    public static AzureProbe<T> Ok(T value) => new(value, AzureProbeOutcome.Succeeded);
+
+    public static AzureProbe<T> NotConfigured(string? detail = null) =>
+        new(default, AzureProbeOutcome.NotConfigured, detail);
+
+    public static AzureProbe<T> Denied(string? detail = null) =>
+        new(default, AzureProbeOutcome.Denied, detail);
+
+    public static AzureProbe<T> Failed(string? detail = null) =>
+        new(default, AzureProbeOutcome.Failed, detail);
+}
+
+public enum AzureProbeOutcome
+{
+    Succeeded = 0,
+
+    /// <summary>No Azure identity is set up — nothing to ask with.</summary>
+    NotConfigured = 1,
+
+    /// <summary>The identity works, and Azure refused the call: a missing role assignment.</summary>
+    Denied = 2,
+
+    /// <summary>Something else — a timeout, a network fault, an unexpected error.</summary>
+    Failed = 3
+}
+
+/// <summary>
+/// Reads what Connapse's own Azure identity can see, so the connection form can be filled in
+/// rather than typed. Every call is read-only.
+/// </summary>
+public interface IAzureBlobDiscovery
+{
+    /// <summary>
+    /// Every storage account in the configured subscription the identity may read metadata for.
+    /// </summary>
+    /// <remarks>Needs <c>Microsoft.Storage/storageAccounts/read</c> at subscription scope. A denial
+    /// must leave the operator typing an account name, never blocked.</remarks>
+    Task<AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>> ListStorageAccountsAsync(CancellationToken ct = default);
+
+    /// <summary>The containers in an account, by its blob endpoint.</summary>
+    /// <remarks>Needs <c>Microsoft.Storage/storageAccounts/blobServices/containers/read</c> on the
+    /// account — a control-plane action even though the call itself is data-plane.</remarks>
+    Task<AzureProbe<IReadOnlyList<string>>> ListContainersAsync(string blobEndpoint, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Models/AzureAdSignInSettings.cs
+++ b/src/Connapse.Core/Models/AzureAdSignInSettings.cs
@@ -35,6 +35,13 @@ public record AzureAdSignInSettings
     /// </summary>
     public string? ClientCertificatePassword { get; init; }
 
+    /// <summary>
+    /// True while the access app's Microsoft Graph permissions still await an administrator's
+    /// consent. Recorded by the setup flow so the state survives a reload; until it clears, the
+    /// directory lookups per-user filtering depends on will fail, and filtering fails closed.
+    /// </summary>
+    public bool AdminConsentPending { get; init; }
+
     /// <summary>True once every field sign-in needs — other than the certificate password — is set.</summary>
     public bool IsConfigured =>
         !string.IsNullOrWhiteSpace(TenantId)

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -183,13 +183,19 @@ public static class AzureCloudShellSetup
         CONNAPSE_CERT_EOF
 
         # --- Least-privilege custom roles: created, or updated in place so re-runs upgrade them ---
-        upsert_role() {  # $1 role name, $2 definition JSON (without id)
-          local id
-          id=$(az role definition list --name "$1" --query '[0].id' -o tsv 2>/dev/null)
-          if [ -z "$id" ]; then
+        upsert_role() {  # $1 role name, $2 definition JSON in the shape `az role definition create` takes
+          local existing
+          existing=$(az role definition list --name "$1" --custom-role-only true -o json 2>/dev/null | jq -c '.[0] // empty')
+          if [ -z "$existing" ]; then
             az role definition create --role-definition "$2" >/dev/null
           else
-            az role definition update --role-definition "$(echo "$2" | jq --arg id "$id" '. + {id: $id}')" >/dev/null
+            # `update` wants the shape `list` returns (roleName, permissions[], id), so patch the
+            # existing definition rather than resending the create-shaped one.
+            az role definition update --role-definition "$(jq -n --argjson e "$existing" --argjson d "$2" '
+              $e | .description = $d.Description
+                 | .permissions = [{actions: $d.Actions, notActions: $d.NotActions,
+                                    dataActions: $d.DataActions, notDataActions: $d.NotDataActions}]
+                 | .assignableScopes = $d.AssignableScopes')" >/dev/null
           fi
         }
         # Data-plane blob reads, plus listing containers (a control-plane action even over the

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -1,42 +1,42 @@
 namespace Connapse.Core.Utilities;
 
-/// <summary>Inputs the operator supplies (or Connapse derives) before generating the Azure setup script.</summary>
-/// <param name="SubscriptionId">The subscription the access identity is scoped to.</param>
-/// <param name="StorageScope">A storage-account resource id to scope the blob-data role to, or null/empty
-/// for subscription-wide.</param>
-/// <param name="RedirectUri">The sign-in app's redirect URI (Connapse's <c>/azure/callback</c>).</param>
-/// <param name="AccessAppName">Display name for the access app registration.</param>
-/// <param name="SignInAppName">Display name for the sign-in app registration.</param>
-/// <param name="PublicCertificatePem">The PUBLIC certificate to upload to both apps. The private key
-/// stays on the Connapse host and never appears in the script.</param>
-public sealed record AzureSetupInput(
+/// <summary>Inputs for the Access step's script: the subscription and storage scope the access identity
+/// is granted on, and the PUBLIC certificate it authenticates with (the private key stays on the host).</summary>
+public sealed record AzureAccessSetupInput(
     string SubscriptionId,
     string? StorageScope,
-    string RedirectUri,
     string AccessAppName,
+    string PublicCertificatePem);
+
+/// <summary>The non-secret identifiers the Access script prints back.</summary>
+public sealed record AzureAccessResult(string TenantId, string SubscriptionId, string AccessAppClientId);
+
+/// <summary>Inputs for the Per-user permissions step's script: which access app to grant Graph
+/// permissions on, the sign-in app's redirect URI, and the PUBLIC certificate for the sign-in app.</summary>
+public sealed record AzurePermissionsSetupInput(
+    string AccessAppClientId,
+    string RedirectUri,
     string SignInAppName,
     string PublicCertificatePem);
 
-/// <summary>The non-secret identifiers a completed Azure setup returns.</summary>
-public sealed record AzureSetupResult(
-    string TenantId,
-    string SubscriptionId,
-    string AccessAppClientId,
-    string SignInAppClientId,
-    bool ConsentGranted,
-    string? ConsentUrl);
+/// <summary>What the Per-user permissions script prints back, including whether the operator was able
+/// to grant admin consent (and the URL to hand an administrator when they were not).</summary>
+public sealed record AzurePermissionsResult(string SignInAppClientId, bool ConsentGranted, string? ConsentUrl);
 
 /// <summary>
-/// Generates the Azure Cloud Shell (<c>az</c>) script that provisions Connapse's Azure access — two
-/// least-privilege custom roles, a certificate-authenticated access app, and an OIDC sign-in app — and
-/// parses the block it prints back. A pure string utility, mirroring <see cref="AwsRolesAnywhereSetup"/>.
-/// Only the PUBLIC certificate travels in the script; admin consent for the access app's Graph
-/// application permissions is attempted and, when the operator lacks the role, deferred to a URL.
+/// Generates the Azure Cloud Shell (<c>az</c>) scripts that provision Connapse's Azure setup, one per
+/// step, and parses the block each prints back. A pure string utility mirroring
+/// <see cref="AwsRolesAnywhereSetup"/>: the Access script creates two least-privilege custom roles and
+/// a certificate-authenticated access app; the Permissions script creates the OIDC sign-in app and
+/// adds the access app's Microsoft Graph application permissions, attempting admin consent. Only the
+/// PUBLIC certificate ever appears in a script.
 /// </summary>
 public static class AzureCloudShellSetup
 {
-    public const string BeginMarker = "----- BEGIN CONNAPSE AZURE SETUP -----";
-    public const string EndMarker = "----- END CONNAPSE AZURE SETUP -----";
+    public const string AccessBeginMarker = "----- BEGIN CONNAPSE AZURE ACCESS -----";
+    public const string AccessEndMarker = "----- END CONNAPSE AZURE ACCESS -----";
+    public const string PermissionsBeginMarker = "----- BEGIN CONNAPSE AZURE PERMISSIONS -----";
+    public const string PermissionsEndMarker = "----- END CONNAPSE AZURE PERMISSIONS -----";
 
     /// <summary>The Microsoft Graph resource app id — stable across tenants.</summary>
     public const string GraphAppId = "00000003-0000-0000-c000-000000000000";
@@ -44,99 +44,132 @@ public static class AzureCloudShellSetup
     public const string BlobDataRoleName = "Connapse Blob Data + Tags Reader";
     public const string RbacReadRoleName = "Connapse RBAC Authorization Reader";
 
-    /// <summary>
-    /// Parses the block the script prints. Anchors on the LAST marker pair so pasting the whole terminal
-    /// (which echoes the script) still reads the printed output rather than the source. Returns null
-    /// unless the four ids are present and well-formed GUIDs.
-    /// </summary>
-    public static AzureSetupResult? ParseResult(string? pasted)
-    {
-        if (string.IsNullOrEmpty(pasted)) return null;
+    /// <summary>What the person running the Access script needs (Azure RBAC + Entra), not the runtime identity.</summary>
+    public static readonly IReadOnlyList<string> AccessScriptRequirements =
+    [
+        "Owner or User Access Administrator on the subscription (to create the two custom roles and assign them)",
+        "permission to register applications (the tenant default, or Application Developer / Application Administrator)",
+    ];
 
-        int end = pasted.LastIndexOf(EndMarker, StringComparison.Ordinal);
-        if (end < 0) return null;
-        int start = pasted.LastIndexOf(BeginMarker, end, StringComparison.Ordinal);
-        if (start < 0) return null;
+    /// <summary>What the person running the Permissions script needs; consent is the one step that may need someone else.</summary>
+    public static readonly IReadOnlyList<string> PermissionsScriptRequirements =
+    [
+        "permission to register applications",
+        "Global Administrator or Privileged Role Administrator to grant admin consent (otherwise the script prints a consent link for one)",
+    ];
 
-        string inner = pasted.Substring(start + BeginMarker.Length, end - start - BeginMarker.Length);
+    // ---- Access step ----
 
-        string? tenant = null, subscription = null, accessId = null, signInId = null,
-            consentGranted = null, consentUrl = null;
-        foreach (string line in inner.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-        {
-            int eq = line.IndexOf('=');
-            if (eq <= 0) continue;
-            string key = line[..eq];
-            string value = line[(eq + 1)..].Trim();
-            switch (key)
-            {
-                case "tenantId": tenant = value; break;
-                case "subscriptionId": subscription = value; break;
-                case "accessAppClientId": accessId = value; break;
-                case "signInAppClientId": signInId = value; break;
-                case "consentGranted": consentGranted = value; break;
-                case "consentUrl": consentUrl = value; break;
-            }
-        }
-
-        // The four ids are the load-bearing values; all must be real GUIDs or the paste is malformed.
-        if (!Guid.TryParse(tenant, out _) || !Guid.TryParse(subscription, out _)
-            || !Guid.TryParse(accessId, out _) || !Guid.TryParse(signInId, out _))
-            return null;
-
-        return new AzureSetupResult(
-            tenant!, subscription!, accessId!, signInId!,
-            ConsentGranted: string.Equals(consentGranted, "true", StringComparison.OrdinalIgnoreCase),
-            ConsentUrl: string.IsNullOrWhiteSpace(consentUrl) ? null : consentUrl);
-    }
-
-    /// <summary>
-    /// The Cloud Shell script. Idempotent where it can be: custom roles are created only if absent, and
-    /// app/SP/permission steps tolerate re-runs. Prints a delimited block for Connapse to parse.
-    /// </summary>
-    public static string GenerateScript(AzureSetupInput input)
+    public static string GenerateAccessScript(AzureAccessSetupInput input)
     {
         ArgumentNullException.ThrowIfNull(input);
-        string cert = input.PublicCertificatePem.Replace("\r\n", "\n").Trim();
         string storageScope = string.IsNullOrWhiteSpace(input.StorageScope)
             ? "/subscriptions/" + input.SubscriptionId
             : input.StorageScope!.Trim();
 
-        return Template
+        return AccessTemplate
             .Replace("{{subscription}}", Shell(input.SubscriptionId))
             .Replace("{{storageScope}}", Shell(storageScope))
-            .Replace("{{redirectUri}}", Shell(input.RedirectUri))
             .Replace("{{accessAppName}}", Shell(input.AccessAppName))
-            .Replace("{{signInAppName}}", Shell(input.SignInAppName))
-            .Replace("{{graphAppId}}", GraphAppId)
             .Replace("{{blobRoleName}}", BlobDataRoleName)
             .Replace("{{rbacRoleName}}", RbacReadRoleName)
-            .Replace("{{beginMarker}}", BeginMarker)
-            .Replace("{{endMarker}}", EndMarker)
-            .Replace("{{cert}}", cert);
+            .Replace("{{beginMarker}}", AccessBeginMarker)
+            .Replace("{{endMarker}}", AccessEndMarker)
+            .Replace("{{cert}}", input.PublicCertificatePem.Replace("\r\n", "\n").Trim());
+    }
+
+    /// <summary>Parses the Access block. Null unless all three ids are present, well-formed GUIDs.</summary>
+    public static AzureAccessResult? ParseAccessResult(string? pasted)
+    {
+        var values = ExtractBlock(pasted, AccessBeginMarker, AccessEndMarker);
+        if (values is null) return null;
+
+        values.TryGetValue("tenantId", out string? tenant);
+        values.TryGetValue("subscriptionId", out string? subscription);
+        values.TryGetValue("accessAppClientId", out string? accessId);
+
+        if (!Guid.TryParse(tenant, out _) || !Guid.TryParse(subscription, out _) || !Guid.TryParse(accessId, out _))
+            return null;
+
+        return new AzureAccessResult(tenant!, subscription!, accessId!);
+    }
+
+    // ---- Per-user permissions step ----
+
+    public static string GeneratePermissionsScript(AzurePermissionsSetupInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        return PermissionsTemplate
+            .Replace("{{accessAppId}}", Shell(input.AccessAppClientId))
+            .Replace("{{redirectUri}}", Shell(input.RedirectUri))
+            .Replace("{{signInAppName}}", Shell(input.SignInAppName))
+            .Replace("{{graphAppId}}", GraphAppId)
+            .Replace("{{beginMarker}}", PermissionsBeginMarker)
+            .Replace("{{endMarker}}", PermissionsEndMarker)
+            .Replace("{{cert}}", input.PublicCertificatePem.Replace("\r\n", "\n").Trim());
+    }
+
+    /// <summary>Parses the Permissions block. Null unless the sign-in app id is a well-formed GUID.</summary>
+    public static AzurePermissionsResult? ParsePermissionsResult(string? pasted)
+    {
+        var values = ExtractBlock(pasted, PermissionsBeginMarker, PermissionsEndMarker);
+        if (values is null) return null;
+
+        values.TryGetValue("signInAppClientId", out string? signInId);
+        if (!Guid.TryParse(signInId, out _)) return null;
+
+        values.TryGetValue("consentGranted", out string? consent);
+        values.TryGetValue("consentUrl", out string? url);
+
+        return new AzurePermissionsResult(
+            signInId!,
+            ConsentGranted: string.Equals(consent, "true", StringComparison.OrdinalIgnoreCase),
+            ConsentUrl: string.IsNullOrWhiteSpace(url) ? null : url);
+    }
+
+    // ---- shared ----
+
+    /// <summary>
+    /// Reads the key=value lines between the LAST marker pair, so pasting the whole terminal (which
+    /// echoes the script) still reads the printed output rather than the source.
+    /// </summary>
+    private static Dictionary<string, string>? ExtractBlock(string? pasted, string begin, string end)
+    {
+        if (string.IsNullOrEmpty(pasted)) return null;
+
+        int endIdx = pasted.LastIndexOf(end, StringComparison.Ordinal);
+        if (endIdx < 0) return null;
+        int startIdx = pasted.LastIndexOf(begin, endIdx, StringComparison.Ordinal);
+        if (startIdx < 0) return null;
+
+        string inner = pasted.Substring(startIdx + begin.Length, endIdx - startIdx - begin.Length);
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string line in inner.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            int eq = line.IndexOf('=');
+            if (eq <= 0) continue;
+            values[line[..eq]] = line[(eq + 1)..].Trim();
+        }
+        return values;
     }
 
     /// <summary>Escapes a value for safe inclusion inside single quotes in the generated bash.</summary>
     private static string Shell(string value) => value.Replace("'", "'\\''");
 
-    private const string Template = """
+    private const string AccessTemplate = """
         #!/usr/bin/env bash
-        # Connapse Azure setup — run this in Azure Cloud Shell (Bash). It provisions two app
-        # registrations and two least-privilege custom roles, then prints a block to paste back into
-        # Connapse. Safe to re-run. Only the PUBLIC certificate is here; Connapse keeps the private key.
+        # Connapse Azure setup — step 1 of 2 (Access). Run in Azure Cloud Shell (Bash). Creates two
+        # least-privilege custom roles and Connapse's certificate-authenticated access app, then prints
+        # a block to paste back into Connapse. Safe to re-run. Only the PUBLIC certificate is here.
         set -euo pipefail
 
         SUBSCRIPTION_ID='{{subscription}}'
         STORAGE_SCOPE='{{storageScope}}'
-        REDIRECT_URI='{{redirectUri}}'
         ACCESS_APP_NAME='{{accessAppName}}'
-        SIGNIN_APP_NAME='{{signInAppName}}'
-        GRAPH_API='{{graphAppId}}'
 
         az account set --subscription "$SUBSCRIPTION_ID"
         TENANT_ID=$(az account show --query tenantId -o tsv)
 
-        # Public certificate → a temp file for upload (removed at the end).
         CERT_FILE=$(mktemp)
         cat > "$CERT_FILE" <<'CONNAPSE_CERT_EOF'
         {{cert}}
@@ -172,8 +205,9 @@ public static class AzureCloudShellSetup
         ACCESS_APP_ID=$(az ad app create --display-name "$ACCESS_APP_NAME" --query appId -o tsv)
         az ad app credential reset --id "$ACCESS_APP_ID" --cert "@$CERT_FILE" --append >/dev/null
         az ad sp create --id "$ACCESS_APP_ID" >/dev/null 2>&1 || true
+        rm -f "$CERT_FILE"
 
-        # Roles wait for the custom-role definitions + SP to propagate; retry briefly.
+        # Role assignments wait for the role definitions + service principal to propagate; retry briefly.
         for i in 1 2 3 4 5; do
           az role assignment create --assignee "$ACCESS_APP_ID" --role '{{blobRoleName}}' --scope "$STORAGE_SCOPE" >/dev/null 2>&1 && break || sleep 10
         done
@@ -181,20 +215,44 @@ public static class AzureCloudShellSetup
           az role assignment create --assignee "$ACCESS_APP_ID" --role '{{rbacRoleName}}' --scope "/subscriptions/$SUBSCRIPTION_ID" >/dev/null 2>&1 && break || sleep 10
         done
 
-        # Microsoft Graph application permissions (resolve the app-role ids live).
-        USER_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='User.Read.All'].id | [0]" -o tsv)
-        GROUP_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='GroupMember.Read.All'].id | [0]" -o tsv)
-        az ad app permission add --id "$ACCESS_APP_ID" --api "$GRAPH_API" --api-permissions "$USER_READ_ALL=Role" >/dev/null
-        az ad app permission add --id "$ACCESS_APP_ID" --api "$GRAPH_API" --api-permissions "$GROUP_READ_ALL=Role" >/dev/null
+        echo
+        printf '%s\ntenantId=%s\nsubscriptionId=%s\naccessAppClientId=%s\n%s\n' \
+          "{{beginMarker}}" "$TENANT_ID" "$SUBSCRIPTION_ID" "$ACCESS_APP_ID" "{{endMarker}}"
+        """;
+
+    private const string PermissionsTemplate = """
+        #!/usr/bin/env bash
+        # Connapse Azure setup — step 2 of 2 (Per-user permissions). Run in Azure Cloud Shell (Bash).
+        # Creates the sign-in app people authenticate through and grants the access app the Microsoft
+        # Graph permissions it reads the directory with. Admin consent needs a Global Administrator or
+        # Privileged Role Administrator; if you are not one, the script prints a link to send them.
+        set -euo pipefail
+
+        ACCESS_APP_ID='{{accessAppId}}'
+        REDIRECT_URI='{{redirectUri}}'
+        SIGNIN_APP_NAME='{{signInAppName}}'
+        GRAPH_API='{{graphAppId}}'
+
+        TENANT_ID=$(az account show --query tenantId -o tsv)
+
+        CERT_FILE=$(mktemp)
+        cat > "$CERT_FILE" <<'CONNAPSE_CERT_EOF'
+        {{cert}}
+        CONNAPSE_CERT_EOF
 
         # --- Sign-in app registration (OIDC, certificate client-assertion) ---
         SIGNIN_APP_ID=$(az ad app create --display-name "$SIGNIN_APP_NAME" --web-redirect-uris "$REDIRECT_URI" --query appId -o tsv)
         az ad app credential reset --id "$SIGNIN_APP_ID" --cert "@$CERT_FILE" --append >/dev/null
         az ad sp create --id "$SIGNIN_APP_ID" >/dev/null 2>&1 || true
-
         rm -f "$CERT_FILE"
 
-        # --- Admin consent (Graph application permissions — Global Admin / Privileged Role Admin only) ---
+        # --- Microsoft Graph application permissions on the ACCESS app (ids resolved live) ---
+        USER_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='User.Read.All'].id | [0]" -o tsv)
+        GROUP_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='GroupMember.Read.All'].id | [0]" -o tsv)
+        az ad app permission add --id "$ACCESS_APP_ID" --api "$GRAPH_API" --api-permissions "$USER_READ_ALL=Role" >/dev/null
+        az ad app permission add --id "$ACCESS_APP_ID" --api "$GRAPH_API" --api-permissions "$GROUP_READ_ALL=Role" >/dev/null
+
+        # --- Admin consent (Global Administrator / Privileged Role Administrator only) ---
         CONSENT_GRANTED=false
         if az ad app permission admin-consent --id "$ACCESS_APP_ID" >/dev/null 2>&1; then
           CONSENT_GRANTED=true
@@ -202,7 +260,7 @@ public static class AzureCloudShellSetup
         CONSENT_URL="https://login.microsoftonline.com/$TENANT_ID/adminconsent?client_id=$ACCESS_APP_ID"
 
         echo
-        printf '%s\ntenantId=%s\nsubscriptionId=%s\naccessAppClientId=%s\nsignInAppClientId=%s\nconsentGranted=%s\nconsentUrl=%s\n%s\n' \
-          "{{beginMarker}}" "$TENANT_ID" "$SUBSCRIPTION_ID" "$ACCESS_APP_ID" "$SIGNIN_APP_ID" "$CONSENT_GRANTED" "$CONSENT_URL" "{{endMarker}}"
+        printf '%s\nsignInAppClientId=%s\nconsentGranted=%s\nconsentUrl=%s\n%s\n' \
+          "{{beginMarker}}" "$SIGNIN_APP_ID" "$CONSENT_GRANTED" "$CONSENT_URL" "{{endMarker}}"
         """;
 }

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -177,31 +177,42 @@ public static class AzureCloudShellSetup
         {{cert}}
         CONNAPSE_CERT_EOF
 
-        # --- Least-privilege custom roles (create only if absent) ---
-        if [ -z "$(az role definition list --name '{{blobRoleName}}' --query '[0].id' -o tsv 2>/dev/null)" ]; then
-          az role definition create --role-definition "{
-            \"Name\": \"{{blobRoleName}}\", \"IsCustom\": true,
-            \"Description\": \"Read blob content and blob index tags for Connapse.\",
-            \"Actions\": [], \"NotActions\": [], \"NotDataActions\": [],
-            \"DataActions\": [
-              \"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\",
-              \"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read\"
-            ],
-            \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
-          }" >/dev/null
-        fi
-        if [ -z "$(az role definition list --name '{{rbacRoleName}}' --query '[0].id' -o tsv 2>/dev/null)" ]; then
-          az role definition create --role-definition "{
-            \"Name\": \"{{rbacRoleName}}\", \"IsCustom\": true,
-            \"Description\": \"Read role and deny assignments at subscription scope for Connapse.\",
-            \"Actions\": [
-              \"Microsoft.Authorization/roleAssignments/read\",
-              \"Microsoft.Authorization/denyAssignments/read\"
-            ],
-            \"NotActions\": [], \"DataActions\": [], \"NotDataActions\": [],
-            \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
-          }" >/dev/null
-        fi
+        # --- Least-privilege custom roles: created, or updated in place so re-runs upgrade them ---
+        upsert_role() {  # $1 role name, $2 definition JSON (without id)
+          local id
+          id=$(az role definition list --name "$1" --query '[0].id' -o tsv 2>/dev/null)
+          if [ -z "$id" ]; then
+            az role definition create --role-definition "$2" >/dev/null
+          else
+            az role definition update --role-definition "$(echo "$2" | jq --arg id "$id" '. + {id: $id}')" >/dev/null
+          fi
+        }
+        # Data-plane blob reads, plus listing containers (a control-plane action even over the
+        # data plane) so the connection form can offer a container list.
+        upsert_role '{{blobRoleName}}' "{
+          \"Name\": \"{{blobRoleName}}\", \"IsCustom\": true,
+          \"Description\": \"Read blob content, blob index tags, and container names for Connapse.\",
+          \"Actions\": [\"Microsoft.Storage/storageAccounts/blobServices/containers/read\"],
+          \"NotActions\": [], \"NotDataActions\": [],
+          \"DataActions\": [
+            \"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\",
+            \"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read\"
+          ],
+          \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
+        }"
+        # Subscription-wide reads: role and deny assignments for per-user filtering, and storage
+        # account metadata (names, endpoints — never keys) so the form can offer an account list.
+        upsert_role '{{rbacRoleName}}' "{
+          \"Name\": \"{{rbacRoleName}}\", \"IsCustom\": true,
+          \"Description\": \"Read role and deny assignments and storage account metadata at subscription scope for Connapse.\",
+          \"Actions\": [
+            \"Microsoft.Authorization/roleAssignments/read\",
+            \"Microsoft.Authorization/denyAssignments/read\",
+            \"Microsoft.Storage/storageAccounts/read\"
+          ],
+          \"NotActions\": [], \"DataActions\": [], \"NotDataActions\": [],
+          \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
+        }"
 
         # --- Access app registration (certificate-authenticated); reused by name on re-runs ---
         ACCESS_APP_ID=$(az ad app list --display-name "$ACCESS_APP_NAME" --query '[0].appId' -o tsv)

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -3,7 +3,13 @@ namespace Connapse.Core.Utilities;
 /// <summary>Inputs for the Access step's script: the app name and the PUBLIC certificate it authenticates
 /// with (the private key stays on the host). The subscription is whichever one Cloud Shell is signed
 /// in to — the script reads it and prints it back, so the operator types nothing.</summary>
-public sealed record AzureAccessSetupInput(string AccessAppName, string PublicCertificatePem);
+/// <param name="ExistingAccessAppClientId">The access app Connapse already recorded, when re-running;
+/// the script reuses exactly that app and never looks one up by display name (names are neither
+/// unique nor authoritative, so a pre-registered look-alike could otherwise be granted the roles).</param>
+public sealed record AzureAccessSetupInput(
+    string AccessAppName,
+    string PublicCertificatePem,
+    string? ExistingAccessAppClientId = null);
 
 /// <summary>The non-secret identifiers the Access script prints back.</summary>
 public sealed record AzureAccessResult(string TenantId, string SubscriptionId, string AccessAppClientId);
@@ -17,7 +23,8 @@ public sealed record AzurePermissionsSetupInput(
     string RedirectUri,
     string ConsentRedirectUri,
     string SignInAppName,
-    string PublicCertificatePem);
+    string PublicCertificatePem,
+    string? ExistingSignInAppClientId = null);
 
 /// <summary>What the Per-user permissions script prints back, including whether the operator was able
 /// to grant admin consent (and the URL to hand an administrator when they were not).</summary>
@@ -65,6 +72,7 @@ public static class AzureCloudShellSetup
         ArgumentNullException.ThrowIfNull(input);
         return AccessTemplate
             .Replace("{{accessAppName}}", Shell(input.AccessAppName))
+            .Replace("{{existingAccessAppId}}", Shell(GuidOrEmpty(input.ExistingAccessAppClientId)))
             .Replace("{{blobRoleName}}", BlobDataRoleName)
             .Replace("{{rbacRoleName}}", RbacReadRoleName)
             .Replace("{{beginMarker}}", AccessBeginMarker)
@@ -98,6 +106,7 @@ public static class AzureCloudShellSetup
             .Replace("{{redirectUri}}", Shell(input.RedirectUri))
             .Replace("{{consentRedirectUri}}", Shell(input.ConsentRedirectUri))
             .Replace("{{consentRedirectEncoded}}", Uri.EscapeDataString(input.ConsentRedirectUri))
+            .Replace("{{existingSignInAppId}}", Shell(GuidOrEmpty(input.ExistingSignInAppClientId)))
             .Replace("{{signInAppName}}", Shell(input.SignInAppName))
             .Replace("{{graphAppId}}", GraphAppId)
             .Replace("{{beginMarker}}", PermissionsBeginMarker)
@@ -151,6 +160,10 @@ public static class AzureCloudShellSetup
 
     /// <summary>Escapes a value for safe inclusion inside single quotes in the generated bash.</summary>
     private static string Shell(string value) => value.Replace("'", "'\\''");
+
+    /// <summary>An app id is only ever a GUID; anything else is treated as "none recorded".</summary>
+    private static string GuidOrEmpty(string? value) =>
+        Guid.TryParse(value?.Trim(), out Guid id) ? id.ToString() : string.Empty;
 
     private const string AccessTemplate = """
         #!/usr/bin/env bash
@@ -225,9 +238,16 @@ public static class AzureCloudShellSetup
           \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
         }"
 
-        # --- Access app registration (certificate-authenticated); reused by name on re-runs ---
-        ACCESS_APP_ID=$(az ad app list --display-name "$ACCESS_APP_NAME" --query '[0].appId' -o tsv)
-        [ -n "$ACCESS_APP_ID" ] || ACCESS_APP_ID=$(az ad app create --display-name "$ACCESS_APP_NAME" --query appId -o tsv)
+        # --- Access app registration (certificate-authenticated) ---
+        # Re-runs reuse exactly the app Connapse recorded, by id. Never by display name: names are
+        # not unique, and a look-alike registered by someone else must not be handed these roles.
+        ACCESS_APP_ID='{{existingAccessAppId}}'
+        if [ -n "$ACCESS_APP_ID" ]; then
+          az ad app show --id "$ACCESS_APP_ID" --query appId -o tsv >/dev/null \
+            || { echo "The access app Connapse recorded ($ACCESS_APP_ID) no longer exists. Reset the Access step in Connapse and run again." >&2; exit 1; }
+        else
+          ACCESS_APP_ID=$(az ad app create --display-name "$ACCESS_APP_NAME" --query appId -o tsv)
+        fi
         # Registers the certificate; a re-run with the same certificate is fine, anything else is fatal.
         register_cert() {
           local out
@@ -239,13 +259,20 @@ public static class AzureCloudShellSetup
         az ad sp create --id "$ACCESS_APP_ID" >/dev/null 2>&1 || true
         rm -f "$CERT_FILE"
 
-        # Role assignments wait for the role definitions + service principal to propagate; retry briefly.
-        for i in 1 2 3 4 5; do
-          az role assignment create --assignee "$ACCESS_APP_ID" --role '{{blobRoleName}}' --scope "$STORAGE_SCOPE" >/dev/null 2>&1 && break || sleep 10
-        done
-        for i in 1 2 3 4 5; do
-          az role assignment create --assignee "$ACCESS_APP_ID" --role '{{rbacRoleName}}' --scope "/subscriptions/$SUBSCRIPTION_ID" >/dev/null 2>&1 && break || sleep 10
-        done
+        # Role assignments wait for the role definitions + service principal to propagate; retry
+        # briefly, and fail the script if they never land — a paste block without these grants
+        # would record a setup that cannot read anything.
+        assign_role() {  # $1 role name, $2 scope
+          local i
+          for i in 1 2 3 4 5; do
+            if az role assignment create --assignee "$ACCESS_APP_ID" --role "$1" --scope "$2" >/dev/null 2>&1; then return 0; fi
+            sleep 10
+          done
+          echo "Could not assign '$1' at $2 after 5 attempts." >&2
+          return 1
+        }
+        assign_role '{{blobRoleName}}' "$STORAGE_SCOPE"
+        assign_role '{{rbacRoleName}}' "/subscriptions/$SUBSCRIPTION_ID"
 
         echo
         printf '%s\ntenantId=%s\nsubscriptionId=%s\naccessAppClientId=%s\n%s\n' \
@@ -279,9 +306,15 @@ public static class AzureCloudShellSetup
         {{cert}}
         CONNAPSE_CERT_EOF
 
-        # --- Sign-in app registration (OIDC, certificate client-assertion); reused by name on re-runs ---
-        SIGNIN_APP_ID=$(az ad app list --display-name "$SIGNIN_APP_NAME" --query '[0].appId' -o tsv)
-        [ -n "$SIGNIN_APP_ID" ] || SIGNIN_APP_ID=$(az ad app create --display-name "$SIGNIN_APP_NAME" --query appId -o tsv)
+        # --- Sign-in app registration (OIDC, certificate client-assertion) ---
+        # Reused only by the id Connapse recorded, never by display name (see the Access script).
+        SIGNIN_APP_ID='{{existingSignInAppId}}'
+        if [ -n "$SIGNIN_APP_ID" ]; then
+          az ad app show --id "$SIGNIN_APP_ID" --query appId -o tsv >/dev/null \
+            || { echo "The sign-in app Connapse recorded ($SIGNIN_APP_ID) no longer exists. Reset the sign-in application in Connapse and run again." >&2; exit 1; }
+        else
+          SIGNIN_APP_ID=$(az ad app create --display-name "$SIGNIN_APP_NAME" --query appId -o tsv)
+        fi
         az ad app update --id "$SIGNIN_APP_ID" --web-redirect-uris "$REDIRECT_URI"
         # Registers the certificate; a re-run with the same certificate is fine, anything else is fatal.
         register_cert() {

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -206,7 +206,14 @@ public static class AzureCloudShellSetup
         # --- Access app registration (certificate-authenticated); reused by name on re-runs ---
         ACCESS_APP_ID=$(az ad app list --display-name "$ACCESS_APP_NAME" --query '[0].appId' -o tsv)
         [ -n "$ACCESS_APP_ID" ] || ACCESS_APP_ID=$(az ad app create --display-name "$ACCESS_APP_NAME" --query appId -o tsv)
-        az ad app credential reset --id "$ACCESS_APP_ID" --cert "@$CERT_FILE" --append >/dev/null
+        # Registers the certificate; a re-run with the same certificate is fine, anything else is fatal.
+        register_cert() {
+          local out
+          if out=$(az ad app credential reset --id "$1" --cert "@$CERT_FILE" --append 2>&1 >/dev/null); then return 0; fi
+          if echo "$out" | grep -qi "exist"; then echo "Certificate already registered on $1."; return 0; fi
+          echo "$out" >&2; return 1
+        }
+        register_cert "$ACCESS_APP_ID"
         az ad sp create --id "$ACCESS_APP_ID" >/dev/null 2>&1 || true
         rm -f "$CERT_FILE"
 
@@ -248,7 +255,14 @@ public static class AzureCloudShellSetup
         SIGNIN_APP_ID=$(az ad app list --display-name "$SIGNIN_APP_NAME" --query '[0].appId' -o tsv)
         [ -n "$SIGNIN_APP_ID" ] || SIGNIN_APP_ID=$(az ad app create --display-name "$SIGNIN_APP_NAME" --query appId -o tsv)
         az ad app update --id "$SIGNIN_APP_ID" --web-redirect-uris "$REDIRECT_URI"
-        az ad app credential reset --id "$SIGNIN_APP_ID" --cert "@$CERT_FILE" --append >/dev/null
+        # Registers the certificate; a re-run with the same certificate is fine, anything else is fatal.
+        register_cert() {
+          local out
+          if out=$(az ad app credential reset --id "$1" --cert "@$CERT_FILE" --append 2>&1 >/dev/null); then return 0; fi
+          if echo "$out" | grep -qi "exist"; then echo "Certificate already registered on $1."; return 0; fi
+          echo "$out" >&2; return 1
+        }
+        register_cert "$SIGNIN_APP_ID"
         az ad sp create --id "$SIGNIN_APP_ID" >/dev/null 2>&1 || true
         rm -f "$CERT_FILE"
 

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -266,6 +266,10 @@ public static class AzureCloudShellSetup
         CONSENT_GRANTED=false
         if az ad app permission admin-consent --id "$ACCESS_APP_ID" >/dev/null 2>&1; then
           CONSENT_GRANTED=true
+          # Same administrator can pre-consent the sign-in app's delegated sign-in scopes for everyone,
+          # so people never see a consent prompt. offline_access is implied by the code flow;
+          # Connapse stores no tokens, only the user's object id and tenant.
+          az ad app permission grant --id "$SIGNIN_APP_ID" --api "$GRAPH_API" --scope "openid profile offline_access" >/dev/null 2>&1 || true
         fi
         CONSENT_URL="https://login.microsoftonline.com/$TENANT_ID/adminconsent?client_id=$ACCESS_APP_ID&redirect_uri={{consentRedirectEncoded}}"
 

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -1,0 +1,208 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>Inputs the operator supplies (or Connapse derives) before generating the Azure setup script.</summary>
+/// <param name="SubscriptionId">The subscription the access identity is scoped to.</param>
+/// <param name="StorageScope">A storage-account resource id to scope the blob-data role to, or null/empty
+/// for subscription-wide.</param>
+/// <param name="RedirectUri">The sign-in app's redirect URI (Connapse's <c>/azure/callback</c>).</param>
+/// <param name="AccessAppName">Display name for the access app registration.</param>
+/// <param name="SignInAppName">Display name for the sign-in app registration.</param>
+/// <param name="PublicCertificatePem">The PUBLIC certificate to upload to both apps. The private key
+/// stays on the Connapse host and never appears in the script.</param>
+public sealed record AzureSetupInput(
+    string SubscriptionId,
+    string? StorageScope,
+    string RedirectUri,
+    string AccessAppName,
+    string SignInAppName,
+    string PublicCertificatePem);
+
+/// <summary>The non-secret identifiers a completed Azure setup returns.</summary>
+public sealed record AzureSetupResult(
+    string TenantId,
+    string SubscriptionId,
+    string AccessAppClientId,
+    string SignInAppClientId,
+    bool ConsentGranted,
+    string? ConsentUrl);
+
+/// <summary>
+/// Generates the Azure Cloud Shell (<c>az</c>) script that provisions Connapse's Azure access — two
+/// least-privilege custom roles, a certificate-authenticated access app, and an OIDC sign-in app — and
+/// parses the block it prints back. A pure string utility, mirroring <see cref="AwsRolesAnywhereSetup"/>.
+/// Only the PUBLIC certificate travels in the script; admin consent for the access app's Graph
+/// application permissions is attempted and, when the operator lacks the role, deferred to a URL.
+/// </summary>
+public static class AzureCloudShellSetup
+{
+    public const string BeginMarker = "----- BEGIN CONNAPSE AZURE SETUP -----";
+    public const string EndMarker = "----- END CONNAPSE AZURE SETUP -----";
+
+    /// <summary>The Microsoft Graph resource app id — stable across tenants.</summary>
+    public const string GraphAppId = "00000003-0000-0000-c000-000000000000";
+
+    public const string BlobDataRoleName = "Connapse Blob Data + Tags Reader";
+    public const string RbacReadRoleName = "Connapse RBAC Authorization Reader";
+
+    /// <summary>
+    /// Parses the block the script prints. Anchors on the LAST marker pair so pasting the whole terminal
+    /// (which echoes the script) still reads the printed output rather than the source. Returns null
+    /// unless the four ids are present and well-formed GUIDs.
+    /// </summary>
+    public static AzureSetupResult? ParseResult(string? pasted)
+    {
+        if (string.IsNullOrEmpty(pasted)) return null;
+
+        int end = pasted.LastIndexOf(EndMarker, StringComparison.Ordinal);
+        if (end < 0) return null;
+        int start = pasted.LastIndexOf(BeginMarker, end, StringComparison.Ordinal);
+        if (start < 0) return null;
+
+        string inner = pasted.Substring(start + BeginMarker.Length, end - start - BeginMarker.Length);
+
+        string? tenant = null, subscription = null, accessId = null, signInId = null,
+            consentGranted = null, consentUrl = null;
+        foreach (string line in inner.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            int eq = line.IndexOf('=');
+            if (eq <= 0) continue;
+            string key = line[..eq];
+            string value = line[(eq + 1)..].Trim();
+            switch (key)
+            {
+                case "tenantId": tenant = value; break;
+                case "subscriptionId": subscription = value; break;
+                case "accessAppClientId": accessId = value; break;
+                case "signInAppClientId": signInId = value; break;
+                case "consentGranted": consentGranted = value; break;
+                case "consentUrl": consentUrl = value; break;
+            }
+        }
+
+        // The four ids are the load-bearing values; all must be real GUIDs or the paste is malformed.
+        if (!Guid.TryParse(tenant, out _) || !Guid.TryParse(subscription, out _)
+            || !Guid.TryParse(accessId, out _) || !Guid.TryParse(signInId, out _))
+            return null;
+
+        return new AzureSetupResult(
+            tenant!, subscription!, accessId!, signInId!,
+            ConsentGranted: string.Equals(consentGranted, "true", StringComparison.OrdinalIgnoreCase),
+            ConsentUrl: string.IsNullOrWhiteSpace(consentUrl) ? null : consentUrl);
+    }
+
+    /// <summary>
+    /// The Cloud Shell script. Idempotent where it can be: custom roles are created only if absent, and
+    /// app/SP/permission steps tolerate re-runs. Prints a delimited block for Connapse to parse.
+    /// </summary>
+    public static string GenerateScript(AzureSetupInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        string cert = input.PublicCertificatePem.Replace("\r\n", "\n").Trim();
+        string storageScope = string.IsNullOrWhiteSpace(input.StorageScope)
+            ? "/subscriptions/" + input.SubscriptionId
+            : input.StorageScope!.Trim();
+
+        return Template
+            .Replace("{{subscription}}", Shell(input.SubscriptionId))
+            .Replace("{{storageScope}}", Shell(storageScope))
+            .Replace("{{redirectUri}}", Shell(input.RedirectUri))
+            .Replace("{{accessAppName}}", Shell(input.AccessAppName))
+            .Replace("{{signInAppName}}", Shell(input.SignInAppName))
+            .Replace("{{graphAppId}}", GraphAppId)
+            .Replace("{{blobRoleName}}", BlobDataRoleName)
+            .Replace("{{rbacRoleName}}", RbacReadRoleName)
+            .Replace("{{beginMarker}}", BeginMarker)
+            .Replace("{{endMarker}}", EndMarker)
+            .Replace("{{cert}}", cert);
+    }
+
+    /// <summary>Escapes a value for safe inclusion inside single quotes in the generated bash.</summary>
+    private static string Shell(string value) => value.Replace("'", "'\\''");
+
+    private const string Template = """
+        #!/usr/bin/env bash
+        # Connapse Azure setup — run this in Azure Cloud Shell (Bash). It provisions two app
+        # registrations and two least-privilege custom roles, then prints a block to paste back into
+        # Connapse. Safe to re-run. Only the PUBLIC certificate is here; Connapse keeps the private key.
+        set -euo pipefail
+
+        SUBSCRIPTION_ID='{{subscription}}'
+        STORAGE_SCOPE='{{storageScope}}'
+        REDIRECT_URI='{{redirectUri}}'
+        ACCESS_APP_NAME='{{accessAppName}}'
+        SIGNIN_APP_NAME='{{signInAppName}}'
+        GRAPH_API='{{graphAppId}}'
+
+        az account set --subscription "$SUBSCRIPTION_ID"
+        TENANT_ID=$(az account show --query tenantId -o tsv)
+
+        # Public certificate → a temp file for upload (removed at the end).
+        CERT_FILE=$(mktemp)
+        cat > "$CERT_FILE" <<'CONNAPSE_CERT_EOF'
+        {{cert}}
+        CONNAPSE_CERT_EOF
+
+        # --- Least-privilege custom roles (create only if absent) ---
+        if [ -z "$(az role definition list --name '{{blobRoleName}}' --query '[0].id' -o tsv 2>/dev/null)" ]; then
+          az role definition create --role-definition "{
+            \"Name\": \"{{blobRoleName}}\", \"IsCustom\": true,
+            \"Description\": \"Read blob content and blob index tags for Connapse.\",
+            \"Actions\": [], \"NotActions\": [], \"NotDataActions\": [],
+            \"DataActions\": [
+              \"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\",
+              \"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read\"
+            ],
+            \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
+          }" >/dev/null
+        fi
+        if [ -z "$(az role definition list --name '{{rbacRoleName}}' --query '[0].id' -o tsv 2>/dev/null)" ]; then
+          az role definition create --role-definition "{
+            \"Name\": \"{{rbacRoleName}}\", \"IsCustom\": true,
+            \"Description\": \"Read role and deny assignments at subscription scope for Connapse.\",
+            \"Actions\": [
+              \"Microsoft.Authorization/roleAssignments/read\",
+              \"Microsoft.Authorization/denyAssignments/read\"
+            ],
+            \"NotActions\": [], \"DataActions\": [], \"NotDataActions\": [],
+            \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
+          }" >/dev/null
+        fi
+
+        # --- Access app registration (certificate-authenticated) ---
+        ACCESS_APP_ID=$(az ad app create --display-name "$ACCESS_APP_NAME" --query appId -o tsv)
+        az ad app credential reset --id "$ACCESS_APP_ID" --cert "@$CERT_FILE" --append >/dev/null
+        az ad sp create --id "$ACCESS_APP_ID" >/dev/null 2>&1 || true
+
+        # Roles wait for the custom-role definitions + SP to propagate; retry briefly.
+        for i in 1 2 3 4 5; do
+          az role assignment create --assignee "$ACCESS_APP_ID" --role '{{blobRoleName}}' --scope "$STORAGE_SCOPE" >/dev/null 2>&1 && break || sleep 10
+        done
+        for i in 1 2 3 4 5; do
+          az role assignment create --assignee "$ACCESS_APP_ID" --role '{{rbacRoleName}}' --scope "/subscriptions/$SUBSCRIPTION_ID" >/dev/null 2>&1 && break || sleep 10
+        done
+
+        # Microsoft Graph application permissions (resolve the app-role ids live).
+        USER_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='User.Read.All'].id | [0]" -o tsv)
+        GROUP_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='GroupMember.Read.All'].id | [0]" -o tsv)
+        az ad app permission add --id "$ACCESS_APP_ID" --api "$GRAPH_API" --api-permissions "$USER_READ_ALL=Role" >/dev/null
+        az ad app permission add --id "$ACCESS_APP_ID" --api "$GRAPH_API" --api-permissions "$GROUP_READ_ALL=Role" >/dev/null
+
+        # --- Sign-in app registration (OIDC, certificate client-assertion) ---
+        SIGNIN_APP_ID=$(az ad app create --display-name "$SIGNIN_APP_NAME" --web-redirect-uris "$REDIRECT_URI" --query appId -o tsv)
+        az ad app credential reset --id "$SIGNIN_APP_ID" --cert "@$CERT_FILE" --append >/dev/null
+        az ad sp create --id "$SIGNIN_APP_ID" >/dev/null 2>&1 || true
+
+        rm -f "$CERT_FILE"
+
+        # --- Admin consent (Graph application permissions — Global Admin / Privileged Role Admin only) ---
+        CONSENT_GRANTED=false
+        if az ad app permission admin-consent --id "$ACCESS_APP_ID" >/dev/null 2>&1; then
+          CONSENT_GRANTED=true
+        fi
+        CONSENT_URL="https://login.microsoftonline.com/$TENANT_ID/adminconsent?client_id=$ACCESS_APP_ID"
+
+        echo
+        printf '%s\ntenantId=%s\nsubscriptionId=%s\naccessAppClientId=%s\nsignInAppClientId=%s\nconsentGranted=%s\nconsentUrl=%s\n%s\n' \
+          "{{beginMarker}}" "$TENANT_ID" "$SUBSCRIPTION_ID" "$ACCESS_APP_ID" "$SIGNIN_APP_ID" "$CONSENT_GRANTED" "$CONSENT_URL" "{{endMarker}}"
+        """;
+}

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -1,12 +1,9 @@
 namespace Connapse.Core.Utilities;
 
-/// <summary>Inputs for the Access step's script: the subscription and storage scope the access identity
-/// is granted on, and the PUBLIC certificate it authenticates with (the private key stays on the host).</summary>
-public sealed record AzureAccessSetupInput(
-    string SubscriptionId,
-    string? StorageScope,
-    string AccessAppName,
-    string PublicCertificatePem);
+/// <summary>Inputs for the Access step's script: the app name and the PUBLIC certificate it authenticates
+/// with (the private key stays on the host). The subscription is whichever one Cloud Shell is signed
+/// in to — the script reads it and prints it back, so the operator types nothing.</summary>
+public sealed record AzureAccessSetupInput(string AccessAppName, string PublicCertificatePem);
 
 /// <summary>The non-secret identifiers the Access script prints back.</summary>
 public sealed record AzureAccessResult(string TenantId, string SubscriptionId, string AccessAppClientId);
@@ -63,13 +60,7 @@ public static class AzureCloudShellSetup
     public static string GenerateAccessScript(AzureAccessSetupInput input)
     {
         ArgumentNullException.ThrowIfNull(input);
-        string storageScope = string.IsNullOrWhiteSpace(input.StorageScope)
-            ? "/subscriptions/" + input.SubscriptionId
-            : input.StorageScope!.Trim();
-
         return AccessTemplate
-            .Replace("{{subscription}}", Shell(input.SubscriptionId))
-            .Replace("{{storageScope}}", Shell(storageScope))
             .Replace("{{accessAppName}}", Shell(input.AccessAppName))
             .Replace("{{blobRoleName}}", BlobDataRoleName)
             .Replace("{{rbacRoleName}}", RbacReadRoleName)
@@ -161,14 +152,20 @@ public static class AzureCloudShellSetup
         # Connapse Azure setup — step 1 of 2 (Access). Run in Azure Cloud Shell (Bash). Creates two
         # least-privilege custom roles and Connapse's certificate-authenticated access app, then prints
         # a block to paste back into Connapse. Safe to re-run. Only the PUBLIC certificate is here.
+        #
+        # It uses the subscription Cloud Shell is signed in to. To use a different one, run
+        #   az account set --subscription <id>
+        # first. To limit the blob role to one storage account instead of the whole subscription,
+        # set STORAGE_SCOPE below to that storage account's resource id.
         set -euo pipefail
 
-        SUBSCRIPTION_ID='{{subscription}}'
-        STORAGE_SCOPE='{{storageScope}}'
         ACCESS_APP_NAME='{{accessAppName}}'
+        STORAGE_SCOPE=""
 
-        az account set --subscription "$SUBSCRIPTION_ID"
+        SUBSCRIPTION_ID=$(az account show --query id -o tsv)
         TENANT_ID=$(az account show --query tenantId -o tsv)
+        [ -n "$STORAGE_SCOPE" ] || STORAGE_SCOPE="/subscriptions/$SUBSCRIPTION_ID"
+        echo "Using subscription $SUBSCRIPTION_ID ($(az account show --query name -o tsv))"
 
         CERT_FILE=$(mktemp)
         cat > "$CERT_FILE" <<'CONNAPSE_CERT_EOF'

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -9,10 +9,13 @@ public sealed record AzureAccessSetupInput(string AccessAppName, string PublicCe
 public sealed record AzureAccessResult(string TenantId, string SubscriptionId, string AccessAppClientId);
 
 /// <summary>Inputs for the Per-user permissions step's script: which access app to grant Graph
-/// permissions on, the sign-in app's redirect URI, and the PUBLIC certificate for the sign-in app.</summary>
+/// permissions on, the sign-in app's redirect URI, the page Entra should bounce back to after admin
+/// consent (registered on the access app — without one, the consent endpoint refuses with
+/// AADSTS500113), and the PUBLIC certificate for the sign-in app.</summary>
 public sealed record AzurePermissionsSetupInput(
     string AccessAppClientId,
     string RedirectUri,
+    string ConsentRedirectUri,
     string SignInAppName,
     string PublicCertificatePem);
 
@@ -93,6 +96,8 @@ public static class AzureCloudShellSetup
         return PermissionsTemplate
             .Replace("{{accessAppId}}", Shell(input.AccessAppClientId))
             .Replace("{{redirectUri}}", Shell(input.RedirectUri))
+            .Replace("{{consentRedirectUri}}", Shell(input.ConsentRedirectUri))
+            .Replace("{{consentRedirectEncoded}}", Uri.EscapeDataString(input.ConsentRedirectUri))
             .Replace("{{signInAppName}}", Shell(input.SignInAppName))
             .Replace("{{graphAppId}}", GraphAppId)
             .Replace("{{beginMarker}}", PermissionsBeginMarker)
@@ -198,8 +203,9 @@ public static class AzureCloudShellSetup
           }" >/dev/null
         fi
 
-        # --- Access app registration (certificate-authenticated) ---
-        ACCESS_APP_ID=$(az ad app create --display-name "$ACCESS_APP_NAME" --query appId -o tsv)
+        # --- Access app registration (certificate-authenticated); reused by name on re-runs ---
+        ACCESS_APP_ID=$(az ad app list --display-name "$ACCESS_APP_NAME" --query '[0].appId' -o tsv)
+        [ -n "$ACCESS_APP_ID" ] || ACCESS_APP_ID=$(az ad app create --display-name "$ACCESS_APP_NAME" --query appId -o tsv)
         az ad app credential reset --id "$ACCESS_APP_ID" --cert "@$CERT_FILE" --append >/dev/null
         az ad sp create --id "$ACCESS_APP_ID" >/dev/null 2>&1 || true
         rm -f "$CERT_FILE"
@@ -227,6 +233,7 @@ public static class AzureCloudShellSetup
 
         ACCESS_APP_ID='{{accessAppId}}'
         REDIRECT_URI='{{redirectUri}}'
+        CONSENT_REDIRECT_URI='{{consentRedirectUri}}'
         SIGNIN_APP_NAME='{{signInAppName}}'
         GRAPH_API='{{graphAppId}}'
 
@@ -237,11 +244,17 @@ public static class AzureCloudShellSetup
         {{cert}}
         CONNAPSE_CERT_EOF
 
-        # --- Sign-in app registration (OIDC, certificate client-assertion) ---
-        SIGNIN_APP_ID=$(az ad app create --display-name "$SIGNIN_APP_NAME" --web-redirect-uris "$REDIRECT_URI" --query appId -o tsv)
+        # --- Sign-in app registration (OIDC, certificate client-assertion); reused by name on re-runs ---
+        SIGNIN_APP_ID=$(az ad app list --display-name "$SIGNIN_APP_NAME" --query '[0].appId' -o tsv)
+        [ -n "$SIGNIN_APP_ID" ] || SIGNIN_APP_ID=$(az ad app create --display-name "$SIGNIN_APP_NAME" --query appId -o tsv)
+        az ad app update --id "$SIGNIN_APP_ID" --web-redirect-uris "$REDIRECT_URI"
         az ad app credential reset --id "$SIGNIN_APP_ID" --cert "@$CERT_FILE" --append >/dev/null
         az ad sp create --id "$SIGNIN_APP_ID" >/dev/null 2>&1 || true
         rm -f "$CERT_FILE"
+
+        # The admin-consent page bounces back to a reply URL registered on the ACCESS app; without one
+        # Entra refuses with AADSTS500113. Connapse's Providers page is that landing spot.
+        az ad app update --id "$ACCESS_APP_ID" --web-redirect-uris "$CONSENT_REDIRECT_URI"
 
         # --- Microsoft Graph application permissions on the ACCESS app (ids resolved live) ---
         USER_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='User.Read.All'].id | [0]" -o tsv)
@@ -254,7 +267,7 @@ public static class AzureCloudShellSetup
         if az ad app permission admin-consent --id "$ACCESS_APP_ID" >/dev/null 2>&1; then
           CONSENT_GRANTED=true
         fi
-        CONSENT_URL="https://login.microsoftonline.com/$TENANT_ID/adminconsent?client_id=$ACCESS_APP_ID"
+        CONSENT_URL="https://login.microsoftonline.com/$TENANT_ID/adminconsent?client_id=$ACCESS_APP_ID&redirect_uri={{consentRedirectEncoded}}"
 
         echo
         printf '%s\nsignInAppClientId=%s\nconsentGranted=%s\nconsentUrl=%s\n%s\n' \

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -162,7 +162,12 @@ public static class AzureCloudShellSetup
         #   az account set --subscription <id>
         # first. To limit the blob role to one storage account instead of the whole subscription,
         # set STORAGE_SCOPE below to that storage account's resource id.
+        #
+        # Runs in a subshell so that pasting it into the interactive shell cannot close your
+        # session on an error: the failing command is printed and you stay signed in.
+        (
         set -euo pipefail
+        trap 'echo; echo "Connapse setup failed at: $BASH_COMMAND" >&2' ERR
 
         ACCESS_APP_NAME='{{accessAppName}}'
         STORAGE_SCOPE=""
@@ -239,6 +244,7 @@ public static class AzureCloudShellSetup
         echo
         printf '%s\ntenantId=%s\nsubscriptionId=%s\naccessAppClientId=%s\n%s\n' \
           "{{beginMarker}}" "$TENANT_ID" "$SUBSCRIPTION_ID" "$ACCESS_APP_ID" "{{endMarker}}"
+        ) || echo "----- CONNAPSE SETUP FAILED: read the error above. Nothing to paste back yet. -----"
         """;
 
     private const string PermissionsTemplate = """
@@ -247,7 +253,12 @@ public static class AzureCloudShellSetup
         # Creates the sign-in app people authenticate through and grants the access app the Microsoft
         # Graph permissions it reads the directory with. Admin consent needs a Global Administrator or
         # Privileged Role Administrator; if you are not one, the script prints a link to send them.
+        #
+        # Runs in a subshell so that pasting it into the interactive shell cannot close your
+        # session on an error: the failing command is printed and you stay signed in.
+        (
         set -euo pipefail
+        trap 'echo; echo "Connapse setup failed at: $BASH_COMMAND" >&2' ERR
 
         ACCESS_APP_ID='{{accessAppId}}'
         REDIRECT_URI='{{redirectUri}}'
@@ -301,5 +312,6 @@ public static class AzureCloudShellSetup
         echo
         printf '%s\nsignInAppClientId=%s\nconsentGranted=%s\nconsentUrl=%s\n%s\n' \
           "{{beginMarker}}" "$SIGNIN_APP_ID" "$CONSENT_GRANTED" "$CONSENT_URL" "{{endMarker}}"
+        ) || echo "----- CONNAPSE SETUP FAILED: read the error above. Nothing to paste back yet. -----"
         """;
 }

--- a/src/Connapse.Core/Utilities/AzureSetupRole.cs
+++ b/src/Connapse.Core/Utilities/AzureSetupRole.cs
@@ -1,0 +1,46 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Builds the <c>az role assignment</c> commands that grant Connapse's blob role on exactly the
+/// containers a connection allows — the Azure counterpart of <see cref="S3SetupPolicy.ForBuckets"/>.
+/// </summary>
+/// <remarks>
+/// Text an operator runs in Cloud Shell; Connapse never assigns a role itself. Aimed at operators
+/// whose access identity was granted subscription-wide by the easy setup and who want this
+/// connection's grant narrowed to what it reads. A prefix inside a container cannot be expressed
+/// as an RBAC scope, so the narrowest grant is the container; the connection's allowed-locations
+/// list still bounds reads below that.
+/// </remarks>
+public static class AzureSetupRole
+{
+    /// <summary>One command per distinct container, or one on the whole account when nothing is allowed yet.</summary>
+    /// <param name="accessClientId">The app (client) id of Connapse's access identity — the assignee.</param>
+    /// <param name="accountResourceId">The storage account's ARM resource id.</param>
+    /// <param name="locations">Allowed locations, each <c>container</c> or <c>container/prefix</c>.</param>
+    public static string AssignmentsFor(string accessClientId, string accountResourceId, IEnumerable<string> locations)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessClientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(accountResourceId);
+
+        var containers = locations
+            .Select(l => (l ?? string.Empty).Trim())
+            .Where(l => l.Length > 0)
+            .Select(l => l.IndexOf('/') is var slash && slash >= 0 ? l[..slash] : l)
+            .Select(c => c.Trim())
+            .Where(c => c.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(c => c, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        string account = accountResourceId.Trim().TrimEnd('/');
+        IEnumerable<string> scopes = containers.Count == 0
+            ? [account]
+            : containers.Select(c => $"{account}/blobServices/default/containers/{c}");
+
+        return string.Join("\n", scopes.Select(scope =>
+            $"az role assignment create --assignee '{Shell(accessClientId.Trim())}' "
+            + $"--role '{AzureCloudShellSetup.BlobDataRoleName}' --scope '{Shell(scope)}'"));
+    }
+
+    private static string Shell(string value) => value.Replace("'", "'\\''");
+}

--- a/src/Connapse.Identity/InternalsVisibleTo.cs
+++ b/src/Connapse.Identity/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Connapse.Identity.Tests")]

--- a/src/Connapse.Identity/Services/AzureOidcTokenExchanger.cs
+++ b/src/Connapse.Identity/Services/AzureOidcTokenExchanger.cs
@@ -62,7 +62,7 @@ public sealed class AzureOidcTokenExchanger(
     // asserting the client's own identity, signed with the certificate configured for Entra
     // rather than a shared secret. iss/sub are both the client id per the spec; aud is the
     // token endpoint being called.
-    private static string BuildClientAssertion(AzureAdSignInSettings settings, string tokenEndpoint)
+    internal static string BuildClientAssertion(AzureAdSignInSettings settings, string tokenEndpoint)
     {
         X509Certificate2 cert = LoadCertificate(settings)
             ?? throw new InvalidOperationException(
@@ -85,12 +85,8 @@ public sealed class AzureOidcTokenExchanger(
                 ["jti"] = Guid.NewGuid().ToString(),
             },
             // Entra identifies the signing cert by the base64url SHA-1 thumbprint in the `x5t`
-            // header, not by `kid` — set it explicitly rather than relying on default header
-            // population.
-            AdditionalHeaderClaims = new Dictionary<string, object>
-            {
-                ["x5t"] = Base64UrlEncoder.Encode(cert.GetCertHash()),
-            },
+            // header. JsonWebTokenHandler writes `x5t` (and `kid`) itself from X509SigningCredentials
+            // and rejects them in AdditionalHeaderClaims (IDX14116), so nothing is added here.
         };
 
         return Handler.CreateToken(descriptor);

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -1,0 +1,118 @@
+using Azure;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
+using Azure.ResourceManager.Storage;
+using Azure.Storage.Blobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Asks Azure what Connapse's own identity can see. Mirrors <see cref="S3Discovery"/>: the same
+/// credential every Azure client uses (<see cref="ConnapseAzureCredentials"/>), read-only calls,
+/// and a denial reported as advice rather than a fault.
+/// </summary>
+public sealed class AzureBlobDiscovery(
+    ConnapseAzureCredentials credentials,
+    IOptionsMonitor<AzureProviderSettings> options,
+    ILogger<AzureBlobDiscovery> logger) : IAzureBlobDiscovery
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(15);
+
+    public async Task<AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>> ListStorageAccountsAsync(
+        CancellationToken ct = default)
+    {
+        AzureProviderSettings settings = options.CurrentValue;
+        if (!IsConfigured(settings))
+            return AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>.NotConfigured(
+                "No Azure identity is set up — configure it on the Azure provider page.");
+        if (string.IsNullOrWhiteSpace(settings.SubscriptionId))
+            return AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>.NotConfigured(
+                "The Azure subscription is not set, so there is nowhere to list accounts from.");
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(Timeout);
+
+        try
+        {
+            var arm = new ArmClient(credentials);
+            SubscriptionResource subscription = arm.GetSubscriptionResource(
+                SubscriptionResource.CreateResourceIdentifier(settings.SubscriptionId.Trim()));
+
+            var accounts = new List<AzureStorageAccountInfo>();
+            await foreach (StorageAccountResource account in subscription.GetStorageAccountsAsync(timeout.Token))
+            {
+                StorageAccountData data = account.Data;
+                Uri? blob = data.PrimaryEndpoints?.BlobUri;
+                if (blob is null) continue; // no blob service (e.g. a files-only account)
+
+                accounts.Add(new AzureStorageAccountInfo(
+                    data.Name,
+                    blob.ToString().TrimEnd('/'),
+                    account.Id.ResourceGroupName ?? string.Empty,
+                    account.Id.ToString(),
+                    data.IsHnsEnabled == true));
+            }
+
+            accounts.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+            return AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>.Ok(accounts);
+        }
+        catch (RequestFailedException ex) when (IsDenial(ex))
+        {
+            // Expected when the subscription-wide reader role has not been assigned — the form
+            // falls back to asking for the account name.
+            logger.LogDebug("Listing storage accounts was denied — the identity has no subscription read");
+            return AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>.Denied(ex.Message);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            logger.LogWarning(ex, "Listing storage accounts failed");
+            return AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>.Failed(ex.Message);
+        }
+    }
+
+    public async Task<AzureProbe<IReadOnlyList<string>>> ListContainersAsync(
+        string blobEndpoint, CancellationToken ct = default)
+    {
+        if (!IsConfigured(options.CurrentValue))
+            return AzureProbe<IReadOnlyList<string>>.NotConfigured(
+                "No Azure identity is set up — configure it on the Azure provider page.");
+        if (!Uri.TryCreate(blobEndpoint?.Trim(), UriKind.Absolute, out Uri? endpoint))
+            return AzureProbe<IReadOnlyList<string>>.Failed("No storage account chosen.");
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(Timeout);
+
+        try
+        {
+            var service = new BlobServiceClient(endpoint, credentials);
+            var names = new List<string>();
+            await foreach (var container in service.GetBlobContainersAsync(cancellationToken: timeout.Token))
+                names.Add(container.Name);
+
+            names.Sort(StringComparer.OrdinalIgnoreCase);
+            return AzureProbe<IReadOnlyList<string>>.Ok(names);
+        }
+        catch (RequestFailedException ex) when (IsDenial(ex))
+        {
+            logger.LogDebug("Listing containers on {Endpoint} was denied", endpoint);
+            return AzureProbe<IReadOnlyList<string>>.Denied(ex.Message);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            logger.LogWarning(ex, "Listing containers on {Endpoint} failed", endpoint);
+            return AzureProbe<IReadOnlyList<string>>.Failed(ex.Message);
+        }
+    }
+
+    /// <summary>The same rule the Providers page uses for "Access is set up".</summary>
+    internal static bool IsConfigured(AzureProviderSettings s) =>
+        !string.IsNullOrWhiteSpace(s.TenantId)
+        && ((!string.IsNullOrWhiteSpace(s.ClientId) && !string.IsNullOrWhiteSpace(s.ClientCertificatePath))
+            || !string.IsNullOrWhiteSpace(s.UserAssignedManagedIdentityClientId));
+
+    internal static bool IsDenial(RequestFailedException ex) => ex.Status is 401 or 403;
+}

--- a/src/Connapse.Storage/CloudScope/AzureCertificateGenerator.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCertificateGenerator.cs
@@ -1,0 +1,39 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>A generated self-signed certificate: the public certificate (uploaded to Entra) and the
+/// combined PEM (certificate + private key) that Connapse stores on its host and authenticates with.</summary>
+public sealed record AzureCertificateMaterial(string PublicCertificatePem, string CombinedPem);
+
+/// <summary>
+/// Generates a self-signed certificate and RSA key locally for Connapse's Azure app registrations.
+/// Only <see cref="AzureCertificateMaterial.PublicCertificatePem"/> is uploaded to Entra (via the setup
+/// script); the private key never leaves the host — the same property as the AWS Roles Anywhere flow.
+/// Mirrors <see cref="RolesAnywhere.RolesAnywhereKeyGenerator"/>.
+/// </summary>
+public static class AzureCertificateGenerator
+{
+    /// <summary>Generates a 1-year self-signed certificate for <paramref name="commonName"/>.</summary>
+    public static AzureCertificateMaterial Generate(string commonName, TimeProvider? clock = null)
+    {
+        DateTimeOffset now = (clock ?? TimeProvider.System).GetUtcNow();
+
+        using RSA key = RSA.Create(2048);
+        var request = new CertificateRequest(
+            $"CN={commonName}", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        // The certificate signs the client assertion Connapse presents to Entra.
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, critical: false));
+
+        using X509Certificate2 certificate = request.CreateSelfSigned(now.AddDays(-1), now.AddYears(1));
+
+        string publicPem = certificate.ExportCertificatePem();
+        string privateKeyPem = key.ExportPkcs8PrivateKeyPem();
+
+        // One PEM holding both, which X509Certificate2.CreateFromPemFile reads back as cert + key.
+        string combined = publicPem + "\n" + privateKeyPem + "\n";
+        return new AzureCertificateMaterial(publicPem, combined);
+    }
+}

--- a/src/Connapse.Storage/Connapse.Storage.csproj
+++ b/src/Connapse.Storage/Connapse.Storage.csproj
@@ -13,7 +13,8 @@
     <PackageReference Include="AWSSDK.SSO" Version="4.0.2.14" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.15" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Azure.Identity" Version="1.16.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.ResourceManager.Storage" Version="1.7.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.22.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">

--- a/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
+++ b/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
@@ -1,5 +1,6 @@
 using Azure.Core;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
@@ -34,12 +35,29 @@ public sealed class AzureBlobConnector : IConnector, IDisposable
 
     public string ResolveJobPath(string relativePath) => CombinePrefix(relativePath);
 
+    /// <summary>
+    /// Whether a listed blob is a directory rather than a file: a Gen2 directory (marked
+    /// <c>hdi_isfolder</c>) or a flat-namespace folder marker (a name ending in <c>/</c>). Either
+    /// one ingested as a file is an empty document with no extension.
+    /// </summary>
+    internal static bool IsDirectoryPlaceholder(string name, IDictionary<string, string>? metadata)
+    {
+        if (name.EndsWith('/')) return true;
+        return metadata is not null
+            && metadata.TryGetValue("hdi_isfolder", out string? isFolder)
+            && string.Equals(isFolder, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
     public async Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
     {
         string effective = CombinePrefix(prefix ?? "");
         var files = new List<ConnectorFile>();
-        await foreach (var item in _container.GetBlobsAsync(prefix: effective, cancellationToken: ct))
+        // Metadata is requested because on a Data Lake Gen2 (hierarchical namespace) account a flat
+        // listing returns each directory as a zero-byte blob whose only tell is hdi_isfolder=true.
+        await foreach (var item in _container.GetBlobsAsync(BlobTraits.Metadata, BlobStates.None, effective, ct))
         {
+            if (IsDirectoryPlaceholder(item.Name, item.Metadata)) continue;
+
             files.Add(new ConnectorFile(
                 item.Name,
                 item.Properties.ContentLength ?? 0,

--- a/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
+++ b/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
@@ -40,8 +40,11 @@ public sealed class AzureBlobConnector : IConnector, IDisposable
     /// <c>hdi_isfolder</c>) or a flat-namespace folder marker (a name ending in <c>/</c>). Either
     /// one ingested as a file is an empty document with no extension.
     /// </summary>
-    internal static bool IsDirectoryPlaceholder(string name, IDictionary<string, string>? metadata)
+    internal static bool IsDirectoryPlaceholder(string name, long? contentLength, IDictionary<string, string>? metadata)
     {
+        // A directory never has content. A blob that does is a file whatever its name or metadata
+        // says — both are application-controlled on a flat-namespace account.
+        if (contentLength is > 0) return false;
         if (name.EndsWith('/')) return true;
         return metadata is not null
             && metadata.TryGetValue("hdi_isfolder", out string? isFolder)
@@ -56,7 +59,7 @@ public sealed class AzureBlobConnector : IConnector, IDisposable
         // listing returns each directory as a zero-byte blob whose only tell is hdi_isfolder=true.
         await foreach (var item in _container.GetBlobsAsync(BlobTraits.Metadata, BlobStates.None, effective, ct))
         {
-            if (IsDirectoryPlaceholder(item.Name, item.Metadata)) continue;
+            if (IsDirectoryPlaceholder(item.Name, item.Properties.ContentLength, item.Metadata)) continue;
 
             files.Add(new ConnectorFile(
                 item.Name,

--- a/src/Connapse.Storage/Connectors/S3Connector.cs
+++ b/src/Connapse.Storage/Connectors/S3Connector.cs
@@ -79,7 +79,7 @@ public class S3Connector : IConnector, IDisposable
                 if (obj.Key == effectivePrefix) continue;
                 // A "folder" made in the S3 console is a zero-byte key ending in "/". It is not a
                 // file, and ingested as one it is an empty document with no extension.
-                if (obj.Key.EndsWith('/')) continue;
+                if (obj.Key.EndsWith('/') && (obj.Size ?? 0) == 0) continue;
                 // Return virtual path: strip config prefix, ensure leading /
                 var virtualPath = StripConfigPrefix(obj.Key);
                 files.Add(new ConnectorFile(

--- a/src/Connapse.Storage/Connectors/S3Connector.cs
+++ b/src/Connapse.Storage/Connectors/S3Connector.cs
@@ -77,6 +77,9 @@ public class S3Connector : IConnector, IDisposable
             foreach (var obj in response.S3Objects ?? [])
             {
                 if (obj.Key == effectivePrefix) continue;
+                // A "folder" made in the S3 console is a zero-byte key ending in "/". It is not a
+                // file, and ingested as one it is an empty document with no extension.
+                if (obj.Key.EndsWith('/')) continue;
                 // Return virtual path: strip config prefix, ensure leading /
                 var virtualPath = StripConfigPrefix(obj.Key);
                 files.Add(new ConnectorFile(

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -258,6 +258,7 @@ public static class ServiceCollectionExtensions
         services.Configure<AzureVerifierSettings>(configuration.GetSection(AzureVerifierSettings.SectionName));
 
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
+        services.AddSingleton<IAzureBlobDiscovery, CloudScope.AzureBlobDiscovery>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();
         services.AddSingleton<IAccessGrantsReader, CloudScope.S3AccessGrantsReader>();
 

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -549,7 +549,10 @@
                 </div>
             }
 
-            <div class="col-12" style="max-width:32rem">
+            @* One full-width column with the fields stacked inside it. As sibling capped columns
+               they float up beside Name and Provider on a wide screen. *@
+            <div class="col-12">
+              <div style="max-width:32rem">
                 <label class="form-label" for="azure-account-name">Storage account name</label>
                 <input id="azure-account-name" class="form-control font-monospace" @bind="form.StorageAccountName"
                        @bind:after="AccountNameChanged"
@@ -635,9 +638,9 @@
                         as its role assignments.
                     </div>
                 }
-            </div>
+              </div>
 
-            <div class="col-12" style="max-width:32rem">
+              <div class="mt-3" style="max-width:32rem">
                 <label class="form-label" for="azure-blob-endpoint">
                     Blob endpoint <span class="text-muted">(optional)</span>
                 </label>
@@ -648,6 +651,7 @@
                     Set only to override the default endpoint above — for example, to point at
                     Azurite or another local emulator.
                 </div>
+              </div>
             </div>
         }
         else if (form.Provider == ConnectionProvider.Sftp)

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -18,6 +18,8 @@
 @inject AzureBlobConnectionTester AzureBlobTester
 @inject SftpConnectionTester SftpTester
 @inject IS3Discovery S3Discovery
+@inject IAzureBlobDiscovery AzureDiscovery
+@inject IOptionsMonitor<AzureProviderSettings> AzureProviderOptions
 @inject IProviderSetupReader SetupReader
 
 @*
@@ -524,14 +526,115 @@
         }
         else if (form.Provider == ConnectionProvider.AzureBlob)
         {
+            @* The same notice the S3 form shows, for the same reason: whether Connapse can reach
+               Azure at all is a property of the deployment, set on the provider page. *@
+            @if (azureAccess is RequirementStatus.NotConfigured or RequirementStatus.Failed
+                                or RequirementStatus.Provisioning or RequirementStatus.Warning)
+            {
+                <div class="col-12">
+                    <div class="alert @(azureAccess == RequirementStatus.Warning ? "alert-secondary" : "alert-warning") d-flex flex-wrap align-items-center gap-2 py-2 mb-0 small">
+                        <span class="bi-cloud-fill"></span>
+                        <span class="flex-grow-1">
+                            @(azureAccess switch
+                            {
+                                RequirementStatus.Warning =>
+                                    "Connapse cannot confirm what its Azure identity reaches. Test this connection to be sure.",
+                                _ => "Connapse cannot read Azure Blob Storage yet — its Azure identity is set up on the provider page, not here."
+                            })
+                        </span>
+                        <a class="btn btn-outline-secondary btn-sm" href="/admin/providers/azure">
+                            Azure setup <span class="bi-box-arrow-up-right ms-1 small"></span>
+                        </a>
+                    </div>
+                </div>
+            }
+
             <div class="col-12" style="max-width:32rem">
                 <label class="form-label" for="azure-account-name">Storage account name</label>
                 <input id="azure-account-name" class="form-control font-monospace" @bind="form.StorageAccountName"
+                       @bind:after="AccountNameChanged"
                        placeholder="mystorageaccount" aria-describedby="azure-account-name-help" />
                 <div id="azure-account-name-help" class="form-text">
                     Connapse reaches it as its own Azure identity — no key or connection string is
                     entered here.
                 </div>
+
+                @* The list, rather than a name typed from memory — the Azure counterpart of the
+                   bucket picker. Listing needs subscription-wide storage-account read, which the
+                   easy setup grants; a denial reads as "type it", not as a fault. *@
+                <div class="mt-2 position-relative">
+                    <button type="button" class="btn btn-sm btn-outline-secondary"
+                            aria-expanded="@(accountPickerOpen ? "true" : "false")"
+                            aria-controls="account-picker"
+                            @onclick="ToggleAccountPicker" disabled="@listingAccounts">
+                        @if (listingAccounts)
+                        {
+                            <span class="spinner-border spinner-border-sm me-1"></span>
+                        }
+                        else
+                        {
+                            <span class="bi-list-ul me-1"></span>
+                        }
+                        <span>Choose from storage accounts Connapse can see</span>
+                        <span class="@(accountPickerOpen ? "bi-chevron-up" : "bi-chevron-down") ms-1 small"></span>
+                    </button>
+
+                    @if (accountPickerOpen)
+                    {
+                        <div id="account-picker" class="card mt-1 shadow-sm">
+                            <div class="card-body p-2">
+                                <label class="form-label small mb-1" for="account-search">Search storage accounts</label>
+                                <input id="account-search" class="form-control form-control-sm mb-2"
+                                       placeholder="Part of an account name"
+                                       @bind="accountFilter" @bind:event="oninput" />
+
+                                @if (!string.IsNullOrEmpty(accountListMessage))
+                                {
+                                    <div class="small text-muted px-1 py-2">@accountListMessage</div>
+                                }
+                                else if (MatchingAccounts() is { Count: 0 })
+                                {
+                                    <div class="small text-muted px-1 py-2">
+                                        No storage account matches “@accountFilter”.
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="list-group list-group-flush overflow-auto" style="max-height:14rem">
+                                        @foreach (var account in MatchingAccounts())
+                                        {
+                                            bool chosen = string.Equals(account.Name, form.StorageAccountName?.Trim(), StringComparison.OrdinalIgnoreCase);
+                                            <button type="button"
+                                                    class="list-group-item list-group-item-action d-flex align-items-center gap-2 py-1 px-2"
+                                                    @onclick="() => ChooseAccount(account)">
+                                                <span class="@(chosen ? "bi-check-lg text-success" : "bi-plus-lg text-primary") small"></span>
+                                                <code class="text-break">@account.Name</code>
+                                                <span class="small text-muted flex-grow-1 text-truncate">@account.ResourceGroup</span>
+                                                @if (account.IsHnsEnabled)
+                                                {
+                                                    <span class="badge text-bg-info">Data Lake Gen2</span>
+                                                }
+                                            </button>
+                                        }
+                                    </div>
+                                    <div class="form-text px-1 mb-0">
+                                        @MatchingAccounts().Count of @(discoveredAccounts?.Count ?? 0)
+                                        storage account@(discoveredAccounts?.Count == 1 ? "" : "s")
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                @if (SelectedAccount() is { IsHnsEnabled: true })
+                {
+                    <div class="form-text">
+                        <span class="badge text-bg-info me-1">Data Lake Gen2</span>
+                        Hierarchical namespace: per-user results follow this account's POSIX ACLs as well
+                        as its role assignments.
+                    </div>
+                }
             </div>
 
             <div class="col-12" style="max-width:32rem">
@@ -814,6 +917,76 @@
                         }
                     </div>
                 }
+                else if (form.Provider == ConnectionProvider.AzureBlob)
+                {
+                    @* The container picker, mirroring the bucket picker above. *@
+                    <div class="mt-2 position-relative" style="max-width:32rem">
+                        <button type="button" class="btn btn-sm btn-outline-secondary"
+                                aria-expanded="@(containerPickerOpen ? "true" : "false")"
+                                aria-controls="container-picker"
+                                @onclick="ToggleContainerPicker"
+                                disabled="@(listingContainers || string.IsNullOrWhiteSpace(form.StorageAccountName))">
+                            @if (listingContainers)
+                            {
+                                <span class="spinner-border spinner-border-sm me-1"></span>
+                            }
+                            else
+                            {
+                                <span class="bi-list-ul me-1"></span>
+                            }
+                            <span>Choose from containers Connapse can see</span>
+                            <span class="@(containerPickerOpen ? "bi-chevron-up" : "bi-chevron-down") ms-1 small"></span>
+                        </button>
+
+                        @if (containerPickerOpen)
+                        {
+                            <div id="container-picker" class="card mt-1 shadow-sm">
+                                <div class="card-body p-2">
+                                    <label class="form-label small mb-1" for="container-search">Search containers</label>
+                                    <input id="container-search" class="form-control form-control-sm mb-2"
+                                           placeholder="Part of a container name"
+                                           @bind="containerFilter" @bind:event="oninput"
+                                           @onkeydown="ContainerSearchKey" />
+
+                                    @if (!string.IsNullOrEmpty(containerListMessage))
+                                    {
+                                        <div class="small text-muted px-1 py-2">@containerListMessage</div>
+                                    }
+                                    else if (MatchingContainers() is { Count: 0 })
+                                    {
+                                        <div class="small text-muted px-1 py-2">
+                                            No container matches “@containerFilter”.
+                                        </div>
+                                    }
+                                    else
+                                    {
+                                        <div class="list-group list-group-flush overflow-auto" style="max-height:14rem">
+                                            @foreach (string container in MatchingContainers())
+                                            {
+                                                bool already = IsAllowed(container);
+                                                <button type="button"
+                                                        class="list-group-item list-group-item-action d-flex align-items-center gap-2 py-1 px-2"
+                                                        disabled="@already"
+                                                        @onclick="() => AllowContainer(container)">
+                                                    <span class="@(already ? "bi-check-lg text-success" : "bi-plus-lg text-primary") small"></span>
+                                                    <code class="flex-grow-1 text-start text-break">@container</code>
+                                                    @if (already)
+                                                    {
+                                                        <span class="small text-muted">added</span>
+                                                    }
+                                                </button>
+                                            }
+                                        </div>
+                                        <div class="form-text px-1 mb-0">
+                                            @MatchingContainers().Count of @(discoveredContainers?.Count ?? 0)
+                                            container@(discoveredContainers?.Count == 1 ? "" : "s")
+                                        </div>
+                                    }
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
 
                 @* Offered once something is allowed, because until then there is nothing to scope
                    a policy to. Aimed at operators whose credential currently allows more than this
@@ -831,6 +1004,25 @@
                             writes to a source. Attach this to narrow a credential that currently
                             allows more, at the cost of a return trip to AWS for every bucket added
                             after it.
+                        </div>
+                    </details>
+                }
+
+                @* The Azure counterpart: role assignments on exactly the chosen containers, for an
+                   identity the easy setup granted subscription-wide. *@
+                @if (form.Provider == ConnectionProvider.AzureBlob && AzureRoleForAllowed() is { } roleCommands)
+                {
+                    <details class="mt-2">
+                        <summary class="small text-muted" style="cursor:pointer">
+                            Role assignments granting exactly this access
+                        </summary>
+                        <pre class="bg-body-tertiary border rounded p-2 small mt-2 mb-1" style="max-height:20rem;overflow:auto"><code>@roleCommands</code></pre>
+                        <div class="form-text">
+                            Reads only — Connapse's blob role on each container named above, run in
+                            Azure Cloud Shell. A prefix inside a container cannot be an RBAC scope, so
+                            the container is the narrowest grant; the allowed locations still bound
+                            reads below it. To narrow an identity granted across the subscription,
+                            remove that wider assignment after adding these.
                         </div>
                     </details>
                 }
@@ -925,6 +1117,11 @@
                         <a class="alert-link ms-1" target="_blank" rel="noopener"
                            href="https://github.com/Destrayon/Connapse/blob/main/docs/aws-setup.md#troubleshooting">Troubleshooting</a>
                     }
+                    @if (!testSuccess && form.Provider == ConnectionProvider.AzureBlob)
+                    {
+                        <a class="alert-link ms-1" target="_blank" rel="noopener"
+                           href="https://github.com/Destrayon/Connapse/blob/main/docs/azure-setup.md#troubleshooting">Troubleshooting</a>
+                    }
                     @if (!testSuccess && testDetail is { Length: > 0 })
                     {
                         <details class="mt-1">
@@ -1009,8 +1206,11 @@
 
         try
         {
-            var aws = (await SetupReader.ReadAsync()).FirstOrDefault(p => p.Key == "aws");
+            var setups = await SetupReader.ReadAsync();
+            var aws = setups.FirstOrDefault(p => p.Key == "aws");
             awsAccess = aws?.Requirements.FirstOrDefault(r => r.Name == "Access")?.Status;
+            var azure = setups.FirstOrDefault(p => p.Key == "azure");
+            azureAccess = azure?.Requirements.FirstOrDefault(r => r.Name == "Access")?.Status;
         }
         catch
         {
@@ -1237,6 +1437,194 @@
         catch
         {
             // Left blank on purpose. A region nobody could look up is one somebody can type.
+        }
+    }
+
+    // ── Azure Blob discovery — the same shape as the S3 pieces above ──────────────────────────
+
+    private RequirementStatus? azureAccess;
+
+    private IReadOnlyList<AzureStorageAccountInfo>? discoveredAccounts;
+    private bool listingAccounts;
+    private string? accountListMessage;
+    private bool accountPickerOpen;
+    private string? accountFilter;
+
+    private IReadOnlyList<string>? discoveredContainers;
+    private bool listingContainers;
+    private string? containerListMessage;
+    private bool containerPickerOpen;
+    private string? containerFilter;
+
+    private IReadOnlyList<AzureStorageAccountInfo> MatchingAccounts()
+    {
+        var all = discoveredAccounts ?? [];
+        if (string.IsNullOrWhiteSpace(accountFilter)) return all;
+
+        return [.. all.Where(a => a.Name.Contains(accountFilter.Trim(), StringComparison.OrdinalIgnoreCase)
+                                || a.ResourceGroup.Contains(accountFilter.Trim(), StringComparison.OrdinalIgnoreCase))];
+    }
+
+    private IReadOnlyList<string> MatchingContainers()
+    {
+        var all = discoveredContainers ?? [];
+        if (string.IsNullOrWhiteSpace(containerFilter)) return all;
+
+        return [.. all.Where(c => c.Contains(containerFilter.Trim(), StringComparison.OrdinalIgnoreCase))];
+    }
+
+    /// <summary>The account the form names, as discovery described it — null when unknown.</summary>
+    private AzureStorageAccountInfo? SelectedAccount() =>
+        discoveredAccounts?.FirstOrDefault(a =>
+            string.Equals(a.Name, form.StorageAccountName?.Trim(), StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>The endpoint the connection will use: the override if set, else the public default.</summary>
+    private string? AzureEndpointForForm()
+    {
+        if (!string.IsNullOrWhiteSpace(form.BlobEndpoint)) return form.BlobEndpoint.Trim();
+        string? name = form.StorageAccountName?.Trim();
+        return string.IsNullOrWhiteSpace(name) ? null : $"https://{name}.blob.core.windows.net";
+    }
+
+    /// <summary>A different account means a different set of containers.</summary>
+    private void AccountNameChanged()
+    {
+        discoveredContainers = null;
+        containerPickerOpen = false;
+    }
+
+    private async Task ToggleAccountPicker()
+    {
+        accountPickerOpen = !accountPickerOpen;
+        if (!accountPickerOpen) return;
+
+        if (discoveredAccounts is null)
+            await ListAccounts();
+    }
+
+    private async Task ListAccounts()
+    {
+        listingAccounts = true;
+        accountListMessage = null;
+        try
+        {
+            var probe = await AzureDiscovery.ListStorageAccountsAsync();
+
+            discoveredAccounts = probe.Value;
+            accountListMessage = probe.Outcome switch
+            {
+                AzureProbeOutcome.Succeeded when probe.Value is { Count: 0 } =>
+                    "No storage accounts in this subscription.",
+                AzureProbeOutcome.Succeeded => null,
+                AzureProbeOutcome.NotConfigured =>
+                    "Connapse has no Azure identity yet — set one up on the Azure provider page.",
+                AzureProbeOutcome.Denied =>
+                    "This identity may not list storage accounts, so type the name instead.",
+                _ => probe.Detail
+            };
+        }
+        finally
+        {
+            listingAccounts = false;
+        }
+    }
+
+    /// <summary>Fills the account from the list; the endpoint only when it is not the public default.</summary>
+    private void ChooseAccount(AzureStorageAccountInfo account)
+    {
+        form.StorageAccountName = account.Name;
+        string publicDefault = $"https://{account.Name}.blob.core.windows.net";
+        form.BlobEndpoint = string.Equals(account.BlobEndpoint, publicDefault, StringComparison.OrdinalIgnoreCase)
+            ? null
+            : account.BlobEndpoint;
+        accountPickerOpen = false;
+        AccountNameChanged();
+    }
+
+    private async Task ToggleContainerPicker()
+    {
+        containerPickerOpen = !containerPickerOpen;
+        if (!containerPickerOpen) return;
+
+        if (discoveredContainers is null)
+            await ListContainers();
+    }
+
+    private async Task ListContainers()
+    {
+        listingContainers = true;
+        containerListMessage = null;
+        try
+        {
+            var probe = await AzureDiscovery.ListContainersAsync(AzureEndpointForForm() ?? "");
+
+            discoveredContainers = probe.Value;
+            containerListMessage = probe.Outcome switch
+            {
+                AzureProbeOutcome.Succeeded when probe.Value is { Count: 0 } =>
+                    "No containers in this storage account.",
+                AzureProbeOutcome.Succeeded => null,
+                AzureProbeOutcome.NotConfigured =>
+                    "Connapse has no Azure identity yet — set one up on the Azure provider page.",
+                AzureProbeOutcome.Denied =>
+                    "This identity may not list containers here, so type the name instead.",
+                _ => probe.Detail
+            };
+        }
+        finally
+        {
+            listingContainers = false;
+        }
+    }
+
+    private Task ContainerSearchKey(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            containerPickerOpen = false;
+            return Task.CompletedTask;
+        }
+
+        if (e.Key != "Enter") return Task.CompletedTask;
+
+        string? first = MatchingContainers().FirstOrDefault(c => !IsAllowed(c));
+        if (first is not null) AllowContainer(first);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Appends a container to the allowlist, the same way a bucket is added above.</summary>
+    private void AllowContainer(string container)
+    {
+        if (IsAllowed(container)) return;
+
+        var entries = AllowedList().ToList();
+        entries.Add(container);
+        form.AllowedLocations = string.Join("\n", entries);
+
+        if (string.IsNullOrWhiteSpace(probeTarget))
+            probeTarget = container;
+
+        if (string.IsNullOrWhiteSpace(form.Name))
+            form.Name = container;
+    }
+
+    /// <summary>Role assignments for whatever is currently allowed, once the account is known.</summary>
+    private string? AzureRoleForAllowed()
+    {
+        var list = AllowedList();
+        if (list.Count == 0) return null;
+
+        string? clientId = AzureProviderOptions.CurrentValue.ClientId;
+        string? accountId = SelectedAccount()?.ResourceId;
+        if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(accountId)) return null;
+
+        try
+        {
+            return AzureSetupRole.AssignmentsFor(clientId, accountId, list);
+        }
+        catch (ArgumentException)
+        {
+            return null;
         }
     }
 

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -645,6 +645,7 @@
                     Blob endpoint <span class="text-muted">(optional)</span>
                 </label>
                 <input id="azure-blob-endpoint" class="form-control font-monospace" @bind="form.BlobEndpoint"
+                       @bind:after="AccountNameChanged"
                        placeholder="@($"https://{(string.IsNullOrWhiteSpace(form.StorageAccountName) ? "account" : form.StorageAccountName)}.blob.core.windows.net")"
                        aria-describedby="azure-blob-endpoint-help" />
                 <div id="azure-blob-endpoint-help" class="form-text">
@@ -1455,6 +1456,10 @@
     private string? accountFilter;
 
     private IReadOnlyList<string>? discoveredContainers;
+
+    /// <summary>The endpoint <see cref="discoveredContainers"/> was listed from. A different endpoint
+    /// — the account name or the override changed — means a different set of containers.</summary>
+    private string? discoveredContainersFor;
     private bool listingContainers;
     private string? containerListMessage;
     private bool containerPickerOpen;
@@ -1550,18 +1555,24 @@
         containerPickerOpen = !containerPickerOpen;
         if (!containerPickerOpen) return;
 
-        if (discoveredContainers is null)
+        if (discoveredContainers is null || discoveredContainersFor != AzureEndpointForForm())
             await ListContainers();
     }
 
     private async Task ListContainers()
     {
+        string endpoint = AzureEndpointForForm() ?? "";
         listingContainers = true;
         containerListMessage = null;
         try
         {
-            var probe = await AzureDiscovery.ListContainersAsync(AzureEndpointForForm() ?? "");
+            var probe = await AzureDiscovery.ListContainersAsync(endpoint);
 
+            // The account may have changed while the request was in flight; a list for the old
+            // endpoint must not be offered as the new one's.
+            if (endpoint != (AzureEndpointForForm() ?? "")) return;
+
+            discoveredContainersFor = endpoint;
             discoveredContainers = probe.Value;
             containerListMessage = probe.Outcome switch
             {

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1142,7 +1142,7 @@
                                     <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
                                     <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
                                 </a>
-                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="GenerateAzureAccessScript">
+                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="NewAzureAccessCertificate">
                                     <span class="bi-arrow-repeat me-1" aria-hidden="true"></span> New certificate
                                 </button>
                                 <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
@@ -1291,7 +1291,7 @@
                                     <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
                                     <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
                                 </a>
-                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="GenerateAzurePermissionsScript">
+                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="NewAzureSignInCertificate">
                                     <span class="bi-arrow-repeat me-1" aria-hidden="true"></span> New certificate
                                 </button>
                                 <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
@@ -2214,9 +2214,11 @@
 
     /// <summary>Generates a fresh certificate on this host and the Access script that uploads only its
     /// public half. The material is held until the operator saves the pasted-back result.</summary>
-    private void GenerateAzureAccessScript()
+    private void NewAzureAccessCertificate() => GenerateAzureAccessScript(newCertificate: true);
+
+    private void GenerateAzureAccessScript(bool newCertificate)
     {
-        azureAccessCert = AzureCertificateGenerator.Generate("connapse-azure-access");
+        azureAccessCert = LoadOrMintAzureCertificate(AzureAccessCertFile, "connapse-azure-access", newCertificate);
         azureAccessScript = AzureCloudShellSetup.GenerateAccessScript(new AzureAccessSetupInput(
             AccessAppName: "Connapse-Azure-Access",
             PublicCertificatePem: azureAccessCert.PublicCertificatePem));
@@ -2226,9 +2228,11 @@
 
     /// <summary>The sign-in app gets its own certificate; the script also grants the saved access app
     /// its Graph permissions, which is why this step waits for the Access step.</summary>
-    private void GenerateAzurePermissionsScript()
+    private void NewAzureSignInCertificate() => GenerateAzurePermissionsScript(newCertificate: true);
+
+    private void GenerateAzurePermissionsScript(bool newCertificate)
     {
-        azureSignInCert = AzureCertificateGenerator.Generate("connapse-azure-signin");
+        azureSignInCert = LoadOrMintAzureCertificate(AzureSignInCertFile, "connapse-azure-signin", newCertificate);
         BuildAzurePermissionsScript();
         azurePermissionsPasted = null;
         copyMessage = null;
@@ -2258,12 +2262,45 @@
     // renders rather than behind a button. Nothing touches disk until Save.
     private void EnsureAzureAccessScript()
     {
-        if (azureAccessScript is null) GenerateAzureAccessScript();
+        if (azureAccessScript is null) GenerateAzureAccessScript(newCertificate: false);
     }
 
     private void EnsureAzurePermissionsScript()
     {
-        if (azurePermissionsScript is null) GenerateAzurePermissionsScript();
+        if (azurePermissionsScript is null) GenerateAzurePermissionsScript(newCertificate: false);
+    }
+
+    private const string AzureAccessCertFile = "connapse-azure-access.pem";
+    private const string AzureSignInCertFile = "connapse-azure-signin.pem";
+
+    /// <summary>
+    /// The certificate a script embeds must be the one Connapse later signs with — across page reloads
+    /// and restarts, which happen between copying a script and pasting its result back. So it lives on
+    /// disk from the moment it is minted, and the guide re-reads that file on later renders instead of
+    /// minting again. Only "New certificate" replaces it. A daemon-app key nothing is registered
+    /// against yet is harmless to keep on disk.
+    /// </summary>
+    private AzureCertificateMaterial LoadOrMintAzureCertificate(string fileName, string commonName, bool newCertificate)
+    {
+        string path = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
+        if (!newCertificate && File.Exists(path))
+        {
+            try
+            {
+                string combined = File.ReadAllText(path);
+                using var existing = System.Security.Cryptography.X509Certificates.X509Certificate2.CreateFromPem(combined);
+                return new AzureCertificateMaterial(existing.ExportCertificatePem(), combined);
+            }
+            catch (Exception ex) when (ex is System.Security.Cryptography.CryptographicException or IOException)
+            {
+                // Unreadable file: fall through and mint a fresh one over it.
+            }
+        }
+
+        AzureCertificateMaterial minted = AzureCertificateGenerator.Generate(commonName);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, minted.CombinedPem);
+        return minted;
     }
 
     private async Task CopyText(string text)

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1547,6 +1547,22 @@
         // The sign-in app's redirect URI is Connapse's Entra callback at the address this admin reached
         // it on; pre-fill the subscription from whatever is already stored.
         easyRedirectUri = Navigation.BaseUri.TrimEnd('/') + "/api/v1/auth/cloud/azure/callback";
+
+        // Returning from Entra's admin-consent page: it bounces back here with ?admin_consent=True
+        // (or ?error=...&error_description=...). Surface which, so "pending" doesn't linger.
+        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(new Uri(Navigation.Uri).Query);
+        if (query.TryGetValue("admin_consent", out var consent)
+            && string.Equals(consent.ToString(), "True", StringComparison.OrdinalIgnoreCase))
+        {
+            saveMessage = "Admin consent granted — Connapse can now look people and groups up in Entra.";
+            saveSuccess = true;
+        }
+        else if (query.TryGetValue("error", out var consentError))
+        {
+            string detail = query.TryGetValue("error_description", out var description) ? description.ToString() : consentError.ToString();
+            saveMessage = $"Admin consent was not granted: {LogSanitizer.Sanitize(detail)}";
+            saveSuccess = false;
+        }
     }
 
     /// <summary>
@@ -2224,9 +2240,14 @@
         azurePermissionsScript = AzureCloudShellSetup.GeneratePermissionsScript(new AzurePermissionsSetupInput(
             AccessAppClientId: azureProviderSettings.ClientId ?? string.Empty,
             RedirectUri: easyRedirectUri.Trim(),
+            ConsentRedirectUri: AzureConsentLandingUri,
             SignInAppName: "Connapse-Azure-SignIn",
             PublicCertificatePem: azureSignInCert!.PublicCertificatePem));
     }
+
+    /// <summary>Where Entra sends the administrator after consent — this page, registered as the access
+    /// app's reply URL by the Permissions script.</summary>
+    private string AzureConsentLandingUri => Navigation.BaseUri.TrimEnd('/') + "/admin/providers/azure";
 
     private void RefreshAzurePermissionsScript()
     {

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1190,6 +1190,13 @@
                 </EasyContent>
                 <Actions>
                     <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
+                    @if (azureProviderSettings.TenantId is { Length: > 0 })
+                    {
+                        <ProviderResetAction Label="Reset access"
+                                             ConfirmLabel="Confirm access reset"
+                                             HelpText="Clears the tenant, subscription, and app identity and discards the stored certificate. Azure connections stop working until access is set up again."
+                                             OnReset="ClearAzureAccess" />
+                    }
                 </Actions>
             </ProviderStepCard>
 
@@ -1339,6 +1346,13 @@
                 </EasyContent>
                 <Actions>
                     <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
+                    @if (azureAdSettings.ClientId is { Length: > 0 })
+                    {
+                        <ProviderResetAction Label="Reset sign-in application"
+                                             ConfirmLabel="Confirm sign-in reset"
+                                             HelpText="Per-user filtering stays on, so Azure searches return nothing for anyone until the application is set up again."
+                                             OnReset="ClearAzureSignIn" />
+                    }
                 </Actions>
             </ProviderStepCard>
         }
@@ -2252,6 +2266,41 @@
     /// <summary>Where Entra sends the administrator after consent — this page, registered as the access
     /// app's reply URL by the Permissions script.</summary>
     private string AzureConsentLandingUri => Navigation.BaseUri.TrimEnd('/') + "/admin/providers/azure";
+
+    /// <summary>Clears the access identity and discards its stored certificate, so the next setup mints
+    /// a fresh key instead of re-offering one an old app registration may still hold.</summary>
+    private async Task ClearAzureAccess()
+    {
+        await SaveAzureProviderFromForm(new AzureProviderSettings());
+        if (!saveSuccess) return;
+
+        DeleteAzureCertificate(AzureAccessCertFile);
+        azureAccessScript = null;
+        azureAccessCert = null;
+        azureAccessPasted = null;
+    }
+
+    private async Task ClearAzureSignIn()
+    {
+        // Enforcement is deliberately left on (the Azure latch never releases). With sign-in
+        // incomplete the verifier denies, so Azure searches return nothing for everyone until the
+        // application is set up again, rather than silently widening to the whole corpus.
+        await SaveAzureAdFromForm(new AzureAdSignInSettings());
+        if (!saveSuccess) return;
+
+        DeleteAzureCertificate(AzureSignInCertFile);
+        azurePermissionsScript = null;
+        azureSignInCert = null;
+        azurePermissionsPasted = null;
+        azureConsentPending = false;
+        azureConsentUrl = null;
+    }
+
+    private void DeleteAzureCertificate(string fileName)
+    {
+        string path = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
+        if (File.Exists(path)) File.Delete(path);
+    }
 
     private void RefreshAzurePermissionsScript()
     {

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -2375,6 +2375,9 @@
             {
                 string combined = File.ReadAllText(path);
                 using var existing = System.Security.Cryptography.X509Certificates.X509Certificate2.CreateFromPem(combined);
+                // A file written before owner-only creation existed keeps its old mode; tighten it.
+                if (!OperatingSystem.IsWindows())
+                    File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
                 return new AzureCertificateMaterial(existing.ExportCertificatePem(), combined);
             }
             catch (Exception ex) when (ex is System.Security.Cryptography.CryptographicException or IOException)

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -16,6 +16,8 @@
 @inject IOptionsMonitor<SamlSignInSettings> SamlOptions
 @inject IOptionsMonitor<PermissionEnforcementSettings> EnforcementOptions
 @inject IOptionsMonitor<IdentityCenterSettings> IdentityCenterOptions
+@inject IOptionsMonitor<AzureProviderSettings> AzureProviderOptions
+@inject IOptionsMonitor<AzureAdSignInSettings> AzureAdOptions
 @inject IProviderSetupReader SetupReader
 @inject IProviderCredentialStore CredentialStore
 @inject IRolesAnywhereSetupValidator RaValidator
@@ -152,8 +154,9 @@
         }
 
         @* AWS renders status and setup together below. Repeating these cards above those sections
-           made the page read like two separate checklists for the same work. *@
-        @if (Key != "aws")
+           made the page read like two separate checklists for the same work. Azure does the same
+           (its setup cards below), so it is excluded here too. *@
+        @if (Key != "aws" && Key != "azure")
         {
         @* Requirements first: someone arriving here is asking what is left to do, and answering
            that before showing forms is the reason this page exists. *@
@@ -1063,6 +1066,46 @@
                 </Actions>
             </ProviderStepCard>
         }
+        else if (Key == "azure")
+        {
+            <p class="text-muted">
+                Two steps: the Azure app identity Connapse reads Blob storage and permissions with,
+                and the Entra application people sign in through. Both are stored in Connapse's
+                settings — no client secrets; Connapse authenticates with a certificate or a managed
+                identity.
+            </p>
+
+            <div class="card mb-3">
+                <div class="card-body">
+                    <div class="d-flex align-items-center gap-2 mb-1">
+                        <span class="@IconClass(AccessStatus)" aria-hidden="true"></span>
+                        <strong>Access</strong>
+                        <span class="badge @BadgeClass(AccessStatus)">@RequirementLabel(AccessStatus)</span>
+                    </div>
+                    <div class="form-text mb-3">
+                        The Azure app identity Connapse reads Blob storage with, and queries Entra and
+                        Azure Resource Manager (role and deny assignments) through.
+                    </div>
+                    <AzureProviderSettingsTab Settings="azureProviderSettings" OnSave="SaveAzureProviderFromForm" />
+                </div>
+            </div>
+
+            <div class="card mb-3">
+                <div class="card-body">
+                    <div class="d-flex align-items-center gap-2 mb-1">
+                        <span class="@IconClass(PermissionsStatus)" aria-hidden="true"></span>
+                        <strong>Per-user permissions</strong>
+                        <span class="badge @BadgeClass(PermissionsStatus)">@RequirementLabel(PermissionsStatus)</span>
+                    </div>
+                    <div class="form-text mb-3">
+                        The Entra application people sign in through, so their Azure results are scoped
+                        to what that identity may read. Needs the subscription above for the RBAC
+                        resolver.
+                    </div>
+                    <AzureAdSignInSettingsTab Settings="azureAdSettings" OnSave="SaveAzureAdFromForm" />
+                </div>
+            </div>
+        }
 
     }
 </div>
@@ -1077,6 +1120,10 @@
 
     private SamlSignInSettings samlSettings = new();
     private bool showSamlManual;
+
+    /// <summary>Backs the Azure setup forms — loaded from the effective settings, saved back per section.</summary>
+    private AzureProviderSettings azureProviderSettings = new();
+    private AzureAdSignInSettings azureAdSettings = new();
 
     private string? grantsCopyMessage;
     private bool grantsCopySucceeded;
@@ -1242,6 +1289,8 @@
         // table, which overrides appsettings.json, and reloads without a restart.
         samlSettings = SamlOptions.CurrentValue;
         identityCenterSettings = IdentityCenterOptions.CurrentValue;
+        azureProviderSettings = AzureProviderOptions.CurrentValue;
+        azureAdSettings = AzureAdOptions.CurrentValue;
     }
 
     /// <summary>
@@ -1780,6 +1829,7 @@
     private static string Offer(ProviderSetup provider) => provider.Key switch
     {
         "aws" => "Read files from S3.",
+        "azure" => "Read files from Azure Blob Storage.",
         _ => $"Set up {provider.DisplayName}."
     };
 
@@ -1850,6 +1900,42 @@
         // form back the previous values and make a save look as though it had not taken. Guarded on
         // success so a failed save leaves the form showing what is actually stored.
         if (saveSuccess) samlSettings = settings;
+
+        await RefreshSetups();
+    }
+
+    /// <summary>Stores the Azure access app credential (Providers:Azure) and re-checks status.</summary>
+    private async Task SaveAzureProviderFromForm(AzureProviderSettings settings)
+    {
+        await SaveSettings("azure", settings);
+
+        if (saveSuccess)
+        {
+            // What was posted, not a re-read: the options reload behind SaveSettings may not have
+            // landed yet, so a stale read would hand the form back the previous values.
+            azureProviderSettings = settings;
+            await AuditLogger.LogAsync("provider.azure.saved", "provider", "azure",
+                new
+                {
+                    HasTenant = !string.IsNullOrWhiteSpace(settings.TenantId),
+                    HasSubscription = !string.IsNullOrWhiteSpace(settings.SubscriptionId),
+                });
+        }
+
+        await RefreshSetups();
+    }
+
+    /// <summary>Stores the Entra sign-in application (Identity:AzureAd) and re-checks status.</summary>
+    private async Task SaveAzureAdFromForm(AzureAdSignInSettings settings)
+    {
+        await SaveSettings("azuread", settings);
+
+        if (saveSuccess)
+        {
+            azureAdSettings = settings;
+            await AuditLogger.LogAsync("provider.azuread.saved", "provider", "azure",
+                new { Configured = settings.IsConfigured });
+        }
 
         await RefreshSetups();
     }
@@ -1933,6 +2019,8 @@
     private static string SettingsName(string category) => category switch
     {
         "samlsignin" => "AWS sign-in",
+        "azure" => "Azure access",
+        "azuread" => "Azure sign-in",
         _ => category
     };
 }

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1215,7 +1215,7 @@
                             <dd class="col-sm-9 font-monospace">@azureAdSettings.RedirectUri</dd>
                         </dl>
                     }
-                    @if (azureConsentPending && azureConsentUrl is { Length: > 0 } consentUrl)
+                    @if (azureAdSettings.AdminConsentPending && AzureConsentUrl is { Length: > 0 } consentUrl)
                     {
                         <div class="alert alert-warning mt-2 mb-0" role="alert">
                             <div class="mb-2">
@@ -1232,7 +1232,7 @@
                                 <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(consentUrl)">
                                     <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy link
                                 </button>
-                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => azureConsentPending = false">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="MarkAzureConsentGranted">
                                     Consent has been granted
                                 </button>
                             </div>
@@ -1388,8 +1388,9 @@
     private AzureCertificateMaterial? azureSignInCert;
     private string? azurePermissionsPasted;
     private bool azureBusy;
-    private string? azureConsentUrl;
-    private bool azureConsentPending;
+
+    /// <summary>Set when Entra bounced back here after the administrator consented; cleared once recorded.</summary>
+    private bool azureConsentBounce;
 
     private string? grantsCopyMessage;
     private bool grantsCopySucceeded;
@@ -1570,6 +1571,7 @@
         {
             saveMessage = "Admin consent granted — Connapse can now look people and groups up in Entra.";
             saveSuccess = true;
+            azureConsentBounce = true;
         }
         else if (query.TryGetValue("error", out var consentError))
         {
@@ -1593,6 +1595,15 @@
 
         setups = await SetupReader.ReadAsync();
         await LoadAwsCredentialModeAsync();
+
+        // Entra bounced back after the administrator consented: record it, so the pending state
+        // clears for good rather than only for this page view.
+        if (azureConsentBounce && azureAdSettings.AdminConsentPending)
+        {
+            azureConsentBounce = false;
+            await MarkAzureConsentGranted();
+        }
+
         StateHasChanged();
     }
 
@@ -2214,6 +2225,11 @@
     /// <summary>Stores the Entra sign-in application (Identity:AzureAd) and re-checks status.</summary>
     private async Task SaveAzureAdFromForm(AzureAdSignInSettings settings)
     {
+        // Latched here, at save time, exactly as SaveSamlSettings does for AWS. The startup latch
+        // alone left a gap: a deployment that configured Azure sign-in and never restarted stayed
+        // NotEnforcing, and every azblob result passed unfiltered until the next process start.
+        bool enforcing = settings.IsConfigured || EnforcementOptions.CurrentValue.AzureEnforcing;
+
         await SaveSettings("azuread", settings);
 
         if (saveSuccess)
@@ -2221,6 +2237,17 @@
             azureAdSettings = settings;
             await AuditLogger.LogAsync("provider.azuread.saved", "provider", "azure",
                 new { Configured = settings.IsConfigured });
+        }
+
+        if (saveSuccess && enforcing != EnforcementOptions.CurrentValue.AzureEnforcing)
+        {
+            await SaveSettings(
+                PermissionEnforcementSettings.Category,
+                new PermissionEnforcementSettings
+                {
+                    IsEnforcing = EnforcementOptions.CurrentValue.IsEnforcing,
+                    AzureEnforcing = enforcing,
+                });
         }
 
         await RefreshSetups();
@@ -2235,7 +2262,8 @@
         azureAccessCert = LoadOrMintAzureCertificate(AzureAccessCertFile, "connapse-azure-access", newCertificate);
         azureAccessScript = AzureCloudShellSetup.GenerateAccessScript(new AzureAccessSetupInput(
             AccessAppName: "Connapse-Azure-Access",
-            PublicCertificatePem: azureAccessCert.PublicCertificatePem));
+            PublicCertificatePem: azureAccessCert.PublicCertificatePem,
+            ExistingAccessAppClientId: azureProviderSettings.ClientId));
         azureAccessPasted = null;
         copyMessage = null;
     }
@@ -2260,7 +2288,8 @@
             RedirectUri: easyRedirectUri.Trim(),
             ConsentRedirectUri: AzureConsentLandingUri,
             SignInAppName: "Connapse-Azure-SignIn",
-            PublicCertificatePem: azureSignInCert!.PublicCertificatePem));
+            PublicCertificatePem: azureSignInCert!.PublicCertificatePem,
+            ExistingSignInAppClientId: azureAdSettings.ClientId));
     }
 
     /// <summary>Where Entra sends the administrator after consent — this page, registered as the access
@@ -2292,8 +2321,6 @@
         azurePermissionsScript = null;
         azureSignInCert = null;
         azurePermissionsPasted = null;
-        azureConsentPending = false;
-        azureConsentUrl = null;
     }
 
     private void DeleteAzureCertificate(string fileName)
@@ -2301,6 +2328,16 @@
         string path = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
         if (File.Exists(path)) File.Delete(path);
     }
+
+    /// <summary>The admin-consent link for the access app — derived from settings, so it survives a
+    /// reload and needs no stored copy.</summary>
+    private string? AzureConsentUrl =>
+        azureProviderSettings is { TenantId: { Length: > 0 } tenant, ClientId: { Length: > 0 } app }
+            ? $"https://login.microsoftonline.com/{tenant}/adminconsent?client_id={app}&redirect_uri={Uri.EscapeDataString(AzureConsentLandingUri)}"
+            : null;
+
+    private Task MarkAzureConsentGranted() =>
+        SaveAzureAdFromForm(azureAdSettings with { AdminConsentPending = false });
 
     private void RefreshAzurePermissionsScript()
     {
@@ -2347,9 +2384,33 @@
         }
 
         AzureCertificateMaterial minted = AzureCertificateGenerator.Generate(commonName);
-        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-        File.WriteAllText(path, minted.CombinedPem);
+        WriteOwnerOnly(path, minted.CombinedPem);
         return minted;
+    }
+
+    /// <summary>
+    /// Writes a private-key file readable by Connapse's own user only: 0600 in a 0700 directory on
+    /// Unix (a default umask would have made it world-readable); on Windows it inherits the app
+    /// directory's ACL. The mode is set again after writing because a create mode only applies to
+    /// a file that did not exist.
+    /// </summary>
+    private static void WriteOwnerOnly(string path, string content)
+    {
+        string dir = Path.GetDirectoryName(path)!;
+        Directory.CreateDirectory(dir);
+        bool unix = !OperatingSystem.IsWindows();
+        if (unix)
+            File.SetUnixFileMode(dir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var options = new FileStreamOptions { Mode = FileMode.Create, Access = FileAccess.Write, Share = FileShare.None };
+        if (unix) options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        using (var stream = new FileStream(path, options))
+        using (var writer = new StreamWriter(stream))
+        {
+            writer.Write(content);
+        }
+
+        if (unix) File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
     }
 
     private async Task CopyText(string text)
@@ -2401,13 +2462,11 @@
 
     /// <summary>The private key stays on this host: the cert + key go to the appdata volume, and only
     /// the public certificate was uploaded to Azure by the script.</summary>
-    private async Task<string> WriteAzureCertificateAsync(string fileName, string combinedPem)
+    private Task<string> WriteAzureCertificateAsync(string fileName, string combinedPem)
     {
-        string certDir = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure");
-        Directory.CreateDirectory(certDir);
-        string certPath = Path.Combine(certDir, fileName);
-        await File.WriteAllTextAsync(certPath, combinedPem);
-        return certPath;
+        string certPath = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
+        WriteOwnerOnly(certPath, combinedPem);
+        return Task.FromResult(certPath);
     }
 
     /// <summary>
@@ -2433,10 +2492,10 @@
                 ClientId = result.SignInAppClientId,
                 RedirectUri = easyRedirectUri.Trim(),
                 ClientCertificatePath = certPath,
+                // Persisted, so a reload cannot turn "consent still pending" into a green card.
+                AdminConsentPending = !result.ConsentGranted,
             });
 
-            azureConsentPending = !result.ConsentGranted;
-            azureConsentUrl = result.ConsentUrl;
             azurePermissionsScript = null;
             azureSignInCert = null;
             azurePermissionsPasted = null;

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1071,120 +1071,121 @@
         else if (Key == "azure")
         {
             <p class="text-muted">
-                Two steps: the Azure app identity Connapse reads Blob storage and permissions with,
-                and the Entra application people sign in through. Both are stored in Connapse's
-                settings — no client secrets; Connapse authenticates with a certificate or a managed
-                identity.
+                Two steps: the Azure app identity Connapse reads Blob storage and permissions with, and
+                the Entra application people sign in through. No client secrets — Connapse authenticates
+                with certificates it generates on this host (the private keys never leave it) or a
+                managed identity.
             </p>
 
-            @if (azureConsentUrl is { Length: > 0 } consentUrl && azureConsentPending)
-            {
-                <div class="alert alert-warning" role="alert">
-                    <div class="mb-2">
-                        <span class="bi-shield-exclamation me-1" aria-hidden="true"></span>
-                        <strong>One step left — admin consent.</strong> The app is created, but the two
-                        Microsoft Graph permissions it uses to look people up need a
-                        <strong>Global Administrator</strong> or <strong>Privileged Role Administrator</strong>
-                        to approve. Send them this link; they sign in and click Accept.
-                    </div>
-                    <div class="d-flex flex-wrap gap-2">
-                        <a class="btn btn-sm btn-primary" href="@consentUrl" target="_blank" rel="noopener">
-                            <span class="bi-box-arrow-up-right me-1" aria-hidden="true"></span> Open consent page
-                        </a>
-                        <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(consentUrl)">
-                            <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy link
-                        </button>
-                        <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
-                    </div>
-                </div>
-            }
-
-            @* Easy setup — Connapse generates a certificate here, hands you one Cloud Shell script,
-               and you paste the result back. The private key never leaves this host. *@
-            <div class="card mb-3">
-                <div class="card-body">
-                    <h2 class="h6 mb-1"><span class="bi-magic me-1" aria-hidden="true"></span> Easy setup with Azure Cloud Shell</h2>
-                    <p class="small text-muted mb-3">
-                        Connapse generates a certificate on this host, gives you one script to run in Azure
-                        Cloud Shell (which creates both app registrations, two least-privilege roles, and the
-                        permissions), and you paste the result back. Only the public certificate is uploaded to
-                        Azure — the private key never leaves this host.
+            <ProviderStepCard Id="azure-access" Title="Access"
+                              Description="The Azure app identity Connapse reads Blob storage with, and queries Entra and Azure Resource Manager (role and deny assignments) through."
+                              Status="AccessStatus" StatusLabel="@RequirementLabel(AccessStatus)"
+                              @bind-Expanded="showAzureAccess" EditLabel="Update or replace"
+                              EasyTitle="Easy setup with Azure Cloud Shell" EasyOpen="true">
+                <Summary>
+                    @if (azureProviderSettings.TenantId is { Length: > 0 })
+                    {
+                        <dl class="row small mb-0">
+                            <dt class="col-sm-3">Tenant</dt>
+                            <dd class="col-sm-9 font-monospace">@azureProviderSettings.TenantId</dd>
+                            <dt class="col-sm-3">Subscription</dt>
+                            <dd class="col-sm-9 font-monospace">@(azureProviderSettings.SubscriptionId is { Length: > 0 } sub ? sub : "not set")</dd>
+                            <dt class="col-sm-3">Identity</dt>
+                            <dd class="col-sm-9 font-monospace">
+                                @if (azureProviderSettings.UserAssignedManagedIdentityClientId is { Length: > 0 } mi)
+                                {
+                                    <text>managed identity @mi</text>
+                                }
+                                else
+                                {
+                                    <text>app @azureProviderSettings.ClientId (certificate)</text>
+                                }
+                            </dd>
+                        </dl>
+                    }
+                </Summary>
+                <ManualContent>
+                    <details class="border rounded p-3 mb-3">
+                        <summary class="fw-semibold">Manual values — use an existing app registration or managed identity</summary>
+                        <div class="mt-3">
+                            <AzureProviderSettingsTab Settings="azureProviderSettings" OnSave="SaveAzureProviderFromForm" />
+                        </div>
+                    </details>
+                </ManualContent>
+                <EasyContent>
+                    <p class="small text-muted">
+                        Connapse generates a certificate on this host. You run one script in Azure Cloud Shell — it
+                        creates two least-privilege custom roles and the access app registration, uploading only the
+                        public certificate — then paste back what it prints.
+                    </p>
+                    <p class="small mb-3">
+                        <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.AccessScriptRequirements).
                     </p>
 
-                    <div class="row g-2" style="max-width:44rem">
+                    <div class="row g-2 mb-3" style="max-width:44rem">
                         <div class="col-12">
-                            <label class="form-label small mb-1" for="az-easy-sub">Subscription ID</label>
-                            <input id="az-easy-sub" class="form-control form-control-sm font-monospace"
+                            <label class="form-label small mb-1" for="az-access-sub">Subscription ID</label>
+                            <input id="az-access-sub" class="form-control form-control-sm font-monospace"
                                    placeholder="00000000-0000-0000-0000-000000000000"
                                    @bind="easySubscriptionId" @bind:event="oninput" />
                         </div>
                         <div class="col-12">
-                            <label class="form-label small mb-1" for="az-easy-scope">
+                            <label class="form-label small mb-1" for="az-access-scope">
                                 Storage account scope <span class="text-muted">(optional)</span>
                             </label>
-                            <input id="az-easy-scope" class="form-control form-control-sm font-monospace"
+                            <input id="az-access-scope" class="form-control form-control-sm font-monospace"
                                    placeholder="Leave blank to cover the whole subscription"
-                                   aria-describedby="az-easy-scope-help" @bind="easyStorageScope" />
-                            <div id="az-easy-scope-help" class="form-text">
-                                A storage-account resource id to scope the blob-data role to; blank grants it
-                                across the subscription.
-                            </div>
-                        </div>
-                        <div class="col-12">
-                            <label class="form-label small mb-1" for="az-easy-redirect">Sign-in redirect URI</label>
-                            <input id="az-easy-redirect" class="form-control form-control-sm font-monospace"
-                                   @bind="easyRedirectUri" aria-describedby="az-easy-redirect-help" />
-                            <div id="az-easy-redirect-help" class="form-text">
-                                Registered on the sign-in app. Auto-filled from the address you reached Connapse on.
+                                   aria-describedby="az-access-scope-help" @bind="easyStorageScope" />
+                            <div id="az-access-scope-help" class="form-text">
+                                A storage-account resource id to scope the blob-data role to; blank grants it across
+                                the subscription.
                             </div>
                         </div>
                     </div>
 
                     @if (string.IsNullOrWhiteSpace(easySubscriptionId))
                     {
-                        <div class="alert alert-secondary py-2 small mt-3 mb-0">
+                        <div class="alert alert-secondary py-2 small mb-0">
                             Enter the subscription ID to generate the setup command.
                         </div>
                     }
                     else
                     {
-                        <button type="button" class="btn btn-sm btn-outline-primary mt-3 mb-2"
-                                @onclick="GenerateAzureScript">
+                        <button type="button" class="btn btn-sm btn-outline-primary mb-2" @onclick="GenerateAzureAccessScript">
                             <span class="bi-arrow-repeat me-1" aria-hidden="true"></span>
-                            @(azureScript is null ? "Generate setup command" : "Regenerate (new certificate)")
+                            @(azureAccessScript is null ? "Generate setup command" : "Regenerate (new certificate)")
                         </button>
 
-                        @if (azureScript is { Length: > 0 } script)
+                        @if (azureAccessScript is { Length: > 0 } accessScript)
                         {
                             <div class="alert alert-secondary py-2 small mb-2">
                                 <span class="bi-info-circle me-1" aria-hidden="true"></span>
-                                Keep this page open until you have pasted the result back — the certificate is
-                                held here until you save. Regenerating makes a fresh one.
+                                Keep this page open until you have pasted the result back — the certificate is held
+                                here until you save. Regenerating makes a fresh one.
                             </div>
 
-                            <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:18rem;overflow:auto"><code>@script</code></pre>
+                            <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:18rem;overflow:auto"><code>@accessScript</code></pre>
 
                             <div class="d-flex flex-wrap gap-2 mb-2">
-                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(script)">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(accessScript)">
                                     <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy command
                                 </button>
-                                <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"
-                                   href="https://shell.azure.com">
+                                <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener" href="https://shell.azure.com">
                                     <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
                                     <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
                                 </a>
                                 <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
                             </div>
 
-                            <label class="form-label small mb-1" for="az-easy-paste">Paste what it printed</label>
-                            <textarea id="az-easy-paste" class="form-control font-monospace" rows="4"
-                                      @bind="azurePasted" @bind:event="oninput"
-                                      placeholder="@AzureCloudShellSetup.BeginMarker&#10;tenantId=…&#10;@AzureCloudShellSetup.EndMarker"></textarea>
+                            <label class="form-label small mb-1" for="az-access-paste">Paste what it printed</label>
+                            <textarea id="az-access-paste" class="form-control font-monospace" rows="4"
+                                      @bind="azureAccessPasted" @bind:event="oninput"
+                                      placeholder="@AzureCloudShellSetup.AccessBeginMarker&#10;tenantId=…&#10;@AzureCloudShellSetup.AccessEndMarker"></textarea>
 
-                            @if (!string.IsNullOrWhiteSpace(azurePasted))
+                            @if (!string.IsNullOrWhiteSpace(azureAccessPasted))
                             {
-                                var parsed = AzureCloudShellSetup.ParseResult(azurePasted);
-                                @if (parsed is null)
+                                var accessResult = AzureCloudShellSetup.ParseAccessResult(azureAccessPasted);
+                                @if (accessResult is null)
                                 {
                                     <div class="alert alert-warning py-2 mt-2 mb-0 small">
                                         <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
@@ -1196,11 +1197,11 @@
                                 {
                                     <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
                                         <span class="small flex-grow-1">
-                                            Access app <code>@parsed.AccessAppClientId</code>, sign-in app
-                                            <code>@parsed.SignInAppClientId</code>@(parsed.ConsentGranted ? " — admin consent granted." : " — admin consent still pending.")
+                                            Access app <code>@accessResult.AccessAppClientId</code> in tenant
+                                            <code>@accessResult.TenantId</code>.
                                         </span>
                                         <button type="button" class="btn btn-sm btn-primary"
-                                                @onclick="() => SaveAzureFromScript(parsed)" disabled="@azureBusy">
+                                                @onclick="() => SaveAzureAccessFromScript(accessResult)" disabled="@azureBusy">
                                             @if (azureBusy)
                                             {
                                                 <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
@@ -1216,39 +1217,161 @@
                             }
                         }
                     }
-                </div>
-            </div>
+                </EasyContent>
+                <Actions>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
+                </Actions>
+            </ProviderStepCard>
 
-            <div class="card mb-3">
-                <div class="card-body">
-                    <div class="d-flex align-items-center gap-2 mb-1">
-                        <span class="@IconClass(AccessStatus)" aria-hidden="true"></span>
-                        <strong>Access</strong>
-                        <span class="badge @BadgeClass(AccessStatus)">@RequirementLabel(AccessStatus)</span>
-                    </div>
-                    <div class="form-text mb-3">
-                        The Azure app identity Connapse reads Blob storage with, and queries Entra and
-                        Azure Resource Manager (role and deny assignments) through.
-                    </div>
-                    <AzureProviderSettingsTab Settings="azureProviderSettings" OnSave="SaveAzureProviderFromForm" />
-                </div>
-            </div>
+            <ProviderStepCard Id="azure-permissions" Title="Per-user permissions"
+                              Description="The Entra application people sign in through, so their Azure results are scoped to what that identity may read. Uses the access app above to look people and groups up."
+                              Status="PermissionsStatus" StatusLabel="@RequirementLabel(PermissionsStatus)"
+                              @bind-Expanded="showAzurePermissions" EditLabel="Update or replace"
+                              EasyTitle="Guided setup" EasyOpen="true">
+                <Summary>
+                    @if (azureAdSettings.ClientId is { Length: > 0 })
+                    {
+                        <dl class="row small mb-0">
+                            <dt class="col-sm-3">Sign-in app</dt>
+                            <dd class="col-sm-9 font-monospace">@azureAdSettings.ClientId</dd>
+                            <dt class="col-sm-3">Redirect URI</dt>
+                            <dd class="col-sm-9 font-monospace">@azureAdSettings.RedirectUri</dd>
+                        </dl>
+                    }
+                    @if (azureConsentPending && azureConsentUrl is { Length: > 0 } consentUrl)
+                    {
+                        <div class="alert alert-warning mt-2 mb-0" role="alert">
+                            <div class="mb-2">
+                                <span class="bi-shield-exclamation me-1" aria-hidden="true"></span>
+                                <strong>One step left — admin consent.</strong> The apps are created, but the two
+                                Microsoft Graph permissions Connapse looks people up with need a
+                                <strong>Global Administrator</strong> or <strong>Privileged Role Administrator</strong>
+                                to approve. Send them this link; they sign in and click Accept.
+                            </div>
+                            <div class="d-flex flex-wrap gap-2">
+                                <a class="btn btn-sm btn-primary" href="@consentUrl" target="_blank" rel="noopener">
+                                    <span class="bi-box-arrow-up-right me-1" aria-hidden="true"></span> Open consent page
+                                </a>
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(consentUrl)">
+                                    <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy link
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => azureConsentPending = false">
+                                    Consent has been granted
+                                </button>
+                            </div>
+                        </div>
+                    }
+                </Summary>
+                <ManualContent>
+                    <details class="border rounded p-3 mb-3">
+                        <summary class="fw-semibold">Manual values — use an existing sign-in app registration</summary>
+                        <div class="mt-3">
+                            <AzureAdSignInSettingsTab Settings="azureAdSettings" OnSave="SaveAzureAdFromForm" />
+                        </div>
+                    </details>
+                </ManualContent>
+                <EasyContent>
+                    @if (azureProviderSettings.ClientId is not { Length: > 0 })
+                    {
+                        <div class="alert alert-secondary py-2 small mb-0">
+                            <span class="bi-info-circle me-1" aria-hidden="true"></span>
+                            Finish the <strong>Access</strong> step with an app registration first — this script grants
+                            that access app its Microsoft Graph permissions. (A managed-identity access step needs those
+                            permissions granted by hand; use the manual values.)
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="small text-muted">
+                            One more Cloud Shell script: it registers the sign-in app (with its own certificate — only
+                            the public half is uploaded), grants the access app
+                            <code>@azureProviderSettings.ClientId</code> the two Graph permissions, and tries to grant
+                            admin consent.
+                        </p>
+                        <p class="small mb-3">
+                            <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.PermissionsScriptRequirements).
+                        </p>
 
-            <div class="card mb-3">
-                <div class="card-body">
-                    <div class="d-flex align-items-center gap-2 mb-1">
-                        <span class="@IconClass(PermissionsStatus)" aria-hidden="true"></span>
-                        <strong>Per-user permissions</strong>
-                        <span class="badge @BadgeClass(PermissionsStatus)">@RequirementLabel(PermissionsStatus)</span>
-                    </div>
-                    <div class="form-text mb-3">
-                        The Entra application people sign in through, so their Azure results are scoped
-                        to what that identity may read. Needs the subscription above for the RBAC
-                        resolver.
-                    </div>
-                    <AzureAdSignInSettingsTab Settings="azureAdSettings" OnSave="SaveAzureAdFromForm" />
-                </div>
-            </div>
+                        <div class="mb-3" style="max-width:44rem">
+                            <label class="form-label small mb-1" for="az-perm-redirect">Sign-in redirect URI</label>
+                            <input id="az-perm-redirect" class="form-control form-control-sm font-monospace"
+                                   @bind="easyRedirectUri" aria-describedby="az-perm-redirect-help" />
+                            <div id="az-perm-redirect-help" class="form-text">
+                                Registered on the sign-in app. Auto-filled from the address you reached Connapse on.
+                            </div>
+                        </div>
+
+                        <button type="button" class="btn btn-sm btn-outline-primary mb-2" @onclick="GenerateAzurePermissionsScript"
+                                disabled="@string.IsNullOrWhiteSpace(easyRedirectUri)">
+                            <span class="bi-arrow-repeat me-1" aria-hidden="true"></span>
+                            @(azurePermissionsScript is null ? "Generate setup command" : "Regenerate (new certificate)")
+                        </button>
+
+                        @if (azurePermissionsScript is { Length: > 0 } permissionsScript)
+                        {
+                            <div class="alert alert-secondary py-2 small mb-2">
+                                <span class="bi-info-circle me-1" aria-hidden="true"></span>
+                                Keep this page open until you have pasted the result back — the sign-in certificate is
+                                held here until you save.
+                            </div>
+
+                            <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:18rem;overflow:auto"><code>@permissionsScript</code></pre>
+
+                            <div class="d-flex flex-wrap gap-2 mb-2">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(permissionsScript)">
+                                    <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy command
+                                </button>
+                                <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener" href="https://shell.azure.com">
+                                    <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
+                                    <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
+                                </a>
+                                <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
+                            </div>
+
+                            <label class="form-label small mb-1" for="az-perm-paste">Paste what it printed</label>
+                            <textarea id="az-perm-paste" class="form-control font-monospace" rows="4"
+                                      @bind="azurePermissionsPasted" @bind:event="oninput"
+                                      placeholder="@AzureCloudShellSetup.PermissionsBeginMarker&#10;signInAppClientId=…&#10;@AzureCloudShellSetup.PermissionsEndMarker"></textarea>
+
+                            @if (!string.IsNullOrWhiteSpace(azurePermissionsPasted))
+                            {
+                                var permissionsResult = AzureCloudShellSetup.ParsePermissionsResult(azurePermissionsPasted);
+                                @if (permissionsResult is null)
+                                {
+                                    <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                        <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                        No valid block found yet. Copy everything the command printed, including
+                                        both <code>-----</code> marker lines.
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+                                        <span class="small flex-grow-1">
+                                            Sign-in app <code>@permissionsResult.SignInAppClientId</code>@(permissionsResult.ConsentGranted ? " — admin consent granted." : " — admin consent still pending.")
+                                        </span>
+                                        <button type="button" class="btn btn-sm btn-primary"
+                                                @onclick="() => SaveAzurePermissionsFromScript(permissionsResult)" disabled="@azureBusy">
+                                            @if (azureBusy)
+                                            {
+                                                <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+                                            }
+                                            else
+                                            {
+                                                <span class="bi-check-lg me-1" aria-hidden="true"></span>
+                                            }
+                                            Save
+                                        </button>
+                                    </div>
+                                }
+                            }
+                        }
+                    }
+                </EasyContent>
+                <Actions>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
+                </Actions>
+            </ProviderStepCard>
         }
 
     }
@@ -1269,13 +1392,20 @@
     private AzureProviderSettings azureProviderSettings = new();
     private AzureAdSignInSettings azureAdSettings = new();
 
-    // Azure easy-setup (Cloud Shell) state.
+    // Azure step cards — expanded state, mirroring the AWS cards.
+    private bool showAzureAccess;
+    private bool showAzurePermissions;
+
+    // Azure easy-setup (Cloud Shell) state — one script per step, each with its own certificate.
     private string? easySubscriptionId;
     private string? easyStorageScope;
     private string easyRedirectUri = "";
-    private string? azureScript;
-    private AzureCertificateMaterial? azureCert;
-    private string? azurePasted;
+    private string? azureAccessScript;
+    private AzureCertificateMaterial? azureAccessCert;
+    private string? azureAccessPasted;
+    private string? azurePermissionsScript;
+    private AzureCertificateMaterial? azureSignInCert;
+    private string? azurePermissionsPasted;
     private bool azureBusy;
     private string? azureConsentUrl;
     private bool azureConsentPending;
@@ -2100,19 +2230,31 @@
         await RefreshSetups();
     }
 
-    /// <summary>Generates a fresh certificate on this host and the Cloud Shell script that uploads only
-    /// its public half. The generated material is held until the operator saves the pasted-back result.</summary>
-    private void GenerateAzureScript()
+    /// <summary>Generates a fresh certificate on this host and the Access script that uploads only its
+    /// public half. The material is held until the operator saves the pasted-back result.</summary>
+    private void GenerateAzureAccessScript()
     {
-        azureCert = AzureCertificateGenerator.Generate("connapse-azure");
-        azureScript = AzureCloudShellSetup.GenerateScript(new AzureSetupInput(
+        azureAccessCert = AzureCertificateGenerator.Generate("connapse-azure-access");
+        azureAccessScript = AzureCloudShellSetup.GenerateAccessScript(new AzureAccessSetupInput(
             SubscriptionId: (easySubscriptionId ?? string.Empty).Trim(),
             StorageScope: string.IsNullOrWhiteSpace(easyStorageScope) ? null : easyStorageScope!.Trim(),
-            RedirectUri: easyRedirectUri.Trim(),
             AccessAppName: "Connapse-Azure-Access",
+            PublicCertificatePem: azureAccessCert.PublicCertificatePem));
+        azureAccessPasted = null;
+        copyMessage = null;
+    }
+
+    /// <summary>The sign-in app gets its own certificate; the script also grants the saved access app
+    /// its Graph permissions, which is why this step waits for the Access step.</summary>
+    private void GenerateAzurePermissionsScript()
+    {
+        azureSignInCert = AzureCertificateGenerator.Generate("connapse-azure-signin");
+        azurePermissionsScript = AzureCloudShellSetup.GeneratePermissionsScript(new AzurePermissionsSetupInput(
+            AccessAppClientId: azureProviderSettings.ClientId ?? string.Empty,
+            RedirectUri: easyRedirectUri.Trim(),
             SignInAppName: "Connapse-Azure-SignIn",
-            PublicCertificatePem: azureCert.PublicCertificatePem));
-        azurePasted = null;
+            PublicCertificatePem: azureSignInCert.PublicCertificatePem));
+        azurePermissionsPasted = null;
         copyMessage = null;
     }
 
@@ -2123,13 +2265,12 @@
     }
 
     /// <summary>
-    /// Stores the pasted-back setup: writes the generated certificate (with its private key) to the
-    /// appdata volume, points both app registrations at it, and records the two client ids + tenant +
-    /// subscription. Surfaces the admin-consent URL when the operator could not consent.
+    /// Stores the Access step: writes the generated certificate (with its private key) to the appdata
+    /// volume and records tenant, subscription, and the access app's client id.
     /// </summary>
-    private async Task SaveAzureFromScript(AzureSetupResult result)
+    private async Task SaveAzureAccessFromScript(AzureAccessResult result)
     {
-        if (azureCert is null)
+        if (azureAccessCert is null)
         {
             saveMessage = "Generate the setup command first, so Connapse has the certificate to store.";
             saveSuccess = false;
@@ -2139,13 +2280,7 @@
         azureBusy = true;
         try
         {
-            // The private key stays on this host: write the cert + key to the appdata volume and point
-            // both apps at it. Only the public certificate was uploaded to Azure by the script.
-            string certDir = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure");
-            Directory.CreateDirectory(certDir);
-            string certPath = Path.Combine(certDir, "connapse-azure.pem");
-            await File.WriteAllTextAsync(certPath, azureCert.CombinedPem);
-
+            string certPath = await WriteAzureCertificateAsync("connapse-azure-access.pem", azureAccessCert.CombinedPem);
             await SaveAzureProviderFromForm(new AzureProviderSettings
             {
                 TenantId = result.TenantId,
@@ -2154,9 +2289,53 @@
                 ClientCertificatePath = certPath,
             });
 
+            azureAccessScript = null;
+            azureAccessCert = null;
+            azureAccessPasted = null;
+            showAzureAccess = false;
+        }
+        catch (Exception ex)
+        {
+            saveMessage = $"Could not save the Azure access setup: {ex.Message}";
+            saveSuccess = false;
+        }
+        finally
+        {
+            azureBusy = false;
+        }
+    }
+
+    /// <summary>The private key stays on this host: the cert + key go to the appdata volume, and only
+    /// the public certificate was uploaded to Azure by the script.</summary>
+    private async Task<string> WriteAzureCertificateAsync(string fileName, string combinedPem)
+    {
+        string certDir = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure");
+        Directory.CreateDirectory(certDir);
+        string certPath = Path.Combine(certDir, fileName);
+        await File.WriteAllTextAsync(certPath, combinedPem);
+        return certPath;
+    }
+
+    /// <summary>
+    /// Stores the Per-user permissions step: the sign-in app's own certificate and client id (tenant
+    /// comes from the Access step). Surfaces the admin-consent URL when the operator could not consent.
+    /// </summary>
+    private async Task SaveAzurePermissionsFromScript(AzurePermissionsResult result)
+    {
+        if (azureSignInCert is null)
+        {
+            saveMessage = "Generate the setup command first, so Connapse has the certificate to store.";
+            saveSuccess = false;
+            return;
+        }
+
+        azureBusy = true;
+        try
+        {
+            string certPath = await WriteAzureCertificateAsync("connapse-azure-signin.pem", azureSignInCert.CombinedPem);
             await SaveAzureAdFromForm(new AzureAdSignInSettings
             {
-                TenantId = result.TenantId,
+                TenantId = azureProviderSettings.TenantId,
                 ClientId = result.SignInAppClientId,
                 RedirectUri = easyRedirectUri.Trim(),
                 ClientCertificatePath = certPath,
@@ -2164,10 +2343,14 @@
 
             azureConsentPending = !result.ConsentGranted;
             azureConsentUrl = result.ConsentUrl;
+            azurePermissionsScript = null;
+            azureSignInCert = null;
+            azurePermissionsPasted = null;
+            showAzurePermissions = false;
         }
         catch (Exception ex)
         {
-            saveMessage = $"Could not save the Azure setup: {ex.Message}";
+            saveMessage = $"Could not save the Azure sign-in setup: {ex.Message}";
             saveSuccess = false;
         }
         finally

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1114,43 +1114,15 @@
                 </ManualContent>
                 <EasyContent>
                     <p class="small text-muted">
-                        Connapse generates a certificate on this host. You run one script in Azure Cloud Shell — it
-                        creates two least-privilege custom roles and the access app registration, uploading only the
-                        public certificate — then paste back what it prints.
+                        Nothing to fill in. Connapse generates a certificate on this host; you run one script in Azure
+                        Cloud Shell — it uses whichever subscription Cloud Shell is signed in to, creates two
+                        least-privilege custom roles and the access app registration, and uploads only the public
+                        certificate — then paste back what it prints.
                     </p>
                     <p class="small mb-3">
                         <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.AccessScriptRequirements).
                     </p>
 
-                    <div class="row g-2 mb-3" style="max-width:44rem">
-                        <div class="col-12">
-                            <label class="form-label small mb-1" for="az-access-sub">Subscription ID</label>
-                            <input id="az-access-sub" class="form-control form-control-sm font-monospace"
-                                   placeholder="00000000-0000-0000-0000-000000000000"
-                                   @bind="easySubscriptionId" @bind:event="oninput" />
-                        </div>
-                        <div class="col-12">
-                            <label class="form-label small mb-1" for="az-access-scope">
-                                Storage account scope <span class="text-muted">(optional)</span>
-                            </label>
-                            <input id="az-access-scope" class="form-control form-control-sm font-monospace"
-                                   placeholder="Leave blank to cover the whole subscription"
-                                   aria-describedby="az-access-scope-help" @bind="easyStorageScope" />
-                            <div id="az-access-scope-help" class="form-text">
-                                A storage-account resource id to scope the blob-data role to; blank grants it across
-                                the subscription.
-                            </div>
-                        </div>
-                    </div>
-
-                    @if (string.IsNullOrWhiteSpace(easySubscriptionId))
-                    {
-                        <div class="alert alert-secondary py-2 small mb-0">
-                            Enter the subscription ID to generate the setup command.
-                        </div>
-                    }
-                    else
-                    {
                         <button type="button" class="btn btn-sm btn-outline-primary mb-2" @onclick="GenerateAzureAccessScript">
                             <span class="bi-arrow-repeat me-1" aria-hidden="true"></span>
                             @(azureAccessScript is null ? "Generate setup command" : "Regenerate (new certificate)")
@@ -1216,7 +1188,6 @@
                                 }
                             }
                         }
-                    }
                 </EasyContent>
                 <Actions>
                     <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
@@ -1397,8 +1368,6 @@
     private bool showAzurePermissions;
 
     // Azure easy-setup (Cloud Shell) state — one script per step, each with its own certificate.
-    private string? easySubscriptionId;
-    private string? easyStorageScope;
     private string easyRedirectUri = "";
     private string? azureAccessScript;
     private AzureCertificateMaterial? azureAccessCert;
@@ -1580,7 +1549,6 @@
         // The sign-in app's redirect URI is Connapse's Entra callback at the address this admin reached
         // it on; pre-fill the subscription from whatever is already stored.
         easyRedirectUri = Navigation.BaseUri.TrimEnd('/') + "/api/v1/auth/cloud/azure/callback";
-        easySubscriptionId = azureProviderSettings.SubscriptionId;
     }
 
     /// <summary>
@@ -2236,8 +2204,6 @@
     {
         azureAccessCert = AzureCertificateGenerator.Generate("connapse-azure-access");
         azureAccessScript = AzureCloudShellSetup.GenerateAccessScript(new AzureAccessSetupInput(
-            SubscriptionId: (easySubscriptionId ?? string.Empty).Trim(),
-            StorageScope: string.IsNullOrWhiteSpace(easyStorageScope) ? null : easyStorageScope!.Trim(),
             AccessAppName: "Connapse-Azure-Access",
             PublicCertificatePem: azureAccessCert.PublicCertificatePem));
         azureAccessPasted = null;

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -9,6 +9,7 @@
 @using Connapse.Web.Components.Settings
 @using Connapse.Web.Services
 @using Connapse.Storage.Settings
+@using Connapse.Storage.CloudScope
 @using Connapse.Storage.CloudScope.RolesAnywhere
 @using Microsoft.Extensions.Options
 @inject ISettingsStore SettingsStore
@@ -18,6 +19,7 @@
 @inject IOptionsMonitor<IdentityCenterSettings> IdentityCenterOptions
 @inject IOptionsMonitor<AzureProviderSettings> AzureProviderOptions
 @inject IOptionsMonitor<AzureAdSignInSettings> AzureAdOptions
+@inject Microsoft.AspNetCore.Hosting.IWebHostEnvironment WebHostEnvironment
 @inject IProviderSetupReader SetupReader
 @inject IProviderCredentialStore CredentialStore
 @inject IRolesAnywhereSetupValidator RaValidator
@@ -1075,6 +1077,148 @@
                 identity.
             </p>
 
+            @if (azureConsentUrl is { Length: > 0 } consentUrl && azureConsentPending)
+            {
+                <div class="alert alert-warning" role="alert">
+                    <div class="mb-2">
+                        <span class="bi-shield-exclamation me-1" aria-hidden="true"></span>
+                        <strong>One step left — admin consent.</strong> The app is created, but the two
+                        Microsoft Graph permissions it uses to look people up need a
+                        <strong>Global Administrator</strong> or <strong>Privileged Role Administrator</strong>
+                        to approve. Send them this link; they sign in and click Accept.
+                    </div>
+                    <div class="d-flex flex-wrap gap-2">
+                        <a class="btn btn-sm btn-primary" href="@consentUrl" target="_blank" rel="noopener">
+                            <span class="bi-box-arrow-up-right me-1" aria-hidden="true"></span> Open consent page
+                        </a>
+                        <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(consentUrl)">
+                            <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy link
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
+                    </div>
+                </div>
+            }
+
+            @* Easy setup — Connapse generates a certificate here, hands you one Cloud Shell script,
+               and you paste the result back. The private key never leaves this host. *@
+            <div class="card mb-3">
+                <div class="card-body">
+                    <h2 class="h6 mb-1"><span class="bi-magic me-1" aria-hidden="true"></span> Easy setup with Azure Cloud Shell</h2>
+                    <p class="small text-muted mb-3">
+                        Connapse generates a certificate on this host, gives you one script to run in Azure
+                        Cloud Shell (which creates both app registrations, two least-privilege roles, and the
+                        permissions), and you paste the result back. Only the public certificate is uploaded to
+                        Azure — the private key never leaves this host.
+                    </p>
+
+                    <div class="row g-2" style="max-width:44rem">
+                        <div class="col-12">
+                            <label class="form-label small mb-1" for="az-easy-sub">Subscription ID</label>
+                            <input id="az-easy-sub" class="form-control form-control-sm font-monospace"
+                                   placeholder="00000000-0000-0000-0000-000000000000"
+                                   @bind="easySubscriptionId" @bind:event="oninput" />
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label small mb-1" for="az-easy-scope">
+                                Storage account scope <span class="text-muted">(optional)</span>
+                            </label>
+                            <input id="az-easy-scope" class="form-control form-control-sm font-monospace"
+                                   placeholder="Leave blank to cover the whole subscription"
+                                   aria-describedby="az-easy-scope-help" @bind="easyStorageScope" />
+                            <div id="az-easy-scope-help" class="form-text">
+                                A storage-account resource id to scope the blob-data role to; blank grants it
+                                across the subscription.
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label small mb-1" for="az-easy-redirect">Sign-in redirect URI</label>
+                            <input id="az-easy-redirect" class="form-control form-control-sm font-monospace"
+                                   @bind="easyRedirectUri" aria-describedby="az-easy-redirect-help" />
+                            <div id="az-easy-redirect-help" class="form-text">
+                                Registered on the sign-in app. Auto-filled from the address you reached Connapse on.
+                            </div>
+                        </div>
+                    </div>
+
+                    @if (string.IsNullOrWhiteSpace(easySubscriptionId))
+                    {
+                        <div class="alert alert-secondary py-2 small mt-3 mb-0">
+                            Enter the subscription ID to generate the setup command.
+                        </div>
+                    }
+                    else
+                    {
+                        <button type="button" class="btn btn-sm btn-outline-primary mt-3 mb-2"
+                                @onclick="GenerateAzureScript">
+                            <span class="bi-arrow-repeat me-1" aria-hidden="true"></span>
+                            @(azureScript is null ? "Generate setup command" : "Regenerate (new certificate)")
+                        </button>
+
+                        @if (azureScript is { Length: > 0 } script)
+                        {
+                            <div class="alert alert-secondary py-2 small mb-2">
+                                <span class="bi-info-circle me-1" aria-hidden="true"></span>
+                                Keep this page open until you have pasted the result back — the certificate is
+                                held here until you save. Regenerating makes a fresh one.
+                            </div>
+
+                            <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:18rem;overflow:auto"><code>@script</code></pre>
+
+                            <div class="d-flex flex-wrap gap-2 mb-2">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(script)">
+                                    <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy command
+                                </button>
+                                <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"
+                                   href="https://shell.azure.com">
+                                    <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
+                                    <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
+                                </a>
+                                <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
+                            </div>
+
+                            <label class="form-label small mb-1" for="az-easy-paste">Paste what it printed</label>
+                            <textarea id="az-easy-paste" class="form-control font-monospace" rows="4"
+                                      @bind="azurePasted" @bind:event="oninput"
+                                      placeholder="@AzureCloudShellSetup.BeginMarker&#10;tenantId=…&#10;@AzureCloudShellSetup.EndMarker"></textarea>
+
+                            @if (!string.IsNullOrWhiteSpace(azurePasted))
+                            {
+                                var parsed = AzureCloudShellSetup.ParseResult(azurePasted);
+                                @if (parsed is null)
+                                {
+                                    <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                        <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                        No valid block found yet. Copy everything the command printed, including
+                                        both <code>-----</code> marker lines.
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+                                        <span class="small flex-grow-1">
+                                            Access app <code>@parsed.AccessAppClientId</code>, sign-in app
+                                            <code>@parsed.SignInAppClientId</code>@(parsed.ConsentGranted ? " — admin consent granted." : " — admin consent still pending.")
+                                        </span>
+                                        <button type="button" class="btn btn-sm btn-primary"
+                                                @onclick="() => SaveAzureFromScript(parsed)" disabled="@azureBusy">
+                                            @if (azureBusy)
+                                            {
+                                                <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+                                            }
+                                            else
+                                            {
+                                                <span class="bi-check-lg me-1" aria-hidden="true"></span>
+                                            }
+                                            Save
+                                        </button>
+                                    </div>
+                                }
+                            }
+                        }
+                    }
+                </div>
+            </div>
+
             <div class="card mb-3">
                 <div class="card-body">
                     <div class="d-flex align-items-center gap-2 mb-1">
@@ -1124,6 +1268,17 @@
     /// <summary>Backs the Azure setup forms — loaded from the effective settings, saved back per section.</summary>
     private AzureProviderSettings azureProviderSettings = new();
     private AzureAdSignInSettings azureAdSettings = new();
+
+    // Azure easy-setup (Cloud Shell) state.
+    private string? easySubscriptionId;
+    private string? easyStorageScope;
+    private string easyRedirectUri = "";
+    private string? azureScript;
+    private AzureCertificateMaterial? azureCert;
+    private string? azurePasted;
+    private bool azureBusy;
+    private string? azureConsentUrl;
+    private bool azureConsentPending;
 
     private string? grantsCopyMessage;
     private bool grantsCopySucceeded;
@@ -1291,6 +1446,11 @@
         identityCenterSettings = IdentityCenterOptions.CurrentValue;
         azureProviderSettings = AzureProviderOptions.CurrentValue;
         azureAdSettings = AzureAdOptions.CurrentValue;
+
+        // The sign-in app's redirect URI is Connapse's Entra callback at the address this admin reached
+        // it on; pre-fill the subscription from whatever is already stored.
+        easyRedirectUri = Navigation.BaseUri.TrimEnd('/') + "/api/v1/auth/cloud/azure/callback";
+        easySubscriptionId = azureProviderSettings.SubscriptionId;
     }
 
     /// <summary>
@@ -1938,6 +2098,82 @@
         }
 
         await RefreshSetups();
+    }
+
+    /// <summary>Generates a fresh certificate on this host and the Cloud Shell script that uploads only
+    /// its public half. The generated material is held until the operator saves the pasted-back result.</summary>
+    private void GenerateAzureScript()
+    {
+        azureCert = AzureCertificateGenerator.Generate("connapse-azure");
+        azureScript = AzureCloudShellSetup.GenerateScript(new AzureSetupInput(
+            SubscriptionId: (easySubscriptionId ?? string.Empty).Trim(),
+            StorageScope: string.IsNullOrWhiteSpace(easyStorageScope) ? null : easyStorageScope!.Trim(),
+            RedirectUri: easyRedirectUri.Trim(),
+            AccessAppName: "Connapse-Azure-Access",
+            SignInAppName: "Connapse-Azure-SignIn",
+            PublicCertificatePem: azureCert.PublicCertificatePem));
+        azurePasted = null;
+        copyMessage = null;
+    }
+
+    private async Task CopyText(string text)
+    {
+        copySucceeded = await JS.InvokeAsync<bool>("connapse.copyToClipboard", text);
+        copyMessage = copySucceeded ? "Copied." : "Could not copy — select it and copy manually.";
+    }
+
+    /// <summary>
+    /// Stores the pasted-back setup: writes the generated certificate (with its private key) to the
+    /// appdata volume, points both app registrations at it, and records the two client ids + tenant +
+    /// subscription. Surfaces the admin-consent URL when the operator could not consent.
+    /// </summary>
+    private async Task SaveAzureFromScript(AzureSetupResult result)
+    {
+        if (azureCert is null)
+        {
+            saveMessage = "Generate the setup command first, so Connapse has the certificate to store.";
+            saveSuccess = false;
+            return;
+        }
+
+        azureBusy = true;
+        try
+        {
+            // The private key stays on this host: write the cert + key to the appdata volume and point
+            // both apps at it. Only the public certificate was uploaded to Azure by the script.
+            string certDir = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure");
+            Directory.CreateDirectory(certDir);
+            string certPath = Path.Combine(certDir, "connapse-azure.pem");
+            await File.WriteAllTextAsync(certPath, azureCert.CombinedPem);
+
+            await SaveAzureProviderFromForm(new AzureProviderSettings
+            {
+                TenantId = result.TenantId,
+                ClientId = result.AccessAppClientId,
+                SubscriptionId = result.SubscriptionId,
+                ClientCertificatePath = certPath,
+            });
+
+            await SaveAzureAdFromForm(new AzureAdSignInSettings
+            {
+                TenantId = result.TenantId,
+                ClientId = result.SignInAppClientId,
+                RedirectUri = easyRedirectUri.Trim(),
+                ClientCertificatePath = certPath,
+            });
+
+            azureConsentPending = !result.ConsentGranted;
+            azureConsentUrl = result.ConsentUrl;
+        }
+        catch (Exception ex)
+        {
+            saveMessage = $"Could not save the Azure setup: {ex.Message}";
+            saveSuccess = false;
+        }
+        finally
+        {
+            azureBusy = false;
+        }
     }
 
     @* Two labels, because Warning means two different things depending on what carries it, and one

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1123,11 +1123,7 @@
                         <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.AccessScriptRequirements).
                     </p>
 
-                        <button type="button" class="btn btn-sm btn-outline-primary mb-2" @onclick="GenerateAzureAccessScript">
-                            <span class="bi-arrow-repeat me-1" aria-hidden="true"></span>
-                            @(azureAccessScript is null ? "Generate setup command" : "Regenerate (new certificate)")
-                        </button>
-
+                        @{ EnsureAzureAccessScript(); }
                         @if (azureAccessScript is { Length: > 0 } accessScript)
                         {
                             <div class="alert alert-secondary py-2 small mb-2">
@@ -1146,6 +1142,9 @@
                                     <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
                                     <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
                                 </a>
+                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="GenerateAzureAccessScript">
+                                    <span class="bi-arrow-repeat me-1" aria-hidden="true"></span> New certificate
+                                </button>
                                 <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
                             </div>
 
@@ -1266,18 +1265,14 @@
                         <div class="mb-3" style="max-width:44rem">
                             <label class="form-label small mb-1" for="az-perm-redirect">Sign-in redirect URI</label>
                             <input id="az-perm-redirect" class="form-control form-control-sm font-monospace"
-                                   @bind="easyRedirectUri" aria-describedby="az-perm-redirect-help" />
+                                   @bind="easyRedirectUri" @bind:after="RefreshAzurePermissionsScript"
+                                   aria-describedby="az-perm-redirect-help" />
                             <div id="az-perm-redirect-help" class="form-text">
                                 Registered on the sign-in app. Auto-filled from the address you reached Connapse on.
                             </div>
                         </div>
 
-                        <button type="button" class="btn btn-sm btn-outline-primary mb-2" @onclick="GenerateAzurePermissionsScript"
-                                disabled="@string.IsNullOrWhiteSpace(easyRedirectUri)">
-                            <span class="bi-arrow-repeat me-1" aria-hidden="true"></span>
-                            @(azurePermissionsScript is null ? "Generate setup command" : "Regenerate (new certificate)")
-                        </button>
-
+                        EnsureAzurePermissionsScript();
                         @if (azurePermissionsScript is { Length: > 0 } permissionsScript)
                         {
                             <div class="alert alert-secondary py-2 small mb-2">
@@ -1296,6 +1291,9 @@
                                     <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
                                     <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
                                 </a>
+                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="GenerateAzurePermissionsScript">
+                                    <span class="bi-arrow-repeat me-1" aria-hidden="true"></span> New certificate
+                                </button>
                                 <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
                             </div>
 
@@ -2215,13 +2213,36 @@
     private void GenerateAzurePermissionsScript()
     {
         azureSignInCert = AzureCertificateGenerator.Generate("connapse-azure-signin");
+        BuildAzurePermissionsScript();
+        azurePermissionsPasted = null;
+        copyMessage = null;
+    }
+
+    /// <summary>Re-renders the Permissions script for the current redirect URI, keeping the certificate.</summary>
+    private void BuildAzurePermissionsScript()
+    {
         azurePermissionsScript = AzureCloudShellSetup.GeneratePermissionsScript(new AzurePermissionsSetupInput(
             AccessAppClientId: azureProviderSettings.ClientId ?? string.Empty,
             RedirectUri: easyRedirectUri.Trim(),
             SignInAppName: "Connapse-Azure-SignIn",
-            PublicCertificatePem: azureSignInCert.PublicCertificatePem));
-        azurePermissionsPasted = null;
-        copyMessage = null;
+            PublicCertificatePem: azureSignInCert!.PublicCertificatePem));
+    }
+
+    private void RefreshAzurePermissionsScript()
+    {
+        if (azureSignInCert is not null) BuildAzurePermissionsScript();
+    }
+
+    // The scripts embed a certificate Connapse mints here, so each is produced the moment its guide
+    // renders rather than behind a button. Nothing touches disk until Save.
+    private void EnsureAzureAccessScript()
+    {
+        if (azureAccessScript is null) GenerateAzureAccessScript();
+    }
+
+    private void EnsureAzurePermissionsScript()
+    {
+        if (azurePermissionsScript is null) GenerateAzurePermissionsScript();
     }
 
     private async Task CopyText(string text)

--- a/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
@@ -1,0 +1,89 @@
+@using Connapse.Core
+@using Connapse.Web.Components.Shared
+
+@*
+    The Entra (Azure AD) application people sign in through to prove which directory user they are,
+    so their Azure results are scoped to what that identity may read. Connapse authenticates to
+    Entra with a certificate, never a client secret. Stored under the Identity:AzureAd settings.
+*@
+
+<div class="row g-3" style="max-width:44rem">
+    <div class="col-12">
+        <label class="form-label" for="azad-tenant">Directory (tenant) ID</label>
+        <input id="azad-tenant" class="form-control font-monospace" @bind="tenantId"
+               placeholder="00000000-0000-0000-0000-000000000000" />
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="azad-client">Application (client) ID</label>
+        <input id="azad-client" class="form-control font-monospace" @bind="clientId"
+               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="azad-client-help" />
+        <div id="azad-client-help" class="form-text">
+            The Entra app registration people sign in through — separate from the access app above.
+        </div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="azad-redirect">Redirect URI</label>
+        <input id="azad-redirect" class="form-control font-monospace" @bind="redirectUri"
+               placeholder="https://connapse.example.com/api/v1/auth/cloud/azure/cb"
+               aria-describedby="azad-redirect-help" />
+        <div id="azad-redirect-help" class="form-text">
+            Registered on the app registration as a redirect URI. Change Connapse's address and this
+            must be updated in Entra too, or sign-in stops with a redirect mismatch.
+        </div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="azad-cert">Client certificate path</label>
+        <input id="azad-cert" class="form-control font-monospace" @bind="certPath"
+               placeholder="/certs/azure-signin.pem" aria-describedby="azad-cert-help" />
+        <div id="azad-cert-help" class="form-text">
+            Path on the Connapse host to the PEM or PFX registered on the sign-in app registration.
+        </div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="azad-cert-pw">
+            Certificate password <span class="text-muted">(PFX only)</span>
+        </label>
+        <SecretTextArea Id="azad-cert-pw" Multiline="false" @bind-Value="certPassword"
+                        Placeholder="Leave blank for a PEM certificate" />
+    </div>
+</div>
+
+<div class="d-flex gap-2 mt-3">
+    <button type="button" class="btn btn-primary" @onclick="HandleSubmit">Save</button>
+    <button type="button" class="btn btn-outline-secondary" @onclick="Reset">Reset</button>
+</div>
+
+@code {
+    [Parameter] public AzureAdSignInSettings Settings { get; set; } = new();
+    [Parameter] public EventCallback<AzureAdSignInSettings> OnSave { get; set; }
+
+    // Local strings: AzureAdSignInSettings is an init-only record, rebuilt on save.
+    private string? tenantId, clientId, redirectUri, certPath, certPassword;
+
+    protected override void OnParametersSet()
+    {
+        tenantId = Settings.TenantId;
+        clientId = Settings.ClientId;
+        redirectUri = Settings.RedirectUri;
+        certPath = Settings.ClientCertificatePath;
+        certPassword = Settings.ClientCertificatePassword;
+    }
+
+    private Task HandleSubmit() =>
+        OnSave.InvokeAsync(new AzureAdSignInSettings
+        {
+            TenantId = Trim(tenantId),
+            ClientId = Trim(clientId),
+            RedirectUri = Trim(redirectUri),
+            ClientCertificatePath = Trim(certPath),
+            ClientCertificatePassword = string.IsNullOrWhiteSpace(certPassword) ? null : certPassword,
+        });
+
+    private static string? Trim(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private void Reset() => OnParametersSet();
+}

--- a/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
@@ -48,7 +48,7 @@
             Certificate password <span class="text-muted">(PFX only)</span>
         </label>
         <SecretTextArea Id="azad-cert-pw" Multiline="false" @bind-Value="certPassword"
-                        Placeholder="Leave blank for a PEM certificate" />
+                        Placeholder="@(Settings.ClientCertificatePassword is { Length: > 0 } ? "Leave blank to keep the stored password" : "Leave blank for a PEM certificate")" />
     </div>
 </div>
 
@@ -70,7 +70,8 @@
         clientId = Settings.ClientId;
         redirectUri = Settings.RedirectUri;
         certPath = Settings.ClientCertificatePath;
-        certPassword = Settings.ClientCertificatePassword;
+        // The stored password is never rehydrated into the browser; blank on save keeps it.
+        certPassword = null;
     }
 
     private Task HandleSubmit() =>
@@ -80,7 +81,8 @@
             ClientId = Trim(clientId),
             RedirectUri = Trim(redirectUri),
             ClientCertificatePath = Trim(certPath),
-            ClientCertificatePassword = string.IsNullOrWhiteSpace(certPassword) ? null : certPassword,
+            ClientCertificatePassword = string.IsNullOrWhiteSpace(certPassword) ? Settings.ClientCertificatePassword : certPassword,
+            AdminConsentPending = Settings.AdminConsentPending,
         });
 
     private static string? Trim(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();

--- a/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
@@ -1,0 +1,115 @@
+@using Connapse.Core
+@using Connapse.Web.Components.Shared
+
+@*
+    Connapse's own Azure app identity — what it reads Blob storage with, and queries Entra and Azure
+    Resource Manager (role/deny assignments) through. A certificate-based app registration or a
+    managed identity; never a client secret. Stored under the Providers:Azure settings.
+*@
+
+<div class="row g-3" style="max-width:44rem">
+    <div class="col-12">
+        <label class="form-label" for="az-tenant">Directory (tenant) ID</label>
+        <input id="az-tenant" class="form-control font-monospace" @bind="tenantId"
+               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="az-tenant-help" />
+        <div id="az-tenant-help" class="form-text">The Entra tenant the app registration lives in.</div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="az-sub">Subscription ID</label>
+        <input id="az-sub" class="form-control font-monospace" @bind="subscriptionId"
+               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="az-sub-help" />
+        <div id="az-sub-help" class="form-text">
+            The subscription whose role and deny assignments per-user filtering reads. Required for
+            Azure permission filtering — without it, Azure searches fail closed.
+        </div>
+    </div>
+
+    <div class="col-12">
+        <hr class="my-1" />
+        <div class="small text-uppercase text-muted">App registration (certificate)</div>
+        <div class="form-text mt-0">Leave these blank to use the host's ambient managed identity instead.</div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="az-client">Application (client) ID</label>
+        <input id="az-client" class="form-control font-monospace" @bind="clientId"
+               placeholder="00000000-0000-0000-0000-000000000000" />
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="az-cert">Client certificate path</label>
+        <input id="az-cert" class="form-control font-monospace" @bind="certPath"
+               placeholder="/certs/azure.pem" aria-describedby="az-cert-help" />
+        <div id="az-cert-help" class="form-text">
+            Path on the Connapse host to the PEM or PFX the app registration trusts. Connapse reads
+            it; it is never uploaded here.
+        </div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="az-cert-pw">
+            Certificate password <span class="text-muted">(PFX only)</span>
+        </label>
+        <SecretTextArea Id="az-cert-pw" Multiline="false" @bind-Value="certPassword"
+                        Placeholder="Leave blank for a PEM certificate" DescribedBy="az-cert-pw-help" />
+        <div id="az-cert-pw-help" class="form-text">Only for a password-protected PFX. Stored encrypted.</div>
+    </div>
+
+    <div class="col-12">
+        <hr class="my-1" />
+        <div class="small text-uppercase text-muted">Or a managed identity</div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="az-mi">
+            User-assigned managed identity client ID <span class="text-muted">(optional)</span>
+        </label>
+        <input id="az-mi" class="form-control font-monospace" @bind="miClientId"
+               placeholder="Leave blank to use the certificate above, or the ambient identity"
+               aria-describedby="az-mi-help" />
+        <div id="az-mi-help" class="form-text">
+            On Azure, leave the certificate blank and Connapse uses the host's managed identity; set
+            this to pick a specific user-assigned one.
+        </div>
+    </div>
+</div>
+
+<div class="d-flex gap-2 mt-3">
+    <button type="button" class="btn btn-primary" @onclick="HandleSubmit">Save</button>
+    <button type="button" class="btn btn-outline-secondary" @onclick="Reset">Reset</button>
+</div>
+
+@code {
+    [Parameter] public AzureProviderSettings Settings { get; set; } = new();
+    [Parameter] public EventCallback<AzureProviderSettings> OnSave { get; set; }
+
+    // Local strings rather than binding the record directly: AzureProviderSettings is init-only, so
+    // it cannot be @bound; the record is rebuilt on save.
+    private string? tenantId, clientId, subscriptionId, certPath, certPassword, miClientId;
+
+    protected override void OnParametersSet()
+    {
+        tenantId = Settings.TenantId;
+        clientId = Settings.ClientId;
+        subscriptionId = Settings.SubscriptionId;
+        certPath = Settings.ClientCertificatePath;
+        certPassword = Settings.ClientCertificatePassword;
+        miClientId = Settings.UserAssignedManagedIdentityClientId;
+    }
+
+    private Task HandleSubmit() =>
+        OnSave.InvokeAsync(new AzureProviderSettings
+        {
+            TenantId = Trim(tenantId),
+            ClientId = Trim(clientId),
+            SubscriptionId = Trim(subscriptionId),
+            ClientCertificatePath = Trim(certPath),
+            ClientCertificatePassword = string.IsNullOrWhiteSpace(certPassword) ? null : certPassword,
+            UserAssignedManagedIdentityClientId = Trim(miClientId),
+        });
+
+    private static string? Trim(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private void Reset() => OnParametersSet();
+}

--- a/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
@@ -52,8 +52,11 @@
             Certificate password <span class="text-muted">(PFX only)</span>
         </label>
         <SecretTextArea Id="az-cert-pw" Multiline="false" @bind-Value="certPassword"
-                        Placeholder="Leave blank for a PEM certificate" DescribedBy="az-cert-pw-help" />
-        <div id="az-cert-pw-help" class="form-text">Only for a password-protected PFX. Stored encrypted.</div>
+                        Placeholder="@(Settings.ClientCertificatePassword is { Length: > 0 } ? "Leave blank to keep the stored password" : "Leave blank for a PEM certificate")"
+                        DescribedBy="az-cert-pw-help" />
+        <div id="az-cert-pw-help" class="form-text">
+            Only for a password-protected PFX. The stored value is never shown here; leave it blank to keep it.
+        </div>
     </div>
 
     <div class="col-12">
@@ -94,7 +97,8 @@
         clientId = Settings.ClientId;
         subscriptionId = Settings.SubscriptionId;
         certPath = Settings.ClientCertificatePath;
-        certPassword = Settings.ClientCertificatePassword;
+        // The stored password is never rehydrated into the browser; blank on save keeps it.
+        certPassword = null;
         miClientId = Settings.UserAssignedManagedIdentityClientId;
     }
 
@@ -105,7 +109,7 @@
             ClientId = Trim(clientId),
             SubscriptionId = Trim(subscriptionId),
             ClientCertificatePath = Trim(certPath),
-            ClientCertificatePassword = string.IsNullOrWhiteSpace(certPassword) ? null : certPassword,
+            ClientCertificatePassword = string.IsNullOrWhiteSpace(certPassword) ? Settings.ClientCertificatePassword : certPassword,
             UserAssignedManagedIdentityClientId = Trim(miClientId),
         });
 

--- a/src/Connapse.Web/Services/ProviderSetupReader.cs
+++ b/src/Connapse.Web/Services/ProviderSetupReader.cs
@@ -16,6 +16,8 @@ namespace Connapse.Web.Services;
 public class ProviderSetupReader(
     IOptionsMonitor<SamlSignInSettings> samlSignIn,
     IOptionsMonitor<IdentityCenterSettings> identityCenter,
+    IOptionsMonitor<AzureProviderSettings> azureProvider,
+    IOptionsMonitor<AzureAdSignInSettings> azureAd,
     IS3Discovery s3Discovery,
     IConnectionStore connections,
     IProviderCredentialStore credentials,
@@ -62,8 +64,75 @@ public class ProviderSetupReader(
                     IdentityCentre(identityCenter.CurrentValue),
                     PerUserPermissions(samlSignIn.CurrentValue)
                 ],
-                InUse: providers.Contains(ConnectionProvider.S3))
+                InUse: providers.Contains(ConnectionProvider.S3)),
+
+            new ProviderSetup("azure", "Azure",
+                [
+                    AzureAccess(azureProvider.CurrentValue),
+                    AzurePerUserPermissions(azureAd.CurrentValue, azureProvider.CurrentValue)
+                ],
+                InUse: providers.Contains(ConnectionProvider.AzureBlob))
         ];
+    }
+
+    /// <summary>
+    /// Whether Connapse has an Azure app identity to read Blob storage (and Entra/ARM) with.
+    /// </summary>
+    /// <remarks>
+    /// Config-only for now — it reports whether a tenant and a credential are set, not a live probe.
+    /// A credential is a certificate-based app registration (<c>ClientId</c> + a certificate) or a
+    /// user-assigned managed identity. An ambient <i>system</i>-assigned managed identity cannot be
+    /// seen from settings, so a deployment relying on one reads as not-configured here even when it
+    /// works; a later iteration adds a live check (parity with AWS's access probe).
+    /// </remarks>
+    private static ProviderRequirement AzureAccess(AzureProviderSettings settings)
+    {
+        const string name = "Access";
+        const string description = "The Azure app identity Connapse reads Blob storage with.";
+
+        bool hasCredential =
+            (!string.IsNullOrWhiteSpace(settings.ClientId)
+                && !string.IsNullOrWhiteSpace(settings.ClientCertificatePath))
+            || !string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId);
+
+        if (string.IsNullOrWhiteSpace(settings.TenantId) || !hasCredential)
+            return new ProviderRequirement(name, description, RequirementStatus.NotConfigured,
+                "Set under the Providers:Azure settings — a tenant and either a certificate app "
+                + "registration or a managed identity — so Connapse can read Azure.");
+
+        return new ProviderRequirement(name, description, RequirementStatus.Satisfied,
+            $"Tenant {settings.TenantId}");
+    }
+
+    /// <summary>
+    /// Whether people can sign in with their Entra identity so their Azure results are scoped to
+    /// what they may read.
+    /// </summary>
+    /// <remarks>
+    /// Two parts: the Entra sign-in application (<c>Identity:AzureAd</c>) and the subscription the
+    /// RBAC resolver queries (<c>Providers:Azure</c> <c>SubscriptionId</c>). Both are needed for
+    /// per-user Azure filtering; sign-in without the subscription fails closed, so that is a warning
+    /// rather than a clean state.
+    /// </remarks>
+    private static ProviderRequirement AzurePerUserPermissions(
+        AzureAdSignInSettings signIn, AzureProviderSettings provider)
+    {
+        const string name = "Per-user permissions";
+        const string description =
+            "The Entra application people sign in through, so their Azure results are scoped to what "
+            + "that identity may read.";
+
+        if (!signIn.IsConfigured)
+            return new ProviderRequirement(name, description, RequirementStatus.NotConfigured,
+                "Set the Identity:AzureAd sign-in application so people can connect their Entra identity.");
+
+        if (string.IsNullOrWhiteSpace(provider.SubscriptionId))
+            return new ProviderRequirement(name, description, RequirementStatus.Warning,
+                "Sign-in is set, but Providers:Azure SubscriptionId is missing — the RBAC resolver "
+                + "needs it, so Azure filtering fails closed until it is set.");
+
+        return new ProviderRequirement(name, description, RequirementStatus.Satisfied,
+            $"Tenant {signIn.TenantId}, subscription {provider.SubscriptionId}");
     }
 
     /// <summary>

--- a/src/Connapse.Web/Services/ProviderSetupReader.cs
+++ b/src/Connapse.Web/Services/ProviderSetupReader.cs
@@ -135,6 +135,12 @@ public class ProviderSetupReader(
                 "Sign-in is set, but Providers:Azure SubscriptionId is missing — the RBAC resolver "
                 + "needs it, so Azure filtering fails closed until it is set.");
 
+        if (signIn.AdminConsentPending)
+            return new ProviderRequirement(name, description, RequirementStatus.Warning,
+                "Sign-in is set, but the access app's Microsoft Graph permissions still need an "
+                + "administrator's consent — directory lookups fail until then, so Azure filtering "
+                + "fails closed.");
+
         return new ProviderRequirement(name, description, RequirementStatus.Satisfied,
             $"Tenant {signIn.TenantId}, subscription {provider.SubscriptionId}");
     }

--- a/src/Connapse.Web/Services/ProviderSetupReader.cs
+++ b/src/Connapse.Web/Services/ProviderSetupReader.cs
@@ -56,6 +56,9 @@ public class ProviderSetupReader(
     {
         var providers = await InUseProvidersAsync(ct);
 
+        var azureAccess = AzureAccess(azureProvider.CurrentValue);
+        var azurePermissions = AzurePerUserPermissions(azureAd.CurrentValue, azureProvider.CurrentValue);
+
         return
         [
             new ProviderSetup("aws", "AWS",
@@ -64,14 +67,15 @@ public class ProviderSetupReader(
                     IdentityCentre(identityCenter.CurrentValue),
                     PerUserPermissions(samlSignIn.CurrentValue)
                 ],
-                InUse: providers.Contains(ConnectionProvider.S3)),
+                InUse: providers.Contains(ConnectionProvider.S3) || samlSignIn.CurrentValue.IsConfigured),
 
+            // Azure access is settings-only (no ambient credential can make it read as configured),
+            // so a saved Access step is as deliberate a choice as sign-in or a connection.
             new ProviderSetup("azure", "Azure",
-                [
-                    AzureAccess(azureProvider.CurrentValue),
-                    AzurePerUserPermissions(azureAd.CurrentValue, azureProvider.CurrentValue)
-                ],
-                InUse: providers.Contains(ConnectionProvider.AzureBlob))
+                [azureAccess, azurePermissions],
+                InUse: providers.Contains(ConnectionProvider.AzureBlob)
+                    || azureAd.CurrentValue.IsConfigured
+                    || azureAccess.Status != RequirementStatus.NotConfigured)
         ];
     }
 

--- a/tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
@@ -15,16 +15,18 @@ public class AzureBlobConnectorUnitTests
             new BlobServiceClient(new Uri("http://127.0.0.1:10000/devstoreaccount1")));
 
     [Theory]
-    [InlineData("reports/", null, true)]                 // flat-namespace folder marker
-    [InlineData("reports/q1", "true", true)]             // Gen2 directory placeholder
-    [InlineData("reports/q1", "True", true)]
-    [InlineData("reports/q1.pdf", "false", false)]
-    [InlineData("reports/q1.pdf", null, false)]
-    [InlineData("README", null, false)]                  // an extension-less real file is still a file
-    public void IsDirectoryPlaceholder_FoldersAreNotFiles(string name, string? hdiIsFolder, bool expected)
+    [InlineData("reports/", 0, null, true)]              // flat-namespace folder marker
+    [InlineData("reports/q1", 0, "true", true)]          // Gen2 directory placeholder
+    [InlineData("reports/q1", 0, "True", true)]
+    [InlineData("reports/q1.pdf", 1234, "false", false)]
+    [InlineData("reports/q1.pdf", 1234, null, false)]
+    [InlineData("README", 0, null, false)]               // an empty extension-less real file is still a file
+    [InlineData("reports/", 512, null, false)]           // a real blob that merely ends in '/' is a file
+    [InlineData("reports/q1", 512, "true", false)]       // content wins over app-controlled metadata
+    public void IsDirectoryPlaceholder_OnlyZeroByteFolderMarkersAreDropped(string name, long length, string? hdiIsFolder, bool expected)
     {
         var metadata = hdiIsFolder is null ? null : new Dictionary<string, string> { ["hdi_isfolder"] = hdiIsFolder };
-        AzureBlobConnector.IsDirectoryPlaceholder(name, metadata).Should().Be(expected);
+        AzureBlobConnector.IsDirectoryPlaceholder(name, length, metadata).Should().Be(expected);
     }
 
     [Fact] public void Type_IsAzureBlob() => Make().Type.Should().Be(ConnectorType.AzureBlob);

--- a/tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
@@ -14,6 +14,19 @@ public class AzureBlobConnectorUnitTests
         new(new AzureBlobConnectorConfig { AccountName = "acct", ContainerName = "docs", Prefix = "reports/" },
             new BlobServiceClient(new Uri("http://127.0.0.1:10000/devstoreaccount1")));
 
+    [Theory]
+    [InlineData("reports/", null, true)]                 // flat-namespace folder marker
+    [InlineData("reports/q1", "true", true)]             // Gen2 directory placeholder
+    [InlineData("reports/q1", "True", true)]
+    [InlineData("reports/q1.pdf", "false", false)]
+    [InlineData("reports/q1.pdf", null, false)]
+    [InlineData("README", null, false)]                  // an extension-less real file is still a file
+    public void IsDirectoryPlaceholder_FoldersAreNotFiles(string name, string? hdiIsFolder, bool expected)
+    {
+        var metadata = hdiIsFolder is null ? null : new Dictionary<string, string> { ["hdi_isfolder"] = hdiIsFolder };
+        AzureBlobConnector.IsDirectoryPlaceholder(name, metadata).Should().Be(expected);
+    }
+
     [Fact] public void Type_IsAzureBlob() => Make().Type.Should().Be(ConnectorType.AzureBlob);
     [Fact] public void SupportsLiveWatch_False() => Make().SupportsLiveWatch.Should().BeFalse();
 

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -172,12 +172,46 @@ public class AzureCloudShellSetupTests
     }
 
     [Fact]
-    public void Scripts_FindExistingAppsByName_SoReRunsDoNotDuplicate()
+    public void Scripts_NeverDiscoverAppsByDisplayName()
     {
-        AzureCloudShellSetup.GenerateAccessScript(AccessInput())
-            .Should().Contain("az ad app list --display-name \"$ACCESS_APP_NAME\"");
-        AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput())
-            .Should().Contain("az ad app list --display-name \"$SIGNIN_APP_NAME\"");
+        // A display name is not unique or authoritative: a look-alike registered by another tenant
+        // user must never be handed Connapse's roles and Graph permissions.
+        AzureCloudShellSetup.GenerateAccessScript(AccessInput()).Should().NotContain("--display-name \"$ACCESS_APP_NAME\" --query '[0]");
+        AzureCloudShellSetup.GenerateAccessScript(AccessInput()).Should().NotContain("az ad app list");
+        AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput()).Should().NotContain("az ad app list");
+    }
+
+    [Fact]
+    public void AccessScript_FirstRun_CreatesAFreshApp_ReRunReusesOnlyTheRecordedId()
+    {
+        string fresh = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+        fresh.Should().Contain("ACCESS_APP_ID=''");
+        fresh.Should().Contain("az ad app create --display-name \"$ACCESS_APP_NAME\"");
+
+        string rerun = AzureCloudShellSetup.GenerateAccessScript(AccessInput() with { ExistingAccessAppClientId = AccessId });
+        rerun.Should().Contain($"ACCESS_APP_ID='{AccessId}'");
+        rerun.Should().Contain("az ad app show --id \"$ACCESS_APP_ID\"");
+
+        // Anything that is not a GUID is treated as "nothing recorded", so it cannot inject shell.
+        AzureCloudShellSetup.GenerateAccessScript(AccessInput() with { ExistingAccessAppClientId = "'; rm -rf / #" })
+            .Should().Contain("ACCESS_APP_ID=''");
+    }
+
+    [Fact]
+    public void PermissionsScript_ReRunReusesOnlyTheRecordedSignInId()
+    {
+        AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput()).Should().Contain("SIGNIN_APP_ID=''");
+        AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput() with { ExistingSignInAppClientId = SignInId })
+            .Should().Contain($"SIGNIN_APP_ID='{SignInId}'").And.Contain("az ad app show --id \"$SIGNIN_APP_ID\"");
+    }
+
+    [Fact]
+    public void AccessScript_RoleAssignmentFailsLoudly_InsteadOfPrintingAPasteBlock()
+    {
+        string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+        s.Should().Contain("assign_role '" + AzureCloudShellSetup.BlobDataRoleName + "' \"$STORAGE_SCOPE\"");
+        s.Should().Contain("after 5 attempts");
+        s.Should().NotContain("&& break || sleep");
     }
 
     [Fact]

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -1,0 +1,123 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class AzureCloudShellSetupTests
+{
+    private static AzureSetupInput Input() => new(
+        SubscriptionId: "33333333-3333-3333-3333-333333333333",
+        StorageScope: null,
+        RedirectUri: "https://connapse.example.com/api/v1/auth/cloud/azure/callback",
+        AccessAppName: "Connapse-Azure-Access",
+        SignInAppName: "Connapse-Azure-SignIn",
+        PublicCertificatePem: "-----BEGIN CERTIFICATE-----\nMIIBfakefakefake\n-----END CERTIFICATE-----");
+
+    [Fact]
+    public void GenerateScript_ContainsTheKeyStepsAndMarkers()
+    {
+        string script = AzureCloudShellSetup.GenerateScript(Input());
+
+        script.Should().Contain(AzureCloudShellSetup.BeginMarker);
+        script.Should().Contain(AzureCloudShellSetup.EndMarker);
+        script.Should().Contain("33333333-3333-3333-3333-333333333333");
+        script.Should().Contain("https://connapse.example.com/api/v1/auth/cloud/azure/callback");
+        script.Should().Contain("az ad app create --display-name \"$ACCESS_APP_NAME\"");
+        script.Should().Contain("az ad app create --display-name \"$SIGNIN_APP_NAME\"");
+        script.Should().Contain("--web-redirect-uris \"$REDIRECT_URI\"");
+        script.Should().Contain(AzureCloudShellSetup.BlobDataRoleName);
+        script.Should().Contain(AzureCloudShellSetup.RbacReadRoleName);
+        script.Should().Contain("blobs/tags/read");
+        script.Should().Contain("Microsoft.Authorization/denyAssignments/read");
+        script.Should().Contain("User.Read.All");
+        script.Should().Contain("GroupMember.Read.All");
+        script.Should().Contain("az ad app permission admin-consent");
+        script.Should().Contain("MIIBfakefakefake"); // the public cert is embedded
+        script.Should().NotContain("PRIVATE KEY");    // never the private key
+    }
+
+    [Fact]
+    public void GenerateScript_StorageScope_DefaultsToSubscription_WhenNull()
+    {
+        string script = AzureCloudShellSetup.GenerateScript(Input());
+        script.Should().Contain("STORAGE_SCOPE='/subscriptions/33333333-3333-3333-3333-333333333333'");
+    }
+
+    [Fact]
+    public void GenerateScript_UsesGivenStorageScope_WhenProvided()
+    {
+        var input = Input() with { StorageScope = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct" };
+        string script = AzureCloudShellSetup.GenerateScript(input);
+        script.Should().Contain("STORAGE_SCOPE='/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct'");
+    }
+
+    private static string Block(string tenant, string sub, string access, string signIn, string consent = "true", string? url = null) =>
+        $"{AzureCloudShellSetup.BeginMarker}\n"
+        + $"tenantId={tenant}\nsubscriptionId={sub}\naccessAppClientId={access}\nsignInAppClientId={signIn}\n"
+        + $"consentGranted={consent}\nconsentUrl={url ?? "https://login.microsoftonline.com/" + tenant + "/adminconsent?client_id=" + access}\n"
+        + $"{AzureCloudShellSetup.EndMarker}";
+
+    [Fact]
+    public void ParseResult_WellFormedBlock_ReturnsAllFields()
+    {
+        AzureSetupResult? r = AzureCloudShellSetup.ParseResult(Block(
+            "11111111-1111-1111-1111-111111111111", "33333333-3333-3333-3333-333333333333",
+            "22222222-2222-2222-2222-222222222222", "44444444-4444-4444-4444-444444444444"));
+
+        r.Should().NotBeNull();
+        r!.TenantId.Should().Be("11111111-1111-1111-1111-111111111111");
+        r.SubscriptionId.Should().Be("33333333-3333-3333-3333-333333333333");
+        r.AccessAppClientId.Should().Be("22222222-2222-2222-2222-222222222222");
+        r.SignInAppClientId.Should().Be("44444444-4444-4444-4444-444444444444");
+        r.ConsentGranted.Should().BeTrue();
+        r.ConsentUrl.Should().Contain("adminconsent");
+    }
+
+    [Fact]
+    public void ParseResult_ConsentNotGranted_CarriesFalseAndUrl()
+    {
+        AzureSetupResult? r = AzureCloudShellSetup.ParseResult(Block(
+            "11111111-1111-1111-1111-111111111111", "33333333-3333-3333-3333-333333333333",
+            "22222222-2222-2222-2222-222222222222", "44444444-4444-4444-4444-444444444444",
+            consent: "false"));
+
+        r!.ConsentGranted.Should().BeFalse();
+        r.ConsentUrl.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ParseResult_AnchorsOnLastMarkerPair_WhenTerminalIsPasted()
+    {
+        // Pasting the whole terminal (script echo THEN the printed block) must read the printed block.
+        string terminal = "az ad app create ...\n" + AzureCloudShellSetup.BeginMarker + "\nnoise\n" + AzureCloudShellSetup.EndMarker
+            + "\n...output...\n" + Block("11111111-1111-1111-1111-111111111111", "33333333-3333-3333-3333-333333333333",
+                "22222222-2222-2222-2222-222222222222", "44444444-4444-4444-4444-444444444444");
+
+        AzureCloudShellSetup.ParseResult(terminal)!.AccessAppClientId
+            .Should().Be("22222222-2222-2222-2222-222222222222");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("no markers here")]
+    public void ParseResult_NoBlock_ReturnsNull(string? pasted) =>
+        AzureCloudShellSetup.ParseResult(pasted).Should().BeNull();
+
+    [Fact]
+    public void ParseResult_NonGuidId_ReturnsNull() =>
+        AzureCloudShellSetup.ParseResult(Block(
+            "not-a-guid", "33333333-3333-3333-3333-333333333333",
+            "22222222-2222-2222-2222-222222222222", "44444444-4444-4444-4444-444444444444"))
+            .Should().BeNull();
+
+    [Fact]
+    public void GenerateScript_ThenParseResult_RoundTripsTheMarkerContract()
+    {
+        // The script's printf uses the same keys ParseResult reads — guard against them drifting apart.
+        string script = AzureCloudShellSetup.GenerateScript(Input());
+        foreach (string key in new[] { "tenantId=", "subscriptionId=", "accessAppClientId=", "signInAppClientId=", "consentGranted=", "consentUrl=" })
+            script.Should().Contain(key);
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -6,118 +6,143 @@ namespace Connapse.Core.Tests.Utilities;
 [Trait("Category", "Unit")]
 public class AzureCloudShellSetupTests
 {
-    private static AzureSetupInput Input() => new(
-        SubscriptionId: "33333333-3333-3333-3333-333333333333",
-        StorageScope: null,
-        RedirectUri: "https://connapse.example.com/api/v1/auth/cloud/azure/callback",
-        AccessAppName: "Connapse-Azure-Access",
-        SignInAppName: "Connapse-Azure-SignIn",
-        PublicCertificatePem: "-----BEGIN CERTIFICATE-----\nMIIBfakefakefake\n-----END CERTIFICATE-----");
+    private const string Sub = "33333333-3333-3333-3333-333333333333";
+    private const string Tenant = "11111111-1111-1111-1111-111111111111";
+    private const string AccessId = "22222222-2222-2222-2222-222222222222";
+    private const string SignInId = "44444444-4444-4444-4444-444444444444";
+    private const string Cert = "-----BEGIN CERTIFICATE-----\nMIIBfakefakefake\n-----END CERTIFICATE-----";
+
+    // ---- Access step ----
+
+    private static AzureAccessSetupInput AccessInput(string? scope = null) =>
+        new(Sub, scope, "Connapse-Azure-Access", Cert);
 
     [Fact]
-    public void GenerateScript_ContainsTheKeyStepsAndMarkers()
+    public void AccessScript_ContainsRolesAppCertAndMarkers_ButNeverThePrivateKey()
     {
-        string script = AzureCloudShellSetup.GenerateScript(Input());
+        string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
 
-        script.Should().Contain(AzureCloudShellSetup.BeginMarker);
-        script.Should().Contain(AzureCloudShellSetup.EndMarker);
-        script.Should().Contain("33333333-3333-3333-3333-333333333333");
-        script.Should().Contain("https://connapse.example.com/api/v1/auth/cloud/azure/callback");
-        script.Should().Contain("az ad app create --display-name \"$ACCESS_APP_NAME\"");
-        script.Should().Contain("az ad app create --display-name \"$SIGNIN_APP_NAME\"");
-        script.Should().Contain("--web-redirect-uris \"$REDIRECT_URI\"");
-        script.Should().Contain(AzureCloudShellSetup.BlobDataRoleName);
-        script.Should().Contain(AzureCloudShellSetup.RbacReadRoleName);
-        script.Should().Contain("blobs/tags/read");
-        script.Should().Contain("Microsoft.Authorization/denyAssignments/read");
-        script.Should().Contain("User.Read.All");
-        script.Should().Contain("GroupMember.Read.All");
-        script.Should().Contain("az ad app permission admin-consent");
-        script.Should().Contain("MIIBfakefakefake"); // the public cert is embedded
-        script.Should().NotContain("PRIVATE KEY");    // never the private key
+        s.Should().Contain(AzureCloudShellSetup.AccessBeginMarker).And.Contain(AzureCloudShellSetup.AccessEndMarker);
+        s.Should().Contain($"SUBSCRIPTION_ID='{Sub}'");
+        s.Should().Contain(AzureCloudShellSetup.BlobDataRoleName).And.Contain("blobs/tags/read");
+        s.Should().Contain(AzureCloudShellSetup.RbacReadRoleName).And.Contain("Microsoft.Authorization/denyAssignments/read");
+        s.Should().Contain("az ad app create --display-name \"$ACCESS_APP_NAME\"");
+        s.Should().Contain("az ad app credential reset").And.Contain("--append");
+        s.Should().Contain("MIIBfakefakefake");
+        s.Should().NotContain("PRIVATE KEY");
+        s.Should().NotContain("admin-consent"); // consent belongs to the Permissions step
     }
 
     [Fact]
-    public void GenerateScript_StorageScope_DefaultsToSubscription_WhenNull()
-    {
-        string script = AzureCloudShellSetup.GenerateScript(Input());
-        script.Should().Contain("STORAGE_SCOPE='/subscriptions/33333333-3333-3333-3333-333333333333'");
-    }
+    public void AccessScript_StorageScope_DefaultsToSubscription() =>
+        AzureCloudShellSetup.GenerateAccessScript(AccessInput())
+            .Should().Contain($"STORAGE_SCOPE='/subscriptions/{Sub}'");
 
     [Fact]
-    public void GenerateScript_UsesGivenStorageScope_WhenProvided()
+    public void AccessScript_UsesGivenStorageScope()
     {
-        var input = Input() with { StorageScope = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct" };
-        string script = AzureCloudShellSetup.GenerateScript(input);
-        script.Should().Contain("STORAGE_SCOPE='/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct'");
+        string scope = $"/subscriptions/{Sub}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+        AzureCloudShellSetup.GenerateAccessScript(AccessInput(scope))
+            .Should().Contain($"STORAGE_SCOPE='{scope}'");
     }
 
-    private static string Block(string tenant, string sub, string access, string signIn, string consent = "true", string? url = null) =>
-        $"{AzureCloudShellSetup.BeginMarker}\n"
-        + $"tenantId={tenant}\nsubscriptionId={sub}\naccessAppClientId={access}\nsignInAppClientId={signIn}\n"
-        + $"consentGranted={consent}\nconsentUrl={url ?? "https://login.microsoftonline.com/" + tenant + "/adminconsent?client_id=" + access}\n"
-        + $"{AzureCloudShellSetup.EndMarker}";
+    private static string AccessBlock(string tenant = Tenant, string sub = Sub, string access = AccessId) =>
+        $"{AzureCloudShellSetup.AccessBeginMarker}\ntenantId={tenant}\nsubscriptionId={sub}\naccessAppClientId={access}\n{AzureCloudShellSetup.AccessEndMarker}";
 
     [Fact]
-    public void ParseResult_WellFormedBlock_ReturnsAllFields()
+    public void ParseAccessResult_WellFormed_ReturnsIds()
     {
-        AzureSetupResult? r = AzureCloudShellSetup.ParseResult(Block(
-            "11111111-1111-1111-1111-111111111111", "33333333-3333-3333-3333-333333333333",
-            "22222222-2222-2222-2222-222222222222", "44444444-4444-4444-4444-444444444444"));
-
+        AzureAccessResult? r = AzureCloudShellSetup.ParseAccessResult(AccessBlock());
         r.Should().NotBeNull();
-        r!.TenantId.Should().Be("11111111-1111-1111-1111-111111111111");
-        r.SubscriptionId.Should().Be("33333333-3333-3333-3333-333333333333");
-        r.AccessAppClientId.Should().Be("22222222-2222-2222-2222-222222222222");
-        r.SignInAppClientId.Should().Be("44444444-4444-4444-4444-444444444444");
-        r.ConsentGranted.Should().BeTrue();
-        r.ConsentUrl.Should().Contain("adminconsent");
+        r!.TenantId.Should().Be(Tenant);
+        r.SubscriptionId.Should().Be(Sub);
+        r.AccessAppClientId.Should().Be(AccessId);
     }
 
     [Fact]
-    public void ParseResult_ConsentNotGranted_CarriesFalseAndUrl()
+    public void ParseAccessResult_AnchorsOnLastMarkerPair_WhenTerminalIsPasted()
     {
-        AzureSetupResult? r = AzureCloudShellSetup.ParseResult(Block(
-            "11111111-1111-1111-1111-111111111111", "33333333-3333-3333-3333-333333333333",
-            "22222222-2222-2222-2222-222222222222", "44444444-4444-4444-4444-444444444444",
-            consent: "false"));
-
-        r!.ConsentGranted.Should().BeFalse();
-        r.ConsentUrl.Should().NotBeNull();
-    }
-
-    [Fact]
-    public void ParseResult_AnchorsOnLastMarkerPair_WhenTerminalIsPasted()
-    {
-        // Pasting the whole terminal (script echo THEN the printed block) must read the printed block.
-        string terminal = "az ad app create ...\n" + AzureCloudShellSetup.BeginMarker + "\nnoise\n" + AzureCloudShellSetup.EndMarker
-            + "\n...output...\n" + Block("11111111-1111-1111-1111-111111111111", "33333333-3333-3333-3333-333333333333",
-                "22222222-2222-2222-2222-222222222222", "44444444-4444-4444-4444-444444444444");
-
-        AzureCloudShellSetup.ParseResult(terminal)!.AccessAppClientId
-            .Should().Be("22222222-2222-2222-2222-222222222222");
+        string terminal = "echo script\n" + AzureCloudShellSetup.AccessBeginMarker + "\nnoise\n" + AzureCloudShellSetup.AccessEndMarker
+            + "\n...\n" + AccessBlock();
+        AzureCloudShellSetup.ParseAccessResult(terminal)!.AccessAppClientId.Should().Be(AccessId);
     }
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    [InlineData("no markers here")]
-    public void ParseResult_NoBlock_ReturnsNull(string? pasted) =>
-        AzureCloudShellSetup.ParseResult(pasted).Should().BeNull();
+    [InlineData("no markers")]
+    public void ParseAccessResult_NoBlock_ReturnsNull(string? pasted) =>
+        AzureCloudShellSetup.ParseAccessResult(pasted).Should().BeNull();
 
     [Fact]
-    public void ParseResult_NonGuidId_ReturnsNull() =>
-        AzureCloudShellSetup.ParseResult(Block(
-            "not-a-guid", "33333333-3333-3333-3333-333333333333",
-            "22222222-2222-2222-2222-222222222222", "44444444-4444-4444-4444-444444444444"))
-            .Should().BeNull();
+    public void ParseAccessResult_NonGuid_ReturnsNull() =>
+        AzureCloudShellSetup.ParseAccessResult(AccessBlock(tenant: "not-a-guid")).Should().BeNull();
 
     [Fact]
-    public void GenerateScript_ThenParseResult_RoundTripsTheMarkerContract()
+    public void AccessScript_PrintsTheKeys_ParseAccessResultReads()
     {
-        // The script's printf uses the same keys ParseResult reads — guard against them drifting apart.
-        string script = AzureCloudShellSetup.GenerateScript(Input());
-        foreach (string key in new[] { "tenantId=", "subscriptionId=", "accessAppClientId=", "signInAppClientId=", "consentGranted=", "consentUrl=" })
-            script.Should().Contain(key);
+        string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+        foreach (string key in new[] { "tenantId=", "subscriptionId=", "accessAppClientId=" })
+            s.Should().Contain(key);
+    }
+
+    // ---- Per-user permissions step ----
+
+    private static AzurePermissionsSetupInput PermissionsInput() =>
+        new(AccessId, "https://connapse.example.com/api/v1/auth/cloud/azure/callback", "Connapse-Azure-SignIn", Cert);
+
+    [Fact]
+    public void PermissionsScript_ContainsSignInAppGraphPermsConsentAndMarkers()
+    {
+        string s = AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput());
+
+        s.Should().Contain(AzureCloudShellSetup.PermissionsBeginMarker).And.Contain(AzureCloudShellSetup.PermissionsEndMarker);
+        s.Should().Contain($"ACCESS_APP_ID='{AccessId}'");
+        s.Should().Contain("--web-redirect-uris \"$REDIRECT_URI\"");
+        s.Should().Contain("https://connapse.example.com/api/v1/auth/cloud/azure/callback");
+        s.Should().Contain("User.Read.All").And.Contain("GroupMember.Read.All");
+        s.Should().Contain("az ad app permission admin-consent");
+        s.Should().Contain("/adminconsent?client_id=");
+        s.Should().Contain("MIIBfakefakefake");
+        s.Should().NotContain("PRIVATE KEY");
+        s.Should().NotContain("az role definition create"); // roles belong to the Access step
+    }
+
+    private static string PermissionsBlock(string signIn = SignInId, string consent = "true") =>
+        $"{AzureCloudShellSetup.PermissionsBeginMarker}\nsignInAppClientId={signIn}\nconsentGranted={consent}\n"
+        + $"consentUrl=https://login.microsoftonline.com/{Tenant}/adminconsent?client_id={AccessId}\n{AzureCloudShellSetup.PermissionsEndMarker}";
+
+    [Fact]
+    public void ParsePermissionsResult_ConsentGranted_ReturnsIdAndTrue()
+    {
+        AzurePermissionsResult? r = AzureCloudShellSetup.ParsePermissionsResult(PermissionsBlock());
+        r.Should().NotBeNull();
+        r!.SignInAppClientId.Should().Be(SignInId);
+        r.ConsentGranted.Should().BeTrue();
+        r.ConsentUrl.Should().Contain("adminconsent");
+    }
+
+    [Fact]
+    public void ParsePermissionsResult_ConsentPending_ReturnsFalseAndUrl()
+    {
+        AzurePermissionsResult? r = AzureCloudShellSetup.ParsePermissionsResult(PermissionsBlock(consent: "false"));
+        r!.ConsentGranted.Should().BeFalse();
+        r.ConsentUrl.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ParsePermissionsResult_NonGuid_ReturnsNull() =>
+        AzureCloudShellSetup.ParsePermissionsResult(PermissionsBlock(signIn: "bad")).Should().BeNull();
+
+    [Fact]
+    public void ParsePermissionsResult_DoesNotReadTheAccessBlock() =>
+        AzureCloudShellSetup.ParsePermissionsResult(AccessBlock()).Should().BeNull();
+
+    [Fact]
+    public void PermissionsScript_PrintsTheKeys_ParsePermissionsResultReads()
+    {
+        string s = AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput());
+        foreach (string key in new[] { "signInAppClientId=", "consentGranted=", "consentUrl=" })
+            s.Should().Contain(key);
     }
 }

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -93,7 +93,11 @@ public class AzureCloudShellSetupTests
     // ---- Per-user permissions step ----
 
     private static AzurePermissionsSetupInput PermissionsInput() =>
-        new(AccessId, "https://connapse.example.com/api/v1/auth/cloud/azure/callback", "Connapse-Azure-SignIn", Cert);
+        new(AccessId,
+            "https://connapse.example.com/api/v1/auth/cloud/azure/callback",
+            "https://connapse.example.com/admin/providers/azure",
+            "Connapse-Azure-SignIn",
+            Cert);
 
     [Fact]
     public void PermissionsScript_ContainsSignInAppGraphPermsConsentAndMarkers()
@@ -102,7 +106,7 @@ public class AzureCloudShellSetupTests
 
         s.Should().Contain(AzureCloudShellSetup.PermissionsBeginMarker).And.Contain(AzureCloudShellSetup.PermissionsEndMarker);
         s.Should().Contain($"ACCESS_APP_ID='{AccessId}'");
-        s.Should().Contain("--web-redirect-uris \"$REDIRECT_URI\"");
+        s.Should().Contain("az ad app update --id \"$SIGNIN_APP_ID\" --web-redirect-uris \"$REDIRECT_URI\"");
         s.Should().Contain("https://connapse.example.com/api/v1/auth/cloud/azure/callback");
         s.Should().Contain("User.Read.All").And.Contain("GroupMember.Read.All");
         s.Should().Contain("az ad app permission admin-consent");
@@ -115,6 +119,27 @@ public class AzureCloudShellSetupTests
     private static string PermissionsBlock(string signIn = SignInId, string consent = "true") =>
         $"{AzureCloudShellSetup.PermissionsBeginMarker}\nsignInAppClientId={signIn}\nconsentGranted={consent}\n"
         + $"consentUrl=https://login.microsoftonline.com/{Tenant}/adminconsent?client_id={AccessId}\n{AzureCloudShellSetup.PermissionsEndMarker}";
+
+    [Fact]
+    public void PermissionsScript_RegistersConsentLandingOnAccessApp_AndPassesItAsRedirectUri()
+    {
+        // The v1 adminconsent endpoint needs a registered reply URL on the app being consented to,
+        // else it fails with AADSTS500113 before showing the prompt.
+        string s = AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput());
+
+        s.Should().Contain("az ad app update --id \"$ACCESS_APP_ID\" --web-redirect-uris \"$CONSENT_REDIRECT_URI\"");
+        s.Should().Contain("CONSENT_REDIRECT_URI='https://connapse.example.com/admin/providers/azure'");
+        s.Should().Contain("&redirect_uri=https%3A%2F%2Fconnapse.example.com%2Fadmin%2Fproviders%2Fazure");
+    }
+
+    [Fact]
+    public void Scripts_FindExistingAppsByName_SoReRunsDoNotDuplicate()
+    {
+        AzureCloudShellSetup.GenerateAccessScript(AccessInput())
+            .Should().Contain("az ad app list --display-name \"$ACCESS_APP_NAME\"");
+        AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput())
+            .Should().Contain("az ad app list --display-name \"$SIGNIN_APP_NAME\"");
+    }
 
     [Fact]
     public void ParsePermissionsResult_ConsentGranted_ReturnsIdAndTrue()

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -14,8 +14,7 @@ public class AzureCloudShellSetupTests
 
     // ---- Access step ----
 
-    private static AzureAccessSetupInput AccessInput(string? scope = null) =>
-        new(Sub, scope, "Connapse-Azure-Access", Cert);
+    private static AzureAccessSetupInput AccessInput() => new("Connapse-Azure-Access", Cert);
 
     [Fact]
     public void AccessScript_ContainsRolesAppCertAndMarkers_ButNeverThePrivateKey()
@@ -23,7 +22,7 @@ public class AzureCloudShellSetupTests
         string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
 
         s.Should().Contain(AzureCloudShellSetup.AccessBeginMarker).And.Contain(AzureCloudShellSetup.AccessEndMarker);
-        s.Should().Contain($"SUBSCRIPTION_ID='{Sub}'");
+        s.Should().Contain("ACCESS_APP_NAME='Connapse-Azure-Access'");
         s.Should().Contain(AzureCloudShellSetup.BlobDataRoleName).And.Contain("blobs/tags/read");
         s.Should().Contain(AzureCloudShellSetup.RbacReadRoleName).And.Contain("Microsoft.Authorization/denyAssignments/read");
         s.Should().Contain("az ad app create --display-name \"$ACCESS_APP_NAME\"");
@@ -34,16 +33,21 @@ public class AzureCloudShellSetupTests
     }
 
     [Fact]
-    public void AccessScript_StorageScope_DefaultsToSubscription() =>
-        AzureCloudShellSetup.GenerateAccessScript(AccessInput())
-            .Should().Contain($"STORAGE_SCOPE='/subscriptions/{Sub}'");
+    public void AccessScript_ReadsTheSignedInSubscription_NothingToTypeUpFront()
+    {
+        string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+
+        s.Should().Contain("SUBSCRIPTION_ID=$(az account show --query id -o tsv)");
+        s.Should().NotContain("{{"); // no unfilled placeholders
+    }
 
     [Fact]
-    public void AccessScript_UsesGivenStorageScope()
+    public void AccessScript_StorageScope_DefaultsToWholeSubscription_AndIsEditableInline()
     {
-        string scope = $"/subscriptions/{Sub}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
-        AzureCloudShellSetup.GenerateAccessScript(AccessInput(scope))
-            .Should().Contain($"STORAGE_SCOPE='{scope}'");
+        string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+
+        s.Should().Contain("STORAGE_SCOPE=\"\"");
+        s.Should().Contain("STORAGE_SCOPE=\"/subscriptions/$SUBSCRIPTION_ID\"");
     }
 
     private static string AccessBlock(string tenant = Tenant, string sub = Sub, string access = AccessId) =>

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -42,7 +42,10 @@ public class AzureCloudShellSetupTests
         s.Should().Contain("\\\"Actions\\\": [\\\"Microsoft.Storage/storageAccounts/blobServices/containers/read\\\"]");
         s.Should().Contain("\\\"Microsoft.Storage/storageAccounts/read\\\"");
         s.Should().NotContain("listKeys");
-        s.Should().Contain("az role definition update");
+        // `update` takes the `list` shape (roleName/permissions), not the create shape — the existing
+        // definition is patched. Resending the create shape fails with KeyError: 'roleName'.
+        s.Should().Contain("az role definition update --role-definition \"$(jq -n --argjson e \"$existing\" --argjson d \"$2\"");
+        s.Should().Contain(".permissions = [{actions: $d.Actions");
     }
 
     [Fact]

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -153,6 +153,22 @@ public class AzureCloudShellSetupTests
     }
 
     [Fact]
+    public void Scripts_RunInASubshell_SoAPasteIntoTheInteractiveShellSurvivesAnError()
+    {
+        // `set -e` pasted into an interactive shell closes the session on the first failure, taking
+        // the error message with it. Both scripts wrap the body and print what failed.
+        foreach (string s in new[]
+                 {
+                     AzureCloudShellSetup.GenerateAccessScript(AccessInput()),
+                     AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput()),
+                 })
+        {
+            s.Should().Contain("\n(\nset -euo pipefail\ntrap 'echo; echo \"Connapse setup failed at: $BASH_COMMAND\" >&2' ERR");
+            s.Should().Contain(") || echo \"----- CONNAPSE SETUP FAILED");
+        }
+    }
+
+    [Fact]
     public void Scripts_FindExistingAppsByName_SoReRunsDoNotDuplicate()
     {
         AzureCloudShellSetup.GenerateAccessScript(AccessInput())

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -133,6 +133,13 @@ public class AzureCloudShellSetupTests
     }
 
     [Fact]
+    public void PermissionsScript_PreConsentsSignInAppForEveryone_WhenAdminConsentSucceeds()
+    {
+        string s = AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput());
+        s.Should().Contain("az ad app permission grant --id \"$SIGNIN_APP_ID\" --api \"$GRAPH_API\" --scope \"openid profile offline_access\"");
+    }
+
+    [Fact]
     public void Scripts_FindExistingAppsByName_SoReRunsDoNotDuplicate()
     {
         AzureCloudShellSetup.GenerateAccessScript(AccessInput())

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -33,6 +33,19 @@ public class AzureCloudShellSetupTests
     }
 
     [Fact]
+    public void AccessScript_RolesGrantListing_AndAreUpdatedInPlaceOnReRun()
+    {
+        string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+
+        // Container listing is a control-plane Action even over the data plane; account listing is
+        // subscription-wide metadata. Both read-only, neither touches keys.
+        s.Should().Contain("\\\"Actions\\\": [\\\"Microsoft.Storage/storageAccounts/blobServices/containers/read\\\"]");
+        s.Should().Contain("\\\"Microsoft.Storage/storageAccounts/read\\\"");
+        s.Should().NotContain("listKeys");
+        s.Should().Contain("az role definition update");
+    }
+
+    [Fact]
     public void AccessScript_ReadsTheSignedInSubscription_NothingToTypeUpFront()
     {
         string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());

--- a/tests/Connapse.Core.Tests/Utilities/AzureSetupRoleTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureSetupRoleTests.cs
@@ -1,0 +1,34 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class AzureSetupRoleTests
+{
+    private const string Client = "22222222-2222-2222-2222-222222222222";
+    private const string Account = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+
+    [Fact]
+    public void AssignmentsFor_OneCommandPerDistinctContainer_PrefixesCollapseToTheirContainer()
+    {
+        string s = AzureSetupRole.AssignmentsFor(Client, Account, ["docs/2024", "docs", "Images/raw"]);
+
+        string[] lines = s.Split('\n');
+        lines.Should().HaveCount(2);
+        lines[0].Should().Contain($"--scope '{Account}/blobServices/default/containers/docs'");
+        lines[1].Should().Contain($"--scope '{Account}/blobServices/default/containers/Images'");
+        lines.Should().OnlyContain(l => l.Contains($"--assignee '{Client}'")
+                                     && l.Contains($"--role '{AzureCloudShellSetup.BlobDataRoleName}'"));
+    }
+
+    [Fact]
+    public void AssignmentsFor_NoLocations_GrantsTheWholeAccount() =>
+        AzureSetupRole.AssignmentsFor(Client, Account + "/", [])
+            .Should().Be($"az role assignment create --assignee '{Client}' --role '{AzureCloudShellSetup.BlobDataRoleName}' --scope '{Account}'");
+
+    [Fact]
+    public void AssignmentsFor_EscapesSingleQuotes() =>
+        AzureSetupRole.AssignmentsFor(Client, Account, ["it's"])
+            .Should().Contain("containers/it'\\''s'");
+}

--- a/tests/Connapse.Identity.Tests/AzureOidcTokenExchangerTests.cs
+++ b/tests/Connapse.Identity.Tests/AzureOidcTokenExchangerTests.cs
@@ -1,0 +1,53 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Connapse.Core;
+using Connapse.Identity.Services;
+using FluentAssertions;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Connapse.Identity.Tests;
+
+[Trait("Category", "Unit")]
+public class AzureOidcTokenExchangerTests
+{
+    private const string ClientId = "44444444-4444-4444-4444-444444444444";
+    private const string TokenEndpoint = "https://login.microsoftonline.com/tenant/oauth2/v2.0/token";
+
+    [Fact]
+    public void BuildClientAssertion_SignsWithTheCertificate_AndCarriesEntraX5tHeader()
+    {
+        // Regression: setting x5t via AdditionalHeaderClaims throws IDX14116 at sign-in time; the
+        // handler must supply it from the X509 signing credentials instead.
+        (string pemPath, string expectedX5t) = WriteSelfSignedPem();
+        try
+        {
+            var settings = new AzureAdSignInSettings { ClientId = ClientId, ClientCertificatePath = pemPath };
+
+            string assertion = AzureOidcTokenExchanger.BuildClientAssertion(settings, TokenEndpoint);
+
+            var jwt = new JsonWebToken(assertion);
+            jwt.Alg.Should().Be(SecurityAlgorithms.RsaSha256);
+            jwt.X5t.Should().Be(expectedX5t);
+            jwt.Issuer.Should().Be(ClientId);
+            jwt.Subject.Should().Be(ClientId);
+            jwt.Audiences.Should().ContainSingle().Which.Should().Be(TokenEndpoint);
+            jwt.GetClaim("jti").Value.Should().NotBeNullOrEmpty();
+        }
+        finally
+        {
+            File.Delete(pemPath);
+        }
+    }
+
+    private static (string Path, string X5t) WriteSelfSignedPem()
+    {
+        using RSA key = RSA.Create(2048);
+        var request = new CertificateRequest("CN=connapse-test", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using X509Certificate2 cert = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+
+        string path = Path.Combine(Path.GetTempPath(), $"connapse-signin-{Guid.NewGuid():N}.pem");
+        File.WriteAllText(path, cert.ExportCertificatePem() + "\n" + key.ExportPkcs8PrivateKeyPem() + "\n");
+        return (path, Base64UrlEncoder.Encode(cert.GetCertHash()));
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
@@ -1,0 +1,82 @@
+using Azure;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureBlobDiscoveryTests
+{
+    private static AzureBlobDiscovery Build(AzureProviderSettings settings)
+    {
+        var monitor = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        monitor.CurrentValue.Returns(settings);
+        return new AzureBlobDiscovery(new ConnapseAzureCredentials(monitor), monitor, NullLogger<AzureBlobDiscovery>.Instance);
+    }
+
+    private static AzureProviderSettings Configured() => new()
+    {
+        TenantId = "11111111-1111-1111-1111-111111111111",
+        ClientId = "22222222-2222-2222-2222-222222222222",
+        ClientCertificatePath = "/nonexistent.pem",
+        SubscriptionId = "33333333-3333-3333-3333-333333333333",
+    };
+
+    [Fact]
+    public async Task ListStorageAccounts_NoIdentity_IsNotConfigured_WithoutCallingAzure()
+    {
+        var probe = await Build(new AzureProviderSettings()).ListStorageAccountsAsync();
+
+        probe.Outcome.Should().Be(AzureProbeOutcome.NotConfigured);
+        probe.Detail.Should().Contain("provider page");
+    }
+
+    [Fact]
+    public async Task ListStorageAccounts_NoSubscription_IsNotConfigured()
+    {
+        var probe = await Build(Configured() with { SubscriptionId = null }).ListStorageAccountsAsync();
+
+        probe.Outcome.Should().Be(AzureProbeOutcome.NotConfigured);
+        probe.Detail.Should().Contain("subscription");
+    }
+
+    [Fact]
+    public async Task ListContainers_NoIdentity_IsNotConfigured()
+    {
+        var probe = await Build(new AzureProviderSettings()).ListContainersAsync("https://acct.blob.core.windows.net");
+        probe.Outcome.Should().Be(AzureProbeOutcome.NotConfigured);
+    }
+
+    [Fact]
+    public async Task ListContainers_NoEndpoint_Fails_WithoutCallingAzure()
+    {
+        var probe = await Build(Configured()).ListContainersAsync("");
+        probe.Outcome.Should().Be(AzureProbeOutcome.Failed);
+        probe.Detail.Should().Contain("No storage account");
+    }
+
+    [Theory]
+    [InlineData(401, true)]
+    [InlineData(403, true)]
+    [InlineData(404, false)]
+    [InlineData(500, false)]
+    public void IsDenial_OnlyForAuthFailures(int status, bool expected) =>
+        AzureBlobDiscovery.IsDenial(new RequestFailedException(status, "x")).Should().Be(expected);
+
+    [Fact]
+    public void IsConfigured_MatchesTheProvidersPageRule()
+    {
+        AzureBlobDiscovery.IsConfigured(Configured()).Should().BeTrue();
+        AzureBlobDiscovery.IsConfigured(Configured() with { ClientCertificatePath = null }).Should().BeFalse();
+        AzureBlobDiscovery.IsConfigured(new AzureProviderSettings
+        {
+            TenantId = "t", UserAssignedManagedIdentityClientId = "mi",
+        }).Should().BeTrue();
+        AzureBlobDiscovery.IsConfigured(Configured() with { TenantId = null }).Should().BeFalse();
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCertificateGeneratorTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCertificateGeneratorTests.cs
@@ -1,0 +1,45 @@
+using System.Security.Cryptography.X509Certificates;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureCertificateGeneratorTests
+{
+    [Fact]
+    public void Generate_PublicPem_IsACertificateWithoutThePrivateKey()
+    {
+        AzureCertificateMaterial material = AzureCertificateGenerator.Generate("connapse-test");
+
+        material.PublicCertificatePem.Should().Contain("BEGIN CERTIFICATE");
+        material.PublicCertificatePem.Should().NotContain("PRIVATE KEY");
+
+        using X509Certificate2 cert = X509Certificate2.CreateFromPem(material.PublicCertificatePem);
+        cert.Subject.Should().Contain("connapse-test");
+        cert.HasPrivateKey.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Generate_CombinedPem_HasBothAndLoadsWithItsPrivateKey_LikeProduction()
+    {
+        AzureCertificateMaterial material = AzureCertificateGenerator.Generate("connapse-test");
+
+        material.CombinedPem.Should().Contain("BEGIN CERTIFICATE");
+        material.CombinedPem.Should().Contain("PRIVATE KEY");
+
+        // Production loads the cert via X509Certificate2.CreateFromPemFile on a single .pem holding both.
+        string path = Path.Combine(Path.GetTempPath(), $"connapse-azure-{Guid.NewGuid():N}.pem");
+        try
+        {
+            File.WriteAllText(path, material.CombinedPem);
+            using X509Certificate2 loaded = X509Certificate2.CreateFromPemFile(path);
+            loaded.HasPrivateKey.Should().BeTrue();
+            loaded.Subject.Should().Contain("connapse-test");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
+++ b/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
@@ -180,6 +180,12 @@ public class ProvidersPageTests
             .And.Contain("Id=\"azure-access\"")
             .And.Contain("Id=\"azure-permissions\"");
         Regex.Matches(markup, "<ProviderResetAction").Count.Should().BeGreaterThanOrEqualTo(3);
+
+        // Saving Azure sign-in must latch Azure enforcement at save time, like the SAML save does —
+        // relying on the startup latch alone left azblob results unfiltered until the next restart.
+        int azureSave = markup.IndexOf("private async Task SaveAzureAdFromForm(", StringComparison.Ordinal);
+        azureSave.Should().BeGreaterThan(0);
+        markup[azureSave..].Should().Contain("AzureEnforcing = enforcing");
         markup.Should().NotContain("confirmResetAccess")
             .And.NotContain("confirmResetIdentityCenter")
             .And.NotContain("confirmResetSamlApplication");

--- a/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
+++ b/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
@@ -172,10 +172,13 @@ public class ProvidersPageTests
         string markup = File.ReadAllText(Path.Combine(
             PageTestPaths.RepositoryRoot(), "src", "Connapse.Web", "Components", "Pages", "Providers.razor"));
 
-        Regex.Matches(markup, "<ProviderStepCard").Should().HaveCount(3);
+        // Three AWS step cards plus the two Azure ones built on the same component.
+        Regex.Matches(markup, "<ProviderStepCard").Should().HaveCount(5);
         markup.Should().Contain("Id=\"access\"")
             .And.Contain("Id=\"identity-center\"")
-            .And.Contain("Id=\"permissions\"");
+            .And.Contain("Id=\"permissions\"")
+            .And.Contain("Id=\"azure-access\"")
+            .And.Contain("Id=\"azure-permissions\"");
         Regex.Matches(markup, "<ProviderResetAction").Count.Should().BeGreaterThanOrEqualTo(3);
         markup.Should().NotContain("confirmResetAccess")
             .And.NotContain("confirmResetIdentityCenter")

--- a/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
+++ b/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
@@ -603,6 +603,19 @@ public class ProviderSetupReaderTests
     }
 
     [Fact]
+    public async Task Azure_PerUserPermissions_ConsentPending_Warns_NotSatisfied()
+    {
+        // The pending flag is stored with the sign-in settings, so a reload cannot turn a
+        // consent-less setup into a green card.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(), azureAd: ConfiguredAzureAd() with { AdminConsentPending = true }));
+
+        var requirement = azure.Requirements.Single(r => r.Name == "Per-user permissions");
+        requirement.Status.Should().Be(RequirementStatus.Warning);
+        requirement.Detail.Should().Contain("consent");
+    }
+
+    [Fact]
     public async Task Azure_PerUserPermissions_WithoutSignIn_IsNotConfigured()
     {
         var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),

--- a/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
+++ b/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
@@ -620,6 +620,36 @@ public class ProviderSetupReaderTests
 
         azure.InUse.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task Azure_WithAccessSavedButNoConnection_IsInUse_SoTheListShowsItsState()
+    {
+        // Saving the Access step is an explicit choice (Azure access is settings-only, nothing ambient
+        // can make it read as configured), so the list must show status rather than an offer.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider()));
+
+        azure.InUse.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Aws_WithSignInConfiguredButNoConnection_IsInUse()
+    {
+        // The documented rule: sign-in configured, or a connection built on it.
+        var setups = await Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            samlSignIn: ConfiguredSignIn()).ReadAsync();
+
+        setups.Single(p => p.Key == "aws").InUse.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Azure_WithSignInConfiguredButNoConnection_IsInUse()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureAd: ConfiguredAzureAd()));
+
+        azure.InUse.Should().BeTrue();
+    }
 }
 
 internal static class OptionsMonitorExtensions

--- a/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
+++ b/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
@@ -38,7 +38,10 @@ public class ProviderSetupReaderTests
         TimeSpan? sinceCreated = null,
         IProviderCredentialStore? credentials = null,
         SamlSignInSettings? samlSignIn = null,
-        IdentityCenterSettings? identityCenter = null)
+        IdentityCenterSettings? identityCenter = null,
+        AzureProviderSettings? azureProvider = null,
+        AzureAdSignInSettings? azureAd = null,
+        IConnectionStore? connections = null)
     {
         var discovery = Substitute.For<IS3Discovery>();
         discovery.WhoAmIAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(identity);
@@ -50,15 +53,20 @@ public class ProviderSetupReaderTests
             credentials.GetStatusAsync("aws", Arg.Any<CancellationToken>()).Returns(stored);
         }
 
-        var connections = Substitute.For<IConnectionStore>();
-        connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns([]);
+        if (connections is null)
+        {
+            connections = Substitute.For<IConnectionStore>();
+            connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns([]);
+        }
 
         return new ProviderSetupReader(
             Options.Create(samlSignIn ?? new SamlSignInSettings()).AsMonitor(),
             // Defaults to located, so a test that varies one thing is not also silently varying
             // this one. The tests that care pass an empty instance explicitly.
             Options.Create(identityCenter ?? LocatedInstance()).AsMonitor(),
+            Options.Create(azureProvider ?? new AzureProviderSettings()).AsMonitor(),
+            Options.Create(azureAd ?? new AzureAdSignInSettings()).AsMonitor(),
             discovery, connections, credentials,
             new FixedClock(new DateTimeOffset(Created) + (sinceCreated ?? TimeSpan.Zero)),
             NullLogger<ProviderSetupReader>.Instance);
@@ -299,6 +307,8 @@ public class ProviderSetupReaderTests
         var reader = new ProviderSetupReader(
             Options.Create(new SamlSignInSettings()).AsMonitor(),
             Options.Create(new IdentityCenterSettings()).AsMonitor(),
+            Options.Create(new AzureProviderSettings()).AsMonitor(),
+            Options.Create(new AzureAdSignInSettings()).AsMonitor(),
             Substitute.For<IS3Discovery>(), connections,
             Substitute.For<IProviderCredentialStore>(),
             new FixedClock(new DateTimeOffset(Created)),
@@ -506,6 +516,109 @@ public class ProviderSetupReaderTests
         ]);
 
         setup.Overall.Should().Be(RequirementStatus.Failed);
+    }
+
+    // ── Azure provider (surfaced on the Providers page) ───────────────
+
+    private static AzureProviderSettings ConfiguredAzureProvider() => new()
+    {
+        TenantId = "11111111-1111-1111-1111-111111111111",
+        ClientId = "22222222-2222-2222-2222-222222222222",
+        ClientCertificatePath = "/certs/azure.pem",
+        SubscriptionId = "33333333-3333-3333-3333-333333333333",
+    };
+
+    private static AzureAdSignInSettings ConfiguredAzureAd() => new()
+    {
+        TenantId = "11111111-1111-1111-1111-111111111111",
+        ClientId = "44444444-4444-4444-4444-444444444444",
+        RedirectUri = "https://connapse.example.com/api/v1/auth/cloud/azure/cb",
+        ClientCertificatePath = "/certs/azure-signin.pem",
+    };
+
+    private static async Task<ProviderSetup> AzureAsync(ProviderSetupReader reader) =>
+        (await reader.ReadAsync()).Single(p => p.Key == "azure");
+
+    private static IConnectionStore ConnectionsWith(params ConnectionProvider[] providers)
+    {
+        var store = Substitute.For<IConnectionStore>();
+        IReadOnlyList<Connection> page = providers
+            .Select(p => new Connection(Guid.NewGuid(), $"{p}", p, null, null, Created, Created))
+            .ToList();
+        // All-matcher stub with a callback: mixing a literal skip (0) with Arg matchers makes
+        // NSubstitute ignore the stub entirely (every page then comes back null).
+        store.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(call => call.ArgAt<int>(0) == 0 ? page : []);
+        return store;
+    }
+
+    [Fact]
+    public async Task Azure_IsListedAsAProvider()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one")));
+
+        azure.DisplayName.Should().Be("Azure");
+    }
+
+    [Fact]
+    public async Task Azure_WithNothingConfigured_IsNotInUseAndAllRequirementsNotConfigured()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one")));
+
+        azure.InUse.Should().BeFalse();
+        azure.Requirements.Should().OnlyContain(r => r.Status == RequirementStatus.NotConfigured);
+    }
+
+    [Fact]
+    public async Task Azure_Access_WithTenantAndCredential_IsSatisfied()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider()));
+
+        azure.Requirements.Single(r => r.Name == "Access").Status
+            .Should().Be(RequirementStatus.Satisfied);
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_SignInAndSubscription_IsSatisfied()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(), azureAd: ConfiguredAzureAd()));
+
+        azure.Requirements.Single(r => r.Name == "Per-user permissions").Status
+            .Should().Be(RequirementStatus.Satisfied);
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_SignInButNoSubscription_Warns()
+    {
+        // The RBAC resolver needs the subscription, so sign-in alone fails closed at query time —
+        // a warning, not a clean state.
+        var noSub = ConfiguredAzureProvider() with { SubscriptionId = null };
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: noSub, azureAd: ConfiguredAzureAd()));
+
+        azure.Requirements.Single(r => r.Name == "Per-user permissions").Status
+            .Should().Be(RequirementStatus.Warning);
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_WithoutSignIn_IsNotConfigured()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider()));
+
+        azure.Requirements.Single(r => r.Name == "Per-user permissions").Status
+            .Should().Be(RequirementStatus.NotConfigured);
+    }
+
+    [Fact]
+    public async Task Azure_WithAnAzureBlobConnection_IsInUse()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            connections: ConnectionsWith(ConnectionProvider.AzureBlob)));
+
+        azure.InUse.Should().BeTrue();
     }
 }
 


### PR DESCRIPTION
Closes #499, closes #500.

Everything found while testing the Azure epic end to end against a real tenant and a Data Lake Gen2 account.

## Providers page
- Azure now appears on the Providers page, built from the same `ProviderStepCard` pieces AWS uses: **Access** and **Per-user permissions** cards, each with an **Easy setup** Cloud Shell guide and **Manual values** form, plus reset actions.
- Easy setup is zero-input: Connapse mints a certificate to `appdata/azure` on render (only the public half goes in the script; the private key never leaves the host), the script reads the signed-in subscription, and the paste-back block fills the settings. Scripts find existing apps by name and create-or-update the two least-privilege custom roles, so re-runs upgrade in place.
- Per-user script registers the sign-in app, grants the access app its Graph permissions, attempts admin consent (with a pending-consent link for a Global Admin, bouncing back to the Providers page), and pre-consents the sign-in app tenant-wide so users never see a prompt.
- A configured provider now counts as **in use**, so the list shows its state instead of an offer (AWS sign-in-only installs were affected too).

## Connection form (parity with S3)
- `IAzureBlobDiscovery` / `AzureBlobDiscovery`: read-only storage-account and container listing with an `AzureProbe` outcome mirroring `AwsProbe`.
- Azure block mirrors S3: readiness banner, account picker with Data Lake Gen2 badge, container picker with name auto-fill, generated `az role assignment` commands scoped to the chosen containers, troubleshooting link to the new `docs/azure-setup.md`.
- Custom roles gain two read-only listing actions (`storageAccounts/read`, `containers/read`); no key access.

## Fixes
- Entra sign-in callback threw IDX14116 building the client assertion (manual `x5t` header).
- Admin-consent link failed with AADSTS500113 (no reply URL on the access app).
- Setup certificate mismatch after a page reload (AADSTS700027) — certificate now stable on disk.
- Setup scripts pasted into Cloud Shell closed the session on error; they now run in a subshell with an ERR trap.
- Role re-run failed with `KeyError: 'roleName'` (`az role definition update` shape).
- Azure Blob and S3 connectors ingested directory placeholders as empty files.

## Packages
`Azure.ResourceManager.Storage` 1.7.0 added; `Azure.Identity` 1.16 → 1.21.

## Testing
All unit suites green (Core 1105, Storage 236, Web 123, Identity 109). Verified live: setup flows, sign-in link, discovery pickers, folder filtering. ACL-based per-user filtering test is set up against a Gen2 account (`Connapse ACL Testers` group) and pending a sign-in as the test user.

Not in this PR (follow-ups): live Azure access probe on the Providers page, consent auto-polling, certificate rotation UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)