### PR TITLE
fix: Azure config pages audited against the config-page rubric

### DIFF
--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -61,11 +61,17 @@ not found (`AADSTS700016`, `AADSTS90002`), missing service principal (`AADSTS700
 a refusal. Throttling, transient faults, and outages read as *Unconfirmed* with a retry, never as
 a demand to set up again.
 
-Old certificate files are removed only once nothing stored names them and they are more than an
-hour old, so two Connapse processes sharing one volume cannot delete each other's key. Saving
-the sign-in application switches per-user enforcement on *before* storing the application; if
-the switch cannot be written the application is not saved, and if it is somehow off while sign-in
-is configured the Per-user permissions card shows Failed and says how to switch it on.
+Each save attempt writes its own file (`connapse-azure-access-<thumbprint>-<attempt>.pem`), so
+attempts never share one. Old certificate files are removed only once nothing stored names them
+and they are more than an hour old, so two Connapse processes sharing one volume cannot delete
+each other's key; if the settings store cannot be read, nothing is deleted at all. Saving the
+sign-in application switches per-user enforcement on *before* storing the application and
+requires the switch to be live in this process; if it cannot be written or applied, the
+application is not saved and the message says to restart and save again. The AWS sign-in save
+carries the Azure switch through unchanged. If enforcement is somehow off while sign-in is
+configured, the Per-user permissions card shows Failed and says how to switch it on. A save
+whose outcome cannot be confirmed (the store failed after committing and could not be read back)
+is reported as unconfirmed rather than as failed; check the card after a restart before retrying.
 
 ## Manual values
 

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -32,6 +32,21 @@ from the lists (or type them), Test connection, Save. People link their Entra id
 Integrations → Microsoft Entra ID; their search results are then limited to what that identity
 may read.
 
+### Connapse running on Azure
+
+If the Connapse host is an Azure VM, App Service, or container with a managed identity, the
+Access guide notices and switches to it: no app registration and no certificate. Its script
+creates the same two custom roles and assigns them to that identity by object id, and the
+paste-back records the identity (tenant, subscription, principal). Whoever runs it needs only
+Owner or User Access Administrator on the subscription. A link under the guide switches back to
+a certificate app if you prefer one; the manual form also offers "This host's managed identity"
+as a choice, needing only the tenant.
+
+The Per-user permissions guide then grants the identity its two Graph permissions as app roles
+(a REST call per permission) instead of consenting an app. If the person running it is not a
+Global Administrator or Privileged Role Administrator, the script reports that and the card
+shows the two commands to hand to one; press "The permissions have been granted" once they have.
+
 ### What Recheck verifies
 
 **Recheck** on the Access card asks Entra for a token as Connapse's identity. *Ready* means Entra
@@ -83,11 +98,11 @@ Microsoft Entra admin center; nothing here is a secret except an optional PFX pa
 | Field | Where to find it |
 |---|---|
 | Directory (tenant) ID | Entra admin center → Overview (the tenant overview). |
-| How Connapse signs in | *App registration with a certificate* — an app you registered and uploaded a certificate to. *User-assigned managed identity* — an identity attached to the host Connapse runs on. |
+| How Connapse signs in | *App registration with a certificate* — an app you registered and uploaded a certificate to. *This host's managed identity* — the system-assigned identity of the Azure host Connapse runs on; nothing else to enter. *A user-assigned managed identity* — an identity attached to the host, named by its client ID. |
 | Application (client) ID | Entra admin center → App registrations → the app → Overview. Certificate app only. |
 | Client certificate path | A path on the Connapse host to a PEM (certificate plus private key) or PFX. Its public certificate must be uploaded under the app's Certificates & secrets. Certificate app only. |
 | Certificate password | Optional; only for a password-protected PFX. Never shown again once stored; leave blank to keep it. |
-| Managed identity client ID | Azure portal → Managed Identities → the identity → Overview → Client ID. Managed identity only. A system-assigned identity cannot be selected here. |
+| Managed identity client ID | Azure portal → Managed Identities → the identity → Overview → Client ID. User-assigned identity only; the host's own identity needs no ID. |
 | Subscription ID | Optional. Azure portal → Subscriptions. Needed for per-user permissions (role assignments are read from it) and for the storage-account list on the connection form. |
 
 The identity needs a role that can read blobs on each storage account — Storage Blob Data

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -47,11 +47,19 @@ the script it produces (which registers the new public certificate alongside the
 back, Save. The old certificate keeps working until you save, and the private keys are stored
 only under `appdata/azure` on the Connapse host, readable by Connapse's own user.
 
-Save is a check first: Connapse asks Entra for a token with the new certificate before it
-replaces the one in use, and refuses to save anything Entra rejects — the working setup stays as
-it was. The script also prints the thumbprint of the certificate it registered; if it differs
-from the one the page holds (another tab made a new certificate in between), Save refuses and
-asks you to run the command shown now. The same check runs when Manual values are saved.
+Save is a check first: Connapse writes the new certificate to a file of its own (named by its
+thumbprint), asks Entra for a token with it, and only then commits settings naming that file.
+The key in use is never moved or overwritten; it is removed only after the new settings are
+stored, and anything Entra rejects is deleted again with the working setup untouched. The script
+also prints the thumbprint of the certificate it registered; if it differs from the one the page
+holds (another tab made a new certificate in between), Save refuses and asks you to run the
+command shown now. The same Entra check runs when Manual values are saved.
+
+Only Entra errors that mean the credential itself is wrong — certificate not registered
+(`AADSTS700027`), keys expired (`AADSTS7000222`), app or tenant not found (`AADSTS700016`,
+`AADSTS90002`), missing service principal (`AADSTS7000229`) — count as a refusal. Throttling,
+transient faults, and outages read as *Unconfirmed* with a retry, never as a demand to set up
+again.
 
 ## Manual values
 

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -20,18 +20,84 @@ Admin → Providers → Azure. Two steps, each with an **Easy setup** guide and 
    updates the roles in place.
 2. **Per-user permissions.** A second script registers the sign-in app people link their Entra
    identity through, grants the access app the two Microsoft Graph permissions
-   (`User.Read.All`, `GroupMember.Read.All`) it looks people and groups up with, and attempts
-   admin consent. Consent needs a Global Administrator or Privileged Role Administrator; if the
-   person running the script is not one, the page shows a consent link to send them. When
-   consent succeeds the script also pre-consents the sign-in app for everyone, so nobody sees a
-   consent prompt when linking.
+   (`User.Read.All`, `GroupMember.Read.All` — read-only lookups of who a person is and which
+   groups they belong to) it looks people and groups up with, and attempts admin consent. Consent
+   needs a Global Administrator or Privileged Role Administrator; if the person running the
+   script is not one, the page shows a consent link to send them. When consent succeeds the
+   script also pre-consents the sign-in app for everyone, so nobody sees a consent prompt when
+   linking.
 
 Then Admin → Connections → New → Azure Blob Storage: choose the storage account and containers
 from the lists (or type them), Test connection, Save. People link their Entra identity under
 Integrations → Microsoft Entra ID; their search results are then limited to what that identity
 may read.
 
+### What Recheck verifies
+
+**Recheck** on the Access card asks Entra for a token as Connapse's identity. *Ready* means Entra
+accepted the certificate (or issued a token to the managed identity); it does not prove any role
+is assigned — **Test connection** on a connection does that. *Failed* means Entra refused the
+credential and quotes the `AADSTS` reason; *Unconfirmed* means Azure could not be reached.
+
+### Certificates
+
+The certificates Connapse generates are valid for one year. Each card shows when its certificate
+expires and warns 30 days ahead. To renew, open the card's guide, choose **New certificate**, run
+the script it produces (which registers the new public certificate alongside the old one), paste
+back, Save. The old certificate keeps working until you save, and the private keys are stored
+only under `appdata/azure` on the Connapse host, readable by Connapse's own user.
+
+## Manual values
+
+Use these when the identity already exists. Every value is read from the Azure portal or the
+Microsoft Entra admin center; nothing here is a secret except an optional PFX password.
+
+### Access
+
+| Field | Where to find it |
+|---|---|
+| Directory (tenant) ID | Entra admin center → Overview (the tenant overview). |
+| How Connapse signs in | *App registration with a certificate* — an app you registered and uploaded a certificate to. *User-assigned managed identity* — an identity attached to the host Connapse runs on. |
+| Application (client) ID | Entra admin center → App registrations → the app → Overview. Certificate app only. |
+| Client certificate path | A path on the Connapse host to a PEM (certificate plus private key) or PFX. Its public certificate must be uploaded under the app's Certificates & secrets. Certificate app only. |
+| Certificate password | Optional; only for a password-protected PFX. Never shown again once stored; leave blank to keep it. |
+| Managed identity client ID | Azure portal → Managed Identities → the identity → Overview → Client ID. Managed identity only. A system-assigned identity cannot be selected here. |
+| Subscription ID | Optional. Azure portal → Subscriptions. Needed for per-user permissions (role assignments are read from it) and for the storage-account list on the connection form. |
+
+The identity needs a role that can read blobs on each storage account — Storage Blob Data
+Reader, or the *Connapse Blob Data + Tags Reader* role the script creates. For per-user
+permissions it also needs *Connapse RBAC Authorization Reader* (or Reader) on the subscription
+and the two Graph permissions above, with admin consent.
+
+### Per-user permissions (sign-in app)
+
+| Field | Where to find it |
+|---|---|
+| Directory (tenant) ID | Filled in from the Access step. Change it only if the sign-in app lives in another tenant. |
+| Application (client) ID | Entra admin center → App registrations → the sign-in app → Overview. |
+| Redirect URI | Filled in from the address you reached Connapse on, plus `/api/v1/auth/cloud/azure/callback`. Register the same value under the app's Authentication page as a Web redirect URI. |
+| Client certificate path | A path on the Connapse host to the sign-in app's PEM or PFX; its public certificate goes under that app's Certificates & secrets. |
+| Certificate password | Optional; PFX only. |
+
+### Connection
+
+| Field | Notes |
+|---|---|
+| Name | Filled in from the first container you choose if left blank. |
+| Storage account name | Pick from the accounts Connapse can see, or type it. Listing needs the Subscription ID on the Access step and *Connapse RBAC Authorization Reader* (or Reader) on the subscription. |
+| Blob endpoint | Optional. Only to point at Azurite or another emulator; otherwise the account's public endpoint is used. |
+| Allowed locations | The containers (optionally `container/prefix`) a source on this connection may name. Pick from the list or type them. |
+| Container to test against | Not saved; the first allowed location when blank. |
+
 ## Troubleshooting
+
+**Access card shows Failed** — Entra refused Connapse's credential; the card quotes the
+`AADSTS` code. `AADSTS700027` (certificate not registered on the application) or an expired
+certificate: open the guide, choose **New certificate**, run the script, paste back, Save.
+`AADSTS700016` (application not found): the app was deleted — Reset access and set it up again.
+
+**Access card shows Unconfirmed** — Azure could not be reached from this server. Check outbound
+access to `login.microsoftonline.com`, then Recheck. Test a connection to be sure.
 
 **`AADSTS700027: The certificate ... is not registered on application`** — the certificate
 Connapse signs with is not the one uploaded to that app. Open the step's guide on the Azure
@@ -51,20 +117,27 @@ are upgraded by re-running the Access script; otherwise assign *Connapse Blob Da
 on the account and *Connapse RBAC Authorization Reader* on the subscription. Typing the names
 still works without the lists.
 
-**Test connection fails with 403 / `AuthorizationPermissionMismatch`** — the access app has no
-blob-read role on that account or container. Use the "Role assignments granting exactly this
-access" snippet on the connection form, or assign *Connapse Blob Data + Tags Reader* at the
-account scope. Role assignments can take a few minutes to propagate.
+**Test connection: "not allowed to list container"** (403, `AuthorizationPermissionMismatch`) —
+the access app has no blob-read role on that account or container. Use the "Role assignments
+granting exactly this access" snippet on the connection form, or assign *Connapse Blob Data +
+Tags Reader* at the account scope. Role assignments can take a few minutes to propagate.
 
-**Test connection fails with 404** — the container name is wrong, or the account is not the one
-you think (check the resource group in the account picker). Azure accounts have no default
-container; the test needs one that exists.
+**Test connection: "no container ... exists"** (404) — the container name is wrong, or the
+account is not the one you think (check the resource group in the account picker). Azure
+accounts have no default container; the test needs one that exists.
+
+**Test connection: "Entra rejected Connapse's identity"** — the same fault as a Failed Access
+card; fix it there, not on the connection.
+
+**Test connection: "Could not reach ..."** — the account name does not resolve. Check the
+spelling, and the blob endpoint if one is set.
 
 **Search returns nothing for a linked user** — per-user filtering is on and the identity lookup
 failed closed. Check that admin consent was granted, that the subscription is set on the Access
-step (the RBAC resolver needs it), and that the user still exists and is enabled in Entra. For
-Data Lake Gen2 accounts, the user also needs Read on the file and Execute on every ancestor
-directory in the POSIX ACLs.
+step, and that the user still exists and is enabled in Entra. For Data Lake Gen2 accounts, the
+user also needs Read on the file and Execute on every ancestor directory in the POSIX ACLs.
 
 **"Could not connect your Entra identity"** — the container log names the cause:
-`docker logs connapse-web-1 | grep -A5 "Entra sign-in callback failed"`.
+`docker logs connapse-web-1 | grep -A5 "Entra sign-in callback failed"`. A redirect mismatch
+means the Redirect URI on the Per-user permissions card differs from the one registered on the
+sign-in app.

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -47,6 +47,30 @@ The Per-user permissions guide then grants the identity its two Graph permission
 Global Administrator or Privileged Role Administrator, the script reports that and the card
 shows the two commands to hand to one; press "The permissions have been granted" once they have.
 
+### Graph permissions for a managed identity
+
+A managed identity has no app registration to consent to, so its two Microsoft Graph
+permissions are app-role assignments on its service principal. The guided Per-user permissions
+script makes them; when it cannot (the runner is not a Global Administrator or Privileged Role
+Administrator), or when the access identity was entered by hand, a directory administrator runs
+these in Cloud Shell, with the identity's **Object (principal) ID** from its Overview page in
+the Azure portal (for a host's own identity, the host's **Identity** page):
+
+```bash
+GRAPH_API='00000003-0000-0000-c000-000000000000'
+MI='<managed-identity-object-id>'
+GRAPH_SP_ID=$(az ad sp show --id "$GRAPH_API" --query id -o tsv)
+for ROLE in User.Read.All GroupMember.Read.All; do
+  ROLE_ID=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='$ROLE'].id | [0]" -o tsv)
+  az rest -m POST -u "https://graph.microsoft.com/v1.0/servicePrincipals/$MI/appRoleAssignments" \
+    -b "{\"principalId\":\"$MI\",\"resourceId\":\"$GRAPH_SP_ID\",\"appRoleId\":\"$ROLE_ID\"}"
+done
+```
+
+"Permission being assigned already exists" means that grant was already in place. Once both are
+made, press **The permissions have been granted** on the Per-user permissions card (or, for a
+hand-entered identity, set the sign-in application up under Manual values).
+
 ### What Recheck verifies
 
 **Recheck** on the Access card asks Entra for a token as Connapse's identity. *Ready* means Entra
@@ -137,9 +161,13 @@ and the two Graph permissions above, with admin consent.
 certificate: open the guide, choose **New certificate**, run the script, paste back, Save.
 `AADSTS700016` (application not found): the app was deleted — Reset access and set it up again.
 
-**Access card shows Unconfirmed** — Azure could not be reached from this server, or, for a
-managed identity, no identity is available on this host. Check outbound access to
-`login.microsoftonline.com`, then Recheck. Test a connection to be sure.
+**Access card shows Unconfirmed** — Azure could not be reached from this server. Check outbound
+access to `login.microsoftonline.com`, then Recheck. Test a connection to be sure.
+
+**Access card shows Failed: "cannot be used from this host"** — the certificate file is missing
+or unreadable, the settings are only partly filled in, or Access is set to a managed identity and
+this host has none (the identity was removed, or the settings came from another host). Fix the
+file or the identity, or set access up again.
 
 **Per-user permissions card shows Failed** — Entra refused the sign-in application's
 certificate; the card quotes the reason. Open the card's guide, choose **New certificate**, run

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -47,6 +47,12 @@ the script it produces (which registers the new public certificate alongside the
 back, Save. The old certificate keeps working until you save, and the private keys are stored
 only under `appdata/azure` on the Connapse host, readable by Connapse's own user.
 
+Save is a check first: Connapse asks Entra for a token with the new certificate before it
+replaces the one in use, and refuses to save anything Entra rejects — the working setup stays as
+it was. The script also prints the thumbprint of the certificate it registered; if it differs
+from the one the page holds (another tab made a new certificate in between), Save refuses and
+asks you to run the command shown now. The same check runs when Manual values are saved.
+
 ## Manual values
 
 Use these when the identity already exists. Every value is read from the Azure portal or the
@@ -96,8 +102,22 @@ and the two Graph permissions above, with admin consent.
 certificate: open the guide, choose **New certificate**, run the script, paste back, Save.
 `AADSTS700016` (application not found): the app was deleted — Reset access and set it up again.
 
-**Access card shows Unconfirmed** — Azure could not be reached from this server. Check outbound
-access to `login.microsoftonline.com`, then Recheck. Test a connection to be sure.
+**Access card shows Unconfirmed** — Azure could not be reached from this server, or, for a
+managed identity, no identity is available on this host. Check outbound access to
+`login.microsoftonline.com`, then Recheck. Test a connection to be sure.
+
+**Per-user permissions card shows Failed** — Entra refused the sign-in application's
+certificate; the card quotes the reason. Open the card's guide, choose **New certificate**, run
+the script, paste back, Save.
+
+**Save says "Entra refused the … credential, so nothing was changed"** — the certificate or
+identity you are about to store does not work, and the current one was left in place. Right
+after running a script, Entra can take up to a minute to register the certificate: wait, then
+Save again. If it persists, the certificate on the app is not the one Connapse holds — re-run the
+command shown on the page.
+
+**Test connection: "Could not reach Entra to sign Connapse in"** — the request never got an
+answer from Entra; the credential was not judged. Check outbound access, then try again.
 
 **`AADSTS700027: The certificate ... is not registered on application`** — the certificate
 Connapse signs with is not the one uploaded to that app. Open the step's guide on the Azure

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -56,10 +56,16 @@ holds (another tab made a new certificate in between), Save refuses and asks you
 command shown now. The same Entra check runs when Manual values are saved.
 
 Only Entra errors that mean the credential itself is wrong — certificate not registered
-(`AADSTS700027`), keys expired (`AADSTS7000222`), app or tenant not found (`AADSTS700016`,
-`AADSTS90002`), missing service principal (`AADSTS7000229`) — count as a refusal. Throttling,
-transient faults, and outages read as *Unconfirmed* with a retry, never as a demand to set up
-again.
+(`AADSTS700027`), keys expired (`AADSTS7000222`), app disabled (`AADSTS7000112`), app or tenant
+not found (`AADSTS700016`, `AADSTS90002`), missing service principal (`AADSTS7000229`) — count as
+a refusal. Throttling, transient faults, and outages read as *Unconfirmed* with a retry, never as
+a demand to set up again.
+
+Old certificate files are removed only once nothing stored names them and they are more than an
+hour old, so two Connapse processes sharing one volume cannot delete each other's key. Saving
+the sign-in application switches per-user enforcement on *before* storing the application; if
+the switch cannot be written the application is not saved, and if it is somehow off while sign-in
+is configured the Per-user permissions card shows Failed and says how to switch it on.
 
 ## Manual values
 

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -16,8 +16,8 @@ Admin → Providers → Azure. Two steps, each with an **Easy setup** guide and 
    - *Connapse RBAC Authorization Reader* — read role and deny assignments and storage-account
      metadata at subscription scope.
    Whoever runs it needs Owner or User Access Administrator on the subscription and permission
-   to register applications. The script is safe to re-run: it finds existing apps by name and
-   updates the roles in place.
+   to register applications. The script is safe to re-run: it reuses the app Connapse recorded
+   (never one found by display name) and updates the roles in place.
 2. **Per-user permissions.** A second script registers the sign-in app people link their Entra
    identity through, grants the access app the two Microsoft Graph permissions
    (`User.Read.All`, `GroupMember.Read.All` — read-only lookups of who a person is and which
@@ -40,7 +40,9 @@ creates the same two custom roles and assigns them to that identity by object id
 paste-back records the identity (tenant, subscription, principal). Whoever runs it needs only
 Owner or User Access Administrator on the subscription. A link under the guide switches back to
 a certificate app if you prefer one; the manual form also offers "This host's managed identity"
-as a choice, needing only the tenant.
+as a choice, needing only the tenant. Detection asks for the host's system-assigned identity; a
+host that has only user-assigned identities may report none — enter such an identity by hand
+under Manual values, by its client ID.
 
 The Per-user permissions guide then grants the identity its two Graph permissions as app roles
 (a REST call per permission) instead of consenting an app. If the person running it is not a

--- a/src/Connapse.Core/Interfaces/IAzureBlobDiscovery.cs
+++ b/src/Connapse.Core/Interfaces/IAzureBlobDiscovery.cs
@@ -57,6 +57,19 @@ public enum AzureProbeOutcome
 public interface IAzureBlobDiscovery
 {
     /// <summary>
+    /// Asks Entra for a token as Connapse's own identity, proving the credential is accepted:
+    /// the certificate is registered on the app and not expired, or the managed identity exists.
+    /// </summary>
+    /// <remarks>
+    /// Authentication only — a token is issued whether or not any role is assigned, so a pass
+    /// says "Entra accepts this identity", not "it can read a container". The value is a sentence
+    /// saying what was verified. <see cref="AzureProbeOutcome.Denied"/> means Entra refused the
+    /// credential itself (an <c>AADSTS</c> error), which only setting access up again can fix;
+    /// <see cref="AzureProbeOutcome.Failed"/> means the check could not complete.
+    /// </remarks>
+    Task<AzureProbe<string>> CheckAccessAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Every storage account in the configured subscription the identity may read metadata for.
     /// </summary>
     /// <remarks>Needs <c>Microsoft.Storage/storageAccounts/read</c> at subscription scope. A denial

--- a/src/Connapse.Core/Interfaces/IAzureBlobDiscovery.cs
+++ b/src/Connapse.Core/Interfaces/IAzureBlobDiscovery.cs
@@ -70,6 +70,14 @@ public interface IAzureBlobDiscovery
     Task<AzureProbe<string>> CheckAccessAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// The same check for settings that are not stored yet — a form about to be saved, or a
+    /// replacement certificate about to be promoted — so nothing that works is replaced by
+    /// something Entra rejects. Also used for the sign-in application, whose identity has the
+    /// same shape. Never answers from a cached token.
+    /// </summary>
+    Task<AzureProbe<string>> CheckAccessAsync(AzureProviderSettings candidate, CancellationToken ct = default);
+
+    /// <summary>
     /// Every storage account in the configured subscription the identity may read metadata for.
     /// </summary>
     /// <remarks>Needs <c>Microsoft.Storage/storageAccounts/read</c> at subscription scope. A denial

--- a/src/Connapse.Core/Interfaces/IAzureBlobDiscovery.cs
+++ b/src/Connapse.Core/Interfaces/IAzureBlobDiscovery.cs
@@ -34,6 +34,9 @@ public record AzureProbe<T>(T? Value, AzureProbeOutcome Outcome, string? Detail 
 
     public static AzureProbe<T> Failed(string? detail = null) =>
         new(default, AzureProbeOutcome.Failed, detail);
+
+    public static AzureProbe<T> Unusable(string? detail = null) =>
+        new(default, AzureProbeOutcome.Unusable, detail);
 }
 
 public enum AzureProbeOutcome
@@ -47,7 +50,12 @@ public enum AzureProbeOutcome
     Denied = 2,
 
     /// <summary>Something else — a timeout, a network fault, an unexpected error.</summary>
-    Failed = 3
+    Failed = 3,
+
+    /// <summary>The identity is configured but cannot be used from this host: its certificate file
+    /// is missing or unreadable, or the configuration is only partly filled in. Nothing was asked of
+    /// Azure; fixing the file or the settings is the whole remedy.</summary>
+    Unusable = 4
 }
 
 /// <summary>

--- a/src/Connapse.Core/Interfaces/IAzureHostIdentity.cs
+++ b/src/Connapse.Core/Interfaces/IAzureHostIdentity.cs
@@ -28,6 +28,7 @@ public interface IAzureHostIdentity
 {
     /// <summary>The host's managed identity, or null when the host has none (or the metadata
     /// service did not answer in time). Never throws; a found identity is remembered for the
-    /// process, since a host's identity does not change while it runs.</summary>
-    Task<AzureHostIdentityInfo?> DetectAsync(CancellationToken ct = default);
+    /// process, since a host's identity rarely changes while it runs — <paramref name="refresh"/>
+    /// asks again regardless, for the cases where it has (an identity disabled and re-enabled).</summary>
+    Task<AzureHostIdentityInfo?> DetectAsync(bool refresh = false, CancellationToken ct = default);
 }

--- a/src/Connapse.Core/Interfaces/IAzureHostIdentity.cs
+++ b/src/Connapse.Core/Interfaces/IAzureHostIdentity.cs
@@ -1,0 +1,33 @@
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// The managed identity the host Connapse runs on can sign in as, described from a token Azure
+/// issued to it.
+/// </summary>
+/// <param name="TenantId">The tenant the identity lives in (the token's <c>tid</c>).</param>
+/// <param name="PrincipalId">The identity's service principal object id (<c>oid</c>) — what roles
+/// and Graph app roles are assigned to.</param>
+/// <param name="ClientId">The identity's application (client) id (<c>appid</c>).</param>
+/// <param name="ResourceId">The Azure resource the identity belongs to (<c>xms_mirid</c>): for a
+/// user-assigned identity the identity resource itself, for a system-assigned one the host.</param>
+/// <param name="SubscriptionId">The subscription parsed out of <paramref name="ResourceId"/>, when present.</param>
+/// <param name="IsUserAssigned">Whether the resource is a user-assigned identity rather than the host.</param>
+public sealed record AzureHostIdentityInfo(
+    string TenantId,
+    string PrincipalId,
+    string ClientId,
+    string? ResourceId,
+    string? SubscriptionId,
+    bool IsUserAssigned);
+
+/// <summary>
+/// Finds out whether the host has a managed identity, so the guided Azure setup can grant it
+/// access instead of creating a certificate app. Off Azure the answer is simply "no".
+/// </summary>
+public interface IAzureHostIdentity
+{
+    /// <summary>The host's managed identity, or null when the host has none (or the metadata
+    /// service did not answer in time). Never throws; a found identity is remembered for the
+    /// process, since a host's identity does not change while it runs.</summary>
+    Task<AzureHostIdentityInfo?> DetectAsync(CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/ISettingsStore.cs
+++ b/src/Connapse.Core/Interfaces/ISettingsStore.cs
@@ -25,6 +25,17 @@ public interface ISettingsStore
     Task SaveAsync<T>(string category, T settings, CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>
+    /// Changes the stored settings for a category in one atomic step: the current value is read
+    /// under a lock, <paramref name="update"/> derives the new one from it, and that is written
+    /// before the lock is released. Two callers updating the same category can therefore never
+    /// overwrite each other's change, which <see cref="SaveAsync{T}"/> — a replace from whatever
+    /// the caller read earlier — cannot promise.
+    /// </summary>
+    /// <param name="update">Receives what is stored now (null when nothing is) and returns what to store.</param>
+    /// <returns>The value stored.</returns>
+    Task<T> UpdateAsync<T>(string category, Func<T?, T> update, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
     /// Resets settings for a specific category to defaults (removes from store).
     /// </summary>
     /// <param name="category">The settings category identifier.</param>

--- a/src/Connapse.Core/Models/AzureProviderSettings.cs
+++ b/src/Connapse.Core/Models/AzureProviderSettings.cs
@@ -15,6 +15,18 @@ public record AzureProviderSettings
     public string? ClientCertificatePassword { get; init; }
     public string? UserAssignedManagedIdentityClientId { get; init; }
 
+    /// <summary>
+    /// Sign in as the system-assigned managed identity of the host Connapse runs on. Explicit,
+    /// because "nothing configured" and "use the host's identity" must never look alike: the
+    /// fail-closed rules treat the first as not set up, and only the second as a credential.
+    /// </summary>
+    public bool UseHostManagedIdentity { get; init; }
+
+    /// <summary>The managed identity's service principal object id, recorded by the guided setup
+    /// so the page can name it and the permissions script can grant to it. Informational: the
+    /// credential itself comes from the host.</summary>
+    public string? ManagedIdentityPrincipalId { get; init; }
+
     /// <summary>The subscription whose role/deny assignments the RBAC resolver queries. Required
     /// for per-user Azure permission filtering; absent → the resolver fails closed.</summary>
     public string? SubscriptionId { get; init; }

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -540,17 +540,19 @@ public static class AzureCloudShellSetup
         echo "Using subscription $SUBSCRIPTION_ID ($(az account show --query name -o tsv))"
 
         # --- Custom roles (created once, updated in place on re-run) ---
-        upsert_role() {  # $1 name, $2 definition json
+        upsert_role() {  # $1 role name, $2 definition JSON in the shape `az role definition create` takes
           local existing
           existing=$(az role definition list --name "$1" --custom-role-only true -o json 2>/dev/null | jq -c '.[0] // empty')
           if [ -z "$existing" ]; then
             az role definition create --role-definition "$2" >/dev/null
           else
+            # `update` wants the shape `list` returns (roleName, permissions[], id), so patch the
+            # existing definition rather than resending the create-shaped one.
             az role definition update --role-definition "$(jq -n --argjson e "$existing" --argjson d "$2" '
-                 $e | .Name = $d.Name | .Description = $d.Description
-                    | .Actions = $d.Actions | .NotActions = $d.NotActions
-                    | .DataActions = $d.DataActions | .NotDataActions = $d.NotDataActions
-                    | .assignableScopes = $d.AssignableScopes')" >/dev/null
+              $e | .description = $d.Description
+                 | .permissions = [{actions: $d.Actions, notActions: $d.NotActions,
+                                    dataActions: $d.DataActions, notDataActions: $d.NotDataActions}]
+                 | .assignableScopes = $d.AssignableScopes')" >/dev/null
           fi
         }
 

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -192,8 +192,10 @@ public static class AzureCloudShellSetup
     public static string GraphAppRoleGrantCommands(string managedIdentityPrincipalId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(managedIdentityPrincipalId);
+        // A GUID or nothing: the id lands inside a JSON body in the script, where anything else
+        // would break the request rather than merely fail it.
         return ManagedIdentityGraphGrantCommands
-            .Replace("{{accessMiPrincipalId}}", Shell(managedIdentityPrincipalId.Trim()))
+            .Replace("{{accessMiPrincipalId}}", GuidOrEmpty(managedIdentityPrincipalId))
             .Replace("{{graphAppId}}", GraphAppId);
     }
 

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -18,17 +18,33 @@ public sealed record AzureAccessSetupInput(
 public sealed record AzureAccessResult(
     string TenantId, string SubscriptionId, string AccessAppClientId, string? CertificateThumbprint = null);
 
-/// <summary>Inputs for the Per-user permissions step's script: which access app to grant Graph
-/// permissions on, the sign-in app's redirect URI, the page Entra should bounce back to after admin
-/// consent (registered on the access app — without one, the consent endpoint refuses with
-/// AADSTS500113), and the PUBLIC certificate for the sign-in app.</summary>
+/// <summary>Inputs for the Access step's script when Connapse runs on an Azure host with a managed
+/// identity: the identity to grant the roles to. No app registration and no certificate.</summary>
+/// <param name="PrincipalId">The identity's service principal object id — what the roles are assigned to.</param>
+/// <param name="ClientId">The identity's application (client) id, printed back for the record.</param>
+/// <param name="IsUserAssigned">Whether it is a user-assigned identity rather than the host's own.</param>
+public sealed record AzureManagedIdentityAccessSetupInput(string PrincipalId, string ClientId, bool IsUserAssigned);
+
+/// <summary>What the managed-identity Access script prints back.</summary>
+public sealed record AzureManagedIdentityAccessResult(
+    string TenantId, string SubscriptionId, string PrincipalId, string ClientId, bool IsUserAssigned);
+
+/// <summary>Inputs for the Per-user permissions step's script: which access identity to grant Graph
+/// permissions on (an app registration by client id, or a managed identity by principal id), the
+/// sign-in app's redirect URI, the page Entra should bounce back to after admin consent (registered
+/// on the access app — without one, the consent endpoint refuses with AADSTS500113), and the PUBLIC
+/// certificate for the sign-in app.</summary>
+/// <param name="AccessManagedIdentityPrincipalId">Set when the access identity is a managed identity:
+/// the Graph permissions are then granted to it as app roles by REST, since there is no app
+/// registration to consent to, and <paramref name="AccessAppClientId"/> is unused.</param>
 public sealed record AzurePermissionsSetupInput(
     string AccessAppClientId,
     string RedirectUri,
     string ConsentRedirectUri,
     string SignInAppName,
     string PublicCertificatePem,
-    string? ExistingSignInAppClientId = null);
+    string? ExistingSignInAppClientId = null,
+    string? AccessManagedIdentityPrincipalId = null);
 
 /// <summary>What the Per-user permissions script prints back, including whether the operator was able
 /// to grant admin consent (and the URL to hand an administrator when they were not).</summary>
@@ -49,6 +65,24 @@ public static class AzureCloudShellSetup
     public const string AccessEndMarker = "----- END CONNAPSE AZURE ACCESS -----";
     public const string PermissionsBeginMarker = "----- BEGIN CONNAPSE AZURE PERMISSIONS -----";
     public const string PermissionsEndMarker = "----- END CONNAPSE AZURE PERMISSIONS -----";
+    public const string ManagedIdentityBeginMarker = "----- BEGIN CONNAPSE AZURE MANAGED IDENTITY -----";
+    public const string ManagedIdentityEndMarker = "----- END CONNAPSE AZURE MANAGED IDENTITY -----";
+
+    /// <summary>What whoever runs the managed-identity Access script needs. No application
+    /// registration is involved, so only the subscription-level rights apply.</summary>
+    public static readonly IReadOnlyList<string> ManagedIdentityAccessScriptRequirements =
+    [
+        "Owner or User Access Administrator on the subscription (to create the two custom roles and assign them to the managed identity)",
+    ];
+
+    /// <summary>What whoever runs the Per-user permissions script needs when the access identity is a
+    /// managed identity: the Graph permissions are app-role assignments, which only a directory
+    /// administrator can write.</summary>
+    public static readonly IReadOnlyList<string> ManagedIdentityPermissionsScriptRequirements =
+    [
+        "permission to register applications (for the sign-in app)",
+        "Global Administrator or Privileged Role Administrator to grant the managed identity its two Microsoft Graph permissions (otherwise the script prints the two commands for one to run)",
+    ];
 
     /// <summary>The Microsoft Graph resource app id — stable across tenants.</summary>
     public const string GraphAppId = "00000003-0000-0000-c000-000000000000";
@@ -111,12 +145,68 @@ public static class AzureCloudShellSetup
         return cleaned.Length == 40 && cleaned.All(Uri.IsHexDigit) ? cleaned : null;
     }
 
+    // ---- Access step, for a Connapse running on Azure with a managed identity ----
+
+    /// <summary>The Access script for a host with a managed identity: the same two custom roles,
+    /// assigned to the identity by object id. Nothing is registered and nothing is uploaded.</summary>
+    public static string GenerateManagedIdentityAccessScript(AzureManagedIdentityAccessSetupInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        return ManagedIdentityAccessTemplate
+            .Replace("{{principalId}}", Shell(GuidOrEmpty(input.PrincipalId)))
+            .Replace("{{clientId}}", Shell(GuidOrEmpty(input.ClientId)))
+            .Replace("{{kind}}", input.IsUserAssigned ? "user-assigned" : "system-assigned")
+            .Replace("{{blobRoleName}}", BlobDataRoleName)
+            .Replace("{{rbacRoleName}}", RbacReadRoleName)
+            .Replace("{{beginMarker}}", ManagedIdentityBeginMarker)
+            .Replace("{{endMarker}}", ManagedIdentityEndMarker);
+    }
+
+    /// <summary>Parses the managed-identity Access block. Null unless every id is a well-formed GUID.</summary>
+    public static AzureManagedIdentityAccessResult? ParseManagedIdentityAccessResult(string? pasted)
+    {
+        var values = ExtractBlock(pasted, ManagedIdentityBeginMarker, ManagedIdentityEndMarker);
+        if (values is null) return null;
+
+        values.TryGetValue("tenantId", out string? tenant);
+        values.TryGetValue("subscriptionId", out string? subscription);
+        values.TryGetValue("managedIdentityPrincipalId", out string? principal);
+        values.TryGetValue("managedIdentityClientId", out string? client);
+        values.TryGetValue("managedIdentityKind", out string? kind);
+
+        if (!Guid.TryParse(tenant, out _) || !Guid.TryParse(subscription, out _)
+            || !Guid.TryParse(principal, out _) || !Guid.TryParse(client, out _))
+            return null;
+
+        return new AzureManagedIdentityAccessResult(
+            tenant!, subscription!, principal!, client!,
+            IsUserAssigned: string.Equals(kind, "user-assigned", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// The two commands that grant a managed identity its Microsoft Graph permissions, for a
+    /// directory administrator to run when whoever ran the permissions script could not. The Graph
+    /// service principal's object id and the two app-role ids are looked up live, so nothing here
+    /// is tenant-specific except the identity.
+    /// </summary>
+    public static string GraphAppRoleGrantCommands(string managedIdentityPrincipalId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(managedIdentityPrincipalId);
+        return ManagedIdentityGraphGrantCommands
+            .Replace("{{accessMiPrincipalId}}", Shell(managedIdentityPrincipalId.Trim()))
+            .Replace("{{graphAppId}}", GraphAppId);
+    }
+
     // ---- Per-user permissions step ----
 
     public static string GeneratePermissionsScript(AzurePermissionsSetupInput input)
     {
         ArgumentNullException.ThrowIfNull(input);
         return PermissionsTemplate
+            .Replace("{{graphGrant}}", input.AccessManagedIdentityPrincipalId is { Length: > 0 }
+                ? ManagedIdentityGraphGrant
+                : AppGraphGrant)
+            .Replace("{{accessMiPrincipalId}}", Shell(GuidOrEmpty(input.AccessManagedIdentityPrincipalId)))
             .Replace("{{accessAppId}}", Shell(input.AccessAppClientId))
             .Replace("{{redirectUri}}", Shell(input.RedirectUri))
             .Replace("{{consentRedirectUri}}", Shell(input.ConsentRedirectUri))
@@ -348,13 +438,24 @@ public static class AzureCloudShellSetup
         CERT_THUMBPRINT=$(openssl x509 -in "$CERT_FILE" -noout -fingerprint -sha1 2>/dev/null | sed 's/.*=//; s/://g') || true
         rm -f "$CERT_FILE"
 
+        USER_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='User.Read.All'].id | [0]" -o tsv)
+        GROUP_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='GroupMember.Read.All'].id | [0]" -o tsv)
+        {{graphGrant}}
+
+        echo
+        printf '%s\nsignInAppClientId=%s\nconsentGranted=%s\nconsentUrl=%s\ncertificateThumbprint=%s\n%s\n' \
+          "{{beginMarker}}" "$SIGNIN_APP_ID" "$CONSENT_GRANTED" "$CONSENT_URL" "$CERT_THUMBPRINT" "{{endMarker}}"
+        ) || echo "----- CONNAPSE SETUP FAILED: read the error above. Nothing to paste back yet. -----"
+        """;
+
+    /// <summary>The Graph section of the permissions script when the access identity is an app
+    /// registration: application permissions added to the app, then admin consent.</summary>
+    private const string AppGraphGrant = """
         # The admin-consent page bounces back to a reply URL registered on the ACCESS app; without one
         # Entra refuses with AADSTS500113. Connapse's Providers page is that landing spot.
         az ad app update --id "$ACCESS_APP_ID" --web-redirect-uris "$CONSENT_REDIRECT_URI"
 
-        # --- Microsoft Graph application permissions on the ACCESS app (ids resolved live) ---
-        USER_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='User.Read.All'].id | [0]" -o tsv)
-        GROUP_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='GroupMember.Read.All'].id | [0]" -o tsv)
+        # --- Microsoft Graph application permissions on the ACCESS app ---
         az ad app permission add --id "$ACCESS_APP_ID" --api "$GRAPH_API" --api-permissions "$USER_READ_ALL=Role" >/dev/null
         az ad app permission add --id "$ACCESS_APP_ID" --api "$GRAPH_API" --api-permissions "$GROUP_READ_ALL=Role" >/dev/null
 
@@ -368,10 +469,132 @@ public static class AzureCloudShellSetup
           az ad app permission grant --id "$SIGNIN_APP_ID" --api "$GRAPH_API" --scope "openid profile offline_access" >/dev/null 2>&1 || true
         fi
         CONSENT_URL="https://login.microsoftonline.com/$TENANT_ID/adminconsent?client_id=$ACCESS_APP_ID&redirect_uri={{consentRedirectEncoded}}"
+        """;
+
+    /// <summary>The Graph section when the access identity is a managed identity: there is no app
+    /// registration to consent to, so the two permissions are app-role assignments on the identity's
+    /// service principal, written by REST. Only a directory administrator can write them; when the
+    /// runner cannot, the script says so and prints false, and the page shows the commands.</summary>
+    private const string ManagedIdentityGraphGrant = """
+        # --- Microsoft Graph application permissions on the ACCESS managed identity (app roles, by REST) ---
+        ACCESS_MI_PRINCIPAL_ID='{{accessMiPrincipalId}}'
+        GRAPH_SP_ID=$(az ad sp show --id "$GRAPH_API" --query id -o tsv)
+        grant_app_role() {  # $1 app role id
+          local out
+          if out=$(az rest -m POST -u "https://graph.microsoft.com/v1.0/servicePrincipals/$ACCESS_MI_PRINCIPAL_ID/appRoleAssignments" \
+                     -b "{\"principalId\":\"$ACCESS_MI_PRINCIPAL_ID\",\"resourceId\":\"$GRAPH_SP_ID\",\"appRoleId\":\"$1\"}" 2>&1 >/dev/null); then return 0; fi
+          if echo "$out" | grep -qi "already exists"; then return 0; fi
+          echo "$out" >&2; return 1
+        }
+        CONSENT_GRANTED=true
+        grant_app_role "$USER_READ_ALL" || CONSENT_GRANTED=false
+        grant_app_role "$GROUP_READ_ALL" || CONSENT_GRANTED=false
+        if [ "$CONSENT_GRANTED" = true ]; then
+          az ad app permission grant --id "$SIGNIN_APP_ID" --api "$GRAPH_API" --scope "openid profile offline_access" >/dev/null 2>&1 || true
+        else
+          echo "Could not grant the managed identity its Graph permissions (a Global Administrator or Privileged Role Administrator must). Connapse shows the two commands to hand them." >&2
+        fi
+        CONSENT_URL=""
+        """;
+
+    /// <summary>The two grants on their own, for an administrator to run when the script's runner could not.</summary>
+    private const string ManagedIdentityGraphGrantCommands = """
+        GRAPH_API='{{graphAppId}}'
+        MI='{{accessMiPrincipalId}}'
+        GRAPH_SP_ID=$(az ad sp show --id "$GRAPH_API" --query id -o tsv)
+        for ROLE in User.Read.All GroupMember.Read.All; do
+          ROLE_ID=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='$ROLE'].id | [0]" -o tsv)
+          az rest -m POST -u "https://graph.microsoft.com/v1.0/servicePrincipals/$MI/appRoleAssignments" \
+            -b "{\"principalId\":\"$MI\",\"resourceId\":\"$GRAPH_SP_ID\",\"appRoleId\":\"$ROLE_ID\"}"
+        done
+        """;
+
+    private const string ManagedIdentityAccessTemplate = """
+        #!/usr/bin/env bash
+        # Connapse Azure setup — step 1 of 2 (Access), for a Connapse running on Azure as a managed
+        # identity. Run in Azure Cloud Shell (Bash). Creates two least-privilege custom roles and assigns
+        # them to the managed identity Connapse runs as ({{kind}}, principal {{principalId}}), then prints
+        # a block to paste back into Connapse. Safe to re-run. No app is registered and nothing is uploaded.
+        #
+        # It uses the subscription Cloud Shell is signed in to. To use a different one, run
+        #   az account set --subscription <id>
+        # first. To limit the blob role to one storage account instead of the whole subscription,
+        # set STORAGE_SCOPE below to that storage account's resource id.
+        #
+        # Runs in a subshell so that pasting it into the interactive shell cannot close your
+        # session on an error: the failing command is printed and you stay signed in.
+        (
+        set -euo pipefail
+        trap 'echo; echo "Connapse setup failed at: $BASH_COMMAND" >&2' ERR
+
+        MI_PRINCIPAL_ID='{{principalId}}'
+        MI_CLIENT_ID='{{clientId}}'
+        MI_KIND='{{kind}}'
+        STORAGE_SCOPE=""
+
+        SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+        TENANT_ID=$(az account show --query tenantId -o tsv)
+        [ -n "$STORAGE_SCOPE" ] || STORAGE_SCOPE="/subscriptions/$SUBSCRIPTION_ID"
+        echo "Using subscription $SUBSCRIPTION_ID ($(az account show --query name -o tsv))"
+
+        # --- Custom roles (created once, updated in place on re-run) ---
+        upsert_role() {  # $1 name, $2 definition json
+          local existing
+          existing=$(az role definition list --name "$1" --custom-role-only true -o json 2>/dev/null | jq -c '.[0] // empty')
+          if [ -z "$existing" ]; then
+            az role definition create --role-definition "$2" >/dev/null
+          else
+            az role definition update --role-definition "$(jq -n --argjson e "$existing" --argjson d "$2" '
+                 $e | .Name = $d.Name | .Description = $d.Description
+                    | .Actions = $d.Actions | .NotActions = $d.NotActions
+                    | .DataActions = $d.DataActions | .NotDataActions = $d.NotDataActions
+                    | .assignableScopes = $d.AssignableScopes')" >/dev/null
+          fi
+        }
+
+        upsert_role '{{blobRoleName}}' "{
+          \"Name\": \"{{blobRoleName}}\", \"IsCustom\": true,
+          \"Description\": \"Read blob content, blob index tags, and container names for Connapse.\",
+          \"Actions\": [\"Microsoft.Storage/storageAccounts/blobServices/containers/read\"],
+          \"NotActions\": [], \"NotDataActions\": [],
+          \"DataActions\": [
+            \"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\",
+            \"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read\"
+          ],
+          \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
+        }"
+
+        upsert_role '{{rbacRoleName}}' "{
+          \"Name\": \"{{rbacRoleName}}\", \"IsCustom\": true,
+          \"Description\": \"Read role and deny assignments and storage account metadata at subscription scope for Connapse.\",
+          \"Actions\": [
+            \"Microsoft.Authorization/roleAssignments/read\",
+            \"Microsoft.Authorization/denyAssignments/read\",
+            \"Microsoft.Storage/storageAccounts/read\"
+          ],
+          \"NotActions\": [], \"DataActions\": [], \"NotDataActions\": [],
+          \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
+        }"
+
+        # --- Role assignments to the managed identity, by object id (no directory lookup needed) ---
+        # Role definitions take a moment to propagate; retry briefly, and fail the script if they never
+        # land — a paste block without these grants would record a setup that cannot read anything.
+        assign_role() {  # $1 role name, $2 scope
+          local i
+          for i in 1 2 3 4 5; do
+            if az role assignment create --assignee-object-id "$MI_PRINCIPAL_ID" --assignee-principal-type ServicePrincipal \
+                 --role "$1" --scope "$2" >/dev/null 2>&1; then return 0; fi
+            sleep 10
+          done
+          echo "Could not assign '$1' at $2 after 5 attempts." >&2
+          return 1
+        }
+        assign_role '{{blobRoleName}}' "$STORAGE_SCOPE"
+        assign_role '{{rbacRoleName}}' "/subscriptions/$SUBSCRIPTION_ID"
 
         echo
-        printf '%s\nsignInAppClientId=%s\nconsentGranted=%s\nconsentUrl=%s\ncertificateThumbprint=%s\n%s\n' \
-          "{{beginMarker}}" "$SIGNIN_APP_ID" "$CONSENT_GRANTED" "$CONSENT_URL" "$CERT_THUMBPRINT" "{{endMarker}}"
+        printf '%s\ntenantId=%s\nsubscriptionId=%s\nmanagedIdentityPrincipalId=%s\nmanagedIdentityClientId=%s\nmanagedIdentityKind=%s\n%s\n' \
+          "{{beginMarker}}" "$TENANT_ID" "$SUBSCRIPTION_ID" "$MI_PRINCIPAL_ID" "$MI_CLIENT_ID" "$MI_KIND" "{{endMarker}}"
         ) || echo "----- CONNAPSE SETUP FAILED: read the error above. Nothing to paste back yet. -----"
         """;
 }

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -12,7 +12,11 @@ public sealed record AzureAccessSetupInput(
     string? ExistingAccessAppClientId = null);
 
 /// <summary>The non-secret identifiers the Access script prints back.</summary>
-public sealed record AzureAccessResult(string TenantId, string SubscriptionId, string AccessAppClientId);
+/// <param name="CertificateThumbprint">SHA-1 thumbprint (upper-case hex, no separators) of the certificate
+/// the script registered, so the page can refuse to promote a different one; null when the paste
+/// predates the script printing it.</param>
+public sealed record AzureAccessResult(
+    string TenantId, string SubscriptionId, string AccessAppClientId, string? CertificateThumbprint = null);
 
 /// <summary>Inputs for the Per-user permissions step's script: which access app to grant Graph
 /// permissions on, the sign-in app's redirect URI, the page Entra should bounce back to after admin
@@ -28,7 +32,8 @@ public sealed record AzurePermissionsSetupInput(
 
 /// <summary>What the Per-user permissions script prints back, including whether the operator was able
 /// to grant admin consent (and the URL to hand an administrator when they were not).</summary>
-public sealed record AzurePermissionsResult(string SignInAppClientId, bool ConsentGranted, string? ConsentUrl);
+public sealed record AzurePermissionsResult(
+    string SignInAppClientId, bool ConsentGranted, string? ConsentUrl, string? CertificateThumbprint = null);
 
 /// <summary>
 /// Generates the Azure Cloud Shell (<c>az</c>) scripts that provision Connapse's Azure setup, one per
@@ -93,7 +98,17 @@ public static class AzureCloudShellSetup
         if (!Guid.TryParse(tenant, out _) || !Guid.TryParse(subscription, out _) || !Guid.TryParse(accessId, out _))
             return null;
 
-        return new AzureAccessResult(tenant!, subscription!, accessId!);
+        values.TryGetValue("certificateThumbprint", out string? thumbprint);
+        return new AzureAccessResult(tenant!, subscription!, accessId!, Thumbprint(thumbprint));
+    }
+
+    /// <summary>A thumbprint as the scripts print it: 40 hex digits, upper-cased here; anything else
+    /// (an older script that did not print one, or openssl missing) reads as none.</summary>
+    private static string? Thumbprint(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        string cleaned = value.Replace(":", "").Trim().ToUpperInvariant();
+        return cleaned.Length == 40 && cleaned.All(Uri.IsHexDigit) ? cleaned : null;
     }
 
     // ---- Per-user permissions step ----
@@ -125,11 +140,13 @@ public static class AzureCloudShellSetup
 
         values.TryGetValue("consentGranted", out string? consent);
         values.TryGetValue("consentUrl", out string? url);
+        values.TryGetValue("certificateThumbprint", out string? thumbprint);
 
         return new AzurePermissionsResult(
             signInId!,
             ConsentGranted: string.Equals(consent, "true", StringComparison.OrdinalIgnoreCase),
-            ConsentUrl: string.IsNullOrWhiteSpace(url) ? null : url);
+            ConsentUrl: string.IsNullOrWhiteSpace(url) ? null : url,
+            CertificateThumbprint: Thumbprint(thumbprint));
     }
 
     // ---- shared ----
@@ -257,6 +274,8 @@ public static class AzureCloudShellSetup
         }
         register_cert "$ACCESS_APP_ID"
         az ad sp create --id "$ACCESS_APP_ID" >/dev/null 2>&1 || true
+        # Printed back so Connapse can refuse to keep a different certificate than the one registered.
+        CERT_THUMBPRINT=$(openssl x509 -in "$CERT_FILE" -noout -fingerprint -sha1 2>/dev/null | sed 's/.*=//; s/://g')
         rm -f "$CERT_FILE"
 
         # Role assignments wait for the role definitions + service principal to propagate; retry
@@ -275,8 +294,8 @@ public static class AzureCloudShellSetup
         assign_role '{{rbacRoleName}}' "/subscriptions/$SUBSCRIPTION_ID"
 
         echo
-        printf '%s\ntenantId=%s\nsubscriptionId=%s\naccessAppClientId=%s\n%s\n' \
-          "{{beginMarker}}" "$TENANT_ID" "$SUBSCRIPTION_ID" "$ACCESS_APP_ID" "{{endMarker}}"
+        printf '%s\ntenantId=%s\nsubscriptionId=%s\naccessAppClientId=%s\ncertificateThumbprint=%s\n%s\n' \
+          "{{beginMarker}}" "$TENANT_ID" "$SUBSCRIPTION_ID" "$ACCESS_APP_ID" "$CERT_THUMBPRINT" "{{endMarker}}"
         ) || echo "----- CONNAPSE SETUP FAILED: read the error above. Nothing to paste back yet. -----"
         """;
 
@@ -325,6 +344,8 @@ public static class AzureCloudShellSetup
         }
         register_cert "$SIGNIN_APP_ID"
         az ad sp create --id "$SIGNIN_APP_ID" >/dev/null 2>&1 || true
+        # Printed back so Connapse can refuse to keep a different certificate than the one registered.
+        CERT_THUMBPRINT=$(openssl x509 -in "$CERT_FILE" -noout -fingerprint -sha1 2>/dev/null | sed 's/.*=//; s/://g')
         rm -f "$CERT_FILE"
 
         # The admin-consent page bounces back to a reply URL registered on the ACCESS app; without one
@@ -349,8 +370,8 @@ public static class AzureCloudShellSetup
         CONSENT_URL="https://login.microsoftonline.com/$TENANT_ID/adminconsent?client_id=$ACCESS_APP_ID&redirect_uri={{consentRedirectEncoded}}"
 
         echo
-        printf '%s\nsignInAppClientId=%s\nconsentGranted=%s\nconsentUrl=%s\n%s\n' \
-          "{{beginMarker}}" "$SIGNIN_APP_ID" "$CONSENT_GRANTED" "$CONSENT_URL" "{{endMarker}}"
+        printf '%s\nsignInAppClientId=%s\nconsentGranted=%s\nconsentUrl=%s\ncertificateThumbprint=%s\n%s\n' \
+          "{{beginMarker}}" "$SIGNIN_APP_ID" "$CONSENT_GRANTED" "$CONSENT_URL" "$CERT_THUMBPRINT" "{{endMarker}}"
         ) || echo "----- CONNAPSE SETUP FAILED: read the error above. Nothing to paste back yet. -----"
         """;
 }

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -275,7 +275,7 @@ public static class AzureCloudShellSetup
         register_cert "$ACCESS_APP_ID"
         az ad sp create --id "$ACCESS_APP_ID" >/dev/null 2>&1 || true
         # Printed back so Connapse can refuse to keep a different certificate than the one registered.
-        CERT_THUMBPRINT=$(openssl x509 -in "$CERT_FILE" -noout -fingerprint -sha1 2>/dev/null | sed 's/.*=//; s/://g')
+        CERT_THUMBPRINT=$(openssl x509 -in "$CERT_FILE" -noout -fingerprint -sha1 2>/dev/null | sed 's/.*=//; s/://g') || true
         rm -f "$CERT_FILE"
 
         # Role assignments wait for the role definitions + service principal to propagate; retry
@@ -345,7 +345,7 @@ public static class AzureCloudShellSetup
         register_cert "$SIGNIN_APP_ID"
         az ad sp create --id "$SIGNIN_APP_ID" >/dev/null 2>&1 || true
         # Printed back so Connapse can refuse to keep a different certificate than the one registered.
-        CERT_THUMBPRINT=$(openssl x509 -in "$CERT_FILE" -noout -fingerprint -sha1 2>/dev/null | sed 's/.*=//; s/://g')
+        CERT_THUMBPRINT=$(openssl x509 -in "$CERT_FILE" -noout -fingerprint -sha1 2>/dev/null | sed 's/.*=//; s/://g') || true
         rm -f "$CERT_FILE"
 
         # The admin-consent page bounces back to a reply URL registered on the ACCESS app; without one

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -48,9 +48,12 @@ public sealed class AzureBlobDiscovery(
             TokenCredential fresh = ConnapseAzureCredentials.Build(candidate);
             await fresh.GetTokenAsync(new TokenRequestContext([ArmScope]), timeout.Token);
 
-            string verified = AzureCredentialChainFactory.IsUserAssignedManagedIdentity(candidate)
-                ? $"Azure issued a token for managed identity {candidate.UserAssignedManagedIdentityClientId}."
-                : $"Entra accepted the certificate for app {candidate.ClientId} in tenant {candidate.TenantId}.";
+            string verified = AzureCredentialChainFactory.IsHostManagedIdentity(candidate)
+                ? "Azure issued a token for this host's managed identity"
+                  + (candidate.ManagedIdentityPrincipalId is { Length: > 0 } principal ? $" (principal {principal})." : ".")
+                : AzureCredentialChainFactory.IsUserAssignedManagedIdentity(candidate)
+                    ? $"Azure issued a token for managed identity {candidate.UserAssignedManagedIdentityClientId}."
+                    : $"Entra accepted the certificate for app {candidate.ClientId} in tenant {candidate.TenantId}.";
             return AzureProbe<string>.Ok(verified);
         }
         catch (AuthenticationFailedException ex) when (IsCredentialRefusal(ex))
@@ -194,11 +197,12 @@ public sealed class AzureBlobDiscovery(
         }
     }
 
-    /// <summary>The same rule the Providers page uses for "Access is set up".</summary>
+    /// <summary>The same rule the Providers page uses for "Access is set up": a tenant, and one of
+    /// a certificate app, a user-assigned managed identity, or the host's own managed identity.</summary>
     internal static bool IsConfigured(AzureProviderSettings s) =>
         !string.IsNullOrWhiteSpace(s.TenantId)
         && ((!string.IsNullOrWhiteSpace(s.ClientId) && !string.IsNullOrWhiteSpace(s.ClientCertificatePath))
-            || !string.IsNullOrWhiteSpace(s.UserAssignedManagedIdentityClientId));
+            || AzureCredentialChainFactory.IsManagedIdentity(s));
 
     internal static bool IsDenial(RequestFailedException ex) => ex.Status is 401 or 403;
 }

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -71,6 +71,15 @@ public sealed class AzureBlobDiscovery(
             logger.LogWarning(ex, "Connapse's Azure identity cannot be used from this host");
             return AzureProbe<string>.Unusable(ex.Message);
         }
+        catch (CredentialUnavailableException ex) when (AzureCredentialChainFactory.IsManagedIdentity(candidate))
+        {
+            // Settings say "sign in as a managed identity" and the host has none to offer: not a
+            // transport fault to retry, the identity is gone from this host (or the settings came
+            // from another one).
+            logger.LogWarning(ex, "Connapse is configured to use a managed identity, but this host has none");
+            return AzureProbe<string>.Unusable(
+                "No managed identity is available on this host: " + ex.Message);
+        }
         catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
         {
             // Network faults, an inconclusive answer from Entra, or no managed identity on this

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -90,10 +90,12 @@ public sealed class AzureBlobDiscovery(
     /// <summary>Entra error codes that mean the credential is invalid: the certificate is not
     /// registered on the app or its assertion is not signed by a registered key (700027), the app's
     /// keys have expired (7000222), the client credential is wrong (7000215), the app has no service
-    /// principal (7000229), the app does not exist (700016), or the tenant does not (90002).</summary>
+    /// principal (7000229), the app is disabled (7000112), the app does not exist (700016), or the
+    /// tenant does not (90002).</summary>
     internal static readonly IReadOnlyList<string> CredentialRefusalCodes =
     [
-        "AADSTS700027", "AADSTS7000222", "AADSTS7000215", "AADSTS7000229", "AADSTS700016", "AADSTS90002",
+        "AADSTS700027", "AADSTS7000222", "AADSTS7000215", "AADSTS7000229", "AADSTS7000112",
+        "AADSTS700016", "AADSTS90002",
     ];
 
     public async Task<AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>> ListStorageAccountsAsync(

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -28,10 +28,12 @@ public sealed class AzureBlobDiscovery(
     /// identity in the tenant, so the check tests the credential and nothing else.</summary>
     private const string ArmScope = "https://management.azure.com/.default";
 
-    public async Task<AzureProbe<string>> CheckAccessAsync(CancellationToken ct = default)
+    public Task<AzureProbe<string>> CheckAccessAsync(CancellationToken ct = default) =>
+        CheckAccessAsync(options.CurrentValue, ct);
+
+    public async Task<AzureProbe<string>> CheckAccessAsync(AzureProviderSettings candidate, CancellationToken ct = default)
     {
-        AzureProviderSettings settings = options.CurrentValue;
-        if (!IsConfigured(settings))
+        if (!IsConfigured(candidate))
             return AzureProbe<string>.NotConfigured(
                 "No Azure identity is set up — configure it on the Azure provider page.");
 
@@ -40,11 +42,15 @@ public sealed class AzureBlobDiscovery(
 
         try
         {
-            await credentials.GetTokenAsync(new TokenRequestContext([ArmScope]), timeout.Token);
+            // A credential of its own, never the shared cached one: ClientCertificateCredential
+            // hands back a token it already holds without asking Entra, and a certificate removed
+            // from the app after that would keep reading as accepted until the token expired.
+            TokenCredential fresh = ConnapseAzureCredentials.Build(candidate);
+            await fresh.GetTokenAsync(new TokenRequestContext([ArmScope]), timeout.Token);
 
-            string verified = string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
-                ? $"Entra accepted the certificate for app {settings.ClientId} in tenant {settings.TenantId}."
-                : $"Azure issued a token for managed identity {settings.UserAssignedManagedIdentityClientId}.";
+            string verified = AzureCredentialChainFactory.IsUserAssignedManagedIdentity(candidate)
+                ? $"Azure issued a token for managed identity {candidate.UserAssignedManagedIdentityClientId}."
+                : $"Entra accepted the certificate for app {candidate.ClientId} in tenant {candidate.TenantId}.";
             return AzureProbe<string>.Ok(verified);
         }
         catch (AuthenticationFailedException ex) when (IsCredentialRefusal(ex))
@@ -59,9 +65,17 @@ public sealed class AzureBlobDiscovery(
             // Network faults, an unreadable certificate file, a partially configured identity, or
             // no managed identity on this host: the check could not be completed either way.
             logger.LogWarning(ex, "Checking Connapse's Azure identity failed");
-            return AzureProbe<string>.Failed(ex.Message);
+            return AzureProbe<string>.Failed(Describe(ex));
         }
     }
+
+    /// <summary>What to tell the operator when the check could not run, by what stopped it.</summary>
+    private static string Describe(Exception ex) => ex switch
+    {
+        CredentialUnavailableException => "No managed identity is available on this host: " + ex.Message,
+        OperationCanceledException => $"Azure did not answer within {Timeout.TotalSeconds:F0} seconds.",
+        _ => ex.Message,
+    };
 
     /// <summary>Whether Entra itself rejected the credential, as opposed to the request not
     /// reaching it. Entra's rejections carry an <c>AADSTS</c> code; transport failures do not.</summary>

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -1,4 +1,6 @@
 using Azure;
+using Azure.Core;
+using Azure.Identity;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Storage;
@@ -21,6 +23,51 @@ public sealed class AzureBlobDiscovery(
     ILogger<AzureBlobDiscovery> logger) : IAzureBlobDiscovery
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>The audience a token is requested for. Azure Resource Manager issues one to any
+    /// identity in the tenant, so the check tests the credential and nothing else.</summary>
+    private const string ArmScope = "https://management.azure.com/.default";
+
+    public async Task<AzureProbe<string>> CheckAccessAsync(CancellationToken ct = default)
+    {
+        AzureProviderSettings settings = options.CurrentValue;
+        if (!IsConfigured(settings))
+            return AzureProbe<string>.NotConfigured(
+                "No Azure identity is set up — configure it on the Azure provider page.");
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(Timeout);
+
+        try
+        {
+            await credentials.GetTokenAsync(new TokenRequestContext([ArmScope]), timeout.Token);
+
+            string verified = string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+                ? $"Entra accepted the certificate for app {settings.ClientId} in tenant {settings.TenantId}."
+                : $"Azure issued a token for managed identity {settings.UserAssignedManagedIdentityClientId}.";
+            return AzureProbe<string>.Ok(verified);
+        }
+        catch (AuthenticationFailedException ex) when (IsCredentialRefusal(ex))
+        {
+            // Entra answered and said no: the certificate is not registered on the app, has
+            // expired, or the app or tenant no longer exists. Only a new setup fixes it.
+            logger.LogWarning("Entra refused Connapse's Azure credential: {Reason}", ex.Message);
+            return AzureProbe<string>.Denied(ex.Message);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            // Network faults, an unreadable certificate file, a partially configured identity, or
+            // no managed identity on this host: the check could not be completed either way.
+            logger.LogWarning(ex, "Checking Connapse's Azure identity failed");
+            return AzureProbe<string>.Failed(ex.Message);
+        }
+    }
+
+    /// <summary>Whether Entra itself rejected the credential, as opposed to the request not
+    /// reaching it. Entra's rejections carry an <c>AADSTS</c> code; transport failures do not.</summary>
+    internal static bool IsCredentialRefusal(AuthenticationFailedException ex) =>
+        ex is not CredentialUnavailableException
+        && ex.Message.Contains("AADSTS", StringComparison.Ordinal);
 
     public async Task<AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>> ListStorageAccountsAsync(
         CancellationToken ct = default)

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -60,10 +60,18 @@ public sealed class AzureBlobDiscovery(
             logger.LogWarning("Entra refused Connapse's Azure credential: {Reason}", ex.Message);
             return AzureProbe<string>.Denied(ex.Message);
         }
+        catch (Exception ex) when (ex is InvalidOperationException || AzureCertificateFile.IsUnreadable(ex))
+        {
+            // The credential could not even be built: the certificate file is missing or unreadable,
+            // or the settings are only partly filled in. Azure was never asked; this host is what
+            // needs fixing, and the card should say so plainly rather than "could not confirm".
+            logger.LogWarning(ex, "Connapse's Azure identity cannot be used from this host");
+            return AzureProbe<string>.Unusable(ex.Message);
+        }
         catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
         {
-            // Network faults, an unreadable certificate file, a partially configured identity, or
-            // no managed identity on this host: the check could not be completed either way.
+            // Network faults, an inconclusive answer from Entra, or no managed identity on this
+            // host: the check could not be completed either way.
             logger.LogWarning(ex, "Checking Connapse's Azure identity failed");
             return AzureProbe<string>.Failed(Describe(ex));
         }
@@ -74,6 +82,8 @@ public sealed class AzureBlobDiscovery(
     {
         CredentialUnavailableException => "No managed identity is available on this host: " + ex.Message,
         OperationCanceledException => $"Azure did not answer within {Timeout.TotalSeconds:F0} seconds.",
+        AuthenticationFailedException when ex.Message.Contains("AADSTS", StringComparison.Ordinal) =>
+            "Entra answered but did not judge the credential (a transient fault or throttling); try again. " + ex.Message,
         _ => ex.Message,
     };
 

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -51,13 +51,15 @@ public sealed class AzureBlobDiscovery(
             // A managed-identity token is issued whatever tenant the settings name, so the tenant
             // is checked against the token itself: one that names another tenant would only fail
             // later, in the sign-in defaults and the role-assignment reads.
-            if (AzureCredentialChainFactory.IsManagedIdentity(candidate)
-                && !string.IsNullOrWhiteSpace(candidate.TenantId)
-                && AzureHostIdentity.Describe(token.Token)?.TenantId is { } issuedFor
-                && !string.Equals(issuedFor, candidate.TenantId.Trim(), StringComparison.OrdinalIgnoreCase))
+            if (AzureCredentialChainFactory.IsManagedIdentity(candidate) && !string.IsNullOrWhiteSpace(candidate.TenantId))
             {
-                return AzureProbe<string>.Unusable(
-                    $"The managed identity is in tenant {issuedFor}, but the settings name tenant {candidate.TenantId}.");
+                string? issuedFor = AzureHostIdentity.Describe(token.Token)?.TenantId;
+                if (issuedFor is null)
+                    logger.LogDebug("The managed identity's token did not name its tenant; the stored tenant was not checked against it");
+                else if (!string.Equals(issuedFor, candidate.TenantId.Trim(), StringComparison.OrdinalIgnoreCase))
+                    return AzureProbe<string>.Unusable(
+                        $"The managed identity is in tenant {issuedFor}, but the settings name tenant "
+                        + $"{candidate.TenantId}. Enter tenant {issuedFor}.");
             }
 
             string verified = AzureCredentialChainFactory.IsHostManagedIdentity(candidate)

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -46,7 +46,19 @@ public sealed class AzureBlobDiscovery(
             // hands back a token it already holds without asking Entra, and a certificate removed
             // from the app after that would keep reading as accepted until the token expired.
             TokenCredential fresh = ConnapseAzureCredentials.Build(candidate);
-            await fresh.GetTokenAsync(new TokenRequestContext([ArmScope]), timeout.Token);
+            AccessToken token = await fresh.GetTokenAsync(new TokenRequestContext([ArmScope]), timeout.Token);
+
+            // A managed-identity token is issued whatever tenant the settings name, so the tenant
+            // is checked against the token itself: one that names another tenant would only fail
+            // later, in the sign-in defaults and the role-assignment reads.
+            if (AzureCredentialChainFactory.IsManagedIdentity(candidate)
+                && !string.IsNullOrWhiteSpace(candidate.TenantId)
+                && AzureHostIdentity.Describe(token.Token)?.TenantId is { } issuedFor
+                && !string.Equals(issuedFor, candidate.TenantId.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                return AzureProbe<string>.Unusable(
+                    $"The managed identity is in tenant {issuedFor}, but the settings name tenant {candidate.TenantId}.");
+            }
 
             string verified = AzureCredentialChainFactory.IsHostManagedIdentity(candidate)
                 ? "Azure issued a token for this host's managed identity"

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -77,11 +77,24 @@ public sealed class AzureBlobDiscovery(
         _ => ex.Message,
     };
 
-    /// <summary>Whether Entra itself rejected the credential, as opposed to the request not
-    /// reaching it. Entra's rejections carry an <c>AADSTS</c> code; transport failures do not.</summary>
+    /// <summary>
+    /// Whether Entra rejected the credential itself — something only setting access up again fixes —
+    /// as opposed to the request not reaching it or Entra being unable to answer. Only the codes that
+    /// mean the certificate, app, or tenant is wrong count; every other <c>AADSTS</c> code (throttling,
+    /// a transient fault, directory unavailability) is inconclusive, not a verdict.
+    /// </summary>
     internal static bool IsCredentialRefusal(AuthenticationFailedException ex) =>
         ex is not CredentialUnavailableException
-        && ex.Message.Contains("AADSTS", StringComparison.Ordinal);
+        && CredentialRefusalCodes.Any(code => ex.Message.Contains(code, StringComparison.Ordinal));
+
+    /// <summary>Entra error codes that mean the credential is invalid: the certificate is not
+    /// registered on the app or its assertion is not signed by a registered key (700027), the app's
+    /// keys have expired (7000222), the client credential is wrong (7000215), the app has no service
+    /// principal (7000229), the app does not exist (700016), or the tenant does not (90002).</summary>
+    internal static readonly IReadOnlyList<string> CredentialRefusalCodes =
+    [
+        "AADSTS700027", "AADSTS7000222", "AADSTS7000215", "AADSTS7000229", "AADSTS700016", "AADSTS90002",
+    ];
 
     public async Task<AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>> ListStorageAccountsAsync(
         CancellationToken ct = default)

--- a/src/Connapse.Storage/CloudScope/AzureCertificateFile.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCertificateFile.cs
@@ -32,11 +32,17 @@ public static class AzureCertificateFile
             using X509Certificate2? certificate = Load(path, password);
             return certificate?.NotAfter.ToUniversalTime();
         }
-        catch (Exception ex) when (ex is CryptographicException or IOException or ArgumentException)
+        catch (Exception ex) when (IsUnreadable(ex))
         {
             return null;
         }
     }
+
+    /// <summary>The ways a certificate file fails to read: not a certificate (or the wrong password),
+    /// an I/O fault, a permission the process lacks, or a path the runtime rejects. None of them is
+    /// a reason for the page showing the file to fail to render.</summary>
+    public static bool IsUnreadable(Exception ex) =>
+        ex is CryptographicException or IOException or UnauthorizedAccessException or ArgumentException;
 
     /// <summary>The SHA-1 thumbprint of a PEM-encoded certificate, upper-case hex with no separators —
     /// the form <c>openssl x509 -fingerprint</c> prints once its colons are stripped, and what Entra

--- a/src/Connapse.Storage/CloudScope/AzureCertificateFile.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCertificateFile.cs
@@ -1,0 +1,49 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Reads the certificate files Connapse's Azure identities sign with, in the two shapes the settings
+/// accept: a PEM holding certificate plus private key (<c>.pem</c>/<c>.crt</c>), or a PKCS#12 bundle
+/// with an optional password. One loader, so the credential chain, the expiry shown on the provider
+/// page, and the setup check all read the same file the same way.
+/// </summary>
+public static class AzureCertificateFile
+{
+    /// <summary>The certificate at <paramref name="path"/>, or null when no path is set or the file is missing.</summary>
+    /// <exception cref="CryptographicException">The file exists but is not a readable certificate (or the password is wrong).</exception>
+    public static X509Certificate2? Load(string? path, string? password)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return null;
+
+        string extension = Path.GetExtension(path).ToLowerInvariant();
+        return extension is ".pem" or ".crt"
+            ? X509Certificate2.CreateFromPemFile(path)
+            : X509CertificateLoader.LoadPkcs12FromFile(path, password);
+    }
+
+    /// <summary>When the certificate at <paramref name="path"/> stops being accepted, in UTC; null
+    /// when there is no readable certificate there.</summary>
+    public static DateTime? Expiry(string? path, string? password)
+    {
+        try
+        {
+            using X509Certificate2? certificate = Load(path, password);
+            return certificate?.NotAfter.ToUniversalTime();
+        }
+        catch (Exception ex) when (ex is CryptographicException or IOException or ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>The SHA-1 thumbprint of a PEM-encoded certificate, upper-case hex with no separators —
+    /// the form <c>openssl x509 -fingerprint</c> prints once its colons are stripped, and what Entra
+    /// shows under Certificates &amp; secrets.</summary>
+    public static string Thumbprint(string certificatePem)
+    {
+        using X509Certificate2 certificate = X509Certificate2.CreateFromPem(certificatePem);
+        return certificate.Thumbprint.ToUpperInvariant();
+    }
+}

--- a/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
@@ -12,10 +12,27 @@ namespace Connapse.Storage.CloudScope;
 /// </summary>
 public static class AzureCredentialChainFactory
 {
+    /// <summary>
+    /// Whether <paramref name="settings"/> name a user-assigned managed identity and nothing of a
+    /// certificate app. The tenant is allowed alongside it — the provider page records the tenant
+    /// for every identity, and a tenant alone is not certificate intent.
+    /// </summary>
+    public static bool IsUserAssignedManagedIdentity(AzureProviderSettings settings) =>
+        !string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+        && string.IsNullOrWhiteSpace(settings.ClientId)
+        && string.IsNullOrWhiteSpace(settings.ClientCertificatePath)
+        && string.IsNullOrWhiteSpace(settings.ClientCertificatePassword);
+
     public static TokenCredential Create(
         AzureProviderSettings settings,
         Func<AzureProviderSettings, X509Certificate2?> certLoader)
     {
+        if (IsUserAssignedManagedIdentity(settings))
+        {
+            return new ChainedTokenCredential(new ManagedIdentityCredential(
+                ManagedIdentityId.FromUserAssignedClientId(settings.UserAssignedManagedIdentityClientId)));
+        }
+
         bool anyServicePrincipalFieldSet =
             !string.IsNullOrWhiteSpace(settings.TenantId)
             || !string.IsNullOrWhiteSpace(settings.ClientId)
@@ -24,13 +41,8 @@ public static class AzureCredentialChainFactory
 
         if (!anyServicePrincipalFieldSet)
         {
-            // No service-principal intent at all: managed-identity-only chain.
-            TokenCredential managedIdentity = string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
-                ? new ManagedIdentityCredential()
-                : new ManagedIdentityCredential(
-                    ManagedIdentityId.FromUserAssignedClientId(settings.UserAssignedManagedIdentityClientId));
-
-            return new ChainedTokenCredential(managedIdentity);
+            // No service-principal intent at all: the host's system-assigned identity.
+            return new ChainedTokenCredential(new ManagedIdentityCredential());
         }
 
         // Any populated service-principal field is intent to use certificate auth.

--- a/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
@@ -23,10 +23,30 @@ public static class AzureCredentialChainFactory
         && string.IsNullOrWhiteSpace(settings.ClientCertificatePath)
         && string.IsNullOrWhiteSpace(settings.ClientCertificatePassword);
 
+    /// <summary>
+    /// Whether <paramref name="settings"/> name the host's own system-assigned managed identity and
+    /// nothing of a certificate app. As with the user-assigned case, the tenant may sit beside it.
+    /// </summary>
+    public static bool IsHostManagedIdentity(AzureProviderSettings settings) =>
+        settings.UseHostManagedIdentity
+        && string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+        && string.IsNullOrWhiteSpace(settings.ClientId)
+        && string.IsNullOrWhiteSpace(settings.ClientCertificatePath)
+        && string.IsNullOrWhiteSpace(settings.ClientCertificatePassword);
+
+    /// <summary>Either kind of managed identity: the host's own, or a user-assigned one by client id.</summary>
+    public static bool IsManagedIdentity(AzureProviderSettings settings) =>
+        IsHostManagedIdentity(settings) || IsUserAssignedManagedIdentity(settings);
+
     public static TokenCredential Create(
         AzureProviderSettings settings,
         Func<AzureProviderSettings, X509Certificate2?> certLoader)
     {
+        if (IsHostManagedIdentity(settings))
+        {
+            return new ChainedTokenCredential(new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned));
+        }
+
         if (IsUserAssignedManagedIdentity(settings))
         {
             return new ChainedTokenCredential(new ManagedIdentityCredential(

--- a/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
@@ -19,6 +19,7 @@ public static class AzureCredentialChainFactory
     /// </summary>
     public static bool IsUserAssignedManagedIdentity(AzureProviderSettings settings) =>
         !string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+        && !settings.UseHostManagedIdentity
         && string.IsNullOrWhiteSpace(settings.ClientId)
         && string.IsNullOrWhiteSpace(settings.ClientCertificatePath)
         && string.IsNullOrWhiteSpace(settings.ClientCertificatePassword);
@@ -42,6 +43,16 @@ public static class AzureCredentialChainFactory
         AzureProviderSettings settings,
         Func<AzureProviderSettings, X509Certificate2?> certLoader)
     {
+        // Two managed identities named at once is a mix the form cannot produce; arriving from
+        // configuration it is a mistake, and picking either side silently would be choosing an
+        // identity nobody asked for.
+        if (settings.UseHostManagedIdentity && !string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId))
+        {
+            throw new InvalidOperationException(
+                "Azure settings name both the host's managed identity (UseHostManagedIdentity) and a "
+                + "user-assigned one (UserAssignedManagedIdentityClientId). Keep one; Connapse will not choose.");
+        }
+
         if (IsHostManagedIdentity(settings))
         {
             return new ChainedTokenCredential(new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned));

--- a/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
@@ -43,14 +43,18 @@ public static class AzureCredentialChainFactory
         AzureProviderSettings settings,
         Func<AzureProviderSettings, X509Certificate2?> certLoader)
     {
-        // Two managed identities named at once is a mix the form cannot produce; arriving from
-        // configuration it is a mistake, and picking either side silently would be choosing an
-        // identity nobody asked for.
-        if (settings.UseHostManagedIdentity && !string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId))
+        // The host's identity named beside another identity is a mix the form cannot produce;
+        // arriving from configuration it is a mistake, and picking either side silently would be
+        // choosing an identity nobody asked for.
+        if (settings.UseHostManagedIdentity
+            && (!string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+                || !string.IsNullOrWhiteSpace(settings.ClientId)
+                || !string.IsNullOrWhiteSpace(settings.ClientCertificatePath)
+                || !string.IsNullOrWhiteSpace(settings.ClientCertificatePassword)))
         {
             throw new InvalidOperationException(
-                "Azure settings name both the host's managed identity (UseHostManagedIdentity) and a "
-                + "user-assigned one (UserAssignedManagedIdentityClientId). Keep one; Connapse will not choose.");
+                "Azure settings name both the host's managed identity (UseHostManagedIdentity) and another "
+                + "identity (a user-assigned managed identity or a certificate app). Keep one; Connapse will not choose.");
         }
 
         if (IsHostManagedIdentity(settings))

--- a/src/Connapse.Storage/CloudScope/AzureHostIdentity.cs
+++ b/src/Connapse.Storage/CloudScope/AzureHostIdentity.cs
@@ -1,0 +1,138 @@
+using System.Text;
+using System.Text.Json;
+using Azure.Core;
+using Azure.Identity;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Detects the host's managed identity by asking Azure's instance metadata service for a token and
+/// reading who the token was issued to. Off Azure the metadata endpoint does not exist and the
+/// credential gives up within about a second; a hard cap covers the slow-network case.
+/// </summary>
+/// <remarks>
+/// The token's claims are read without validating its signature. That is fine here: nothing is
+/// authorised by them. They only describe the identity so the setup script can name it, and every
+/// later call to Azure authenticates for real with a token of its own.
+/// </remarks>
+public sealed class AzureHostIdentity(ILogger<AzureHostIdentity> logger) : IAzureHostIdentity
+{
+    private const string ArmScope = "https://management.azure.com/.default";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    private readonly SemaphoreSlim gate = new(1, 1);
+    private AzureHostIdentityInfo? found;
+
+    /// <summary>How the token is obtained; replaced in tests so no metadata service is needed.</summary>
+    internal Func<CancellationToken, Task<string>> AcquireToken { get; init; } = async ct =>
+    {
+        var credential = new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned);
+        AccessToken token = await credential.GetTokenAsync(new TokenRequestContext([ArmScope]), ct);
+        return token.Token;
+    };
+
+    public async Task<AzureHostIdentityInfo?> DetectAsync(CancellationToken ct = default)
+    {
+        if (found is not null) return found;
+
+        await gate.WaitAsync(ct);
+        try
+        {
+            if (found is not null) return found;
+
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeout.CancelAfter(Timeout);
+            try
+            {
+                string token = await AcquireToken(timeout.Token);
+                found = Describe(token);
+                if (found is null)
+                    logger.LogWarning("The host's managed identity issued a token, but it carried none of the claims that name the identity");
+                return found;
+            }
+            catch (CredentialUnavailableException)
+            {
+                // The ordinary answer off Azure: no metadata service, so no identity.
+                return null;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+            {
+                logger.LogDebug(ex, "Could not detect a managed identity on this host");
+                return null;
+            }
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>Reads the identity a managed-identity token describes, or null when the required
+    /// claims are missing.</summary>
+    public static AzureHostIdentityInfo? Describe(string jwt)
+    {
+        string[] parts = jwt.Split('.');
+        if (parts.Length < 2) return null;
+
+        JsonDocument payload;
+        try
+        {
+            payload = JsonDocument.Parse(Base64UrlDecode(parts[1]));
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException)
+        {
+            return null;
+        }
+
+        using (payload)
+        {
+            JsonElement root = payload.RootElement;
+            string? tenant = Claim(root, "tid");
+            string? principal = Claim(root, "oid");
+            string? client = Claim(root, "appid");
+            if (tenant is null || principal is null || client is null) return null;
+
+            string? resourceId = Claim(root, "xms_mirid");
+            return new AzureHostIdentityInfo(
+                tenant, principal, client, resourceId,
+                SubscriptionFrom(resourceId),
+                resourceId?.Contains("/providers/Microsoft.ManagedIdentity/userAssignedIdentities/", StringComparison.OrdinalIgnoreCase) == true);
+        }
+    }
+
+    /// <summary>The subscription segment of an ARM resource id, or null.</summary>
+    public static string? SubscriptionFrom(string? resourceId)
+    {
+        if (string.IsNullOrWhiteSpace(resourceId)) return null;
+        string[] segments = resourceId.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (int i = 0; i + 1 < segments.Length; i++)
+        {
+            if (segments[i].Equals("subscriptions", StringComparison.OrdinalIgnoreCase) && Guid.TryParse(segments[i + 1], out Guid id))
+                return id.ToString();
+        }
+        return null;
+    }
+
+    private static string? Claim(JsonElement root, string name) =>
+        root.TryGetProperty(name, out JsonElement value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static byte[] Base64UrlDecode(string value)
+    {
+        string padded = value.Replace('-', '+').Replace('_', '/');
+        padded = padded.PadRight(padded.Length + (4 - padded.Length % 4) % 4, '=');
+        return Convert.FromBase64String(padded);
+    }
+
+    /// <summary>Encodes a payload the way a token carries it; used by tests to build one.</summary>
+    public static string EncodePayload(object payload)
+    {
+        byte[] json = JsonSerializer.SerializeToUtf8Bytes(payload);
+        string body = Convert.ToBase64String(json).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        string header = Convert.ToBase64String(Encoding.UTF8.GetBytes("{\"alg\":\"none\"}")).TrimEnd('=');
+        return $"{header}.{body}.";
+    }
+}

--- a/src/Connapse.Storage/CloudScope/AzureHostIdentity.cs
+++ b/src/Connapse.Storage/CloudScope/AzureHostIdentity.cs
@@ -33,14 +33,14 @@ public sealed class AzureHostIdentity(ILogger<AzureHostIdentity> logger) : IAzur
         return token.Token;
     };
 
-    public async Task<AzureHostIdentityInfo?> DetectAsync(CancellationToken ct = default)
+    public async Task<AzureHostIdentityInfo?> DetectAsync(bool refresh = false, CancellationToken ct = default)
     {
-        if (found is not null) return found;
+        if (!refresh && found is not null) return found;
 
         await gate.WaitAsync(ct);
         try
         {
-            if (found is not null) return found;
+            if (!refresh && found is not null) return found;
 
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
             timeout.CancelAfter(Timeout);
@@ -54,7 +54,9 @@ public sealed class AzureHostIdentity(ILogger<AzureHostIdentity> logger) : IAzur
             }
             catch (CredentialUnavailableException)
             {
-                // The ordinary answer off Azure: no metadata service, so no identity.
+                // The ordinary answer off Azure: no metadata service, so no identity. On a refresh
+                // it also means an identity remembered earlier is gone, and must not be handed out.
+                if (refresh) found = null;
                 return null;
             }
             catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)

--- a/src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs
+++ b/src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs
@@ -49,19 +49,14 @@ public sealed class ConnapseAzureCredentials : TokenCredential, IDisposable
     public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken ct) =>
         Current.GetTokenAsync(requestContext, ct);
 
-    private static TokenCredential Build(AzureProviderSettings settings) =>
+    /// <summary>A credential built from <paramref name="settings"/> alone, sharing nothing with the
+    /// cached one — so a check made with it always goes to Entra rather than answering from a token
+    /// the shared credential still holds.</summary>
+    public static TokenCredential Build(AzureProviderSettings settings) =>
         AzureCredentialChainFactory.Create(settings, LoadCertificate);
 
-    private static X509Certificate2? LoadCertificate(AzureProviderSettings s)
-    {
-        if (string.IsNullOrWhiteSpace(s.ClientCertificatePath)) return null;
-        if (!File.Exists(s.ClientCertificatePath)) return null;
-
-        string ext = Path.GetExtension(s.ClientCertificatePath).ToLowerInvariant();
-        return ext is ".pem" or ".crt"
-            ? X509Certificate2.CreateFromPemFile(s.ClientCertificatePath)
-            : X509CertificateLoader.LoadPkcs12FromFile(s.ClientCertificatePath, s.ClientCertificatePassword);
-    }
+    private static X509Certificate2? LoadCertificate(AzureProviderSettings s) =>
+        AzureCertificateFile.Load(s.ClientCertificatePath, s.ClientCertificatePassword);
 
     public void Dispose() => _reload?.Dispose();
 }

--- a/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
@@ -62,15 +62,32 @@ public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentia
                 },
                 stopwatch.Elapsed);
         }
-        catch (AuthenticationFailedException ex)
+        catch (AuthenticationFailedException ex) when (AzureBlobDiscovery.IsCredentialRefusal(ex))
         {
-            // Entra would not issue a token: the certificate is not registered on the app, has
-            // expired, or no managed identity exists on this host. Nothing on the connection form
-            // fixes that.
+            // Entra answered and would not issue a token: the certificate is not registered on the
+            // app, has expired, or the app is gone. Nothing on the connection form fixes that.
             stopwatch.Stop();
             return Failure(
                 "Entra rejected Connapse's identity, so nothing on this account can be read. Check "
                 + "the Access step on the Azure provider page — Recheck there says why.",
+                ex, stopwatch.Elapsed);
+        }
+        catch (CredentialUnavailableException ex)
+        {
+            stopwatch.Stop();
+            return Failure(
+                "No managed identity is available on this host, so Connapse has nothing to sign in "
+                + "with. Check the Access step on the Azure provider page.",
+                ex, stopwatch.Elapsed);
+        }
+        catch (AuthenticationFailedException ex)
+        {
+            // The sign-in request never got an answer from Entra — a transport fault, not a
+            // verdict on the credential.
+            stopwatch.Stop();
+            return Failure(
+                "Could not reach Entra to sign Connapse in, so the credential was not checked. Confirm "
+                + "this server can reach login.microsoftonline.com, then try again.",
                 ex, stopwatch.Elapsed);
         }
         catch (InvalidOperationException ex)

--- a/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
@@ -29,12 +29,20 @@ public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentia
         cts.CancelAfter(limit);
 
         string endpoint = cfg.BlobEndpoint ?? $"https://{cfg.AccountName}.blob.core.windows.net";
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? endpointUri) || endpointUri.Scheme is not ("https" or "http"))
+        {
+            return ConnectionTestResult.CreateFailure(
+                $"'{endpoint}' is not a full https:// address. Fix the Blob endpoint field, or clear it to "
+                + "use the account's default endpoint.",
+                new Dictionary<string, object> { ["error"] = "Invalid blob endpoint", ["endpoint"] = endpoint });
+        }
+
         string where = string.IsNullOrEmpty(cfg.Prefix) ? "" : $" under prefix '{cfg.Prefix}'";
         var stopwatch = Stopwatch.StartNew();
 
         try
         {
-            var service = new BlobServiceClient(new Uri(endpoint), credentials);
+            var service = new BlobServiceClient(endpointUri, credentials);
             var container = service.GetBlobContainerClient(cfg.ContainerName);
 
             int seen = 0;
@@ -78,6 +86,16 @@ public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentia
             return Failure(
                 "No managed identity is available on this host, so Connapse has nothing to sign in "
                 + "with. Check the Access step on the Azure provider page.",
+                ex, stopwatch.Elapsed);
+        }
+        catch (AuthenticationFailedException ex) when (ex.Message.Contains("AADSTS", StringComparison.Ordinal))
+        {
+            // Entra answered, but with a code that is not a verdict on the credential — a transient
+            // fault, throttling, clock skew. Retrying is the remedy, not re-setup or the network.
+            stopwatch.Stop();
+            return Failure(
+                "Entra answered but did not judge Connapse's credential (a transient fault or throttling), "
+                + "so the test is inconclusive. Try again in a moment; the raw reply is below.",
                 ex, stopwatch.Elapsed);
         }
         catch (AuthenticationFailedException ex)
@@ -132,7 +150,7 @@ public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentia
             stopwatch.Stop();
             return ConnectionTestResult.CreateFailure(
                 $"Azure did not answer within {limit.TotalSeconds:F0} seconds. Check that this server can "
-                + $"reach {new Uri(endpoint).Host}, then try again.",
+                + $"reach {endpointUri.Host}, then try again.",
                 new Dictionary<string, object>
                 {
                     ["error"] = "Timeout",
@@ -144,7 +162,7 @@ public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentia
         {
             stopwatch.Stop();
             return Failure(
-                $"Could not reach '{new Uri(endpoint).Host}': {ex.Message} Check the storage account name "
+                $"Could not reach '{endpointUri.Host}': {ex.Message} Check the storage account name "
                 + "and, if one is set, the blob endpoint.",
                 ex, stopwatch.Elapsed);
         }

--- a/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using Azure;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
@@ -8,6 +10,11 @@ using Connapse.Storage.Connectors;
 namespace Connapse.Storage.ConnectionTesters;
 
 /// <summary>Validates an Azure Blob connection by listing a few blobs with Connapse's identity.</summary>
+/// <remarks>
+/// Every message says which layer failed — reaching the account, Entra accepting Connapse's
+/// credential, the role assignment allowing the read, or the container existing — and what to
+/// change. The raw reason travels in <c>Details["error"]</c> for the operator who wants it.
+/// </remarks>
 public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentials) : IConnectionTester
 {
     public async Task<ConnectionTestResult> TestConnectionAsync(
@@ -17,41 +24,122 @@ public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentia
             return ConnectionTestResult.CreateFailure(
                 "Invalid settings: expected AzureBlobConnectorConfig.");
 
+        TimeSpan limit = timeout ?? TimeSpan.FromSeconds(10);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        cts.CancelAfter(timeout ?? TimeSpan.FromSeconds(10));
+        cts.CancelAfter(limit);
+
+        string endpoint = cfg.BlobEndpoint ?? $"https://{cfg.AccountName}.blob.core.windows.net";
+        string where = string.IsNullOrEmpty(cfg.Prefix) ? "" : $" under prefix '{cfg.Prefix}'";
+        var stopwatch = Stopwatch.StartNew();
 
         try
         {
-            var service = new BlobServiceClient(
-                new Uri(cfg.BlobEndpoint ?? $"https://{cfg.AccountName}.blob.core.windows.net"),
-                credentials);
+            var service = new BlobServiceClient(new Uri(endpoint), credentials);
             var container = service.GetBlobContainerClient(cfg.ContainerName);
 
             int seen = 0;
+            bool hasMore = false;
             await foreach (var _ in container.GetBlobsAsync(prefix: cfg.Prefix, cancellationToken: cts.Token))
-                if (++seen >= 5) break;
+            {
+                if (++seen >= 5) { hasMore = true; break; }
+            }
+
+            stopwatch.Stop();
+            string what = seen > 0
+                ? $"{seen}{(hasMore ? "+" : "")} blob{(seen != 1 ? "s" : "")} found{where}"
+                : $"it is empty{where}";
 
             return ConnectionTestResult.CreateSuccess(
-                $"Connected to container '{cfg.ContainerName}' on account '{cfg.AccountName}'.");
+                $"Reached account '{cfg.AccountName}', Entra accepted Connapse's identity, and listed "
+                + $"container '{cfg.ContainerName}': {what}.",
+                new Dictionary<string, object>
+                {
+                    ["accountName"] = cfg.AccountName,
+                    ["containerName"] = cfg.ContainerName,
+                    ["prefix"] = cfg.Prefix ?? "(none)",
+                    ["blobsFound"] = seen,
+                    ["hasMore"] = hasMore,
+                },
+                stopwatch.Elapsed);
         }
-        catch (RequestFailedException ex) when (ex.Status == 403)
+        catch (AuthenticationFailedException ex)
         {
-            return ConnectionTestResult.CreateFailure(
-                "Authorization failed — Connapse's identity lacks read access to this container "
-                + "(needs Storage Blob Data Reader).");
+            // Entra would not issue a token: the certificate is not registered on the app, has
+            // expired, or no managed identity exists on this host. Nothing on the connection form
+            // fixes that.
+            stopwatch.Stop();
+            return Failure(
+                "Entra rejected Connapse's identity, so nothing on this account can be read. Check "
+                + "the Access step on the Azure provider page — Recheck there says why.",
+                ex, stopwatch.Elapsed);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // The credential chain refuses to build: the certificate file is missing or the
+            // identity is only partly configured.
+            stopwatch.Stop();
+            return Failure(
+                "Connapse's Azure identity is not usable: " + ex.Message
+                + " Fix it on the Access step of the Azure provider page.",
+                ex, stopwatch.Elapsed);
+        }
+        catch (RequestFailedException ex) when (ex.Status is 401 or 403)
+        {
+            stopwatch.Stop();
+            return Failure(
+                $"Entra accepted Connapse's identity, but it is not allowed to list container "
+                + $"'{cfg.ContainerName}' on account '{cfg.AccountName}'. Assign it the "
+                + $"'{Core.Utilities.AzureCloudShellSetup.BlobDataRoleName}' role (or Storage Blob Data Reader) on "
+                + "the account or container — the commands under the allowed locations do exactly that. "
+                + "A new assignment can take a few minutes to apply.",
+                ex, stopwatch.Elapsed);
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
         {
-            return ConnectionTestResult.CreateFailure(
-                $"Container '{cfg.ContainerName}' or account '{cfg.AccountName}' not found.");
+            stopwatch.Stop();
+            return Failure(
+                $"Entra accepted Connapse's identity, but no container '{cfg.ContainerName}' exists on "
+                + $"account '{cfg.AccountName}'. Check the name — Azure has no default container, so "
+                + "the test needs one that exists.",
+                ex, stopwatch.Elapsed);
+        }
+        catch (RequestFailedException ex)
+        {
+            stopwatch.Stop();
+            return Failure(
+                $"Azure refused the request ({ex.ErrorCode ?? "unknown code"}): {ex.Message}",
+                ex, stopwatch.Elapsed);
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
-            return ConnectionTestResult.CreateFailure("Connection test timed out.");
+            stopwatch.Stop();
+            return ConnectionTestResult.CreateFailure(
+                $"Azure did not answer within {limit.TotalSeconds:F0} seconds. Check that this server can "
+                + $"reach {new Uri(endpoint).Host}, then try again.",
+                new Dictionary<string, object>
+                {
+                    ["error"] = "Timeout",
+                    ["timeoutSeconds"] = limit.TotalSeconds,
+                },
+                stopwatch.Elapsed);
         }
         catch (Exception ex)
         {
-            return ConnectionTestResult.CreateFailure($"Connection test failed: {ex.Message}");
+            stopwatch.Stop();
+            return Failure(
+                $"Could not reach '{new Uri(endpoint).Host}': {ex.Message} Check the storage account name "
+                + "and, if one is set, the blob endpoint.",
+                ex, stopwatch.Elapsed);
         }
     }
+
+    private static ConnectionTestResult Failure(string message, Exception ex, TimeSpan elapsed) =>
+        ConnectionTestResult.CreateFailure(
+            message,
+            new Dictionary<string, object>
+            {
+                ["error"] = ex.Message,
+                ["errorType"] = ex.GetType().Name,
+            },
+            elapsed);
 }

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -259,6 +259,9 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
         services.AddSingleton<IAzureBlobDiscovery, CloudScope.AzureBlobDiscovery>();
+        // Remembers the host's managed identity once found, so the provider page's detection is
+        // one metadata call per process, not one per render.
+        services.AddSingleton<IAzureHostIdentity, CloudScope.AzureHostIdentity>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();
         services.AddSingleton<IAccessGrantsReader, CloudScope.S3AccessGrantsReader>();
 

--- a/src/Connapse.Storage/Settings/PostgresSettingsStore.cs
+++ b/src/Connapse.Storage/Settings/PostgresSettingsStore.cs
@@ -10,6 +10,12 @@ namespace Connapse.Storage.Settings;
 /// PostgreSQL-backed settings store using JSONB for flexible schema.
 /// Settings are stored by category and can be updated at runtime.
 /// </summary>
+/// <remarks>
+/// The context is scoped and shared with everything else in the request, so a write that fails
+/// must not leave its mutation tracked: the next successful save of any category would carry it
+/// along and commit the change that was reported as failed. Every write path clears the tracker
+/// on failure before rethrowing.
+/// </remarks>
 public class PostgresSettingsStore(KnowledgeDbContext context, ISettingsReloader settingsReloader) : ISettingsStore
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -39,47 +45,104 @@ public class PostgresSettingsStore(KnowledgeDbContext context, ISettingsReloader
         var json = JsonSerializer.Serialize(settings, JsonOptions);
         var jsonDocument = JsonDocument.Parse(json);
 
-        var entity = await context.Settings
-            .FirstOrDefaultAsync(s => s.Category == category, cancellationToken);
-
-        if (entity is null)
+        try
         {
-            // Create new entry
-            entity = new SettingEntity
+            var entity = await context.Settings
+                .FirstOrDefaultAsync(s => s.Category == category, cancellationToken);
+
+            if (entity is null)
             {
-                Category = category,
-                Values = jsonDocument,
-                UpdatedAt = DateTime.UtcNow
-            };
-            context.Settings.Add(entity);
-        }
-        else
-        {
-            // Update existing entry
-            entity.Values = jsonDocument;
-            entity.UpdatedAt = DateTime.UtcNow;
-            context.Settings.Update(entity);
-        }
+                // Create new entry
+                entity = new SettingEntity
+                {
+                    Category = category,
+                    Values = jsonDocument,
+                    UpdatedAt = DateTime.UtcNow
+                };
+                context.Settings.Add(entity);
+            }
+            else
+            {
+                // Update existing entry
+                entity.Values = jsonDocument;
+                entity.UpdatedAt = DateTime.UtcNow;
+                context.Settings.Update(entity);
+            }
 
-        await context.SaveChangesAsync(cancellationToken);
+            await context.SaveChangesAsync(cancellationToken);
+        }
+        catch
+        {
+            context.ChangeTracker.Clear();
+            throw;
+        }
 
         // Reload configuration to notify IOptionsMonitor subscribers of the change
         settingsReloader.Reload();
     }
 
+    public async Task<T> UpdateAsync<T>(string category, Func<T?, T> update, CancellationToken cancellationToken = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(update);
+
+        T updated;
+        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            // Make sure there is a row to lock, then lock it: the read and the write below happen
+            // with every other updater of this category waiting, in this process or any other.
+            DateTime now = DateTime.UtcNow;
+            await context.Database.ExecuteSqlAsync(
+                $$"""INSERT INTO settings (category, "values", updated_at) VALUES ({{category}}, '{}'::jsonb, {{now}}) ON CONFLICT (category) DO NOTHING""",
+                cancellationToken);
+
+            var entity = await context.Settings
+                .FromSql($"SELECT * FROM settings WHERE category = {category} FOR UPDATE")
+                .AsNoTracking()
+                .FirstAsync(cancellationToken);
+
+            string currentJson = entity.Values.RootElement.GetRawText();
+            T? current = currentJson == "{}" ? null : JsonSerializer.Deserialize<T>(currentJson, JsonOptions);
+
+            updated = update(current);
+            string json = JsonSerializer.Serialize(updated, JsonOptions);
+            await context.Database.ExecuteSqlAsync(
+                $"""UPDATE settings SET "values" = {json}::jsonb, updated_at = {now} WHERE category = {category}""",
+                cancellationToken);
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            context.ChangeTracker.Clear();
+            throw;
+        }
+
+        settingsReloader.Reload();
+        return updated;
+    }
+
     public async Task ResetAsync(string category, CancellationToken cancellationToken = default)
     {
-        var entity = await context.Settings
-            .FirstOrDefaultAsync(s => s.Category == category, cancellationToken);
-
-        if (entity is not null)
+        try
         {
+            var entity = await context.Settings
+                .FirstOrDefaultAsync(s => s.Category == category, cancellationToken);
+
+            if (entity is null)
+                return;
+
             context.Settings.Remove(entity);
             await context.SaveChangesAsync(cancellationToken);
-
-            // Reload configuration to notify IOptionsMonitor subscribers of the change
-            settingsReloader.Reload();
         }
+        catch
+        {
+            context.ChangeTracker.Clear();
+            throw;
+        }
+
+        // Reload configuration to notify IOptionsMonitor subscribers of the change
+        settingsReloader.Reload();
     }
 
     public async Task<IReadOnlyList<string>> GetCategoriesAsync(CancellationToken cancellationToken = default)

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -471,6 +471,10 @@
                 {
                     <text>Filled in from the first bucket you choose if left blank.</text>
                 }
+                else if (form.Provider == ConnectionProvider.AzureBlob)
+                {
+                    <text>Filled in from the first container you choose if left blank.</text>
+                }
             </div>
         </div>
 
@@ -734,7 +738,7 @@
                                 @bind-Value="form.PrivateKey" />
                 <div id="sftp-key-help" class="form-text">
                     Encrypted at rest and never shown again. This is an SSH key for a server you run —
-                    the rule that Connapse stores no cloud credentials is about AWS
+                    the rule that Connapse stores no cloud credentials is about AWS and Azure
                     identities, which are not stored and are not asked for.
                     @if (!isNew)
                     {
@@ -1079,7 +1083,8 @@
                 <input id="probe-target" class="form-control font-monospace" @bind="probeTarget"
                        placeholder="@ProbePlaceholder()" aria-describedby="probe-target-help" />
                 <div id="probe-target-help" class="form-text">
-                    Not saved. The connection holds no bucket of its own, so testing needs one to probe.
+                    Not saved. The connection holds no @(form.Provider == ConnectionProvider.S3 ? "bucket" : "container")
+                    of its own, so testing needs one to probe.
                 </div>
             </div>
         }

--- a/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
+++ b/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
@@ -230,7 +230,7 @@
                         <div class="rounded-3 p-3" style="background: rgba(0, 120, 212, 0.08); border: 1px solid rgba(0, 120, 212, 0.2);">
                             <small class="d-flex align-items-start" style="color: #60a5fa;">
                                 <span class="bi-info-circle-fill me-2 mt-1 flex-shrink-0"></span>
-                                <span>Entra ID sign-in is not set up yet. An administrator configures this under Providers &rarr; Microsoft Entra ID before anyone can connect.</span>
+                                <span>Entra ID sign-in is not set up yet. An administrator configures this under Providers &rarr; Azure &rarr; Per-user permissions before anyone can connect.</span>
                             </small>
                         </div>
                     }

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -20,6 +20,7 @@
 @inject IOptionsMonitor<AzureProviderSettings> AzureProviderOptions
 @inject IOptionsMonitor<AzureAdSignInSettings> AzureAdOptions
 @inject IAzureBlobDiscovery AzureDiscovery
+@inject IAzureHostIdentity HostIdentity
 @inject Microsoft.AspNetCore.Hosting.IWebHostEnvironment WebHostEnvironment
 @inject IProviderSetupReader SetupReader
 @inject IProviderCredentialStore CredentialStore
@@ -1092,7 +1093,7 @@
                               Description="The Azure app identity Connapse reads Blob storage with, and queries Entra and Azure Resource Manager (role and deny assignments) through."
                               Status="AccessStatus" StatusLabel="@RequirementLabel(AccessStatus)"
                               @bind-Expanded="showAzureAccess" EditLabel="Update or replace"
-                              EasyTitle="Easy setup with Azure Cloud Shell" EasyOpen="true">
+                              EasyTitle="@(UseManagedIdentityGuide ? "Easy setup with this host's managed identity" : "Easy setup with Azure Cloud Shell")" EasyOpen="true">
                 <Summary>
                     @RequirementDetail(AccessRequirement)
                     @if (azureAccessCertProblem is { Length: > 0 } accessProblem)
@@ -1110,7 +1111,11 @@
                             <dd class="col-sm-9 font-monospace">@(azureProviderSettings.SubscriptionId is { Length: > 0 } sub ? sub : "not set")</dd>
                             <dt class="col-sm-3">Identity</dt>
                             <dd class="col-sm-9 font-monospace">
-                                @if (azureProviderSettings.UserAssignedManagedIdentityClientId is { Length: > 0 } mi)
+                                @if (AzureCredentialChainFactory.IsHostManagedIdentity(azureProviderSettings))
+                                {
+                                    <text>this host's managed identity@(azureProviderSettings.ManagedIdentityPrincipalId is { Length: > 0 } principal ? $" (principal {principal})" : "")</text>
+                                }
+                                else if (azureProviderSettings.UserAssignedManagedIdentityClientId is { Length: > 0 } mi)
                                 {
                                     <text>managed identity @mi</text>
                                 }
@@ -1154,17 +1159,106 @@
                     </details>
                 </ManualContent>
                 <EasyContent>
+                    @if (UseManagedIdentityGuide && hostIdentity is { } host)
+                    {
+                        <p class="small text-muted">
+                            This host runs on Azure as a managed identity
+                            (@(host.IsUserAssigned ? "user-assigned" : "system-assigned"), principal
+                            <code>@host.PrincipalId</code>). Nothing to fill in and no certificate to keep: you run one
+                            script in Azure Cloud Shell — it uses whichever subscription Cloud Shell is signed in to,
+                            creates two least-privilege custom roles, and assigns them to that identity — then paste
+                            back what it prints.
+                        </p>
+                        <p class="small mb-1">
+                            <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.ManagedIdentityAccessScriptRequirements).
+                        </p>
+                        <p class="small mb-3">
+                            <button type="button" class="btn btn-link btn-sm p-0 align-baseline" @onclick="() => preferCertificateApp = true">
+                                Use a certificate app registration instead
+                            </button>
+                        </p>
+
+                        EnsureAzureManagedIdentityScript(host);
+                        @if (azureManagedIdentityScript is { Length: > 0 } miScript)
+                        {
+                            <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:18rem;overflow:auto"><code>@miScript</code></pre>
+
+                            <div class="d-flex flex-wrap gap-2 mb-2">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(miScript)">
+                                    <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy command
+                                </button>
+                                <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener" href="https://shell.azure.com">
+                                    <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
+                                    <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
+                                </a>
+                                <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
+                            </div>
+
+                            <label class="form-label small mb-1" for="az-mi-paste">Paste what it printed</label>
+                            <textarea id="az-mi-paste" class="form-control font-monospace" rows="4"
+                                      @bind="azureManagedIdentityPasted" @bind:event="oninput" disabled="@azureBusy"
+                                      placeholder="@AzureCloudShellSetup.ManagedIdentityBeginMarker&#10;tenantId=…&#10;@AzureCloudShellSetup.ManagedIdentityEndMarker"></textarea>
+
+                            @if (!string.IsNullOrWhiteSpace(azureManagedIdentityPasted))
+                            {
+                                var miResult = AzureCloudShellSetup.ParseManagedIdentityAccessResult(azureManagedIdentityPasted);
+                                @if (miResult is null)
+                                {
+                                    <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                        <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                        No valid block found yet. Copy everything the command printed, including
+                                        both <code>-----</code> marker lines.
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+                                        <span class="small flex-grow-1">
+                                            Managed identity <code>@miResult.PrincipalId</code> in tenant
+                                            <code>@miResult.TenantId</code>, subscription <code>@miResult.SubscriptionId</code>.
+                                        </span>
+                                        <button type="button" class="btn btn-sm btn-primary"
+                                                @onclick="() => SaveAzureAccessFromManagedIdentityScript(miResult)" disabled="@azureBusy">
+                                            @if (azureBusy)
+                                            {
+                                                <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+                                            }
+                                            else
+                                            {
+                                                <span class="bi-check-lg me-1" aria-hidden="true"></span>
+                                            }
+                                            Save
+                                        </button>
+                                    </div>
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
                     <p class="small text-muted">
                         Nothing to fill in. Connapse generates a certificate on this host; you run one script in Azure
                         Cloud Shell — it uses whichever subscription Cloud Shell is signed in to, creates two
                         least-privilege custom roles and the access app registration, and uploads only the public
                         certificate — then paste back what it prints.
                     </p>
-                    <p class="small mb-3">
+                    <p class="small mb-1">
                         <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.AccessScriptRequirements).
                     </p>
+                    @if (hostIdentity is not null)
+                    {
+                        <p class="small mb-3">
+                            <button type="button" class="btn btn-link btn-sm p-0 align-baseline" @onclick="() => preferCertificateApp = false">
+                                This host has a managed identity — use it instead, with no certificate
+                            </button>
+                        </p>
+                    }
+                    else
+                    {
+                        <p class="mb-2"></p>
+                    }
 
-                        @{ EnsureAzureAccessScript(); }
+                        EnsureAzureAccessScript();
                         @if (azureAccessScript is { Length: > 0 } accessScript)
                         {
                             <div class="alert alert-secondary py-2 small mb-2">
@@ -1229,6 +1323,7 @@
                                 }
                             }
                         }
+                    }
                 </EasyContent>
                 <Actions>
                     @if (AccessStatus == RequirementStatus.Satisfied)
@@ -1293,7 +1388,30 @@
                             </div>
                         }
                     }
-                    @if (azureAdSettings.AdminConsentPending && AzureConsentUrl is { Length: > 0 } consentUrl)
+                    @if (azureAdSettings.AdminConsentPending && AzureAccessManagedIdentityPrincipal is { } pendingPrincipal)
+                    {
+                        <div class="alert alert-warning mt-2 mb-0" role="alert">
+                            <div class="mb-2">
+                                <span class="bi-shield-exclamation me-1" aria-hidden="true"></span>
+                                <strong>One step left — the managed identity's Graph permissions.</strong> The apps are
+                                created, but the two Microsoft Graph permissions Connapse looks people up with —
+                                <code>User.Read.All</code> and <code>GroupMember.Read.All</code>, read-only lookups of who
+                                a person is and which groups they belong to — are app roles on the managed identity, and
+                                only a <strong>Global Administrator</strong> or <strong>Privileged Role Administrator</strong>
+                                can grant them. Send them these commands to run in Cloud Shell.
+                            </div>
+                            <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:12rem;overflow:auto"><code>@AzureCloudShellSetup.GraphAppRoleGrantCommands(pendingPrincipal)</code></pre>
+                            <div class="d-flex flex-wrap gap-2">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(AzureCloudShellSetup.GraphAppRoleGrantCommands(pendingPrincipal))">
+                                    <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy commands
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="MarkAzureConsentGranted">
+                                    The permissions have been granted
+                                </button>
+                            </div>
+                        </div>
+                    }
+                    else if (azureAdSettings.AdminConsentPending && AzureConsentUrl is { Length: > 0 } consentUrl)
                     {
                         <div class="alert alert-warning mt-2 mb-0" role="alert">
                             <div class="mb-2">
@@ -1330,26 +1448,40 @@
                     </details>
                 </ManualContent>
                 <EasyContent>
-                    @if (azureProviderSettings.ClientId is not { Length: > 0 })
+                    @if (AzureAccessManagedIdentityPrincipal is null && azureProviderSettings.ClientId is not { Length: > 0 })
                     {
                         <div class="alert alert-secondary py-2 small mb-0">
                             <span class="bi-info-circle me-1" aria-hidden="true"></span>
-                            Finish the <strong>Access</strong> step with an app registration first — this script grants
-                            that access app its Microsoft Graph permissions. (A managed-identity access step needs those
-                            permissions granted by hand; use the manual values.)
+                            Finish the <strong>Access</strong> step first — this script grants the access identity its
+                            Microsoft Graph permissions. (A user-assigned managed identity entered by hand needs those
+                            permissions granted by hand too; use the manual values here.)
                         </div>
                     }
                     else
                     {
-                        <p class="small text-muted">
-                            One more Cloud Shell script: it registers the sign-in app (with its own certificate — only
-                            the public half is uploaded), grants the access app
-                            <code>@azureProviderSettings.ClientId</code> the two Graph permissions, and tries to grant
-                            admin consent.
-                        </p>
-                        <p class="small mb-3">
-                            <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.PermissionsScriptRequirements).
-                        </p>
+                        @if (AzureAccessManagedIdentityPrincipal is { } accessPrincipal)
+                        {
+                            <p class="small text-muted">
+                                One more Cloud Shell script: it registers the sign-in app (with its own certificate — only
+                                the public half is uploaded) and grants the managed identity
+                                <code>@accessPrincipal</code> the two Graph permissions as app roles.
+                            </p>
+                            <p class="small mb-3">
+                                <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.ManagedIdentityPermissionsScriptRequirements).
+                            </p>
+                        }
+                        else
+                        {
+                            <p class="small text-muted">
+                                One more Cloud Shell script: it registers the sign-in app (with its own certificate — only
+                                the public half is uploaded), grants the access app
+                                <code>@azureProviderSettings.ClientId</code> the two Graph permissions, and tries to grant
+                                admin consent.
+                            </p>
+                            <p class="small mb-3">
+                                <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.PermissionsScriptRequirements).
+                            </p>
+                        }
 
                         <div class="mb-3" style="max-width:44rem">
                             <label class="form-label small mb-1" for="az-perm-redirect">Sign-in redirect URI</label>
@@ -1676,6 +1808,10 @@
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
+
+        // Whether this host has a managed identity, so the Azure guide can offer it. Off Azure the
+        // answer is a quick "no"; on Azure it is remembered for the process after the first look.
+        hostIdentity = await HostIdentity.DetectAsync();
 
         setups = await SetupReader.ReadAsync();
         await LoadAwsCredentialModeAsync();
@@ -2489,6 +2625,84 @@
         return committed;
     }
 
+    // ── The Azure host's managed identity: the guided Access setup without a certificate ──────────
+
+    /// <summary>The managed identity this host runs as, if it has one; null off Azure.</summary>
+    private AzureHostIdentityInfo? hostIdentity;
+
+    /// <summary>Set when the operator asks for a certificate app although the host has a managed identity.</summary>
+    private bool preferCertificateApp;
+
+    private string? azureManagedIdentityScript;
+    private string? azureManagedIdentityPasted;
+
+    /// <summary>
+    /// Whether the Access guide offers the host's managed identity rather than a certificate app:
+    /// the host has one, the operator has not asked for a certificate app instead, and Access is
+    /// not already a certificate app being replaced.
+    /// </summary>
+    private bool UseManagedIdentityGuide =>
+        hostIdentity is not null
+        && !preferCertificateApp
+        && string.IsNullOrWhiteSpace(azureProviderSettings.ClientId);
+
+    private void EnsureAzureManagedIdentityScript(AzureHostIdentityInfo host)
+    {
+        azureManagedIdentityScript ??= AzureCloudShellSetup.GenerateManagedIdentityAccessScript(
+            new AzureManagedIdentityAccessSetupInput(host.PrincipalId, host.ClientId, host.IsUserAssigned));
+    }
+
+    /// <summary>
+    /// Stores the Access step for a managed identity: the tenant, subscription, and the identity the
+    /// script granted the roles to. No certificate is written; the host itself is the credential,
+    /// and it is asked for a token before anything is stored.
+    /// </summary>
+    private async Task SaveAzureAccessFromManagedIdentityScript(AzureManagedIdentityAccessResult result)
+    {
+        if (hostIdentity is { } host && !string.Equals(host.PrincipalId, result.PrincipalId, StringComparison.OrdinalIgnoreCase))
+        {
+            saveMessage = "The script you ran granted access to a different managed identity than the one this host "
+                + "runs as. Nothing was changed. Copy the command shown now, run it again, and paste that result.";
+            saveSuccess = false;
+            return;
+        }
+
+        azureBusy = true;
+        try
+        {
+            var candidate = new AzureProviderSettings
+            {
+                TenantId = result.TenantId,
+                SubscriptionId = result.SubscriptionId,
+                UseHostManagedIdentity = !result.IsUserAssigned,
+                UserAssignedManagedIdentityClientId = result.IsUserAssigned ? result.ClientId : null,
+                ManagedIdentityPrincipalId = result.PrincipalId,
+            };
+            var check = await AzureDiscovery.CheckAccessAsync(candidate);
+            if (!check.Succeeded)
+            {
+                saveMessage = AzureCheckRefused("access", check);
+                saveSuccess = false;
+                return;
+            }
+
+            if (await SaveAzureProviderFromForm(candidate, verified: true) != true) return;
+
+            azureManagedIdentityScript = null;
+            azureManagedIdentityPasted = null;
+            showAzureAccess = false;
+        }
+        catch (Exception ex)
+        {
+            saveMessage = $"Could not save the Azure access setup: {ex.Message}";
+            saveSuccess = false;
+        }
+        finally
+        {
+            azureBusy = false;
+        }
+    }
+
     /// <summary>Generates a fresh certificate on this host and the Access script that uploads only its
     /// public half. The material is held until the operator saves the pasted-back result.</summary>
     private void NewAzureAccessCertificate() => GenerateAzureAccessScript(newCertificate: true);
@@ -2527,8 +2741,18 @@
             ConsentRedirectUri: AzureConsentLandingUri,
             SignInAppName: "Connapse-Azure-SignIn",
             PublicCertificatePem: azureSignInCert!.PublicCertificatePem,
-            ExistingSignInAppClientId: azureAdSettings.ClientId));
+            ExistingSignInAppClientId: azureAdSettings.ClientId,
+            AccessManagedIdentityPrincipalId: AzureAccessManagedIdentityPrincipal));
     }
+
+    /// <summary>The access identity's service principal when it is a managed identity the guided
+    /// setup recorded — what the permissions script grants Graph app roles to. Null for a certificate
+    /// app, and for a user-assigned identity entered by hand (no principal id was recorded).</summary>
+    private string? AzureAccessManagedIdentityPrincipal =>
+        AzureCredentialChainFactory.IsManagedIdentity(azureProviderSettings)
+        && azureProviderSettings.ManagedIdentityPrincipalId is { Length: > 0 } principal
+            ? principal
+            : null;
 
     /// <summary>Where Entra sends the administrator after consent — this page, registered as the access
     /// app's reply URL by the Permissions script.</summary>

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -2323,21 +2323,14 @@
         // Latched here, at save time, exactly as SaveSamlSettings does for AWS. The startup latch
         // alone left a gap: a deployment that configured Azure sign-in and never restarted stayed
         // NotEnforcing, and every azblob result passed unfiltered until the next process start.
+        //
+        // Latched BEFORE the sign-in settings, never after. With enforcement on and sign-in not yet
+        // stored, Azure searches deny — closed. The other order, sign-in stored and then the latch
+        // failing, would leave sign-in configured with filtering off: every Azure result to everyone.
+        // So a latch that cannot be written stops the save, and the sign-in settings stay as they were.
         bool enforcing = settings.IsConfigured || EnforcementOptions.CurrentValue.AzureEnforcing;
-
-        bool committed = await SaveSettings("azuread", settings);
-
-        if (committed)
+        if (enforcing != EnforcementOptions.CurrentValue.AzureEnforcing)
         {
-            azureAdSettings = settings;
-            LoadAzureCertificateExpiry();
-            await AuditLogger.LogAsync("provider.azuread.saved", "provider", "azure",
-                new { Configured = settings.IsConfigured });
-        }
-
-        if (committed && enforcing != EnforcementOptions.CurrentValue.AzureEnforcing)
-        {
-            string savedMessage = saveMessage ?? string.Empty;
             bool latched = await SaveSettings(
                 PermissionEnforcementSettings.Category,
                 new PermissionEnforcementSettings
@@ -2347,12 +2340,21 @@
                 });
             if (!latched)
             {
-                // The sign-in settings are stored; only the latch is not. Say both, and keep the
-                // save reported as what it is — committed.
-                saveMessage = $"{savedMessage} Per-user enforcement could not be switched on, though: "
-                    + $"{saveMessage} Save the sign-in application again to retry.";
-                saveSuccess = true;
+                saveMessage = "Per-user enforcement for Azure could not be switched on, so the sign-in "
+                    + $"application was not saved: {saveMessage}";
+                saveSuccess = false;
+                return false;
             }
+        }
+
+        bool committed = await SaveSettings("azuread", settings);
+
+        if (committed)
+        {
+            azureAdSettings = settings;
+            LoadAzureCertificateExpiry();
+            await AuditLogger.LogAsync("provider.azuread.saved", "provider", "azure",
+                new { Configured = settings.IsConfigured });
         }
 
         await RefreshSetups();
@@ -2411,12 +2413,22 @@
     /// a fresh key instead of re-offering one an old app registration may still hold.</summary>
     private async Task ClearAzureAccess()
     {
-        if (!await SaveAzureProviderFromForm(new AzureProviderSettings())) return;
+        // Under the same gate as promotion, so a reset cannot interleave with a save in progress
+        // and remove the key it is about to commit.
+        await AzureCertificateGate.WaitAsync();
+        try
+        {
+            if (!await SaveAzureProviderFromForm(new AzureProviderSettings())) return;
 
-        DeleteAzureCertificate(AzureAccessCertFile);
-        azureAccessScript = null;
-        azureAccessCert = null;
-        azureAccessPasted = null;
+            await DeleteAzureCertificatesAsync(AzureAccessCertFile);
+            azureAccessScript = null;
+            azureAccessCert = null;
+            azureAccessPasted = null;
+        }
+        finally
+        {
+            AzureCertificateGate.Release();
+        }
     }
 
     private async Task ClearAzureSignIn()
@@ -2424,23 +2436,44 @@
         // Enforcement is deliberately left on (the Azure latch never releases). With sign-in
         // incomplete the verifier denies, so Azure searches return nothing for everyone until the
         // application is set up again, rather than silently widening to the whole corpus.
-        if (!await SaveAzureAdFromForm(new AzureAdSignInSettings())) return;
+        await AzureCertificateGate.WaitAsync();
+        try
+        {
+            if (!await SaveAzureAdFromForm(new AzureAdSignInSettings())) return;
 
-        DeleteAzureCertificate(AzureSignInCertFile);
-        azurePermissionsScript = null;
-        azureSignInCert = null;
-        azurePermissionsPasted = null;
+            await DeleteAzureCertificatesAsync(AzureSignInCertFile);
+            azurePermissionsScript = null;
+            azureSignInCert = null;
+            azurePermissionsPasted = null;
+        }
+        finally
+        {
+            AzureCertificateGate.Release();
+        }
     }
 
-    /// <summary>After a reset: nothing references any certificate of this kind, so every file of it
-    /// under appdata/azure goes — versioned, fixed-name, and pending alike.</summary>
-    private void DeleteAzureCertificate(string fileName)
+    /// <summary>
+    /// After a reset: the pending copy goes, and so does every file of this kind that nothing committed
+    /// names — read back from the store, since another session may have saved a replacement in the
+    /// meantime — once it is past the grace period. A younger unreferenced file is left for a later
+    /// sweep rather than risk removing a key another process committed a moment ago.
+    /// </summary>
+    private async Task DeleteAzureCertificatesAsync(string fileName)
     {
         string directory = Path.GetDirectoryName(AzureCertificatePath(fileName))!;
         if (!Directory.Exists(directory)) return;
 
+        string pendingPath = AzurePendingCertificatePath(fileName);
+        if (File.Exists(pendingPath)) File.Delete(pendingPath);
+
+        var referenced = await PersistedAzureCertificatePathsAsync();
+        DateTime cutoff = DateTime.UtcNow - AzureCertificateGrace;
         foreach (string path in Directory.EnumerateFiles(directory, Path.GetFileNameWithoutExtension(fileName) + "*.pem"))
+        {
+            if (referenced.Contains(Path.GetFullPath(path))) continue;
+            if (File.GetLastWriteTimeUtc(path) > cutoff) continue;
             File.Delete(path);
+        }
     }
 
     /// <summary>The admin-consent link for the access app — derived from settings, so it survives a
@@ -2617,20 +2650,19 @@
             var check = await AzureDiscovery.CheckAccessAsync(candidate);
             if (!check.Succeeded)
             {
-                DeleteAzureCertificateUnlessReferenced(newPath, azureProviderSettings.ClientCertificatePath);
+                await DeleteAzureCandidateAsync(newPath);
                 saveMessage = AzureCheckRefused("access", check);
                 saveSuccess = false;
                 return;
             }
 
-            string? previousPath = azureProviderSettings.ClientCertificatePath;
             if (!await SaveAzureProviderFromForm(candidate, verified: true))
             {
-                DeleteAzureCertificateUnlessReferenced(newPath, previousPath);
+                await DeleteAzureCandidateAsync(newPath);
                 return;
             }
 
-            SweepAzureCertificates(AzureAccessCertFile, keep: newPath, promotedPem: material.CombinedPem);
+            await SweepAzureCertificatesAsync(AzureAccessCertFile, promotedPem: material.CombinedPem);
             azureAccessScript = null;
             azureAccessCert = null;
             azureAccessPasted = null;
@@ -2663,32 +2695,68 @@
         return AzureCertificatePath($"{Path.GetFileNameWithoutExtension(fileName)}-{thumbprint[..12].ToLowerInvariant()}.pem");
     }
 
-    /// <summary>Removes a candidate file that will not be used, unless the stored settings already
-    /// name it — a re-save of the certificate in use must not delete it.</summary>
-    private static void DeleteAzureCertificateUnlessReferenced(string path, string? referencedPath)
+    /// <summary>
+    /// The certificate files anything committed names right now: both Azure settings categories, read
+    /// back from the store rather than from this page's copy — another session or process may have
+    /// committed since this page loaded — plus the live options as a floor when the store has no row
+    /// (settings coming from appsettings or the environment).
+    /// </summary>
+    private async Task<HashSet<string>> PersistedAzureCertificatePathsAsync()
     {
-        if (string.Equals(path, referencedPath, StringComparison.OrdinalIgnoreCase)) return;
-        if (File.Exists(path)) File.Delete(path);
+        var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        void Add(string? path) { if (!string.IsNullOrWhiteSpace(path)) paths.Add(Path.GetFullPath(path)); }
+
+        Add(AzureProviderOptions.CurrentValue.ClientCertificatePath);
+        Add(AzureAdOptions.CurrentValue.ClientCertificatePath);
+        Add((await SettingsStore.GetAsync<AzureProviderSettings>("azure"))?.ClientCertificatePath);
+        Add((await SettingsStore.GetAsync<AzureAdSignInSettings>("azuread"))?.ClientCertificatePath);
+        return paths;
     }
 
     /// <summary>
-    /// After settings naming <paramref name="keep"/> are committed: every other certificate file of
-    /// this kind under appdata/azure is superseded and removed — earlier versioned files, the single
-    /// fixed-name file older saves wrote — and the pending copy goes only if it is the material just
-    /// promoted, so another session's replacement in progress is left alone.
+    /// How long a certificate file is left alone after it was written, whatever else is known. Two
+    /// processes sharing the volume have no lock in common; a candidate one of them wrote seconds ago
+    /// may be committed a moment after the other reads the store. Nothing in flight lives this long.
     /// </summary>
-    private void SweepAzureCertificates(string fileName, string keep, string promotedPem)
+    private static readonly TimeSpan AzureCertificateGrace = TimeSpan.FromHours(1);
+
+    /// <summary>Removes a candidate that will not be used — unless something committed names it,
+    /// which happens when two sessions carried the same material and the other one saved it.</summary>
+    private async Task DeleteAzureCandidateAsync(string path)
+    {
+        if (!File.Exists(path)) return;
+        var referenced = await PersistedAzureCertificatePathsAsync();
+        if (referenced.Contains(Path.GetFullPath(path))) return;
+        File.Delete(path);
+    }
+
+    /// <summary>
+    /// After a commit: certificate files of this kind under appdata/azure that nothing committed names
+    /// and that are past the grace period are superseded and removed — earlier versioned files, the
+    /// single fixed-name file older saves wrote. The pending copy goes only if it is the material just
+    /// promoted, so another session's replacement in progress is left alone. Anything not removed now
+    /// is removed by a later sweep.
+    /// </summary>
+    private async Task SweepAzureCertificatesAsync(string fileName, string promotedPem)
     {
         string directory = Path.GetDirectoryName(AzureCertificatePath(fileName))!;
         if (!Directory.Exists(directory)) return;
 
+        var referenced = await PersistedAzureCertificatePathsAsync();
         string stem = Path.GetFileNameWithoutExtension(fileName);
-        string pendingPath = AzurePendingCertificatePath(fileName);
+        string pendingPath = Path.GetFullPath(AzurePendingCertificatePath(fileName));
+        DateTime cutoff = DateTime.UtcNow - AzureCertificateGrace;
+
         foreach (string path in Directory.EnumerateFiles(directory, stem + "*.pem"))
         {
-            if (string.Equals(path, keep, StringComparison.OrdinalIgnoreCase)) continue;
-            if (string.Equals(path, pendingPath, StringComparison.OrdinalIgnoreCase)
-                && File.ReadAllText(path) != promotedPem) continue;
+            string full = Path.GetFullPath(path);
+            if (referenced.Contains(full)) continue;
+            if (string.Equals(full, pendingPath, StringComparison.OrdinalIgnoreCase))
+            {
+                if (File.ReadAllText(path) == promotedPem) File.Delete(path);
+                continue;
+            }
+            if (File.GetLastWriteTimeUtc(path) > cutoff) continue;
             File.Delete(path);
         }
     }
@@ -2749,13 +2817,12 @@
             });
             if (!check.Succeeded)
             {
-                DeleteAzureCertificateUnlessReferenced(newPath, azureAdSettings.ClientCertificatePath);
+                await DeleteAzureCandidateAsync(newPath);
                 saveMessage = AzureCheckRefused("sign-in", check);
                 saveSuccess = false;
                 return;
             }
 
-            string? previousPath = azureAdSettings.ClientCertificatePath;
             bool committed = await SaveAzureAdFromForm(new AzureAdSignInSettings
             {
                 TenantId = azureProviderSettings.TenantId,
@@ -2767,11 +2834,11 @@
             }, verified: true);
             if (!committed)
             {
-                DeleteAzureCertificateUnlessReferenced(newPath, previousPath);
+                await DeleteAzureCandidateAsync(newPath);
                 return;
             }
 
-            SweepAzureCertificates(AzureSignInCertFile, keep: newPath, promotedPem: material.CombinedPem);
+            await SweepAzureCertificatesAsync(AzureSignInCertFile, promotedPem: material.CombinedPem);
             azurePermissionsScript = null;
             azureSignInCert = null;
             azurePermissionsPasted = null;
@@ -2843,34 +2910,60 @@
         _ => "bi-question-circle text-secondary"
     };
 
-    /// <summary>Stores a settings category. Returns whether it was committed — a reload that fails
-    /// after the commit is reported, but the settings are stored and callers must treat them as such.</summary>
+    /// <summary>
+    /// Stores a settings category. Returns whether it was committed. The store reloads the options
+    /// after its own commit, so an exception out of it does not say which half failed; the store is
+    /// read back and compared, and a commit whose reload failed is reported as stored-but-not-applied
+    /// rather than as a failure — callers rolling back on false must never undo a commit.
+    /// </summary>
     private async Task<bool> SaveSettings<T>(string category, T settings) where T : class
     {
+        string? reloadProblem = null;
         try
         {
             await SettingsStore.SaveAsync(category, settings);
         }
         catch (Exception ex)
         {
-            saveMessage = $"Failed to save {SettingsName(category)} settings: {ex.Message}";
-            saveSuccess = false;
-            return false;
+            if (!await IsStoredAsync(category, settings))
+            {
+                saveMessage = $"Failed to save {SettingsName(category)} settings: {ex.Message}";
+                saveSuccess = false;
+                return false;
+            }
+            reloadProblem = ex.Message;
         }
 
         try
         {
-            ReloadService.Reload();
-            saveMessage = $"{SettingsName(category)} settings saved successfully!";
+            if (!ReloadService.Reload()) reloadProblem ??= "the settings reload reported failure";
         }
         catch (Exception ex)
         {
-            saveMessage = $"{SettingsName(category)} settings were saved, but applying them without a "
-                + $"restart failed: {ex.Message} Restart Connapse to apply them.";
+            reloadProblem ??= ex.Message;
         }
 
+        saveMessage = reloadProblem is null
+            ? $"{SettingsName(category)} settings saved successfully!"
+            : $"{SettingsName(category)} settings were saved, but applying them without a restart "
+              + $"failed: {reloadProblem}. Restart Connapse to apply them.";
         saveSuccess = true;
         return true;
+    }
+
+    /// <summary>Whether the store now holds exactly <paramref name="settings"/> under <paramref name="category"/>.</summary>
+    private async Task<bool> IsStoredAsync<T>(string category, T settings) where T : class
+    {
+        try
+        {
+            T? stored = await SettingsStore.GetAsync<T>(category);
+            return stored is not null
+                && System.Text.Json.JsonSerializer.Serialize(stored) == System.Text.Json.JsonSerializer.Serialize(settings);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
     }
 
     /// <summary>What to call a settings category in a sentence.</summary>

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1114,6 +1114,17 @@
                                 @if (AzureCredentialChainFactory.IsHostManagedIdentity(azureProviderSettings))
                                 {
                                     <text>this host's managed identity@(azureProviderSettings.ManagedIdentityPrincipalId is { Length: > 0 } principal ? $" (principal {principal})" : "")</text>
+                                    @if (azureProviderSettings.ManagedIdentityPrincipalId is { Length: > 0 } recorded
+                                         && hostIdentity is { IsUserAssigned: false } current
+                                         && !string.Equals(recorded, current.PrincipalId, StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        <div class="alert alert-warning py-2 mt-2 mb-0 small font-sans-serif" role="status">
+                                            <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                            The host now reports principal <code>@current.PrincipalId</code>; the roles
+                                            were granted to <code>@recorded</code>. The identity was re-created since
+                                            setup — run the Access script again so the new one has the roles.
+                                        </div>
+                                    }
                                 }
                                 else if (azureProviderSettings.UserAssignedManagedIdentityClientId is { Length: > 0 } mi)
                                 {
@@ -1245,7 +1256,14 @@
                     <p class="small mb-1">
                         <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.AccessScriptRequirements).
                     </p>
-                    @if (hostIdentity is not null && string.IsNullOrWhiteSpace(azureProviderSettings.ClientId))
+                    @if (detectingHostIdentity)
+                    {
+                        <p class="small text-muted mb-3" role="status">
+                            <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+                            Checking whether this host has a managed identity to use instead…
+                        </p>
+                    }
+                    else if (hostIdentity is not null && string.IsNullOrWhiteSpace(azureProviderSettings.ClientId))
                     {
                         <p class="small mb-3">
                             <button type="button" class="btn btn-link btn-sm p-0 align-baseline" @onclick="() => preferCertificateApp = false">
@@ -1439,6 +1457,27 @@
                                     Consent has been granted
                                 </button>
                             </div>
+                        </div>
+                    }
+                    else if (azureAdSettings.AdminConsentPending)
+                    {
+                        @* The access identity changed after the sign-in app was set up (re-entered by hand,
+                           say), so neither the consent link nor the grant commands can be built. The
+                           pending state still needs a way out. *@
+                        <div class="alert alert-warning mt-2 mb-0" role="alert">
+                            <div class="mb-2">
+                                <span class="bi-shield-exclamation me-1" aria-hidden="true"></span>
+                                <strong>One step left — the access identity's Graph permissions.</strong> Grant the
+                                access identity <code>User.Read.All</code> and <code>GroupMember.Read.All</code> (a
+                                Global Administrator consents an app registration; for a managed identity, the
+                                commands are under
+                                <a href="https://github.com/Destrayon/Connapse/blob/main/docs/azure-setup.md#graph-permissions-for-a-managed-identity"
+                                   target="_blank" rel="noopener">Graph permissions for a managed identity</a>),
+                                then confirm here.
+                            </div>
+                            <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="MarkAzureConsentGranted">
+                                The permissions have been granted
+                            </button>
                         </div>
                     }
                 </Summary>
@@ -1839,16 +1878,7 @@
     {
         if (!firstRender) return;
 
-        // Whether this host has a managed identity, so the Azure guide can offer it — asked only on
-        // the Azure page, and alongside the status read rather than before it, since off Azure the
-        // metadata probe is a second or so of waiting for nothing. A found identity is remembered
-        // for the process after the first look.
-        Task<AzureHostIdentityInfo?> detection = Key == "azure"
-            ? HostIdentity.DetectAsync()
-            : Task.FromResult<AzureHostIdentityInfo?>(null);
-
         setups = await SetupReader.ReadAsync();
-        hostIdentity = await detection;
         await LoadAwsCredentialModeAsync();
 
         // Entra bounced back after the administrator consented: record it, so the pending state
@@ -2519,6 +2549,18 @@
         // A reset (blank tenant) has nothing to verify.
         if (!verified && !string.IsNullOrWhiteSpace(settings.TenantId))
         {
+            // The host's own identity is in one tenant, and a managed-identity token check cannot
+            // tell whether the tenant typed matches it; the host already said which it is.
+            if (AzureCredentialChainFactory.IsHostManagedIdentity(settings)
+                && hostIdentity is { } host
+                && !string.Equals(host.TenantId, settings.TenantId.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                saveMessage = $"This host's managed identity is in tenant {host.TenantId}, not {settings.TenantId}. "
+                    + "Nothing was changed; enter that tenant.";
+                saveSuccess = false;
+                return false;
+            }
+
             var check = await AzureDiscovery.CheckAccessAsync(settings);
             if (!check.Succeeded)
             {
@@ -2669,8 +2711,43 @@
     /// <summary>The managed identity this host runs as, if it has one; null off Azure.</summary>
     private AzureHostIdentityInfo? hostIdentity;
 
+    /// <summary>Whether the host has been asked, and whether the answer is still on its way.</summary>
+    private bool hostIdentityRequested, detectingHostIdentity;
+
     /// <summary>Set when the operator asks for a certificate app although the host has a managed identity.</summary>
     private bool preferCertificateApp;
+
+    /// <summary>
+    /// Asks the host whether it has a managed identity, once, the first time the Azure page is
+    /// shown. From here rather than the first render: the list and the provider page are one
+    /// component, and arriving from the list changes only the route parameter — no first render
+    /// happens again. The answer is awaited off the render path, since off Azure the metadata
+    /// probe is a second or so of waiting for nothing; the guide updates when it lands.
+    /// </summary>
+    protected override void OnParametersSet()
+    {
+        if (Key != "azure" || hostIdentityRequested) return;
+        hostIdentityRequested = true;
+        detectingHostIdentity = true;
+        _ = DetectHostIdentityAsync();
+    }
+
+    private async Task DetectHostIdentityAsync()
+    {
+        try
+        {
+            hostIdentity = await HostIdentity.DetectAsync();
+        }
+        catch (Exception)
+        {
+            hostIdentity = null;
+        }
+        finally
+        {
+            detectingHostIdentity = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
 
     private string? azureManagedIdentityScript;
     private string? azureManagedIdentityPasted;
@@ -2808,14 +2885,16 @@
         get
         {
             if (!AzureCredentialChainFactory.IsManagedIdentity(azureProviderSettings)) return null;
-            if (azureProviderSettings.ManagedIdentityPrincipalId is { Length: > 0 } recorded) return recorded;
 
-            // The host's own identity entered by hand records no principal, but the page has already
-            // asked the host who it is; that answer is the principal.
-            return AzureCredentialChainFactory.IsHostManagedIdentity(azureProviderSettings)
-                && hostIdentity is { IsUserAssigned: false } host
-                    ? host.PrincipalId
-                    : null;
+            // For the host's own identity, what the host says now outranks what was recorded: a
+            // system-assigned identity that was removed and re-enabled has a new principal, and
+            // Graph grants must go to the one that exists. A hand-entered host identity records no
+            // principal at all, and this is where it comes from.
+            if (AzureCredentialChainFactory.IsHostManagedIdentity(azureProviderSettings)
+                && hostIdentity is { IsUserAssigned: false } host)
+                return host.PrincipalId;
+
+            return azureProviderSettings.ManagedIdentityPrincipalId is { Length: > 0 } recorded ? recorded : null;
         }
     }
 
@@ -2841,6 +2920,10 @@
             azureAccessScript = null;
             azureAccessCert = null;
             azureAccessPasted = null;
+            // A fresh start offers the host's identity again, as the "Reset access first" note promises.
+            preferCertificateApp = false;
+            azureManagedIdentityScript = null;
+            azureManagedIdentityPasted = null;
         }
         finally
         {
@@ -3250,7 +3333,8 @@
             + "ran the script, Entra may still be registering the certificate — wait a minute and save again.",
         AzureProbeOutcome.Unusable =>
             $"The {which} credential cannot be used from this host, so nothing was changed: {check.Detail} "
-            + "Check the certificate path and that Connapse can read the file.",
+            + "For a certificate, check the path and that Connapse can read the file; for a managed identity, "
+            + "that this host has one.",
         _ => $"Could not confirm the {which} credential with Azure, so nothing was changed. {check.Detail}",
     };
 

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1087,6 +1087,7 @@
                               @bind-Expanded="showAzureAccess" EditLabel="Update or replace"
                               EasyTitle="Easy setup with Azure Cloud Shell" EasyOpen="true">
                 <Summary>
+                    @RequirementDetail(AccessRequirement)
                     @if (azureProviderSettings.TenantId is { Length: > 0 })
                     {
                         <dl class="row small mb-0">
@@ -1240,6 +1241,7 @@
                               @bind-Expanded="showAzurePermissions" EditLabel="Update or replace"
                               EasyTitle="Guided setup" EasyOpen="true">
                 <Summary>
+                    @RequirementDetail(PermissionsRequirement)
                     @if (azureAdSettings.ClientId is { Length: > 0 })
                     {
                         <dl class="row small mb-0">
@@ -1757,6 +1759,34 @@
     /// <summary>Looks up one of the current provider's requirements by name.</summary>
     private ProviderRequirement? Requirement(string name) =>
         Current?.Requirements.FirstOrDefault(requirement => requirement.Name == name);
+
+    /// <summary>
+    /// What the reader found out about a requirement, in the words it chose: the reason Entra gave
+    /// and what to do about it when it failed, why it could not be confirmed, or what was verified
+    /// when it is ready. A failure is announced; the rest is read in place.
+    /// </summary>
+    private static RenderFragment RequirementDetail(ProviderRequirement? requirement) => builder =>
+    {
+        if (requirement?.Detail is not { Length: > 0 } detail) return;
+
+        (string css, string? role, string icon) = requirement.Status switch
+        {
+            RequirementStatus.Failed => ("alert alert-danger py-2 mb-2 small", "alert", "bi-x-circle"),
+            RequirementStatus.Warning => ("alert alert-warning py-2 mb-2 small", "status", "bi-exclamation-triangle"),
+            RequirementStatus.Provisioning => ("alert alert-info py-2 mb-2 small", "status", "bi-hourglass-split"),
+            _ => ("small text-body-secondary mb-2", null, "bi-check-circle"),
+        };
+
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "class", css);
+        if (role is not null) builder.AddAttribute(2, "role", role);
+        builder.OpenElement(3, "span");
+        builder.AddAttribute(4, "class", icon + " me-1");
+        builder.AddAttribute(5, "aria-hidden", "true");
+        builder.CloseElement();
+        builder.AddContent(6, detail);
+        builder.CloseElement();
+    };
 
     private ProviderRequirement? AccessRequirement => Requirement("Access");
     private ProviderRequirement? IdentityCenterRequirement => Requirement("IAM Identity Center");

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1088,6 +1088,12 @@
                               EasyTitle="Easy setup with Azure Cloud Shell" EasyOpen="true">
                 <Summary>
                     @RequirementDetail(AccessRequirement)
+                    @if (azureAccessCertProblem is { Length: > 0 } accessProblem)
+                    {
+                        <div class="alert alert-danger py-2 mb-2 small" role="alert">
+                            <span class="bi-file-earmark-x me-1" aria-hidden="true"></span>@accessProblem
+                        </div>
+                    }
                     @if (azureProviderSettings.TenantId is { Length: > 0 })
                     {
                         <dl class="row small mb-0">
@@ -1242,6 +1248,12 @@
                               EasyTitle="Guided setup" EasyOpen="true">
                 <Summary>
                     @RequirementDetail(PermissionsRequirement)
+                    @if (azureSignInCertProblem is { Length: > 0 } signInProblem)
+                    {
+                        <div class="alert alert-danger py-2 mb-2 small" role="alert">
+                            <span class="bi-file-earmark-x me-1" aria-hidden="true"></span>@signInProblem
+                        </div>
+                    }
                     @if (azureAdSettings.ClientId is { Length: > 0 })
                     {
                         <dl class="row small mb-0">
@@ -2646,7 +2658,7 @@
                 File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
             return new AzureCertificateMaterial(existing.ExportCertificatePem(), combined);
         }
-        catch (Exception ex) when (ex is System.Security.Cryptography.CryptographicException or IOException)
+        catch (Exception ex) when (AzureCertificateFile.IsUnreadable(ex))
         {
             return null;
         }
@@ -2655,14 +2667,37 @@
     private DateTime? azureAccessCertExpires;
     private DateTime? azureSignInCertExpires;
 
+    /// <summary>Why the certificate a card's settings name could not be read, if it could not; shown on
+    /// that card so the administrator can fix the file or set access up again.</summary>
+    private string? azureAccessCertProblem;
+    private string? azureSignInCertProblem;
+
     /// <summary>Read through the same loader the credentials use, so a PFX with a password shows its
-    /// expiry exactly as a PEM does.</summary>
+    /// expiry exactly as a PEM does. Never throws: a file this process cannot read is a fact to show
+    /// on the card, not a reason for the page — every provider's page — to fail to render.</summary>
     private void LoadAzureCertificateExpiry()
     {
-        azureAccessCertExpires = AzureCertificateFile.Expiry(
+        (azureAccessCertExpires, azureAccessCertProblem) = InspectAzureCertificate(
             azureProviderSettings.ClientCertificatePath, azureProviderSettings.ClientCertificatePassword);
-        azureSignInCertExpires = AzureCertificateFile.Expiry(
+        (azureSignInCertExpires, azureSignInCertProblem) = InspectAzureCertificate(
             azureAdSettings.ClientCertificatePath, azureAdSettings.ClientCertificatePassword);
+    }
+
+    private static (DateTime? Expires, string? Problem) InspectAzureCertificate(string? path, string? password)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return (null, null);
+        try
+        {
+            using var certificate = AzureCertificateFile.Load(path, password);
+            return certificate is null
+                ? (null, $"The certificate file {path} does not exist on this host, so Connapse cannot sign in. Set access up again, or restore the file.")
+                : (certificate.NotAfter.ToUniversalTime(), null);
+        }
+        catch (Exception ex) when (AzureCertificateFile.IsUnreadable(ex))
+        {
+            return (null, $"Connapse cannot read its certificate file {path}: {ex.Message} Check the file's "
+                + "permissions for the user Connapse runs as, or set access up again.");
+        }
     }
 
     /// <summary>

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1170,7 +1170,7 @@
                                     <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
                                     <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
                                 </a>
-                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="NewAzureAccessCertificate">
+                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="NewAzureAccessCertificate" disabled="@azureBusy">
                                     <span class="bi-arrow-repeat me-1" aria-hidden="true"></span> New certificate
                                 </button>
                                 <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
@@ -1178,7 +1178,7 @@
 
                             <label class="form-label small mb-1" for="az-access-paste">Paste what it printed</label>
                             <textarea id="az-access-paste" class="form-control font-monospace" rows="4"
-                                      @bind="azureAccessPasted" @bind:event="oninput"
+                                      @bind="azureAccessPasted" @bind:event="oninput" disabled="@azureBusy"
                                       placeholder="@AzureCloudShellSetup.AccessBeginMarker&#10;tenantId=…&#10;@AzureCloudShellSetup.AccessEndMarker"></textarea>
 
                             @if (!string.IsNullOrWhiteSpace(azureAccessPasted))
@@ -1360,7 +1360,7 @@
                                     <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
                                     <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
                                 </a>
-                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="NewAzureSignInCertificate">
+                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="NewAzureSignInCertificate" disabled="@azureBusy">
                                     <span class="bi-arrow-repeat me-1" aria-hidden="true"></span> New certificate
                                 </button>
                                 <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
@@ -1368,7 +1368,7 @@
 
                             <label class="form-label small mb-1" for="az-perm-paste">Paste what it printed</label>
                             <textarea id="az-perm-paste" class="form-control font-monospace" rows="4"
-                                      @bind="azurePermissionsPasted" @bind:event="oninput"
+                                      @bind="azurePermissionsPasted" @bind:event="oninput" disabled="@azureBusy"
                                       placeholder="@AzureCloudShellSetup.PermissionsBeginMarker&#10;signInAppClientId=…&#10;@AzureCloudShellSetup.PermissionsEndMarker"></textarea>
 
                             @if (!string.IsNullOrWhiteSpace(azurePermissionsPasted))
@@ -2269,7 +2269,7 @@
     /// caller has already verified <paramref name="settings"/>, Entra is asked first, and a credential
     /// it refuses is not stored — the one that works stays in place.
     /// </summary>
-    private async Task SaveAzureProviderFromForm(AzureProviderSettings settings, bool verified = false)
+    private async Task<bool> SaveAzureProviderFromForm(AzureProviderSettings settings, bool verified = false)
     {
         // A reset (blank tenant) has nothing to verify.
         if (!verified && !string.IsNullOrWhiteSpace(settings.TenantId))
@@ -2279,13 +2279,13 @@
             {
                 saveMessage = AzureCheckRefused("access", check);
                 saveSuccess = false;
-                return;
+                return false;
             }
         }
 
-        await SaveSettings("azure", settings);
+        bool committed = await SaveSettings("azure", settings);
 
-        if (saveSuccess)
+        if (committed)
         {
             // What was posted, not a re-read: the options reload behind SaveSettings may not have
             // landed yet, so a stale read would hand the form back the previous values.
@@ -2300,11 +2300,14 @@
         }
 
         await RefreshSetups();
+        return committed;
     }
 
     /// <summary>Stores the Entra sign-in application (Identity:AzureAd) and re-checks status. As with
-    /// the access app, a credential Entra refuses is not stored unless the caller already verified it.</summary>
-    private async Task SaveAzureAdFromForm(AzureAdSignInSettings settings, bool verified = false)
+    /// the access app, a credential Entra refuses is not stored unless the caller already verified it.
+    /// Returns whether the sign-in settings themselves were committed; the enforcement latch saved
+    /// after them is reported separately and never turns a committed save into a failed one.</summary>
+    private async Task<bool> SaveAzureAdFromForm(AzureAdSignInSettings settings, bool verified = false)
     {
         if (!verified && settings.IsConfigured)
         {
@@ -2313,7 +2316,7 @@
             {
                 saveMessage = AzureCheckRefused("sign-in", check);
                 saveSuccess = false;
-                return;
+                return false;
             }
         }
 
@@ -2322,9 +2325,9 @@
         // NotEnforcing, and every azblob result passed unfiltered until the next process start.
         bool enforcing = settings.IsConfigured || EnforcementOptions.CurrentValue.AzureEnforcing;
 
-        await SaveSettings("azuread", settings);
+        bool committed = await SaveSettings("azuread", settings);
 
-        if (saveSuccess)
+        if (committed)
         {
             azureAdSettings = settings;
             LoadAzureCertificateExpiry();
@@ -2332,18 +2335,28 @@
                 new { Configured = settings.IsConfigured });
         }
 
-        if (saveSuccess && enforcing != EnforcementOptions.CurrentValue.AzureEnforcing)
+        if (committed && enforcing != EnforcementOptions.CurrentValue.AzureEnforcing)
         {
-            await SaveSettings(
+            string savedMessage = saveMessage ?? string.Empty;
+            bool latched = await SaveSettings(
                 PermissionEnforcementSettings.Category,
                 new PermissionEnforcementSettings
                 {
                     IsEnforcing = EnforcementOptions.CurrentValue.IsEnforcing,
                     AzureEnforcing = enforcing,
                 });
+            if (!latched)
+            {
+                // The sign-in settings are stored; only the latch is not. Say both, and keep the
+                // save reported as what it is — committed.
+                saveMessage = $"{savedMessage} Per-user enforcement could not be switched on, though: "
+                    + $"{saveMessage} Save the sign-in application again to retry.";
+                saveSuccess = true;
+            }
         }
 
         await RefreshSetups();
+        return committed;
     }
 
     /// <summary>Generates a fresh certificate on this host and the Access script that uploads only its
@@ -2352,7 +2365,8 @@
 
     private void GenerateAzureAccessScript(bool newCertificate)
     {
-        azureAccessCert = LoadOrMintAzureCertificate(AzureAccessCertFile, "connapse-azure-access", newCertificate);
+        azureAccessCert = LoadOrMintAzureCertificate(
+            AzureAccessCertFile, "connapse-azure-access", newCertificate, azureProviderSettings.ClientCertificatePath);
         azureAccessScript = AzureCloudShellSetup.GenerateAccessScript(new AzureAccessSetupInput(
             AccessAppName: "Connapse-Azure-Access",
             PublicCertificatePem: azureAccessCert.PublicCertificatePem,
@@ -2367,7 +2381,8 @@
 
     private void GenerateAzurePermissionsScript(bool newCertificate)
     {
-        azureSignInCert = LoadOrMintAzureCertificate(AzureSignInCertFile, "connapse-azure-signin", newCertificate);
+        azureSignInCert = LoadOrMintAzureCertificate(
+            AzureSignInCertFile, "connapse-azure-signin", newCertificate, azureAdSettings.ClientCertificatePath);
         BuildAzurePermissionsScript();
         azurePermissionsPasted = null;
         copyMessage = null;
@@ -2396,8 +2411,7 @@
     /// a fresh key instead of re-offering one an old app registration may still hold.</summary>
     private async Task ClearAzureAccess()
     {
-        await SaveAzureProviderFromForm(new AzureProviderSettings());
-        if (!saveSuccess) return;
+        if (!await SaveAzureProviderFromForm(new AzureProviderSettings())) return;
 
         DeleteAzureCertificate(AzureAccessCertFile);
         azureAccessScript = null;
@@ -2410,8 +2424,7 @@
         // Enforcement is deliberately left on (the Azure latch never releases). With sign-in
         // incomplete the verifier denies, so Azure searches return nothing for everyone until the
         // application is set up again, rather than silently widening to the whole corpus.
-        await SaveAzureAdFromForm(new AzureAdSignInSettings());
-        if (!saveSuccess) return;
+        if (!await SaveAzureAdFromForm(new AzureAdSignInSettings())) return;
 
         DeleteAzureCertificate(AzureSignInCertFile);
         azurePermissionsScript = null;
@@ -2419,12 +2432,15 @@
         azurePermissionsPasted = null;
     }
 
+    /// <summary>After a reset: nothing references any certificate of this kind, so every file of it
+    /// under appdata/azure goes — versioned, fixed-name, and pending alike.</summary>
     private void DeleteAzureCertificate(string fileName)
     {
-        foreach (string path in new[] { AzureCertificatePath(fileName), AzurePendingCertificatePath(fileName), AzurePreviousCertificatePath(fileName) })
-        {
-            if (File.Exists(path)) File.Delete(path);
-        }
+        string directory = Path.GetDirectoryName(AzureCertificatePath(fileName))!;
+        if (!Directory.Exists(directory)) return;
+
+        foreach (string path in Directory.EnumerateFiles(directory, Path.GetFileNameWithoutExtension(fileName) + "*.pem"))
+            File.Delete(path);
     }
 
     /// <summary>The admin-consent link for the access app — derived from settings, so it survives a
@@ -2468,22 +2484,22 @@
     /// The certificate a script embeds must be the one Connapse later signs with — across page reloads
     /// and restarts, which happen between copying a script and pasting its result back. So a minted
     /// certificate lives in a pending file from the moment it is made, and the guide re-reads that file
-    /// on later renders instead of minting again. The live file — the one the stored settings point at
-    /// and Connapse signs with today — is never written here; <see cref="WriteAzureCertificateAsync"/>
-    /// replaces it on Save. Until then "New certificate" only replaces the pending one, so an Access
-    /// step that already works keeps working while a replacement is being set up.
+    /// on later renders instead of minting again. The file the stored settings point at — the key
+    /// Connapse signs with today — is never written here; Save writes the new key to a file of its own
+    /// and commits settings naming it. Until then "New certificate" only replaces the pending one, so
+    /// an Access step that already works keeps working while a replacement is being set up.
     /// </summary>
-    private AzureCertificateMaterial LoadOrMintAzureCertificate(string fileName, string commonName, bool newCertificate)
+    /// <param name="currentPath">The certificate the stored settings name, if any: re-running a script
+    /// with no replacement pending re-registers the key Connapse already holds.</param>
+    private AzureCertificateMaterial LoadOrMintAzureCertificate(
+        string fileName, string commonName, bool newCertificate, string? currentPath)
     {
         string pendingPath = AzurePendingCertificatePath(fileName);
         if (!newCertificate)
         {
-            // Pending first: a replacement in progress is what the script must embed. Otherwise the
-            // live certificate, so re-running a script re-registers the key Connapse already holds.
-            foreach (string path in new[] { pendingPath, AzureCertificatePath(fileName) })
-            {
-                if (ReadAzureCertificate(path) is { } existing) return existing;
-            }
+            // Pending first: a replacement in progress is what the script must embed.
+            if (ReadAzureCertificate(pendingPath) is { } pending) return pending;
+            if (currentPath is { Length: > 0 } && ReadAzureCertificate(currentPath) is { } current) return current;
         }
 
         AzureCertificateMaterial minted = AzureCertificateGenerator.Generate(commonName);
@@ -2553,14 +2569,6 @@
         if (unix) File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
     }
 
-    /// <summary>Moves a private-key file, keeping it readable by Connapse's own user only.</summary>
-    private static void MoveOwnerOnly(string from, string to)
-    {
-        File.Move(from, to, overwrite: true);
-        if (!OperatingSystem.IsWindows())
-            File.SetUnixFileMode(to, UnixFileMode.UserRead | UnixFileMode.UserWrite);
-    }
-
     private async Task CopyText(string text)
     {
         copySucceeded = await JS.InvokeAsync<bool>("connapse.copyToClipboard", text);
@@ -2573,7 +2581,10 @@
     /// </summary>
     private async Task SaveAzureAccessFromScript(AzureAccessResult result)
     {
-        if (azureAccessCert is null)
+        // A snapshot: the field can be replaced by "New certificate" in another render while the
+        // Entra check below is awaited, and the material verified must be the material stored.
+        AzureCertificateMaterial? material = azureAccessCert;
+        if (material is null)
         {
             saveMessage = "Generate the setup command first, so Connapse has the certificate to store.";
             saveSuccess = false;
@@ -2581,43 +2592,45 @@
         }
 
         azureBusy = true;
+        await AzureCertificateGate.WaitAsync();
         try
         {
-            if (!ThumbprintMatches(result.CertificateThumbprint, azureAccessCert))
+            if (!ThumbprintMatches(result.CertificateThumbprint, material))
             {
                 saveMessage = AzureThumbprintMismatch;
                 saveSuccess = false;
                 return;
             }
 
-            // Verified from the pending file, before anything live is touched: only a certificate
-            // Entra already accepts replaces the one Connapse signs with today.
-            string pendingPath = AzurePendingCertificatePath(AzureAccessCertFile);
-            WriteOwnerOnly(pendingPath, azureAccessCert.CombinedPem);
+            // The candidate gets a file of its own, named by its thumbprint, and is verified from
+            // there. The key Connapse signs with today is never moved or overwritten: the stored
+            // settings keep pointing at it until the ones naming the new file are committed.
+            string newPath = AzureVersionedCertificatePath(AzureAccessCertFile, material);
+            WriteOwnerOnly(newPath, material.CombinedPem);
             var candidate = new AzureProviderSettings
             {
                 TenantId = result.TenantId,
                 ClientId = result.AccessAppClientId,
                 SubscriptionId = result.SubscriptionId,
-                ClientCertificatePath = pendingPath,
+                ClientCertificatePath = newPath,
             };
             var check = await AzureDiscovery.CheckAccessAsync(candidate);
             if (!check.Succeeded)
             {
+                DeleteAzureCertificateUnlessReferenced(newPath, azureProviderSettings.ClientCertificatePath);
                 saveMessage = AzureCheckRefused("access", check);
                 saveSuccess = false;
                 return;
             }
 
-            string certPath = PromoteAzureCertificate(AzureAccessCertFile, azureAccessCert.CombinedPem);
-            await SaveAzureProviderFromForm(candidate with { ClientCertificatePath = certPath }, verified: true);
-            if (!saveSuccess)
+            string? previousPath = azureProviderSettings.ClientCertificatePath;
+            if (!await SaveAzureProviderFromForm(candidate, verified: true))
             {
-                RestoreAzureCertificate(AzureAccessCertFile);
+                DeleteAzureCertificateUnlessReferenced(newPath, previousPath);
                 return;
             }
 
-            DiscardAzureCertificateCopies(AzureAccessCertFile, azureAccessCert.CombinedPem);
+            SweepAzureCertificates(AzureAccessCertFile, keep: newPath, promotedPem: material.CombinedPem);
             azureAccessScript = null;
             azureAccessCert = null;
             azureAccessPasted = null;
@@ -2630,50 +2643,55 @@
         }
         finally
         {
+            AzureCertificateGate.Release();
             azureBusy = false;
         }
     }
 
     /// <summary>
-    /// Makes <paramref name="combinedPem"/> the live certificate — the file the stored settings point
-    /// at and Connapse signs with. The private key stays on this host; only the public certificate was
-    /// uploaded to Azure by the script. The key being replaced is kept beside it until the settings
-    /// that reference the new one are saved, so a failed save can put it back.
+    /// One promotion at a time in this process. Two administrators saving together would otherwise
+    /// interleave the write / verify / commit / sweep steps and sweep each other's files.
     /// </summary>
-    private string PromoteAzureCertificate(string fileName, string combinedPem)
+    private static readonly SemaphoreSlim AzureCertificateGate = new(1, 1);
+
+    /// <summary>Where a candidate certificate lives: its own file, named by the thumbprint, so no two
+    /// candidates — from this session or another — ever share a path with each other or with the key
+    /// in use.</summary>
+    private string AzureVersionedCertificatePath(string fileName, AzureCertificateMaterial material)
     {
-        string livePath = AzureCertificatePath(fileName);
-        string previousPath = AzurePreviousCertificatePath(fileName);
-        if (File.Exists(livePath)) MoveOwnerOnly(livePath, previousPath);
-        WriteOwnerOnly(livePath, combinedPem);
-        return livePath;
+        string thumbprint = AzureCertificateFile.Thumbprint(material.PublicCertificatePem);
+        return AzureCertificatePath($"{Path.GetFileNameWithoutExtension(fileName)}-{thumbprint[..12].ToLowerInvariant()}.pem");
     }
 
-    /// <summary>Undoes <see cref="PromoteAzureCertificate"/> after the settings save failed: the
-    /// previous key goes back, or, when there was none, the unreferenced new one is removed.</summary>
-    private void RestoreAzureCertificate(string fileName)
+    /// <summary>Removes a candidate file that will not be used, unless the stored settings already
+    /// name it — a re-save of the certificate in use must not delete it.</summary>
+    private static void DeleteAzureCertificateUnlessReferenced(string path, string? referencedPath)
     {
-        string livePath = AzureCertificatePath(fileName);
-        string previousPath = AzurePreviousCertificatePath(fileName);
-        if (File.Exists(previousPath)) MoveOwnerOnly(previousPath, livePath);
-        else if (File.Exists(livePath)) File.Delete(livePath);
+        if (string.Equals(path, referencedPath, StringComparison.OrdinalIgnoreCase)) return;
+        if (File.Exists(path)) File.Delete(path);
     }
 
-    /// <summary>After a successful save: the replaced key is no longer needed, and the pending copy is
-    /// removed only if it is the material just promoted — another session's replacement in progress
-    /// is left alone.</summary>
-    private void DiscardAzureCertificateCopies(string fileName, string promotedPem)
+    /// <summary>
+    /// After settings naming <paramref name="keep"/> are committed: every other certificate file of
+    /// this kind under appdata/azure is superseded and removed — earlier versioned files, the single
+    /// fixed-name file older saves wrote — and the pending copy goes only if it is the material just
+    /// promoted, so another session's replacement in progress is left alone.
+    /// </summary>
+    private void SweepAzureCertificates(string fileName, string keep, string promotedPem)
     {
-        string previousPath = AzurePreviousCertificatePath(fileName);
-        if (File.Exists(previousPath)) File.Delete(previousPath);
+        string directory = Path.GetDirectoryName(AzureCertificatePath(fileName))!;
+        if (!Directory.Exists(directory)) return;
 
+        string stem = Path.GetFileNameWithoutExtension(fileName);
         string pendingPath = AzurePendingCertificatePath(fileName);
-        if (File.Exists(pendingPath) && File.ReadAllText(pendingPath) == promotedPem) File.Delete(pendingPath);
+        foreach (string path in Directory.EnumerateFiles(directory, stem + "*.pem"))
+        {
+            if (string.Equals(path, keep, StringComparison.OrdinalIgnoreCase)) continue;
+            if (string.Equals(path, pendingPath, StringComparison.OrdinalIgnoreCase)
+                && File.ReadAllText(path) != promotedPem) continue;
+            File.Delete(path);
+        }
     }
-
-    /// <summary>Where the key being replaced waits between promotion and the settings save.</summary>
-    private string AzurePreviousCertificatePath(string fileName) =>
-        AzureCertificatePath(Path.GetFileNameWithoutExtension(fileName) + ".previous.pem");
 
     /// <summary>Whether the certificate the script registered is the one this page holds. A paste from
     /// a script that predates the thumbprint cannot be checked and is accepted; the Entra check that
@@ -2702,7 +2720,8 @@
     /// </summary>
     private async Task SaveAzurePermissionsFromScript(AzurePermissionsResult result)
     {
-        if (azureSignInCert is null)
+        AzureCertificateMaterial? material = azureSignInCert;
+        if (material is null)
         {
             saveMessage = "Generate the setup command first, so Connapse has the certificate to store.";
             saveSuccess = false;
@@ -2710,47 +2729,49 @@
         }
 
         azureBusy = true;
+        await AzureCertificateGate.WaitAsync();
         try
         {
-            if (!ThumbprintMatches(result.CertificateThumbprint, azureSignInCert))
+            if (!ThumbprintMatches(result.CertificateThumbprint, material))
             {
                 saveMessage = AzureThumbprintMismatch;
                 saveSuccess = false;
                 return;
             }
 
-            string pendingPath = AzurePendingCertificatePath(AzureSignInCertFile);
-            WriteOwnerOnly(pendingPath, azureSignInCert.CombinedPem);
+            string newPath = AzureVersionedCertificatePath(AzureSignInCertFile, material);
+            WriteOwnerOnly(newPath, material.CombinedPem);
             var check = await AzureDiscovery.CheckAccessAsync(new AzureProviderSettings
             {
                 TenantId = azureProviderSettings.TenantId,
                 ClientId = result.SignInAppClientId,
-                ClientCertificatePath = pendingPath,
+                ClientCertificatePath = newPath,
             });
             if (!check.Succeeded)
             {
+                DeleteAzureCertificateUnlessReferenced(newPath, azureAdSettings.ClientCertificatePath);
                 saveMessage = AzureCheckRefused("sign-in", check);
                 saveSuccess = false;
                 return;
             }
 
-            string certPath = PromoteAzureCertificate(AzureSignInCertFile, azureSignInCert.CombinedPem);
-            await SaveAzureAdFromForm(new AzureAdSignInSettings
+            string? previousPath = azureAdSettings.ClientCertificatePath;
+            bool committed = await SaveAzureAdFromForm(new AzureAdSignInSettings
             {
                 TenantId = azureProviderSettings.TenantId,
                 ClientId = result.SignInAppClientId,
                 RedirectUri = easyRedirectUri.Trim(),
-                ClientCertificatePath = certPath,
+                ClientCertificatePath = newPath,
                 // Persisted, so a reload cannot turn "consent still pending" into a green card.
                 AdminConsentPending = !result.ConsentGranted,
             }, verified: true);
-            if (!saveSuccess)
+            if (!committed)
             {
-                RestoreAzureCertificate(AzureSignInCertFile);
+                DeleteAzureCertificateUnlessReferenced(newPath, previousPath);
                 return;
             }
 
-            DiscardAzureCertificateCopies(AzureSignInCertFile, azureSignInCert.CombinedPem);
+            SweepAzureCertificates(AzureSignInCertFile, keep: newPath, promotedPem: material.CombinedPem);
             azurePermissionsScript = null;
             azureSignInCert = null;
             azurePermissionsPasted = null;
@@ -2763,6 +2784,7 @@
         }
         finally
         {
+            AzureCertificateGate.Release();
             azureBusy = false;
         }
     }
@@ -2821,20 +2843,34 @@
         _ => "bi-question-circle text-secondary"
     };
 
-    private async Task SaveSettings<T>(string category, T settings) where T : class
+    /// <summary>Stores a settings category. Returns whether it was committed — a reload that fails
+    /// after the commit is reported, but the settings are stored and callers must treat them as such.</summary>
+    private async Task<bool> SaveSettings<T>(string category, T settings) where T : class
     {
         try
         {
             await SettingsStore.SaveAsync(category, settings);
-            ReloadService.Reload();
-            saveMessage = $"{SettingsName(category)} settings saved successfully!";
-            saveSuccess = true;
         }
         catch (Exception ex)
         {
             saveMessage = $"Failed to save {SettingsName(category)} settings: {ex.Message}";
             saveSuccess = false;
+            return false;
         }
+
+        try
+        {
+            ReloadService.Reload();
+            saveMessage = $"{SettingsName(category)} settings saved successfully!";
+        }
+        catch (Exception ex)
+        {
+            saveMessage = $"{SettingsName(category)} settings were saved, but applying them without a "
+                + $"restart failed: {ex.Message} Restart Connapse to apply them.";
+        }
+
+        saveSuccess = true;
+        return true;
     }
 
     /// <summary>What to call a settings category in a sentence.</summary>

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -207,6 +207,13 @@
         </div>
         }
 
+        @if (checking)
+        {
+            <div class="text-muted small mb-2" role="status">
+                <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span> Checking @Current.DisplayName…
+            </div>
+        }
+
         @if (!string.IsNullOrEmpty(saveMessage))
         {
             <div class="alert @(saveSuccess ? "alert-success" : "alert-danger") alert-dismissible fade show" role="alert">
@@ -2214,12 +2221,28 @@
         await JS.InvokeVoidAsync("connapse.scrollToId", elementId);
     }
 
+    /// <summary>Whether a status re-read is in flight, shown beside the page title.</summary>
+    private bool checking;
+
+    /// <summary>
+    /// Re-reads every provider's status. The cards stay mounted while it runs: clearing the list
+    /// first would replace them with a spinner and dispose the forms inside them, and with them
+    /// whatever an operator had typed into a manual form whose save had just been refused.
+    /// </summary>
     private async Task RefreshSetups()
     {
-        setups = null;
+        checking = true;
         StateHasChanged();
-        setups = await SetupReader.ReadAsync();
-        await LoadAwsCredentialModeAsync();
+        try
+        {
+            setups = await SetupReader.ReadAsync();
+            await LoadAwsCredentialModeAsync();
+            LoadAzureCertificateExpiry();
+        }
+        finally
+        {
+            checking = false;
+        }
     }
 
     /// <summary>What a provider would let you do, for one you have not taken up.</summary>
@@ -2348,9 +2371,10 @@
                     HasTenant = !string.IsNullOrWhiteSpace(settings.TenantId),
                     HasSubscription = !string.IsNullOrWhiteSpace(settings.SubscriptionId),
                 }));
+            // Only after a commit: nothing changed otherwise, so there is nothing to re-read.
+            await AfterAzureCommitAsync(RefreshSetups);
         }
 
-        await AfterAzureCommitAsync(RefreshSetups);
         return committed;
     }
 
@@ -2459,9 +2483,9 @@
             LoadAzureCertificateExpiry();
             await AfterAzureCommitAsync(() => AuditLogger.LogAsync("provider.azuread.saved", "provider", "azure",
                 new { Configured = settings.IsConfigured }));
+            await AfterAzureCommitAsync(RefreshSetups);
         }
 
-        await AfterAzureCommitAsync(RefreshSetups);
         return committed;
     }
 
@@ -2645,16 +2669,26 @@
         return minted;
     }
 
+    /// <summary>Whether a path is one of the certificate files Connapse itself writes under appdata/azure.</summary>
+    private bool IsConnapseAzureFile(string path)
+    {
+        string? directory = Path.GetDirectoryName(Path.GetFullPath(path));
+        string own = Path.GetFullPath(Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure"));
+        return directory is not null && string.Equals(directory, own, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>Reads a combined PEM back as material, or null when the file is missing or unreadable.</summary>
-    private static AzureCertificateMaterial? ReadAzureCertificate(string path)
+    private AzureCertificateMaterial? ReadAzureCertificate(string path)
     {
         if (!File.Exists(path)) return null;
         try
         {
             string combined = File.ReadAllText(path);
             using var existing = System.Security.Cryptography.X509Certificates.X509Certificate2.CreateFromPem(combined);
-            // A file written before owner-only creation existed keeps its old mode; tighten it.
-            if (!OperatingSystem.IsWindows())
+            // A file Connapse wrote before owner-only creation existed keeps its old mode; tighten
+            // it. Only Connapse's own files: a certificate an operator supplied may be shared with
+            // another service or mounted read-only, and its permissions are theirs to set.
+            if (!OperatingSystem.IsWindows() && IsConnapseAzureFile(path))
                 File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
             return new AzureCertificateMaterial(existing.ExportCertificatePem(), combined);
         }
@@ -2890,7 +2924,10 @@
         string pendingPath = Path.GetFullPath(AzurePendingCertificatePath(fileName));
         DateTime cutoff = DateTime.UtcNow - AzureCertificateGrace;
 
-        foreach (string path in Directory.EnumerateFiles(directory, stem + "*.pem"))
+        // "*.pem*" also catches the ".pem.tmp" a write leaves behind if it is interrupted before
+        // the move: a private key nothing will ever read, and the sweep is the only thing that
+        // knows to remove it.
+        foreach (string path in Directory.EnumerateFiles(directory, stem + "*.pem*"))
         {
             string full = Path.GetFullPath(path);
             if (referenced.Contains(full)) continue;
@@ -2922,6 +2959,9 @@
         AzureProbeOutcome.Denied =>
             $"Entra refused the {which} credential, so nothing was changed. {check.Detail} If you just "
             + "ran the script, Entra may still be registering the certificate — wait a minute and save again.",
+        AzureProbeOutcome.Unusable =>
+            $"The {which} credential cannot be used from this host, so nothing was changed: {check.Detail} "
+            + "Check the certificate path and that Connapse can read the file.",
         _ => $"Could not confirm the {which} credential with Azure, so nothing was changed. {check.Detail}",
     };
 

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1260,7 +1260,8 @@
                     {
                         <p class="small text-muted mb-3" role="status">
                             <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
-                            Checking whether this host has a managed identity to use instead…
+                            Checking whether this host has a managed identity to use instead — the guide switches
+                            to it if so…
                         </p>
                     }
                     else if (hostIdentity is not null && string.IsNullOrWhiteSpace(azureProviderSettings.ClientId))
@@ -1279,7 +1280,9 @@
                         </p>
                     }
 
-                        EnsureAzureAccessScript();
+                        // Not while the host is still being asked: a certificate minted now would sit
+                        // unused if the answer is a managed identity.
+                        if (!detectingHostIdentity) EnsureAzureAccessScript();
                         @if (azureAccessScript is { Length: > 0 } accessScript)
                         {
                             <div class="alert alert-secondary py-2 small mb-2">
@@ -2436,7 +2439,13 @@
         StateHasChanged();
         try
         {
+            // The host is asked again as well: a probe that timed out, or an identity re-created
+            // since the process cached it, is what Recheck exists to notice.
+            Task detection = Key == "azure" && hostIdentityRequested
+                ? DetectHostIdentityAsync(refresh: true)
+                : Task.CompletedTask;
             setups = await SetupReader.ReadAsync();
+            await detection;
             await LoadAwsCredentialModeAsync();
             LoadAzureCertificateExpiry();
         }
@@ -2729,14 +2738,14 @@
         if (Key != "azure" || hostIdentityRequested) return;
         hostIdentityRequested = true;
         detectingHostIdentity = true;
-        _ = DetectHostIdentityAsync();
+        _ = DetectHostIdentityAsync(refresh: false);
     }
 
-    private async Task DetectHostIdentityAsync()
+    private async Task DetectHostIdentityAsync(bool refresh)
     {
         try
         {
-            hostIdentity = await HostIdentity.DetectAsync();
+            hostIdentity = await HostIdentity.DetectAsync(refresh);
         }
         catch (Exception)
         {
@@ -2745,6 +2754,9 @@
         finally
         {
             detectingHostIdentity = false;
+            // A permissions script generated before the answer landed names whatever principal was
+            // recorded; the host's own answer outranks it, so the script is rebuilt to match.
+            RefreshAzurePermissionsScript();
             await InvokeAsync(StateHasChanged);
         }
     }

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -2240,19 +2240,34 @@
         // the environment, so copying those values into a row here would shadow them permanently.
         bool enforcing = settings.IsConfigured || EnforcementOptions.CurrentValue.IsEnforcing;
 
-        await SaveSettings("samlsignin", settings);
+        // The latch first, and the Azure latch carried along unchanged: the record holds one flag
+        // per provider, and writing it with only this one would switch Azure filtering off. Written
+        // before the sign-in settings for the same reason as the Azure save — a latch that cannot be
+        // written must not leave sign-in configured with filtering off.
+        if (enforcing != EnforcementOptions.CurrentValue.IsEnforcing)
+        {
+            bool? latched = await SaveSettings(
+                PermissionEnforcementSettings.Category,
+                new PermissionEnforcementSettings
+                {
+                    IsEnforcing = enforcing,
+                    AzureEnforcing = EnforcementOptions.CurrentValue.AzureEnforcing,
+                });
+            if (latched != true || EnforcementOptions.CurrentValue.IsEnforcing != enforcing)
+            {
+                saveMessage = "Per-user enforcement for AWS could not be switched on in this process, so "
+                    + $"the sign-in application was not saved: {saveMessage} Restart Connapse and save again.";
+                saveSuccess = false;
+                return;
+            }
+        }
 
-        if (saveSuccess)
+        bool? committed = await SaveSettings("samlsignin", settings);
+
+        if (committed == true)
         {
             await AuditLogger.LogAsync("provider.saml.saved", "provider", "aws",
                 new { settings.EntityId, settings.IdpEntityId, Configured = settings.IsConfigured });
-        }
-
-        if (saveSuccess && enforcing != EnforcementOptions.CurrentValue.IsEnforcing)
-        {
-            await SaveSettings(
-                PermissionEnforcementSettings.Category,
-                new PermissionEnforcementSettings { IsEnforcing = enforcing });
         }
 
         // What was posted, not a re-read of CurrentValue. The options reload behind SaveSettings is
@@ -2269,7 +2284,7 @@
     /// caller has already verified <paramref name="settings"/>, Entra is asked first, and a credential
     /// it refuses is not stored — the one that works stays in place.
     /// </summary>
-    private async Task<bool> SaveAzureProviderFromForm(AzureProviderSettings settings, bool verified = false)
+    private async Task<bool?> SaveAzureProviderFromForm(AzureProviderSettings settings, bool verified = false)
     {
         // A reset (blank tenant) has nothing to verify.
         if (!verified && !string.IsNullOrWhiteSpace(settings.TenantId))
@@ -2283,31 +2298,49 @@
             }
         }
 
-        bool committed = await SaveSettings("azure", settings);
+        bool? committed = await SaveSettings("azure", settings);
 
-        if (committed)
+        if (committed == true)
         {
             // What was posted, not a re-read: the options reload behind SaveSettings may not have
             // landed yet, so a stale read would hand the form back the previous values.
             azureProviderSettings = settings;
             LoadAzureCertificateExpiry();
-            await AuditLogger.LogAsync("provider.azure.saved", "provider", "azure",
+            await AfterAzureCommitAsync(() => AuditLogger.LogAsync("provider.azure.saved", "provider", "azure",
                 new
                 {
                     HasTenant = !string.IsNullOrWhiteSpace(settings.TenantId),
                     HasSubscription = !string.IsNullOrWhiteSpace(settings.SubscriptionId),
-                });
+                }));
         }
 
-        await RefreshSetups();
+        await AfterAzureCommitAsync(RefreshSetups);
         return committed;
+    }
+
+    /// <summary>
+    /// Runs a step that follows a commit — the audit line, the status refresh, a cleanup — so that
+    /// its failure is reported beside the save rather than as the save failing. The settings are
+    /// stored by then; telling the operator otherwise would send them to retry a replacement that
+    /// already happened.
+    /// </summary>
+    private async Task AfterAzureCommitAsync(Func<Task> step)
+    {
+        try
+        {
+            await step();
+        }
+        catch (Exception ex)
+        {
+            saveMessage = $"{saveMessage} A follow-up step failed afterwards ({ex.Message}); the settings themselves are stored.";
+        }
     }
 
     /// <summary>Stores the Entra sign-in application (Identity:AzureAd) and re-checks status. As with
     /// the access app, a credential Entra refuses is not stored unless the caller already verified it.
     /// Returns whether the sign-in settings themselves were committed; the enforcement latch saved
     /// after them is reported separately and never turns a committed save into a failed one.</summary>
-    private async Task<bool> SaveAzureAdFromForm(AzureAdSignInSettings settings, bool verified = false)
+    private async Task<bool?> SaveAzureAdFromForm(AzureAdSignInSettings settings, bool verified = false)
     {
         if (!verified && settings.IsConfigured)
         {
@@ -2331,33 +2364,36 @@
         bool enforcing = settings.IsConfigured || EnforcementOptions.CurrentValue.AzureEnforcing;
         if (enforcing != EnforcementOptions.CurrentValue.AzureEnforcing)
         {
-            bool latched = await SaveSettings(
+            bool? latched = await SaveSettings(
                 PermissionEnforcementSettings.Category,
                 new PermissionEnforcementSettings
                 {
                     IsEnforcing = EnforcementOptions.CurrentValue.IsEnforcing,
                     AzureEnforcing = enforcing,
                 });
-            if (!latched)
+            // Stored is not enough: the resolver reads the live options, so a latch that was written
+            // but not applied (the reload failed) would let sign-in be saved into an unfiltered
+            // process. Only a latch this process can see counts.
+            if (latched != true || EnforcementOptions.CurrentValue.AzureEnforcing != enforcing)
             {
-                saveMessage = "Per-user enforcement for Azure could not be switched on, so the sign-in "
-                    + $"application was not saved: {saveMessage}";
+                saveMessage = "Per-user enforcement for Azure could not be switched on in this process, so "
+                    + $"the sign-in application was not saved: {saveMessage} Restart Connapse and save again.";
                 saveSuccess = false;
                 return false;
             }
         }
 
-        bool committed = await SaveSettings("azuread", settings);
+        bool? committed = await SaveSettings("azuread", settings);
 
-        if (committed)
+        if (committed == true)
         {
             azureAdSettings = settings;
             LoadAzureCertificateExpiry();
-            await AuditLogger.LogAsync("provider.azuread.saved", "provider", "azure",
-                new { Configured = settings.IsConfigured });
+            await AfterAzureCommitAsync(() => AuditLogger.LogAsync("provider.azuread.saved", "provider", "azure",
+                new { Configured = settings.IsConfigured }));
         }
 
-        await RefreshSetups();
+        await AfterAzureCommitAsync(RefreshSetups);
         return committed;
     }
 
@@ -2418,7 +2454,7 @@
         await AzureCertificateGate.WaitAsync();
         try
         {
-            if (!await SaveAzureProviderFromForm(new AzureProviderSettings())) return;
+            if (await SaveAzureProviderFromForm(new AzureProviderSettings()) != true) return;
 
             await DeleteAzureCertificatesAsync(AzureAccessCertFile);
             azureAccessScript = null;
@@ -2439,7 +2475,7 @@
         await AzureCertificateGate.WaitAsync();
         try
         {
-            if (!await SaveAzureAdFromForm(new AzureAdSignInSettings())) return;
+            if (await SaveAzureAdFromForm(new AzureAdSignInSettings()) != true) return;
 
             await DeleteAzureCertificatesAsync(AzureSignInCertFile);
             azurePermissionsScript = null;
@@ -2467,6 +2503,7 @@
         if (File.Exists(pendingPath)) File.Delete(pendingPath);
 
         var referenced = await PersistedAzureCertificatePathsAsync();
+        if (referenced is null) return;
         DateTime cutoff = DateTime.UtcNow - AzureCertificateGrace;
         foreach (string path in Directory.EnumerateFiles(directory, Path.GetFileNameWithoutExtension(fileName) + "*.pem"))
         {
@@ -2656,13 +2693,16 @@
                 return;
             }
 
-            if (!await SaveAzureProviderFromForm(candidate, verified: true))
+            bool? committed = await SaveAzureProviderFromForm(candidate, verified: true);
+            if (committed != true)
             {
-                await DeleteAzureCandidateAsync(newPath);
+                // False: not stored, the candidate is surplus. Null: unknown — the file may be the
+                // one the store names by now, so it stays, and so does the paste for a retry.
+                if (committed == false) await DeleteAzureCandidateAsync(newPath);
                 return;
             }
 
-            await SweepAzureCertificatesAsync(AzureAccessCertFile, promotedPem: material.CombinedPem);
+            await AfterAzureCommitAsync(() => SweepAzureCertificatesAsync(AzureAccessCertFile, promotedPem: material.CombinedPem));
             azureAccessScript = null;
             azureAccessCert = null;
             azureAccessPasted = null;
@@ -2686,13 +2726,15 @@
     /// </summary>
     private static readonly SemaphoreSlim AzureCertificateGate = new(1, 1);
 
-    /// <summary>Where a candidate certificate lives: its own file, named by the thumbprint, so no two
-    /// candidates — from this session or another — ever share a path with each other or with the key
-    /// in use.</summary>
+    /// <summary>Where a candidate certificate lives: its own file, named by the thumbprint and a
+    /// per-attempt suffix, so no two attempts — in this session, another, or another process that
+    /// picked up the same pending material — ever share a path with each other or with the key in
+    /// use. One attempt's cleanup can therefore never touch another's file.</summary>
     private string AzureVersionedCertificatePath(string fileName, AzureCertificateMaterial material)
     {
         string thumbprint = AzureCertificateFile.Thumbprint(material.PublicCertificatePem);
-        return AzureCertificatePath($"{Path.GetFileNameWithoutExtension(fileName)}-{thumbprint[..12].ToLowerInvariant()}.pem");
+        string attempt = Guid.NewGuid().ToString("N")[..8];
+        return AzureCertificatePath($"{Path.GetFileNameWithoutExtension(fileName)}-{thumbprint[..12].ToLowerInvariant()}-{attempt}.pem");
     }
 
     /// <summary>
@@ -2701,15 +2743,24 @@
     /// committed since this page loaded — plus the live options as a floor when the store has no row
     /// (settings coming from appsettings or the environment).
     /// </summary>
-    private async Task<HashSet<string>> PersistedAzureCertificatePathsAsync()
+    private async Task<HashSet<string>?> PersistedAzureCertificatePathsAsync()
     {
         var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         void Add(string? path) { if (!string.IsNullOrWhiteSpace(path)) paths.Add(Path.GetFullPath(path)); }
 
         Add(AzureProviderOptions.CurrentValue.ClientCertificatePath);
         Add(AzureAdOptions.CurrentValue.ClientCertificatePath);
-        Add((await SettingsStore.GetAsync<AzureProviderSettings>("azure"))?.ClientCertificatePath);
-        Add((await SettingsStore.GetAsync<AzureAdSignInSettings>("azuread"))?.ClientCertificatePath);
+        try
+        {
+            Add((await SettingsStore.GetAsync<AzureProviderSettings>("azure"))?.ClientCertificatePath);
+            Add((await SettingsStore.GetAsync<AzureAdSignInSettings>("azuread"))?.ClientCertificatePath);
+        }
+        catch (Exception)
+        {
+            // Not knowing what is referenced is not the same as nothing being referenced: with the
+            // store unreadable, nothing is deleted at all.
+            return null;
+        }
         return paths;
     }
 
@@ -2726,7 +2777,7 @@
     {
         if (!File.Exists(path)) return;
         var referenced = await PersistedAzureCertificatePathsAsync();
-        if (referenced.Contains(Path.GetFullPath(path))) return;
+        if (referenced is null || referenced.Contains(Path.GetFullPath(path))) return;
         File.Delete(path);
     }
 
@@ -2743,6 +2794,7 @@
         if (!Directory.Exists(directory)) return;
 
         var referenced = await PersistedAzureCertificatePathsAsync();
+        if (referenced is null) return;
         string stem = Path.GetFileNameWithoutExtension(fileName);
         string pendingPath = Path.GetFullPath(AzurePendingCertificatePath(fileName));
         DateTime cutoff = DateTime.UtcNow - AzureCertificateGrace;
@@ -2823,7 +2875,7 @@
                 return;
             }
 
-            bool committed = await SaveAzureAdFromForm(new AzureAdSignInSettings
+            bool? committed = await SaveAzureAdFromForm(new AzureAdSignInSettings
             {
                 TenantId = azureProviderSettings.TenantId,
                 ClientId = result.SignInAppClientId,
@@ -2832,13 +2884,13 @@
                 // Persisted, so a reload cannot turn "consent still pending" into a green card.
                 AdminConsentPending = !result.ConsentGranted,
             }, verified: true);
-            if (!committed)
+            if (committed != true)
             {
-                await DeleteAzureCandidateAsync(newPath);
+                if (committed == false) await DeleteAzureCandidateAsync(newPath);
                 return;
             }
 
-            await SweepAzureCertificatesAsync(AzureSignInCertFile, promotedPem: material.CombinedPem);
+            await AfterAzureCommitAsync(() => SweepAzureCertificatesAsync(AzureSignInCertFile, promotedPem: material.CombinedPem));
             azurePermissionsScript = null;
             azureSignInCert = null;
             azurePermissionsPasted = null;
@@ -2916,7 +2968,9 @@
     /// read back and compared, and a commit whose reload failed is reported as stored-but-not-applied
     /// rather than as a failure — callers rolling back on false must never undo a commit.
     /// </summary>
-    private async Task<bool> SaveSettings<T>(string category, T settings) where T : class
+    /// <returns>True when committed, false when not, null when the store threw and could not be read
+    /// back either — the outcome is unknown, and callers must neither roll back nor report success.</returns>
+    private async Task<bool?> SaveSettings<T>(string category, T settings) where T : class
     {
         string? reloadProblem = null;
         try
@@ -2925,11 +2979,17 @@
         }
         catch (Exception ex)
         {
-            if (!await IsStoredAsync(category, settings))
+            switch (await IsStoredAsync(category, settings))
             {
-                saveMessage = $"Failed to save {SettingsName(category)} settings: {ex.Message}";
-                saveSuccess = false;
-                return false;
+                case false:
+                    saveMessage = $"Failed to save {SettingsName(category)} settings: {ex.Message}";
+                    saveSuccess = false;
+                    return false;
+                case null:
+                    saveMessage = $"Could not confirm whether {SettingsName(category)} settings were saved: "
+                        + $"{ex.Message} Check this card again after a restart before retrying.";
+                    saveSuccess = false;
+                    return null;
             }
             reloadProblem = ex.Message;
         }
@@ -2951,8 +3011,9 @@
         return true;
     }
 
-    /// <summary>Whether the store now holds exactly <paramref name="settings"/> under <paramref name="category"/>.</summary>
-    private async Task<bool> IsStoredAsync<T>(string category, T settings) where T : class
+    /// <summary>Whether the store now holds exactly <paramref name="settings"/> under
+    /// <paramref name="category"/>; null when the store cannot be read, which is not a no.</summary>
+    private async Task<bool?> IsStoredAsync<T>(string category, T settings) where T : class
     {
         try
         {
@@ -2962,7 +3023,7 @@
         }
         catch (Exception)
         {
-            return false;
+            return null;
         }
     }
 

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -19,6 +19,7 @@
 @inject IOptionsMonitor<IdentityCenterSettings> IdentityCenterOptions
 @inject IOptionsMonitor<AzureProviderSettings> AzureProviderOptions
 @inject IOptionsMonitor<AzureAdSignInSettings> AzureAdOptions
+@inject IAzureBlobDiscovery AzureDiscovery
 @inject Microsoft.AspNetCore.Hosting.IWebHostEnvironment WebHostEnvironment
 @inject IProviderSetupReader SetupReader
 @inject IProviderCredentialStore CredentialStore
@@ -1134,7 +1135,7 @@
                     <details class="border rounded p-3 mb-3">
                         <summary class="fw-semibold">Manual values — use an existing app registration or managed identity</summary>
                         <div class="mt-3">
-                            <AzureProviderSettingsTab Settings="azureProviderSettings" OnSave="SaveAzureProviderFromForm" />
+                            <AzureProviderSettingsTab Settings="azureProviderSettings" OnSave="s => SaveAzureProviderFromForm(s)" />
                         </div>
                     </details>
                 </ManualContent>
@@ -1301,7 +1302,7 @@
                     <details class="border rounded p-3 mb-3">
                         <summary class="fw-semibold">Manual values — use an existing sign-in app registration</summary>
                         <div class="mt-3">
-                            <AzureAdSignInSettingsTab Settings="azureAdSettings" OnSave="SaveAzureAdFromForm"
+                            <AzureAdSignInSettingsTab Settings="azureAdSettings" OnSave="s => SaveAzureAdFromForm(s)"
                                                       DefaultTenantId="@azureProviderSettings.TenantId"
                                                       DefaultRedirectUri="@easyRedirectUri" />
                         </div>
@@ -2263,9 +2264,25 @@
         await RefreshSetups();
     }
 
-    /// <summary>Stores the Azure access app credential (Providers:Azure) and re-checks status.</summary>
-    private async Task SaveAzureProviderFromForm(AzureProviderSettings settings)
+    /// <summary>
+    /// Stores the Azure access app credential (Providers:Azure) and re-checks status. Unless the
+    /// caller has already verified <paramref name="settings"/>, Entra is asked first, and a credential
+    /// it refuses is not stored — the one that works stays in place.
+    /// </summary>
+    private async Task SaveAzureProviderFromForm(AzureProviderSettings settings, bool verified = false)
     {
+        // A reset (blank tenant) has nothing to verify.
+        if (!verified && !string.IsNullOrWhiteSpace(settings.TenantId))
+        {
+            var check = await AzureDiscovery.CheckAccessAsync(settings);
+            if (!check.Succeeded)
+            {
+                saveMessage = AzureCheckRefused("access", check);
+                saveSuccess = false;
+                return;
+            }
+        }
+
         await SaveSettings("azure", settings);
 
         if (saveSuccess)
@@ -2285,9 +2302,21 @@
         await RefreshSetups();
     }
 
-    /// <summary>Stores the Entra sign-in application (Identity:AzureAd) and re-checks status.</summary>
-    private async Task SaveAzureAdFromForm(AzureAdSignInSettings settings)
+    /// <summary>Stores the Entra sign-in application (Identity:AzureAd) and re-checks status. As with
+    /// the access app, a credential Entra refuses is not stored unless the caller already verified it.</summary>
+    private async Task SaveAzureAdFromForm(AzureAdSignInSettings settings, bool verified = false)
     {
+        if (!verified && settings.IsConfigured)
+        {
+            var check = await AzureDiscovery.CheckAccessAsync(ProviderSetupReader.SignInIdentity(settings));
+            if (!check.Succeeded)
+            {
+                saveMessage = AzureCheckRefused("sign-in", check);
+                saveSuccess = false;
+                return;
+            }
+        }
+
         // Latched here, at save time, exactly as SaveSamlSettings does for AWS. The startup latch
         // alone left a gap: a deployment that configured Azure sign-in and never restarted stayed
         // NotEnforcing, and every azblob result passed unfiltered until the next process start.
@@ -2392,7 +2421,7 @@
 
     private void DeleteAzureCertificate(string fileName)
     {
-        foreach (string path in new[] { AzureCertificatePath(fileName), AzurePendingCertificatePath(fileName) })
+        foreach (string path in new[] { AzureCertificatePath(fileName), AzurePendingCertificatePath(fileName), AzurePreviousCertificatePath(fileName) })
         {
             if (File.Exists(path)) File.Delete(path);
         }
@@ -2481,37 +2510,25 @@
         }
     }
 
-    /// <summary>When the certificate at a stored path stops being accepted; null when there is none to read.</summary>
-    private static DateTime? AzureCertificateExpiry(string? certificatePath)
-    {
-        if (string.IsNullOrWhiteSpace(certificatePath) || !File.Exists(certificatePath)) return null;
-        string extension = Path.GetExtension(certificatePath).ToLowerInvariant();
-        if (extension is not (".pem" or ".crt")) return null;
-
-        try
-        {
-            return CertificateExpiry(File.ReadAllText(certificatePath));
-        }
-        catch (IOException)
-        {
-            return null;
-        }
-    }
-
     private DateTime? azureAccessCertExpires;
     private DateTime? azureSignInCertExpires;
 
+    /// <summary>Read through the same loader the credentials use, so a PFX with a password shows its
+    /// expiry exactly as a PEM does.</summary>
     private void LoadAzureCertificateExpiry()
     {
-        azureAccessCertExpires = AzureCertificateExpiry(azureProviderSettings.ClientCertificatePath);
-        azureSignInCertExpires = AzureCertificateExpiry(azureAdSettings.ClientCertificatePath);
+        azureAccessCertExpires = AzureCertificateFile.Expiry(
+            azureProviderSettings.ClientCertificatePath, azureProviderSettings.ClientCertificatePassword);
+        azureSignInCertExpires = AzureCertificateFile.Expiry(
+            azureAdSettings.ClientCertificatePath, azureAdSettings.ClientCertificatePassword);
     }
 
     /// <summary>
     /// Writes a private-key file readable by Connapse's own user only: 0600 in a 0700 directory on
     /// Unix (a default umask would have made it world-readable); on Windows it inherits the app
-    /// directory's ACL. The mode is set again after writing because a create mode only applies to
-    /// a file that did not exist.
+    /// directory's ACL. Written to a sibling temporary file and moved into place, so an interrupted
+    /// write leaves the previous file intact rather than truncated. The mode is set again after the
+    /// move because a create mode only applies to a file that did not exist.
     /// </summary>
     private static void WriteOwnerOnly(string path, string content)
     {
@@ -2521,15 +2538,27 @@
         if (unix)
             File.SetUnixFileMode(dir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
 
+        string temp = path + ".tmp";
         var options = new FileStreamOptions { Mode = FileMode.Create, Access = FileAccess.Write, Share = FileShare.None };
         if (unix) options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
-        using (var stream = new FileStream(path, options))
+        using (var stream = new FileStream(temp, options))
         using (var writer = new StreamWriter(stream))
         {
             writer.Write(content);
+            writer.Flush();
+            stream.Flush(flushToDisk: true);
         }
 
+        File.Move(temp, path, overwrite: true);
         if (unix) File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    /// <summary>Moves a private-key file, keeping it readable by Connapse's own user only.</summary>
+    private static void MoveOwnerOnly(string from, string to)
+    {
+        File.Move(from, to, overwrite: true);
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(to, UnixFileMode.UserRead | UnixFileMode.UserWrite);
     }
 
     private async Task CopyText(string text)
@@ -2554,15 +2583,41 @@
         azureBusy = true;
         try
         {
-            string certPath = await WriteAzureCertificateAsync("connapse-azure-access.pem", azureAccessCert.CombinedPem);
-            await SaveAzureProviderFromForm(new AzureProviderSettings
+            if (!ThumbprintMatches(result.CertificateThumbprint, azureAccessCert))
+            {
+                saveMessage = AzureThumbprintMismatch;
+                saveSuccess = false;
+                return;
+            }
+
+            // Verified from the pending file, before anything live is touched: only a certificate
+            // Entra already accepts replaces the one Connapse signs with today.
+            string pendingPath = AzurePendingCertificatePath(AzureAccessCertFile);
+            WriteOwnerOnly(pendingPath, azureAccessCert.CombinedPem);
+            var candidate = new AzureProviderSettings
             {
                 TenantId = result.TenantId,
                 ClientId = result.AccessAppClientId,
                 SubscriptionId = result.SubscriptionId,
-                ClientCertificatePath = certPath,
-            });
+                ClientCertificatePath = pendingPath,
+            };
+            var check = await AzureDiscovery.CheckAccessAsync(candidate);
+            if (!check.Succeeded)
+            {
+                saveMessage = AzureCheckRefused("access", check);
+                saveSuccess = false;
+                return;
+            }
 
+            string certPath = PromoteAzureCertificate(AzureAccessCertFile, azureAccessCert.CombinedPem);
+            await SaveAzureProviderFromForm(candidate with { ClientCertificatePath = certPath }, verified: true);
+            if (!saveSuccess)
+            {
+                RestoreAzureCertificate(AzureAccessCertFile);
+                return;
+            }
+
+            DiscardAzureCertificateCopies(AzureAccessCertFile, azureAccessCert.CombinedPem);
             azureAccessScript = null;
             azureAccessCert = null;
             azureAccessPasted = null;
@@ -2579,19 +2634,67 @@
         }
     }
 
-    /// <summary>The private key stays on this host: the cert + key go to the appdata volume, and only
-    /// the public certificate was uploaded to Azure by the script. This is the one place the live file
-    /// is written; the pending copy it came from is removed once it is.</summary>
-    private Task<string> WriteAzureCertificateAsync(string fileName, string combinedPem)
+    /// <summary>
+    /// Makes <paramref name="combinedPem"/> the live certificate — the file the stored settings point
+    /// at and Connapse signs with. The private key stays on this host; only the public certificate was
+    /// uploaded to Azure by the script. The key being replaced is kept beside it until the settings
+    /// that reference the new one are saved, so a failed save can put it back.
+    /// </summary>
+    private string PromoteAzureCertificate(string fileName, string combinedPem)
     {
-        string certPath = AzureCertificatePath(fileName);
-        WriteOwnerOnly(certPath, combinedPem);
+        string livePath = AzureCertificatePath(fileName);
+        string previousPath = AzurePreviousCertificatePath(fileName);
+        if (File.Exists(livePath)) MoveOwnerOnly(livePath, previousPath);
+        WriteOwnerOnly(livePath, combinedPem);
+        return livePath;
+    }
+
+    /// <summary>Undoes <see cref="PromoteAzureCertificate"/> after the settings save failed: the
+    /// previous key goes back, or, when there was none, the unreferenced new one is removed.</summary>
+    private void RestoreAzureCertificate(string fileName)
+    {
+        string livePath = AzureCertificatePath(fileName);
+        string previousPath = AzurePreviousCertificatePath(fileName);
+        if (File.Exists(previousPath)) MoveOwnerOnly(previousPath, livePath);
+        else if (File.Exists(livePath)) File.Delete(livePath);
+    }
+
+    /// <summary>After a successful save: the replaced key is no longer needed, and the pending copy is
+    /// removed only if it is the material just promoted — another session's replacement in progress
+    /// is left alone.</summary>
+    private void DiscardAzureCertificateCopies(string fileName, string promotedPem)
+    {
+        string previousPath = AzurePreviousCertificatePath(fileName);
+        if (File.Exists(previousPath)) File.Delete(previousPath);
 
         string pendingPath = AzurePendingCertificatePath(fileName);
-        if (File.Exists(pendingPath)) File.Delete(pendingPath);
-
-        return Task.FromResult(certPath);
+        if (File.Exists(pendingPath) && File.ReadAllText(pendingPath) == promotedPem) File.Delete(pendingPath);
     }
+
+    /// <summary>Where the key being replaced waits between promotion and the settings save.</summary>
+    private string AzurePreviousCertificatePath(string fileName) =>
+        AzureCertificatePath(Path.GetFileNameWithoutExtension(fileName) + ".previous.pem");
+
+    /// <summary>Whether the certificate the script registered is the one this page holds. A paste from
+    /// a script that predates the thumbprint cannot be checked and is accepted; the Entra check that
+    /// follows is the backstop.</summary>
+    private static bool ThumbprintMatches(string? printed, AzureCertificateMaterial material) =>
+        printed is null
+        || string.Equals(printed, AzureCertificateFile.Thumbprint(material.PublicCertificatePem), StringComparison.OrdinalIgnoreCase);
+
+    private const string AzureThumbprintMismatch =
+        "The script you ran registered a different certificate from the one this page holds — another "
+        + "tab or session may have made a new one since. Nothing was changed. Copy the command shown "
+        + "now, run it again, and paste that result.";
+
+    /// <summary>What to say when Entra would not accept a credential about to be stored.</summary>
+    private static string AzureCheckRefused(string which, AzureProbe<string> check) => check.Outcome switch
+    {
+        AzureProbeOutcome.Denied =>
+            $"Entra refused the {which} credential, so nothing was changed. {check.Detail} If you just "
+            + "ran the script, Entra may still be registering the certificate — wait a minute and save again.",
+        _ => $"Could not confirm the {which} credential with Azure, so nothing was changed. {check.Detail}",
+    };
 
     /// <summary>
     /// Stores the Per-user permissions step: the sign-in app's own certificate and client id (tenant
@@ -2609,7 +2712,29 @@
         azureBusy = true;
         try
         {
-            string certPath = await WriteAzureCertificateAsync("connapse-azure-signin.pem", azureSignInCert.CombinedPem);
+            if (!ThumbprintMatches(result.CertificateThumbprint, azureSignInCert))
+            {
+                saveMessage = AzureThumbprintMismatch;
+                saveSuccess = false;
+                return;
+            }
+
+            string pendingPath = AzurePendingCertificatePath(AzureSignInCertFile);
+            WriteOwnerOnly(pendingPath, azureSignInCert.CombinedPem);
+            var check = await AzureDiscovery.CheckAccessAsync(new AzureProviderSettings
+            {
+                TenantId = azureProviderSettings.TenantId,
+                ClientId = result.SignInAppClientId,
+                ClientCertificatePath = pendingPath,
+            });
+            if (!check.Succeeded)
+            {
+                saveMessage = AzureCheckRefused("sign-in", check);
+                saveSuccess = false;
+                return;
+            }
+
+            string certPath = PromoteAzureCertificate(AzureSignInCertFile, azureSignInCert.CombinedPem);
             await SaveAzureAdFromForm(new AzureAdSignInSettings
             {
                 TenantId = azureProviderSettings.TenantId,
@@ -2618,8 +2743,14 @@
                 ClientCertificatePath = certPath,
                 // Persisted, so a reload cannot turn "consent still pending" into a green card.
                 AdminConsentPending = !result.ConsentGranted,
-            });
+            }, verified: true);
+            if (!saveSuccess)
+            {
+                RestoreAzureCertificate(AzureSignInCertFile);
+                return;
+            }
 
+            DiscardAzureCertificateCopies(AzureSignInCertFile, azureSignInCert.CombinedPem);
             azurePermissionsScript = null;
             azureSignInCert = null;
             azurePermissionsPasted = null;

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1245,11 +1245,7 @@
                     <p class="small mb-1">
                         <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.AccessScriptRequirements).
                     </p>
-                    @if (hostIdentity is null)
-                    {
-                        <p class="mb-2"></p>
-                    }
-                    else if (string.IsNullOrWhiteSpace(azureProviderSettings.ClientId))
+                    @if (hostIdentity is not null && string.IsNullOrWhiteSpace(azureProviderSettings.ClientId))
                     {
                         <p class="small mb-3">
                             <button type="button" class="btn btn-link btn-sm p-0 align-baseline" @onclick="() => preferCertificateApp = false">
@@ -1257,7 +1253,7 @@
                             </button>
                         </p>
                     }
-                    else
+                    else if (hostIdentity is not null)
                     {
                         <p class="small text-muted mb-3">
                             This host has a managed identity. To switch to it, with no certificate, choose
@@ -1465,9 +1461,21 @@
                             {
                                 <text>
                                     The access identity is a user-assigned managed identity entered by hand, so its
-                                    Microsoft Graph permissions are granted by hand too: run the two commands from
-                                    <code>docs/azure-setup.md</code> (Graph app roles for a managed identity) as a Global
-                                    Administrator, then set the sign-in application up under Manual values here.
+                                    Microsoft Graph permissions are granted by hand too: run the two commands under
+                                    <a href="https://github.com/Destrayon/Connapse/blob/main/docs/azure-setup.md#graph-permissions-for-a-managed-identity"
+                                       target="_blank" rel="noopener">Graph permissions for a managed identity</a>
+                                    as a Global Administrator, then set the sign-in application up under Manual values here.
+                                </text>
+                            }
+                            else if (AzureCredentialChainFactory.IsHostManagedIdentity(azureProviderSettings))
+                            {
+                                <text>
+                                    Access is set to this host's managed identity, but the page could not tell which
+                                    identity that is — the host reported none, or a user-assigned one. Grant the Graph
+                                    permissions by hand with the two commands under
+                                    <a href="https://github.com/Destrayon/Connapse/blob/main/docs/azure-setup.md#graph-permissions-for-a-managed-identity"
+                                       target="_blank" rel="noopener">Graph permissions for a managed identity</a>,
+                                    then set the sign-in application up under Manual values here.
                                 </text>
                             }
                             else
@@ -2698,15 +2706,31 @@
             return;
         }
 
+        // The tenant comes from whatever Cloud Shell was signed in to, and a managed-identity token
+        // does not care what tenant is stored, so the credential check cannot catch a wrong one.
+        // The host already said which tenant it is in.
+        if (hostIdentity is { } hostTenant && !string.Equals(hostTenant.TenantId, result.TenantId, StringComparison.OrdinalIgnoreCase))
+        {
+            saveMessage = $"The script ran in tenant {result.TenantId}, but this host's managed identity is in tenant "
+                + $"{hostTenant.TenantId}. Nothing was changed. In Cloud Shell, switch to that tenant (az login --tenant …), "
+                + "run the command again, and paste that result.";
+            saveSuccess = false;
+            return;
+        }
+
         azureBusy = true;
         try
         {
+            // What the host knows about itself outranks what was pasted: the kind and client id come
+            // from the token the host was issued, and the paste is only allowed to agree.
+            bool userAssigned = hostIdentity?.IsUserAssigned ?? result.IsUserAssigned;
+            string clientId = hostIdentity?.ClientId ?? result.ClientId;
             var candidate = new AzureProviderSettings
             {
                 TenantId = result.TenantId,
                 SubscriptionId = result.SubscriptionId,
-                UseHostManagedIdentity = !result.IsUserAssigned,
-                UserAssignedManagedIdentityClientId = result.IsUserAssigned ? result.ClientId : null,
+                UseHostManagedIdentity = !userAssigned,
+                UserAssignedManagedIdentityClientId = userAssigned ? clientId : null,
                 ManagedIdentityPrincipalId = result.PrincipalId,
             };
             var check = await AzureDiscovery.CheckAccessAsync(candidate);

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1245,7 +1245,11 @@
                     <p class="small mb-1">
                         <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.AccessScriptRequirements).
                     </p>
-                    @if (hostIdentity is not null)
+                    @if (hostIdentity is null)
+                    {
+                        <p class="mb-2"></p>
+                    }
+                    else if (string.IsNullOrWhiteSpace(azureProviderSettings.ClientId))
                     {
                         <p class="small mb-3">
                             <button type="button" class="btn btn-link btn-sm p-0 align-baseline" @onclick="() => preferCertificateApp = false">
@@ -1255,7 +1259,10 @@
                     }
                     else
                     {
-                        <p class="mb-2"></p>
+                        <p class="small text-muted mb-3">
+                            This host has a managed identity. To switch to it, with no certificate, choose
+                            <strong>Reset access</strong> below first; the guide then offers it.
+                        </p>
                     }
 
                         EnsureAzureAccessScript();
@@ -1337,14 +1344,16 @@
                     {
                         <ProviderResetAction Label="Reset access"
                                              ConfirmLabel="Confirm access reset"
-                                             HelpText="Clears the tenant, subscription, and app identity and discards the stored certificate. Azure connections stop working until access is set up again."
+                                             HelpText="@(AzureCredentialChainFactory.IsManagedIdentity(azureProviderSettings)
+                                                 ? "Clears the tenant, subscription, and managed identity; the roles assigned in Azure stay until you remove them there. Azure connections stop working until access is set up again."
+                                                 : "Clears the tenant, subscription, and app identity and discards the stored certificate. Azure connections stop working until access is set up again.")"
                                              OnReset="ClearAzureAccess" />
                     }
                 </Actions>
             </ProviderStepCard>
 
             <ProviderStepCard Id="azure-permissions" Title="Per-user permissions"
-                              Description="The Entra application people sign in through, so their Azure results are scoped to what that identity may read. Uses the access app above to look people and groups up."
+                              Description="The Entra application people sign in through, so their Azure results are scoped to what that identity may read. Uses the access identity above to look people and groups up."
                               Status="PermissionsStatus" StatusLabel="@RequirementLabel(PermissionsStatus)"
                               @bind-Expanded="showAzurePermissions" EditLabel="Update or replace"
                               EasyTitle="Guided setup" EasyOpen="true">
@@ -1452,9 +1461,22 @@
                     {
                         <div class="alert alert-secondary py-2 small mb-0">
                             <span class="bi-info-circle me-1" aria-hidden="true"></span>
-                            Finish the <strong>Access</strong> step first — this script grants the access identity its
-                            Microsoft Graph permissions. (A user-assigned managed identity entered by hand needs those
-                            permissions granted by hand too; use the manual values here.)
+                            @if (AzureCredentialChainFactory.IsUserAssignedManagedIdentity(azureProviderSettings))
+                            {
+                                <text>
+                                    The access identity is a user-assigned managed identity entered by hand, so its
+                                    Microsoft Graph permissions are granted by hand too: run the two commands from
+                                    <code>docs/azure-setup.md</code> (Graph app roles for a managed identity) as a Global
+                                    Administrator, then set the sign-in application up under Manual values here.
+                                </text>
+                            }
+                            else
+                            {
+                                <text>
+                                    Finish the <strong>Access</strong> step first — this script grants the access identity
+                                    its Microsoft Graph permissions.
+                                </text>
+                            }
                         </div>
                     }
                     else
@@ -1809,11 +1831,16 @@
     {
         if (!firstRender) return;
 
-        // Whether this host has a managed identity, so the Azure guide can offer it. Off Azure the
-        // answer is a quick "no"; on Azure it is remembered for the process after the first look.
-        hostIdentity = await HostIdentity.DetectAsync();
+        // Whether this host has a managed identity, so the Azure guide can offer it — asked only on
+        // the Azure page, and alongside the status read rather than before it, since off Azure the
+        // metadata probe is a second or so of waiting for nothing. A found identity is remembered
+        // for the process after the first look.
+        Task<AzureHostIdentityInfo?> detection = Key == "azure"
+            ? HostIdentity.DetectAsync()
+            : Task.FromResult<AzureHostIdentityInfo?>(null);
 
         setups = await SetupReader.ReadAsync();
+        hostIdentity = await detection;
         await LoadAwsCredentialModeAsync();
 
         // Entra bounced back after the administrator consented: record it, so the pending state
@@ -2501,6 +2528,10 @@
             // landed yet, so a stale read would hand the form back the previous values.
             azureProviderSettings = settings;
             LoadAzureCertificateExpiry();
+            // The permissions script names the access identity and takes a different shape for a
+            // managed identity than for an app; one already generated for the old identity must
+            // not stay on screen under an intro describing the new one.
+            RefreshAzurePermissionsScript();
             await AfterAzureCommitAsync(() => AuditLogger.LogAsync("provider.azure.saved", "provider", "azure",
                 new
                 {
@@ -2748,11 +2779,21 @@
     /// <summary>The access identity's service principal when it is a managed identity the guided
     /// setup recorded — what the permissions script grants Graph app roles to. Null for a certificate
     /// app, and for a user-assigned identity entered by hand (no principal id was recorded).</summary>
-    private string? AzureAccessManagedIdentityPrincipal =>
-        AzureCredentialChainFactory.IsManagedIdentity(azureProviderSettings)
-        && azureProviderSettings.ManagedIdentityPrincipalId is { Length: > 0 } principal
-            ? principal
-            : null;
+    private string? AzureAccessManagedIdentityPrincipal
+    {
+        get
+        {
+            if (!AzureCredentialChainFactory.IsManagedIdentity(azureProviderSettings)) return null;
+            if (azureProviderSettings.ManagedIdentityPrincipalId is { Length: > 0 } recorded) return recorded;
+
+            // The host's own identity entered by hand records no principal, but the page has already
+            // asked the host who it is; that answer is the principal.
+            return AzureCredentialChainFactory.IsHostManagedIdentity(azureProviderSettings)
+                && hostIdentity is { IsUserAssigned: false } host
+                    ? host.PrincipalId
+                    : null;
+        }
+    }
 
     /// <summary>Where Entra sends the administrator after consent — this page, registered as the access
     /// app's reply URL by the Permissions script.</summary>

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -2754,15 +2754,33 @@
         finally
         {
             detectingHostIdentity = false;
-            // A permissions script generated before the answer landed names whatever principal was
-            // recorded; the host's own answer outranks it, so the script is rebuilt to match.
-            RefreshAzurePermissionsScript();
+            try
+            {
+                // Scripts generated before the answer landed name whatever principal was known then;
+                // the host's own answer outranks it, so they are rebuilt to match. The Access script
+                // is dropped only when the principal it was built for is no longer the host's — a
+                // paste for that script would be refused, and the refusal says to run the one shown.
+                if (azureManagedIdentityScript is not null
+                    && !string.Equals(azureManagedIdentityScriptFor, hostIdentity?.PrincipalId, StringComparison.OrdinalIgnoreCase))
+                {
+                    azureManagedIdentityScript = null;
+                    azureManagedIdentityPasted = null;
+                }
+                RefreshAzurePermissionsScript();
+            }
+            catch (Exception)
+            {
+                // A rebuild that fails is regenerated on the next render; the page must still update.
+            }
             await InvokeAsync(StateHasChanged);
         }
     }
 
     private string? azureManagedIdentityScript;
     private string? azureManagedIdentityPasted;
+
+    /// <summary>The principal the managed-identity Access script on screen was built for.</summary>
+    private string? azureManagedIdentityScriptFor;
 
     /// <summary>
     /// Whether the Access guide offers the host's managed identity rather than a certificate app:
@@ -2776,8 +2794,10 @@
 
     private void EnsureAzureManagedIdentityScript(AzureHostIdentityInfo host)
     {
-        azureManagedIdentityScript ??= AzureCloudShellSetup.GenerateManagedIdentityAccessScript(
+        if (azureManagedIdentityScript is not null) return;
+        azureManagedIdentityScript = AzureCloudShellSetup.GenerateManagedIdentityAccessScript(
             new AzureManagedIdentityAccessSetupInput(host.PrincipalId, host.ClientId, host.IsUserAssigned));
+        azureManagedIdentityScriptFor = host.PrincipalId;
     }
 
     /// <summary>

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -2244,16 +2244,10 @@
         // per provider, and writing it with only this one would switch Azure filtering off. Written
         // before the sign-in settings for the same reason as the Azure save — a latch that cannot be
         // written must not leave sign-in configured with filtering off.
-        if (enforcing != EnforcementOptions.CurrentValue.IsEnforcing)
+        if (enforcing && !EnforcementOptions.CurrentValue.IsEnforcing)
         {
-            bool? latched = await SaveSettings(
-                PermissionEnforcementSettings.Category,
-                new PermissionEnforcementSettings
-                {
-                    IsEnforcing = enforcing,
-                    AzureEnforcing = EnforcementOptions.CurrentValue.AzureEnforcing,
-                });
-            if (latched != true || EnforcementOptions.CurrentValue.IsEnforcing != enforcing)
+            bool latched = await LatchEnforcementAsync(saml: true);
+            if (!latched || !EnforcementOptions.CurrentValue.IsEnforcing)
             {
                 saveMessage = "Per-user enforcement for AWS could not be switched on in this process, so "
                     + $"the sign-in application was not saved: {saveMessage} Restart Connapse and save again.";
@@ -2332,8 +2326,47 @@
         }
         catch (Exception ex)
         {
-            saveMessage = $"{saveMessage} A follow-up step failed afterwards ({ex.Message}); the settings themselves are stored.";
+            saveMessage = saveSuccess
+                ? $"{saveMessage} A follow-up step failed afterwards ({ex.Message}); the settings themselves are stored."
+                : $"{saveMessage} A follow-up step also failed ({ex.Message}).";
         }
+    }
+
+    /// <summary>
+    /// Switches a per-provider enforcement latch on. Written as a merge under the store's lock, never
+    /// as a replace: two administrators saving the two providers at once would otherwise each write
+    /// the whole record from their own stale copy, and one of them would switch the other's filtering
+    /// off. A latch only ever goes on, so the merge is an OR of what is stored, what this process
+    /// sees, and what is being asked for. Returns whether the record was written.
+    /// </summary>
+    private async Task<bool> LatchEnforcementAsync(bool saml = false, bool azure = false)
+    {
+        try
+        {
+            await SettingsStore.UpdateAsync<PermissionEnforcementSettings>(
+                PermissionEnforcementSettings.Category,
+                stored => new PermissionEnforcementSettings
+                {
+                    IsEnforcing = (stored?.IsEnforcing ?? false) || EnforcementOptions.CurrentValue.IsEnforcing || saml,
+                    AzureEnforcing = (stored?.AzureEnforcing ?? false) || EnforcementOptions.CurrentValue.AzureEnforcing || azure,
+                });
+        }
+        catch (Exception ex)
+        {
+            saveMessage = $"Failed to record per-user enforcement: {ex.Message}";
+            saveSuccess = false;
+            return false;
+        }
+
+        try
+        {
+            ReloadService.Reload();
+        }
+        catch (Exception)
+        {
+            // The live check that follows every latch is what decides; a failed reload shows there.
+        }
+        return true;
     }
 
     /// <summary>Stores the Entra sign-in application (Identity:AzureAd) and re-checks status. As with
@@ -2361,20 +2394,13 @@
         // stored, Azure searches deny — closed. The other order, sign-in stored and then the latch
         // failing, would leave sign-in configured with filtering off: every Azure result to everyone.
         // So a latch that cannot be written stops the save, and the sign-in settings stay as they were.
-        bool enforcing = settings.IsConfigured || EnforcementOptions.CurrentValue.AzureEnforcing;
-        if (enforcing != EnforcementOptions.CurrentValue.AzureEnforcing)
+        if (settings.IsConfigured && !EnforcementOptions.CurrentValue.AzureEnforcing)
         {
-            bool? latched = await SaveSettings(
-                PermissionEnforcementSettings.Category,
-                new PermissionEnforcementSettings
-                {
-                    IsEnforcing = EnforcementOptions.CurrentValue.IsEnforcing,
-                    AzureEnforcing = enforcing,
-                });
+            bool latched = await LatchEnforcementAsync(azure: true);
             // Stored is not enough: the resolver reads the live options, so a latch that was written
             // but not applied (the reload failed) would let sign-in be saved into an unfiltered
             // process. Only a latch this process can see counts.
-            if (latched != true || EnforcementOptions.CurrentValue.AzureEnforcing != enforcing)
+            if (!latched || !EnforcementOptions.CurrentValue.AzureEnforcing)
             {
                 saveMessage = "Per-user enforcement for Azure could not be switched on in this process, so "
                     + $"the sign-in application was not saved: {saveMessage} Restart Connapse and save again.";

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -1074,7 +1074,10 @@
                 Two steps: the Azure app identity Connapse reads Blob storage and permissions with, and
                 the Entra application people sign in through. No client secrets — Connapse authenticates
                 with certificates it generates on this host (the private keys never leave it) or a
-                managed identity.
+                managed identity. Every field, where to find its value, and what each error means are in
+                the
+                <a href="https://github.com/Destrayon/Connapse/blob/main/docs/azure-setup.md"
+                   target="_blank" rel="noopener">Azure setup guide</a>.
             </p>
 
             <ProviderStepCard Id="azure-access" Title="Access"
@@ -1101,7 +1104,30 @@
                                     <text>app @azureProviderSettings.ClientId (certificate)</text>
                                 }
                             </dd>
+                            @if (azureAccessCertExpires is { } expires)
+                            {
+                                <dt class="col-sm-3">Certificate expires</dt>
+                                <dd class="col-sm-9">@expires.ToString("u")</dd>
+                            }
                         </dl>
+                        @if (azureAccessCertExpires is { } expired && expired <= DateTime.UtcNow)
+                        {
+                            <div class="alert alert-danger py-2 mt-2 mb-0 small" role="alert">
+                                <span class="bi-x-circle me-1" aria-hidden="true"></span>
+                                The certificate has expired, so Entra refuses this identity and Azure
+                                sources no longer sync. Set access up again below: choose New certificate,
+                                run the script, and paste back what it prints.
+                            </div>
+                        }
+                        else if (azureAccessCertExpires is { } soon && soon <= DateTime.UtcNow.AddDays(30))
+                        {
+                            <div class="alert alert-warning py-2 mt-2 mb-0 small" role="status">
+                                <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                The certificate expires in @((soon - DateTime.UtcNow).Days) days. Choose
+                                New certificate below and run the script before then, or Azure sources
+                                stop syncing.
+                            </div>
+                        }
                     }
                 </Summary>
                 <ManualContent>
@@ -1128,8 +1154,9 @@
                         {
                             <div class="alert alert-secondary py-2 small mb-2">
                                 <span class="bi-info-circle me-1" aria-hidden="true"></span>
-                                Keep this page open until you have pasted the result back — the certificate is held
-                                here until you save. Regenerating makes a fresh one.
+                                The script carries the certificate Connapse holds on this host, so it can be
+                                re-run at any time. New certificate makes a replacement that only takes over
+                                once you save; until then the current one keeps working.
                             </div>
 
                             <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:18rem;overflow:auto"><code>@accessScript</code></pre>
@@ -1189,7 +1216,13 @@
                         }
                 </EasyContent>
                 <Actions>
-                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
+                    @if (AccessStatus == RequirementStatus.Satisfied)
+                    {
+                        <a class="btn btn-sm btn-primary" href="/connections">
+                            <span class="bi-plug me-1" aria-hidden="true"></span> Add a connection
+                        </a>
+                    }
+                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Recheck</button>
                     @if (azureProviderSettings.TenantId is { Length: > 0 })
                     {
                         <ProviderResetAction Label="Reset access"
@@ -1213,7 +1246,30 @@
                             <dd class="col-sm-9 font-monospace">@azureAdSettings.ClientId</dd>
                             <dt class="col-sm-3">Redirect URI</dt>
                             <dd class="col-sm-9 font-monospace">@azureAdSettings.RedirectUri</dd>
+                            @if (azureSignInCertExpires is { } expires)
+                            {
+                                <dt class="col-sm-3">Certificate expires</dt>
+                                <dd class="col-sm-9">@expires.ToString("u")</dd>
+                            }
                         </dl>
+                        @if (azureSignInCertExpires is { } expired && expired <= DateTime.UtcNow)
+                        {
+                            <div class="alert alert-danger py-2 mt-2 mb-0 small" role="alert">
+                                <span class="bi-x-circle me-1" aria-hidden="true"></span>
+                                The sign-in certificate has expired, so nobody can connect an Entra
+                                identity. Set the application up again below: choose New certificate,
+                                run the script, and paste back what it prints.
+                            </div>
+                        }
+                        else if (azureSignInCertExpires is { } soon && soon <= DateTime.UtcNow.AddDays(30))
+                        {
+                            <div class="alert alert-warning py-2 mt-2 mb-0 small" role="status">
+                                <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                The sign-in certificate expires in @((soon - DateTime.UtcNow).Days) days.
+                                Choose New certificate below and run the script before then, or Entra
+                                sign-in stops working.
+                            </div>
+                        }
                     }
                     @if (azureAdSettings.AdminConsentPending && AzureConsentUrl is { Length: > 0 } consentUrl)
                     {
@@ -1221,7 +1277,9 @@
                             <div class="mb-2">
                                 <span class="bi-shield-exclamation me-1" aria-hidden="true"></span>
                                 <strong>One step left — admin consent.</strong> The apps are created, but the two
-                                Microsoft Graph permissions Connapse looks people up with need a
+                                Microsoft Graph permissions Connapse looks people up with —
+                                <code>User.Read.All</code> and <code>GroupMember.Read.All</code>, read-only
+                                lookups of who a person is and which groups they belong to — need a
                                 <strong>Global Administrator</strong> or <strong>Privileged Role Administrator</strong>
                                 to approve. Send them this link; they sign in and click Accept.
                             </div>
@@ -1243,7 +1301,9 @@
                     <details class="border rounded p-3 mb-3">
                         <summary class="fw-semibold">Manual values — use an existing sign-in app registration</summary>
                         <div class="mt-3">
-                            <AzureAdSignInSettingsTab Settings="azureAdSettings" OnSave="SaveAzureAdFromForm" />
+                            <AzureAdSignInSettingsTab Settings="azureAdSettings" OnSave="SaveAzureAdFromForm"
+                                                      DefaultTenantId="@azureProviderSettings.TenantId"
+                                                      DefaultRedirectUri="@easyRedirectUri" />
                         </div>
                     </details>
                 </ManualContent>
@@ -1284,8 +1344,9 @@
                         {
                             <div class="alert alert-secondary py-2 small mb-2">
                                 <span class="bi-info-circle me-1" aria-hidden="true"></span>
-                                Keep this page open until you have pasted the result back — the sign-in certificate is
-                                held here until you save.
+                                The script carries the sign-in certificate Connapse holds on this host, so it
+                                can be re-run at any time. New certificate makes a replacement that only takes
+                                over once you save.
                             </div>
 
                             <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:18rem;overflow:auto"><code>@permissionsScript</code></pre>
@@ -1345,7 +1406,7 @@
                     }
                 </EasyContent>
                 <Actions>
-                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Recheck</button>
                     @if (azureAdSettings.ClientId is { Length: > 0 })
                     {
                         <ProviderResetAction Label="Reset sign-in application"
@@ -1558,10 +1619,11 @@
         identityCenterSettings = IdentityCenterOptions.CurrentValue;
         azureProviderSettings = AzureProviderOptions.CurrentValue;
         azureAdSettings = AzureAdOptions.CurrentValue;
+        LoadAzureCertificateExpiry();
 
         // The sign-in app's redirect URI is Connapse's Entra callback at the address this admin reached
-        // it on; pre-fill the subscription from whatever is already stored.
-        easyRedirectUri = Navigation.BaseUri.TrimEnd('/') + "/api/v1/auth/cloud/azure/callback";
+        // it on.
+        easyRedirectUri = Navigation.BaseUri.TrimEnd('/') + AzureCallbackPath;
 
         // Returning from Entra's admin-consent page: it bounces back here with ?admin_consent=True
         // (or ?error=...&error_description=...). Surface which, so "pending" doesn't linger.
@@ -2211,6 +2273,7 @@
             // What was posted, not a re-read: the options reload behind SaveSettings may not have
             // landed yet, so a stale read would hand the form back the previous values.
             azureProviderSettings = settings;
+            LoadAzureCertificateExpiry();
             await AuditLogger.LogAsync("provider.azure.saved", "provider", "azure",
                 new
                 {
@@ -2235,6 +2298,7 @@
         if (saveSuccess)
         {
             azureAdSettings = settings;
+            LoadAzureCertificateExpiry();
             await AuditLogger.LogAsync("provider.azuread.saved", "provider", "azure",
                 new { Configured = settings.IsConfigured });
         }
@@ -2296,6 +2360,9 @@
     /// app's reply URL by the Permissions script.</summary>
     private string AzureConsentLandingUri => Navigation.BaseUri.TrimEnd('/') + "/admin/providers/azure";
 
+    /// <summary>The path Entra redirects a person back to after sign-in; the sign-in app must register it.</summary>
+    private const string AzureCallbackPath = "/api/v1/auth/cloud/azure/callback";
+
     /// <summary>Clears the access identity and discards its stored certificate, so the next setup mints
     /// a fresh key instead of re-offering one an old app registration may still hold.</summary>
     private async Task ClearAzureAccess()
@@ -2325,8 +2392,10 @@
 
     private void DeleteAzureCertificate(string fileName)
     {
-        string path = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
-        if (File.Exists(path)) File.Delete(path);
+        foreach (string path in new[] { AzureCertificatePath(fileName), AzurePendingCertificatePath(fileName) })
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
     }
 
     /// <summary>The admin-consent link for the access app — derived from settings, so it survives a
@@ -2345,7 +2414,7 @@
     }
 
     // The scripts embed a certificate Connapse mints here, so each is produced the moment its guide
-    // renders rather than behind a button. Nothing touches disk until Save.
+    // renders rather than behind a button.
     private void EnsureAzureAccessScript()
     {
         if (azureAccessScript is null) GenerateAzureAccessScript(newCertificate: false);
@@ -2359,36 +2428,83 @@
     private const string AzureAccessCertFile = "connapse-azure-access.pem";
     private const string AzureSignInCertFile = "connapse-azure-signin.pem";
 
+    private string AzureCertificatePath(string fileName) =>
+        Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
+
+    /// <summary>The file a certificate waits in between being minted and being saved.</summary>
+    private string AzurePendingCertificatePath(string fileName) =>
+        AzureCertificatePath(Path.GetFileNameWithoutExtension(fileName) + ".pending.pem");
+
     /// <summary>
     /// The certificate a script embeds must be the one Connapse later signs with — across page reloads
-    /// and restarts, which happen between copying a script and pasting its result back. So it lives on
-    /// disk from the moment it is minted, and the guide re-reads that file on later renders instead of
-    /// minting again. Only "New certificate" replaces it. A daemon-app key nothing is registered
-    /// against yet is harmless to keep on disk.
+    /// and restarts, which happen between copying a script and pasting its result back. So a minted
+    /// certificate lives in a pending file from the moment it is made, and the guide re-reads that file
+    /// on later renders instead of minting again. The live file — the one the stored settings point at
+    /// and Connapse signs with today — is never written here; <see cref="WriteAzureCertificateAsync"/>
+    /// replaces it on Save. Until then "New certificate" only replaces the pending one, so an Access
+    /// step that already works keeps working while a replacement is being set up.
     /// </summary>
     private AzureCertificateMaterial LoadOrMintAzureCertificate(string fileName, string commonName, bool newCertificate)
     {
-        string path = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
-        if (!newCertificate && File.Exists(path))
+        string pendingPath = AzurePendingCertificatePath(fileName);
+        if (!newCertificate)
         {
-            try
+            // Pending first: a replacement in progress is what the script must embed. Otherwise the
+            // live certificate, so re-running a script re-registers the key Connapse already holds.
+            foreach (string path in new[] { pendingPath, AzureCertificatePath(fileName) })
             {
-                string combined = File.ReadAllText(path);
-                using var existing = System.Security.Cryptography.X509Certificates.X509Certificate2.CreateFromPem(combined);
-                // A file written before owner-only creation existed keeps its old mode; tighten it.
-                if (!OperatingSystem.IsWindows())
-                    File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
-                return new AzureCertificateMaterial(existing.ExportCertificatePem(), combined);
-            }
-            catch (Exception ex) when (ex is System.Security.Cryptography.CryptographicException or IOException)
-            {
-                // Unreadable file: fall through and mint a fresh one over it.
+                if (ReadAzureCertificate(path) is { } existing) return existing;
             }
         }
 
         AzureCertificateMaterial minted = AzureCertificateGenerator.Generate(commonName);
-        WriteOwnerOnly(path, minted.CombinedPem);
+        WriteOwnerOnly(pendingPath, minted.CombinedPem);
         return minted;
+    }
+
+    /// <summary>Reads a combined PEM back as material, or null when the file is missing or unreadable.</summary>
+    private static AzureCertificateMaterial? ReadAzureCertificate(string path)
+    {
+        if (!File.Exists(path)) return null;
+        try
+        {
+            string combined = File.ReadAllText(path);
+            using var existing = System.Security.Cryptography.X509Certificates.X509Certificate2.CreateFromPem(combined);
+            // A file written before owner-only creation existed keeps its old mode; tighten it.
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            return new AzureCertificateMaterial(existing.ExportCertificatePem(), combined);
+        }
+        catch (Exception ex) when (ex is System.Security.Cryptography.CryptographicException or IOException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>When the certificate at a stored path stops being accepted; null when there is none to read.</summary>
+    private static DateTime? AzureCertificateExpiry(string? certificatePath)
+    {
+        if (string.IsNullOrWhiteSpace(certificatePath) || !File.Exists(certificatePath)) return null;
+        string extension = Path.GetExtension(certificatePath).ToLowerInvariant();
+        if (extension is not (".pem" or ".crt")) return null;
+
+        try
+        {
+            return CertificateExpiry(File.ReadAllText(certificatePath));
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+
+    private DateTime? azureAccessCertExpires;
+    private DateTime? azureSignInCertExpires;
+
+    private void LoadAzureCertificateExpiry()
+    {
+        azureAccessCertExpires = AzureCertificateExpiry(azureProviderSettings.ClientCertificatePath);
+        azureSignInCertExpires = AzureCertificateExpiry(azureAdSettings.ClientCertificatePath);
     }
 
     /// <summary>
@@ -2464,11 +2580,16 @@
     }
 
     /// <summary>The private key stays on this host: the cert + key go to the appdata volume, and only
-    /// the public certificate was uploaded to Azure by the script.</summary>
+    /// the public certificate was uploaded to Azure by the script. This is the one place the live file
+    /// is written; the pending copy it came from is removed once it is.</summary>
     private Task<string> WriteAzureCertificateAsync(string fileName, string combinedPem)
     {
-        string certPath = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
+        string certPath = AzureCertificatePath(fileName);
         WriteOwnerOnly(certPath, combinedPem);
+
+        string pendingPath = AzurePendingCertificatePath(fileName);
+        if (File.Exists(pendingPath)) File.Delete(pendingPath);
+
         return Task.FromResult(certPath);
     }
 

--- a/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
@@ -11,46 +11,80 @@
     <div class="col-12">
         <label class="form-label" for="azad-tenant">Directory (tenant) ID</label>
         <input id="azad-tenant" class="form-control font-monospace" @bind="tenantId"
-               placeholder="00000000-0000-0000-0000-000000000000" />
+               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="azad-tenant-help"
+               aria-invalid="@(problemField == "azad-tenant" ? "true" : null)" />
+        <div id="azad-tenant-help" class="form-text">
+            @if (DefaultTenantId is { Length: > 0 })
+            {
+                <text>Filled in from the Access step; change it only if the sign-in app lives in another tenant.</text>
+            }
+            else
+            {
+                <text>
+                    The Entra tenant the sign-in app is registered in. Shown on the
+                    <a href="https://entra.microsoft.com/#view/Microsoft_AAD_IAM/TenantOverview.ReactView" target="_blank" rel="noopener">tenant overview</a>
+                    in the Microsoft Entra admin center.
+                </text>
+            }
+        </div>
     </div>
 
     <div class="col-12">
         <label class="form-label" for="azad-client">Application (client) ID</label>
         <input id="azad-client" class="form-control font-monospace" @bind="clientId"
-               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="azad-client-help" />
+               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="azad-client-help"
+               aria-invalid="@(problemField == "azad-client" ? "true" : null)" />
         <div id="azad-client-help" class="form-text">
-            The Entra app registration people sign in through — separate from the access app above.
+            The app registration people sign in through — separate from the access app above. On its
+            Overview page under
+            <a href="https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade" target="_blank" rel="noopener">App registrations</a>.
         </div>
     </div>
 
     <div class="col-12">
         <label class="form-label" for="azad-redirect">Redirect URI</label>
         <input id="azad-redirect" class="form-control font-monospace" @bind="redirectUri"
-               placeholder="https://connapse.example.com/api/v1/auth/cloud/azure/cb"
-               aria-describedby="azad-redirect-help" />
+               placeholder="@(DefaultRedirectUri ?? "https://connapse.example.com/api/v1/auth/cloud/azure/callback")"
+               aria-describedby="azad-redirect-help"
+               aria-invalid="@(problemField == "azad-redirect" ? "true" : null)" />
         <div id="azad-redirect-help" class="form-text">
-            Registered on the app registration as a redirect URI. Change Connapse's address and this
-            must be updated in Entra too, or sign-in stops with a redirect mismatch.
+            Where Entra sends people back after they sign in: Connapse's address plus
+            <code>/api/v1/auth/cloud/azure/callback</code>. Add the same value under the app's
+            <strong>Authentication</strong> page as a Web redirect URI; if Connapse's address changes,
+            update it in both places or sign-in stops with a redirect mismatch.
         </div>
     </div>
 
     <div class="col-12">
         <label class="form-label" for="azad-cert">Client certificate path</label>
         <input id="azad-cert" class="form-control font-monospace" @bind="certPath"
-               placeholder="/certs/azure-signin.pem" aria-describedby="azad-cert-help" />
+               placeholder="/certs/azure-signin.pem" aria-describedby="azad-cert-help"
+               aria-invalid="@(problemField == "azad-cert" ? "true" : null)" />
         <div id="azad-cert-help" class="form-text">
-            Path on the Connapse host to the PEM or PFX registered on the sign-in app registration.
+            Path on the Connapse host to the PEM (certificate plus private key) or PFX whose public
+            certificate is uploaded under the sign-in app's <strong>Certificates &amp; secrets</strong>.
         </div>
     </div>
 
     <div class="col-12">
         <label class="form-label" for="azad-cert-pw">
-            Certificate password <span class="text-muted">(PFX only)</span>
+            Certificate password <span class="text-muted">(optional — PFX only)</span>
         </label>
         <SecretTextArea Id="azad-cert-pw" Multiline="false" @bind-Value="certPassword"
-                        Placeholder="@(Settings.ClientCertificatePassword is { Length: > 0 } ? "Leave blank to keep the stored password" : "Leave blank for a PEM certificate")" />
+                        Placeholder="@(Settings.ClientCertificatePassword is { Length: > 0 } ? "Leave blank to keep the stored password" : "Leave blank for a PEM certificate")"
+                        DescribedBy="azad-cert-pw-help" />
+        <div id="azad-cert-pw-help" class="form-text">
+            Only for a password-protected PFX. The stored value is never shown here; leave it blank to keep it.
+        </div>
     </div>
 </div>
+
+@if (problem is not null)
+{
+    <div class="alert alert-danger py-2 mt-3 mb-0 small" role="alert">
+        <span class="bi-x-circle me-1" aria-hidden="true"></span>@problem
+    </div>
+}
 
 <div class="d-flex gap-2 mt-3">
     <button type="button" class="btn btn-primary" @onclick="HandleSubmit">Save</button>
@@ -61,21 +95,51 @@
     [Parameter] public AzureAdSignInSettings Settings { get; set; } = new();
     [Parameter] public EventCallback<AzureAdSignInSettings> OnSave { get; set; }
 
+    /// <summary>The tenant the Access step recorded, used when nothing is stored here yet.</summary>
+    [Parameter] public string? DefaultTenantId { get; set; }
+
+    /// <summary>Connapse's own callback at the address this page was reached on, used when nothing is stored here yet.</summary>
+    [Parameter] public string? DefaultRedirectUri { get; set; }
+
     // Local strings: AzureAdSignInSettings is an init-only record, rebuilt on save.
     private string? tenantId, clientId, redirectUri, certPath, certPassword;
 
+    /// <summary>The first thing stopping a save, and the id of the field it is about; null until Save is tried.</summary>
+    private string? problem, problemField;
+
     protected override void OnParametersSet()
     {
-        tenantId = Settings.TenantId;
+        tenantId = Settings.TenantId ?? DefaultTenantId;
         clientId = Settings.ClientId;
-        redirectUri = Settings.RedirectUri;
+        redirectUri = Settings.RedirectUri ?? DefaultRedirectUri;
         certPath = Settings.ClientCertificatePath;
         // The stored password is never rehydrated into the browser; blank on save keeps it.
         certPassword = null;
     }
 
-    private Task HandleSubmit() =>
-        OnSave.InvokeAsync(new AzureAdSignInSettings
+    private (string Message, string Field)? Validate()
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            return ("Enter the Directory (tenant) ID.", "azad-tenant");
+        if (string.IsNullOrWhiteSpace(clientId))
+            return ("Enter the Application (client) ID.", "azad-client");
+        if (!Uri.TryCreate(redirectUri?.Trim(), UriKind.Absolute, out Uri? uri) || uri.Scheme is not ("https" or "http"))
+            return ("Enter the redirect URI as a full address, starting with https://.", "azad-redirect");
+        if (string.IsNullOrWhiteSpace(certPath))
+            return ("Enter the path to the client certificate on the Connapse host.", "azad-cert");
+        return null;
+    }
+
+    private Task HandleSubmit()
+    {
+        if (Validate() is { } failed)
+        {
+            (problem, problemField) = failed;
+            return Task.CompletedTask;
+        }
+
+        problem = problemField = null;
+        return OnSave.InvokeAsync(new AzureAdSignInSettings
         {
             TenantId = Trim(tenantId),
             ClientId = Trim(clientId),
@@ -84,8 +148,13 @@
             ClientCertificatePassword = string.IsNullOrWhiteSpace(certPassword) ? Settings.ClientCertificatePassword : certPassword,
             AdminConsentPending = Settings.AdminConsentPending,
         });
+    }
 
     private static string? Trim(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
-    private void Reset() => OnParametersSet();
+    private void Reset()
+    {
+        OnParametersSet();
+        problem = problemField = null;
+    }
 }

--- a/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
@@ -111,18 +111,42 @@
     /// parent render; only a different record means the values on screen should be replaced.</summary>
     private AzureAdSignInSettings? loadedFrom;
 
+    /// <summary>The defaults last applied, so a changed default (the Access step saved after this form
+    /// first rendered) can replace a field that still holds the old one or nothing — never something typed.</summary>
+    private string? appliedDefaultTenant, appliedDefaultRedirect;
+
     protected override void OnParametersSet()
     {
-        if (ReferenceEquals(Settings, loadedFrom)) return;
-        Load();
+        if (!ReferenceEquals(Settings, loadedFrom))
+        {
+            Load();
+            return;
+        }
+
+        // Same stored record, but the defaults may have moved: this card is visible before Access is
+        // saved, so the tenant arrives after the form exists.
+        if (Settings.TenantId is null && DefaultTenantId != appliedDefaultTenant
+            && (string.IsNullOrWhiteSpace(tenantId) || tenantId == appliedDefaultTenant))
+        {
+            tenantId = DefaultTenantId;
+            appliedDefaultTenant = DefaultTenantId;
+        }
+        if (Settings.RedirectUri is null && DefaultRedirectUri != appliedDefaultRedirect
+            && (string.IsNullOrWhiteSpace(redirectUri) || redirectUri == appliedDefaultRedirect))
+        {
+            redirectUri = DefaultRedirectUri;
+            appliedDefaultRedirect = DefaultRedirectUri;
+        }
     }
 
     private void Load()
     {
         loadedFrom = Settings;
         tenantId = Settings.TenantId ?? DefaultTenantId;
+        appliedDefaultTenant = DefaultTenantId;
         clientId = Settings.ClientId;
         redirectUri = Settings.RedirectUri ?? DefaultRedirectUri;
+        appliedDefaultRedirect = DefaultRedirectUri;
         certPath = Settings.ClientCertificatePath;
         // The stored password is never rehydrated into the browser; blank on save keeps it.
         certPassword = null;

--- a/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
@@ -107,8 +107,19 @@
     /// <summary>The first thing stopping a save, and the id of the field it is about; null until Save is tried.</summary>
     private string? problem, problemField;
 
+    /// <summary>Which stored settings this form was last loaded from. Parameters arrive again on every
+    /// parent render; only a different record means the values on screen should be replaced.</summary>
+    private AzureAdSignInSettings? loadedFrom;
+
     protected override void OnParametersSet()
     {
+        if (ReferenceEquals(Settings, loadedFrom)) return;
+        Load();
+    }
+
+    private void Load()
+    {
+        loadedFrom = Settings;
         tenantId = Settings.TenantId ?? DefaultTenantId;
         clientId = Settings.ClientId;
         redirectUri = Settings.RedirectUri ?? DefaultRedirectUri;
@@ -154,7 +165,7 @@
 
     private void Reset()
     {
-        OnParametersSet();
+        Load();
         problem = problemField = null;
     }
 }

--- a/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
@@ -7,76 +7,125 @@
     managed identity; never a client secret. Stored under the Providers:Azure settings.
 *@
 
+<p class="small text-muted mb-3">
+    Before you start: the identity needs a role that can read blobs on each storage account
+    (<em>Storage Blob Data Reader</em>, or the <em>@Connapse.Core.Utilities.AzureCloudShellSetup.BlobDataRoleName</em>
+    role the script creates). Per-user permissions also need
+    <em>@Connapse.Core.Utilities.AzureCloudShellSetup.RbacReadRoleName</em> on the subscription and the
+    <code>User.Read.All</code> and <code>GroupMember.Read.All</code> Microsoft Graph permissions with admin consent.
+</p>
+
 <div class="row g-3" style="max-width:44rem">
     <div class="col-12">
         <label class="form-label" for="az-tenant">Directory (tenant) ID</label>
         <input id="az-tenant" class="form-control font-monospace" @bind="tenantId"
-               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="az-tenant-help" />
-        <div id="az-tenant-help" class="form-text">The Entra tenant the app registration lives in.</div>
+               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="az-tenant-help"
+               aria-invalid="@(problemField == "az-tenant" ? "true" : null)" />
+        <div id="az-tenant-help" class="form-text">
+            The Entra tenant the identity lives in. Shown on the
+            <a href="https://entra.microsoft.com/#view/Microsoft_AAD_IAM/TenantOverview.ReactView" target="_blank" rel="noopener">tenant overview</a>
+            in the Microsoft Entra admin center.
+        </div>
     </div>
 
     <div class="col-12">
-        <label class="form-label" for="az-sub">Subscription ID</label>
+        <fieldset>
+            <legend class="form-label fs-6 mb-2">How Connapse signs in to Azure</legend>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" name="az-auth" id="az-auth-cert"
+                       checked="@(!useManagedIdentity)" @onchange="() => ChooseAuth(managedIdentity: false)" />
+                <label class="form-check-label" for="az-auth-cert">
+                    App registration with a certificate
+                </label>
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" name="az-auth" id="az-auth-mi"
+                       checked="@useManagedIdentity" @onchange="() => ChooseAuth(managedIdentity: true)"
+                       aria-describedby="az-auth-mi-help" />
+                <label class="form-check-label" for="az-auth-mi">
+                    User-assigned managed identity — Connapse runs on Azure
+                </label>
+            </div>
+            <div id="az-auth-mi-help" class="form-text">
+                A managed identity attached to the Connapse host needs no certificate: Azure gives the
+                host its identity.
+            </div>
+        </fieldset>
+    </div>
+
+    @if (!useManagedIdentity)
+    {
+        <div class="col-12">
+            <label class="form-label" for="az-client">Application (client) ID</label>
+            <input id="az-client" class="form-control font-monospace" @bind="clientId"
+                   placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="az-client-help"
+                   aria-invalid="@(problemField == "az-client" ? "true" : null)" />
+            <div id="az-client-help" class="form-text">
+                On the app's Overview page under
+                <a href="https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade" target="_blank" rel="noopener">App registrations</a>.
+            </div>
+        </div>
+
+        <div class="col-12">
+            <label class="form-label" for="az-cert">Client certificate path</label>
+            <input id="az-cert" class="form-control font-monospace" @bind="certPath"
+                   placeholder="/certs/azure.pem" aria-describedby="az-cert-help"
+                   aria-invalid="@(problemField == "az-cert" ? "true" : null)" />
+            <div id="az-cert-help" class="form-text">
+                Path on the Connapse host to the PEM (certificate plus private key) or PFX whose public
+                certificate is uploaded under the app's <strong>Certificates &amp; secrets</strong>. Connapse
+                reads the file; it is never uploaded here.
+            </div>
+        </div>
+
+        <div class="col-12">
+            <label class="form-label" for="az-cert-pw">
+                Certificate password <span class="text-muted">(optional — PFX only)</span>
+            </label>
+            <SecretTextArea Id="az-cert-pw" Multiline="false" @bind-Value="certPassword"
+                            Placeholder="@(Settings.ClientCertificatePassword is { Length: > 0 } ? "Leave blank to keep the stored password" : "Leave blank for a PEM certificate")"
+                            DescribedBy="az-cert-pw-help" />
+            <div id="az-cert-pw-help" class="form-text">
+                Only for a password-protected PFX. The stored value is never shown here; leave it blank to keep it.
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="col-12">
+            <label class="form-label" for="az-mi">Managed identity client ID</label>
+            <input id="az-mi" class="form-control font-monospace" @bind="miClientId"
+                   placeholder="00000000-0000-0000-0000-000000000000"
+                   aria-describedby="az-mi-help" aria-invalid="@(problemField == "az-mi" ? "true" : null)" />
+            <div id="az-mi-help" class="form-text">
+                The Client ID shown on the identity's Overview page under
+                <a href="https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.ManagedIdentity%2FuserAssignedIdentities" target="_blank" rel="noopener">Managed Identities</a>
+                in the Azure portal.
+            </div>
+        </div>
+    }
+
+    <div class="col-12">
+        <label class="form-label" for="az-sub">
+            Subscription ID <span class="text-muted">(optional — needed for per-user permissions and the account list)</span>
+        </label>
         <input id="az-sub" class="form-control font-monospace" @bind="subscriptionId"
                placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="az-sub-help" />
         <div id="az-sub-help" class="form-text">
-            The subscription whose role and deny assignments per-user filtering reads. Required for
-            Azure permission filtering — without it, Azure searches fail closed.
-        </div>
-    </div>
-
-    <div class="col-12">
-        <hr class="my-1" />
-        <div class="small text-uppercase text-muted">App registration (certificate)</div>
-        <div class="form-text mt-0">Leave these blank to use the host's ambient managed identity instead.</div>
-    </div>
-
-    <div class="col-12">
-        <label class="form-label" for="az-client">Application (client) ID</label>
-        <input id="az-client" class="form-control font-monospace" @bind="clientId"
-               placeholder="00000000-0000-0000-0000-000000000000" />
-    </div>
-
-    <div class="col-12">
-        <label class="form-label" for="az-cert">Client certificate path</label>
-        <input id="az-cert" class="form-control font-monospace" @bind="certPath"
-               placeholder="/certs/azure.pem" aria-describedby="az-cert-help" />
-        <div id="az-cert-help" class="form-text">
-            Path on the Connapse host to the PEM or PFX the app registration trusts. Connapse reads
-            it; it is never uploaded here.
-        </div>
-    </div>
-
-    <div class="col-12">
-        <label class="form-label" for="az-cert-pw">
-            Certificate password <span class="text-muted">(PFX only)</span>
-        </label>
-        <SecretTextArea Id="az-cert-pw" Multiline="false" @bind-Value="certPassword"
-                        Placeholder="@(Settings.ClientCertificatePassword is { Length: > 0 } ? "Leave blank to keep the stored password" : "Leave blank for a PEM certificate")"
-                        DescribedBy="az-cert-pw-help" />
-        <div id="az-cert-pw-help" class="form-text">
-            Only for a password-protected PFX. The stored value is never shown here; leave it blank to keep it.
-        </div>
-    </div>
-
-    <div class="col-12">
-        <hr class="my-1" />
-        <div class="small text-uppercase text-muted">Or a managed identity</div>
-    </div>
-
-    <div class="col-12">
-        <label class="form-label" for="az-mi">
-            User-assigned managed identity client ID <span class="text-muted">(optional)</span>
-        </label>
-        <input id="az-mi" class="form-control font-monospace" @bind="miClientId"
-               placeholder="Leave blank to use the certificate above, or the ambient identity"
-               aria-describedby="az-mi-help" />
-        <div id="az-mi-help" class="form-text">
-            On Azure, leave the certificate blank and Connapse uses the host's managed identity; set
-            this to pick a specific user-assigned one.
+            The subscription holding the storage accounts. Per-user filtering reads role assignments from
+            it, and the connection form lists its accounts. Copy it from
+            <a href="https://portal.azure.com/#view/Microsoft_Azure_Billing/SubscriptionsBladeV2" target="_blank" rel="noopener">Subscriptions</a>
+            in the Azure portal.
         </div>
     </div>
 </div>
+
+@if (problem is not null)
+{
+    <div class="alert alert-danger py-2 mt-3 mb-0 small" role="alert">
+        <span class="bi-x-circle me-1" aria-hidden="true"></span>@problem
+    </div>
+}
 
 <div class="d-flex gap-2 mt-3">
     <button type="button" class="btn btn-primary" @onclick="HandleSubmit">Save</button>
@@ -91,6 +140,13 @@
     // it cannot be @bound; the record is rebuilt on save.
     private string? tenantId, clientId, subscriptionId, certPath, certPassword, miClientId;
 
+    /// <summary>Which branch of the form is shown. A stored managed-identity id selects that branch;
+    /// otherwise the certificate app, which is what the easy setup produces.</summary>
+    private bool useManagedIdentity;
+
+    /// <summary>The first thing stopping a save, and the id of the field it is about; null until Save is tried.</summary>
+    private string? problem, problemField;
+
     protected override void OnParametersSet()
     {
         tenantId = Settings.TenantId;
@@ -100,20 +156,63 @@
         // The stored password is never rehydrated into the browser; blank on save keeps it.
         certPassword = null;
         miClientId = Settings.UserAssignedManagedIdentityClientId;
+        useManagedIdentity = !string.IsNullOrWhiteSpace(Settings.UserAssignedManagedIdentityClientId)
+            && string.IsNullOrWhiteSpace(Settings.ClientId);
     }
 
-    private Task HandleSubmit() =>
-        OnSave.InvokeAsync(new AzureProviderSettings
+    private void ChooseAuth(bool managedIdentity)
+    {
+        useManagedIdentity = managedIdentity;
+        problem = problemField = null;
+    }
+
+    /// <summary>What is missing for the chosen branch, checked only when Save is pressed.</summary>
+    private (string Message, string Field)? Validate()
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            return ("Enter the Directory (tenant) ID.", "az-tenant");
+        if (useManagedIdentity)
+            return string.IsNullOrWhiteSpace(miClientId)
+                ? ("Enter the managed identity's client ID.", "az-mi")
+                : null;
+        if (string.IsNullOrWhiteSpace(clientId))
+            return ("Enter the Application (client) ID.", "az-client");
+        if (string.IsNullOrWhiteSpace(certPath))
+            return ("Enter the path to the client certificate on the Connapse host.", "az-cert");
+        return null;
+    }
+
+    /// <summary>
+    /// Saves only the chosen branch. The credential chain refuses a half-filled certificate setup
+    /// rather than falling back to a managed identity, so switching branches must clear the other
+    /// one's fields instead of leaving them to trip that check.
+    /// </summary>
+    private Task HandleSubmit()
+    {
+        if (Validate() is { } failed)
+        {
+            (problem, problemField) = failed;
+            return Task.CompletedTask;
+        }
+
+        problem = problemField = null;
+        return OnSave.InvokeAsync(new AzureProviderSettings
         {
             TenantId = Trim(tenantId),
-            ClientId = Trim(clientId),
             SubscriptionId = Trim(subscriptionId),
-            ClientCertificatePath = Trim(certPath),
-            ClientCertificatePassword = string.IsNullOrWhiteSpace(certPassword) ? Settings.ClientCertificatePassword : certPassword,
-            UserAssignedManagedIdentityClientId = Trim(miClientId),
+            ClientId = useManagedIdentity ? null : Trim(clientId),
+            ClientCertificatePath = useManagedIdentity ? null : Trim(certPath),
+            ClientCertificatePassword = useManagedIdentity ? null
+                : string.IsNullOrWhiteSpace(certPassword) ? Settings.ClientCertificatePassword : certPassword,
+            UserAssignedManagedIdentityClientId = useManagedIdentity ? Trim(miClientId) : null,
         });
+    }
 
     private static string? Trim(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
-    private void Reset() => OnParametersSet();
+    private void Reset()
+    {
+        OnParametersSet();
+        problem = problemField = null;
+    }
 }

--- a/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
@@ -236,12 +236,19 @@
                 : string.IsNullOrWhiteSpace(certPassword) ? Settings.ClientCertificatePassword : certPassword,
             UserAssignedManagedIdentityClientId = userAssigned ? Trim(miClientId) : null,
             UseHostManagedIdentity = mode == AuthMode.HostManagedIdentity,
-            // Only the guided setup learns the principal; a hand-entered identity keeps whatever was
-            // recorded for the same kind, and nothing for a different one.
-            ManagedIdentityPrincipalId = mode != AuthMode.Certificate
-                && (mode == AuthMode.HostManagedIdentity) == Settings.UseHostManagedIdentity
-                    ? Settings.ManagedIdentityPrincipalId
-                    : null,
+            // Only the guided setup learns the principal, and it belongs to one identity: it is kept
+            // only while the identity is the same one — the host's, or the same user-assigned client
+            // id. Carried onto a different identity it would send the permissions script's Graph
+            // grants to the wrong principal.
+            ManagedIdentityPrincipalId = mode switch
+            {
+                AuthMode.HostManagedIdentity when Settings.UseHostManagedIdentity => Settings.ManagedIdentityPrincipalId,
+                AuthMode.UserAssignedManagedIdentity
+                    when !Settings.UseHostManagedIdentity
+                    && string.Equals(Trim(miClientId), Settings.UserAssignedManagedIdentityClientId, StringComparison.OrdinalIgnoreCase)
+                    => Settings.ManagedIdentityPrincipalId,
+                _ => null,
+            },
         });
     }
 

--- a/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
@@ -1,10 +1,12 @@
 @using Connapse.Core
+@using Connapse.Storage.CloudScope
 @using Connapse.Web.Components.Shared
 
 @*
     Connapse's own Azure app identity — what it reads Blob storage with, and queries Entra and Azure
-    Resource Manager (role/deny assignments) through. A certificate-based app registration or a
-    managed identity; never a client secret. Stored under the Providers:Azure settings.
+    Resource Manager (role/deny assignments) through. A certificate-based app registration, a
+    user-assigned managed identity, or the managed identity of the host Connapse runs on; never a
+    client secret. Stored under the Providers:Azure settings.
 *@
 
 <p class="small text-muted mb-3">
@@ -33,27 +35,38 @@
             <legend class="form-label fs-6 mb-2">How Connapse signs in to Azure</legend>
             <div class="form-check">
                 <input class="form-check-input" type="radio" name="az-auth" id="az-auth-cert"
-                       checked="@(!useManagedIdentity)" @onchange="() => ChooseAuth(managedIdentity: false)" />
+                       checked="@(mode == AuthMode.Certificate)" @onchange="() => ChooseAuth(AuthMode.Certificate)" />
                 <label class="form-check-label" for="az-auth-cert">
                     App registration with a certificate
                 </label>
             </div>
             <div class="form-check">
+                <input class="form-check-input" type="radio" name="az-auth" id="az-auth-host"
+                       checked="@(mode == AuthMode.HostManagedIdentity)" @onchange="() => ChooseAuth(AuthMode.HostManagedIdentity)"
+                       aria-describedby="az-auth-host-help" />
+                <label class="form-check-label" for="az-auth-host">
+                    This host's managed identity — Connapse runs on Azure with a system-assigned identity
+                </label>
+            </div>
+            <div id="az-auth-host-help" class="form-text">
+                Nothing else to enter: Azure gives the host its identity. Assign the roles above to the
+                identity shown on the host's <strong>Identity</strong> page in the Azure portal.
+            </div>
+            <div class="form-check">
                 <input class="form-check-input" type="radio" name="az-auth" id="az-auth-mi"
-                       checked="@useManagedIdentity" @onchange="() => ChooseAuth(managedIdentity: true)"
+                       checked="@(mode == AuthMode.UserAssignedManagedIdentity)" @onchange="() => ChooseAuth(AuthMode.UserAssignedManagedIdentity)"
                        aria-describedby="az-auth-mi-help" />
                 <label class="form-check-label" for="az-auth-mi">
-                    User-assigned managed identity — Connapse runs on Azure
+                    A user-assigned managed identity attached to this host
                 </label>
             </div>
             <div id="az-auth-mi-help" class="form-text">
-                A managed identity attached to the Connapse host needs no certificate: Azure gives the
-                host its identity.
+                Also no certificate; the identity is named by its client ID.
             </div>
         </fieldset>
     </div>
 
-    @if (!useManagedIdentity)
+    @if (mode == AuthMode.Certificate)
     {
         <div class="col-12">
             <label class="form-label" for="az-client">Application (client) ID</label>
@@ -90,7 +103,7 @@
             </div>
         </div>
     }
-    else
+    else if (mode == AuthMode.UserAssignedManagedIdentity)
     {
         <div class="col-12">
             <label class="form-label" for="az-mi">Managed identity client ID</label>
@@ -136,19 +149,32 @@
     [Parameter] public AzureProviderSettings Settings { get; set; } = new();
     [Parameter] public EventCallback<AzureProviderSettings> OnSave { get; set; }
 
+    private enum AuthMode { Certificate, HostManagedIdentity, UserAssignedManagedIdentity }
+
     // Local strings rather than binding the record directly: AzureProviderSettings is init-only, so
     // it cannot be @bound; the record is rebuilt on save.
     private string? tenantId, clientId, subscriptionId, certPath, certPassword, miClientId;
 
-    /// <summary>Which branch of the form is shown. A stored managed-identity id selects that branch;
-    /// otherwise the certificate app, which is what the easy setup produces.</summary>
-    private bool useManagedIdentity;
+    /// <summary>Which branch of the form is shown, read from what is stored; the certificate app,
+    /// which is what the easy setup off Azure produces, when nothing says otherwise.</summary>
+    private AuthMode mode;
 
     /// <summary>The first thing stopping a save, and the id of the field it is about; null until Save is tried.</summary>
     private string? problem, problemField;
 
+    /// <summary>Which stored settings this form was last loaded from. Parameters arrive again on every
+    /// parent render; only a different record means the values on screen should be replaced.</summary>
+    private AzureProviderSettings? loadedFrom;
+
     protected override void OnParametersSet()
     {
+        if (ReferenceEquals(Settings, loadedFrom)) return;
+        Load();
+    }
+
+    private void Load()
+    {
+        loadedFrom = Settings;
         tenantId = Settings.TenantId;
         clientId = Settings.ClientId;
         subscriptionId = Settings.SubscriptionId;
@@ -156,13 +182,14 @@
         // The stored password is never rehydrated into the browser; blank on save keeps it.
         certPassword = null;
         miClientId = Settings.UserAssignedManagedIdentityClientId;
-        useManagedIdentity = !string.IsNullOrWhiteSpace(Settings.UserAssignedManagedIdentityClientId)
-            && string.IsNullOrWhiteSpace(Settings.ClientId);
+        mode = AzureCredentialChainFactory.IsHostManagedIdentity(Settings) ? AuthMode.HostManagedIdentity
+            : AzureCredentialChainFactory.IsUserAssignedManagedIdentity(Settings) ? AuthMode.UserAssignedManagedIdentity
+            : AuthMode.Certificate;
     }
 
-    private void ChooseAuth(bool managedIdentity)
+    private void ChooseAuth(AuthMode chosen)
     {
-        useManagedIdentity = managedIdentity;
+        mode = chosen;
         problem = problemField = null;
     }
 
@@ -171,21 +198,22 @@
     {
         if (string.IsNullOrWhiteSpace(tenantId))
             return ("Enter the Directory (tenant) ID.", "az-tenant");
-        if (useManagedIdentity)
-            return string.IsNullOrWhiteSpace(miClientId)
-                ? ("Enter the managed identity's client ID.", "az-mi")
-                : null;
-        if (string.IsNullOrWhiteSpace(clientId))
-            return ("Enter the Application (client) ID.", "az-client");
-        if (string.IsNullOrWhiteSpace(certPath))
-            return ("Enter the path to the client certificate on the Connapse host.", "az-cert");
-        return null;
+        return mode switch
+        {
+            AuthMode.HostManagedIdentity => null,
+            AuthMode.UserAssignedManagedIdentity when string.IsNullOrWhiteSpace(miClientId) =>
+                ("Enter the managed identity's client ID.", "az-mi"),
+            AuthMode.UserAssignedManagedIdentity => null,
+            _ when string.IsNullOrWhiteSpace(clientId) => ("Enter the Application (client) ID.", "az-client"),
+            _ when string.IsNullOrWhiteSpace(certPath) => ("Enter the path to the client certificate on the Connapse host.", "az-cert"),
+            _ => null,
+        };
     }
 
     /// <summary>
     /// Saves only the chosen branch. The credential chain refuses a half-filled certificate setup
     /// rather than falling back to a managed identity, so switching branches must clear the other
-    /// one's fields instead of leaving them to trip that check.
+    /// ones' fields instead of leaving them to trip that check.
     /// </summary>
     private Task HandleSubmit()
     {
@@ -196,15 +224,24 @@
         }
 
         problem = problemField = null;
+        bool certificate = mode == AuthMode.Certificate;
+        bool userAssigned = mode == AuthMode.UserAssignedManagedIdentity;
         return OnSave.InvokeAsync(new AzureProviderSettings
         {
             TenantId = Trim(tenantId),
             SubscriptionId = Trim(subscriptionId),
-            ClientId = useManagedIdentity ? null : Trim(clientId),
-            ClientCertificatePath = useManagedIdentity ? null : Trim(certPath),
-            ClientCertificatePassword = useManagedIdentity ? null
+            ClientId = certificate ? Trim(clientId) : null,
+            ClientCertificatePath = certificate ? Trim(certPath) : null,
+            ClientCertificatePassword = !certificate ? null
                 : string.IsNullOrWhiteSpace(certPassword) ? Settings.ClientCertificatePassword : certPassword,
-            UserAssignedManagedIdentityClientId = useManagedIdentity ? Trim(miClientId) : null,
+            UserAssignedManagedIdentityClientId = userAssigned ? Trim(miClientId) : null,
+            UseHostManagedIdentity = mode == AuthMode.HostManagedIdentity,
+            // Only the guided setup learns the principal; a hand-entered identity keeps whatever was
+            // recorded for the same kind, and nothing for a different one.
+            ManagedIdentityPrincipalId = mode != AuthMode.Certificate
+                && (mode == AuthMode.HostManagedIdentity) == Settings.UseHostManagedIdentity
+                    ? Settings.ManagedIdentityPrincipalId
+                    : null,
         });
     }
 
@@ -212,7 +249,7 @@
 
     private void Reset()
     {
-        OnParametersSet();
+        Load();
         problem = problemField = null;
     }
 }

--- a/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
@@ -198,6 +198,10 @@
     {
         if (string.IsNullOrWhiteSpace(tenantId))
             return ("Enter the Directory (tenant) ID.", "az-tenant");
+        // A managed identity's token names its tenant by id, and the check that compares the two
+        // needs an id on this side too; a certificate app may also use a verified domain name.
+        if (mode != AuthMode.Certificate && !Guid.TryParse(tenantId.Trim(), out _))
+            return ("Enter the Directory (tenant) ID as its ID — the GUID shown on the tenant overview.", "az-tenant");
         return mode switch
         {
             AuthMode.HostManagedIdentity => null,

--- a/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
@@ -414,9 +414,8 @@ public static class CloudIdentityEndpoints
 
             if (cloudProvider == CloudProvider.Azure)
             {
-                // Azure links hold no cloud-scoped search permissions yet — the scope cache only
-                // ever gets populated for S3 sources today, so there is nothing Azure-shaped to
-                // invalidate here. Wiring that up is Phase 4's job (#478 covers only the link).
+                // Azure permissions are resolved live per search hit rather than cached against
+                // the link, so removing the link is the whole revocation.
                 bool azureDeleted = await azureLinks.DisconnectAsync(userId.Value, ct);
                 return azureDeleted ? Results.NoContent() : Results.NotFound();
             }

--- a/src/Connapse.Web/Services/CloudEnforcementLatch.cs
+++ b/src/Connapse.Web/Services/CloudEnforcementLatch.cs
@@ -92,7 +92,7 @@ public sealed class CloudEnforcementLatch(
             // A merge under the store's lock, not a replace: a save on the Providers page can be
             // latching the other provider at this same moment, and a replace from this snapshot
             // would switch that one back off. A latch only ever goes on, so the merge is an OR.
-            await settings.UpdateAsync<PermissionEnforcementSettings>(
+            PermissionEnforcementSettings merged = await settings.UpdateAsync<PermissionEnforcementSettings>(
                 PermissionEnforcementSettings.Category,
                 stored => new PermissionEnforcementSettings
                 {
@@ -100,6 +100,19 @@ public sealed class CloudEnforcementLatch(
                     AzureEnforcing = (stored?.AzureEnforcing ?? false) || azureLatched,
                 },
                 cancellationToken);
+
+            // Stored is not applied. The resolvers read the live options, and the store's reload
+            // after its commit can fail; completing the migration then would declare a flag that
+            // this process cannot see, and the resolver would answer unfiltered. Undetermined
+            // denies, which is the right posture until the next successful reload.
+            PermissionEnforcementSettings live = enforcement.CurrentValue;
+            if (live.IsEnforcing != merged.IsEnforcing || live.AzureEnforcing != merged.AzureEnforcing)
+            {
+                logger.LogError(
+                    "Per-user enforcement was recorded (SAML={SamlEnforcing}, Azure={AzureEnforcing}) but the stored settings could not be reloaded into this process; searches will be refused until they are",
+                    merged.IsEnforcing, merged.AzureEnforcing);
+                return;
+            }
 
             migration.Complete();
 

--- a/src/Connapse.Web/Services/CloudEnforcementLatch.cs
+++ b/src/Connapse.Web/Services/CloudEnforcementLatch.cs
@@ -109,7 +109,7 @@ public sealed class CloudEnforcementLatch(
             if (live.IsEnforcing != merged.IsEnforcing || live.AzureEnforcing != merged.AzureEnforcing)
             {
                 logger.LogError(
-                    "Per-user enforcement was recorded (SAML={SamlEnforcing}, Azure={AzureEnforcing}) but the stored settings could not be reloaded into this process; searches will be refused until they are",
+                    "Per-user enforcement was recorded (SAML={SamlEnforcing}, Azure={AzureEnforcing}) but the stored settings could not be reloaded into this process; searches will be refused until Connapse is restarted with the database reachable",
                     merged.IsEnforcing, merged.AzureEnforcing);
                 return;
             }

--- a/src/Connapse.Web/Services/CloudEnforcementLatch.cs
+++ b/src/Connapse.Web/Services/CloudEnforcementLatch.cs
@@ -89,9 +89,16 @@ public sealed class CloudEnforcementLatch(
             await using var scope = scopes.CreateAsyncScope();
             var settings = scope.ServiceProvider.GetRequiredService<ISettingsStore>();
 
-            await settings.SaveAsync(
+            // A merge under the store's lock, not a replace: a save on the Providers page can be
+            // latching the other provider at this same moment, and a replace from this snapshot
+            // would switch that one back off. A latch only ever goes on, so the merge is an OR.
+            await settings.UpdateAsync<PermissionEnforcementSettings>(
                 PermissionEnforcementSettings.Category,
-                new PermissionEnforcementSettings { IsEnforcing = samlLatched, AzureEnforcing = azureLatched },
+                stored => new PermissionEnforcementSettings
+                {
+                    IsEnforcing = (stored?.IsEnforcing ?? false) || samlLatched,
+                    AzureEnforcing = (stored?.AzureEnforcing ?? false) || azureLatched,
+                },
                 cancellationToken);
 
             migration.Complete();

--- a/src/Connapse.Web/Services/ProviderSetupReader.cs
+++ b/src/Connapse.Web/Services/ProviderSetupReader.cs
@@ -20,6 +20,7 @@ public class ProviderSetupReader(
     IOptionsMonitor<AzureAdSignInSettings> azureAd,
     IS3Discovery s3Discovery,
     IAzureBlobDiscovery azureDiscovery,
+    IOptionsMonitor<PermissionEnforcementSettings> enforcement,
     IConnectionStore connections,
     IProviderCredentialStore credentials,
     TimeProvider clock,
@@ -152,6 +153,15 @@ public class ProviderSetupReader(
         if (!signIn.IsConfigured)
             return new ProviderRequirement(name, description, RequirementStatus.NotConfigured,
                 "Nobody can connect an Entra identity until the sign-in application is set up below.");
+
+        // Sign-in configured with the enforcement latch off is the one state that is open: the
+        // resolver returns every Azure result to everyone. Saving the sign-in application writes
+        // the latch first, and a restart latches it too, so this only shows when both failed.
+        if (!enforcement.CurrentValue.AzureEnforcing)
+            return new ProviderRequirement(name, description, RequirementStatus.Failed,
+                "Sign-in is set, but per-user enforcement for Azure is switched off, so Azure results "
+                + "are not filtered by who is asking. Save the sign-in application again, or restart "
+                + "Connapse, to switch it on.");
 
         var probe = await azureDiscovery.CheckAccessAsync(SignInIdentity(signIn), ct);
         switch (probe.Outcome)

--- a/src/Connapse.Web/Services/ProviderSetupReader.cs
+++ b/src/Connapse.Web/Services/ProviderSetupReader.cs
@@ -125,8 +125,14 @@ public class ProviderSetupReader(
                 + "is not registered on the app, has expired, or the app no longer exists — set "
                 + $"access up again below. Entra said: {probe.Detail}"),
 
+            AzureProbeOutcome.Unusable => new ProviderRequirement(name, description,
+                RequirementStatus.Failed,
+                "Connapse's Azure identity cannot be used from this host, so Azure sources cannot "
+                + "sync: the certificate file is missing or unreadable, or the settings are only "
+                + $"partly filled in. Fix the file, or set access up again below. Detail: {probe.Detail}"),
+
             _ => new ProviderRequirement(name, description, RequirementStatus.Warning,
-                "Connapse could not reach Azure to confirm its identity, so this may or may not "
+                "Connapse could not confirm its identity with Azure, so this may or may not "
                 + $"work. Test a connection to be sure. The check reported: {probe.Detail}")
         };
     }
@@ -171,9 +177,14 @@ public class ProviderSetupReader(
                     "Entra refused the sign-in application's credential, so nobody can connect an Entra "
                     + "identity. The certificate is not registered on the app, has expired, or the app no "
                     + $"longer exists — set the application up again below. Entra said: {probe.Detail}");
+            case AzureProbeOutcome.Unusable:
+                return new ProviderRequirement(name, description, RequirementStatus.Failed,
+                    "The sign-in application's certificate cannot be used from this host — the file is "
+                    + "missing or unreadable, or the settings are only partly filled in — so nobody can "
+                    + $"connect an Entra identity. Fix the file, or set the application up again below. Detail: {probe.Detail}");
             case AzureProbeOutcome.Failed:
                 return new ProviderRequirement(name, description, RequirementStatus.Warning,
-                    "Connapse could not reach Azure to confirm the sign-in application's credential, so "
+                    "Connapse could not confirm the sign-in application's credential with Azure, so "
                     + $"this may or may not work. The check reported: {probe.Detail}");
         }
 

--- a/src/Connapse.Web/Services/ProviderSetupReader.cs
+++ b/src/Connapse.Web/Services/ProviderSetupReader.cs
@@ -129,8 +129,9 @@ public class ProviderSetupReader(
             AzureProbeOutcome.Unusable => new ProviderRequirement(name, description,
                 RequirementStatus.Failed,
                 "Connapse's Azure identity cannot be used from this host, so Azure sources cannot "
-                + "sync: the certificate file is missing or unreadable, or the settings are only "
-                + $"partly filled in. Fix the file, or set access up again below. Detail: {probe.Detail}"),
+                + "sync: the certificate file is missing or unreadable, the settings are only partly "
+                + "filled in, or the managed identity they name is not available on this host. Fix the "
+                + $"file or the identity, or set access up again below. Detail: {probe.Detail}"),
 
             _ => new ProviderRequirement(name, description, RequirementStatus.Warning,
                 "Connapse could not confirm its identity with Azure, so this may or may not "
@@ -197,9 +198,9 @@ public class ProviderSetupReader(
 
         if (signIn.AdminConsentPending)
             return new ProviderRequirement(name, description, RequirementStatus.Warning,
-                "Sign-in is set, but the access app's Microsoft Graph permissions still need an "
-                + "administrator's consent. Until then Connapse cannot look people up, so Azure "
-                + "searches return nothing for anyone.");
+                "Sign-in is set, but the access identity's Microsoft Graph permissions still need an "
+                + "administrator's consent (for a managed identity, the two app-role grants). Until then "
+                + "Connapse cannot look people up, so Azure searches return nothing for anyone.");
 
         return new ProviderRequirement(name, description, RequirementStatus.Satisfied,
             $"Tenant {signIn.TenantId}, subscription {provider.SubscriptionId}");

--- a/src/Connapse.Web/Services/ProviderSetupReader.cs
+++ b/src/Connapse.Web/Services/ProviderSetupReader.cs
@@ -1,5 +1,6 @@
 ﻿using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
 using Microsoft.Extensions.Options;
 
 namespace Connapse.Web.Services;
@@ -105,7 +106,7 @@ public class ProviderSetupReader(
         bool hasCredential =
             (!string.IsNullOrWhiteSpace(settings.ClientId)
                 && !string.IsNullOrWhiteSpace(settings.ClientCertificatePath))
-            || !string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId);
+            || AzureCredentialChainFactory.IsManagedIdentity(settings);
 
         if (string.IsNullOrWhiteSpace(settings.TenantId) || !hasCredential)
             return new ProviderRequirement(name, description, RequirementStatus.NotConfigured,

--- a/src/Connapse.Web/Services/ProviderSetupReader.cs
+++ b/src/Connapse.Web/Services/ProviderSetupReader.cs
@@ -57,8 +57,11 @@ public class ProviderSetupReader(
     {
         var providers = await InUseProvidersAsync(ct);
 
-        var azureAccess = await AzureAccessAsync(azureProvider.CurrentValue, ct);
-        var azurePermissions = AzurePerUserPermissions(azureAd.CurrentValue, azureProvider.CurrentValue);
+        // Two round trips to Entra, made together: a page load should not pay for them in series.
+        Task<ProviderRequirement> azureAccessTask = AzureAccessAsync(azureProvider.CurrentValue, ct);
+        Task<ProviderRequirement> azurePermissionsTask = AzurePerUserPermissionsAsync(azureAd.CurrentValue, azureProvider.CurrentValue, ct);
+        var azureAccess = await azureAccessTask;
+        var azurePermissions = await azurePermissionsTask;
 
         return
         [
@@ -132,13 +135,14 @@ public class ProviderSetupReader(
     /// what they may read.
     /// </summary>
     /// <remarks>
-    /// Two parts: the Entra sign-in application (<c>Identity:AzureAd</c>) and the subscription the
-    /// RBAC resolver queries (<c>Providers:Azure</c> <c>SubscriptionId</c>). Both are needed for
-    /// per-user Azure filtering; sign-in without the subscription fails closed, so that is a warning
-    /// rather than a clean state.
+    /// Three parts: Entra still accepting the sign-in application's certificate (checked live, the
+    /// same way as Access — an expired or removed certificate must not read as Ready), the
+    /// subscription the RBAC resolver queries (<c>Providers:Azure</c> <c>SubscriptionId</c>), and
+    /// admin consent. Sign-in without the subscription or consent fails closed, so those are
+    /// warnings rather than a clean state.
     /// </remarks>
-    private static ProviderRequirement AzurePerUserPermissions(
-        AzureAdSignInSettings signIn, AzureProviderSettings provider)
+    private async Task<ProviderRequirement> AzurePerUserPermissionsAsync(
+        AzureAdSignInSettings signIn, AzureProviderSettings provider, CancellationToken ct)
     {
         const string name = "Per-user permissions";
         const string description =
@@ -148,6 +152,20 @@ public class ProviderSetupReader(
         if (!signIn.IsConfigured)
             return new ProviderRequirement(name, description, RequirementStatus.NotConfigured,
                 "Nobody can connect an Entra identity until the sign-in application is set up below.");
+
+        var probe = await azureDiscovery.CheckAccessAsync(SignInIdentity(signIn), ct);
+        switch (probe.Outcome)
+        {
+            case AzureProbeOutcome.Denied:
+                return new ProviderRequirement(name, description, RequirementStatus.Failed,
+                    "Entra refused the sign-in application's credential, so nobody can connect an Entra "
+                    + "identity. The certificate is not registered on the app, has expired, or the app no "
+                    + $"longer exists — set the application up again below. Entra said: {probe.Detail}");
+            case AzureProbeOutcome.Failed:
+                return new ProviderRequirement(name, description, RequirementStatus.Warning,
+                    "Connapse could not reach Azure to confirm the sign-in application's credential, so "
+                    + $"this may or may not work. The check reported: {probe.Detail}");
+        }
 
         if (string.IsNullOrWhiteSpace(provider.SubscriptionId))
             return new ProviderRequirement(name, description, RequirementStatus.Warning,
@@ -164,6 +182,16 @@ public class ProviderSetupReader(
         return new ProviderRequirement(name, description, RequirementStatus.Satisfied,
             $"Tenant {signIn.TenantId}, subscription {provider.SubscriptionId}");
     }
+
+    /// <summary>The sign-in application in the shape the credential check takes: it authenticates
+    /// with a certificate exactly as the access app does, so the same check applies.</summary>
+    public static AzureProviderSettings SignInIdentity(AzureAdSignInSettings signIn) => new()
+    {
+        TenantId = signIn.TenantId,
+        ClientId = signIn.ClientId,
+        ClientCertificatePath = signIn.ClientCertificatePath,
+        ClientCertificatePassword = signIn.ClientCertificatePassword,
+    };
 
     /// <summary>
     /// Which cloud providers this installation has actually taken up.

--- a/src/Connapse.Web/Services/ProviderSetupReader.cs
+++ b/src/Connapse.Web/Services/ProviderSetupReader.cs
@@ -19,6 +19,7 @@ public class ProviderSetupReader(
     IOptionsMonitor<AzureProviderSettings> azureProvider,
     IOptionsMonitor<AzureAdSignInSettings> azureAd,
     IS3Discovery s3Discovery,
+    IAzureBlobDiscovery azureDiscovery,
     IConnectionStore connections,
     IProviderCredentialStore credentials,
     TimeProvider clock,
@@ -56,7 +57,7 @@ public class ProviderSetupReader(
     {
         var providers = await InUseProvidersAsync(ct);
 
-        var azureAccess = AzureAccess(azureProvider.CurrentValue);
+        var azureAccess = await AzureAccessAsync(azureProvider.CurrentValue, ct);
         var azurePermissions = AzurePerUserPermissions(azureAd.CurrentValue, azureProvider.CurrentValue);
 
         return
@@ -80,16 +81,19 @@ public class ProviderSetupReader(
     }
 
     /// <summary>
-    /// Whether Connapse has an Azure app identity to read Blob storage (and Entra/ARM) with.
+    /// Whether Connapse has an Azure app identity to read Blob storage (and Entra/ARM) with, and
+    /// whether Entra still accepts it.
     /// </summary>
     /// <remarks>
-    /// Config-only for now — it reports whether a tenant and a credential are set, not a live probe.
     /// A credential is a certificate-based app registration (<c>ClientId</c> + a certificate) or a
-    /// user-assigned managed identity. An ambient <i>system</i>-assigned managed identity cannot be
-    /// seen from settings, so a deployment relying on one reads as not-configured here even when it
-    /// works; a later iteration adds a live check (parity with AWS's access probe).
+    /// user-assigned managed identity; a deployment relying on an ambient system-assigned identity
+    /// has nothing in settings to check and reads as not set up. Once something is configured the
+    /// answer comes from Entra: a token issued means the certificate is registered and unexpired,
+    /// a refusal carrying an <c>AADSTS</c> code means it is not, and anything else is the check
+    /// failing to complete — reported as a warning, as the AWS probe does, because "cannot confirm"
+    /// is a different claim from "does not work".
     /// </remarks>
-    private static ProviderRequirement AzureAccess(AzureProviderSettings settings)
+    private async Task<ProviderRequirement> AzureAccessAsync(AzureProviderSettings settings, CancellationToken ct)
     {
         const string name = "Access";
         const string description = "The Azure app identity Connapse reads Blob storage with.";
@@ -101,11 +105,26 @@ public class ProviderSetupReader(
 
         if (string.IsNullOrWhiteSpace(settings.TenantId) || !hasCredential)
             return new ProviderRequirement(name, description, RequirementStatus.NotConfigured,
-                "Set under the Providers:Azure settings — a tenant and either a certificate app "
-                + "registration or a managed identity — so Connapse can read Azure.");
+                "Nothing can read Azure until this is set up: run the script below, or enter an "
+                + "existing app registration or managed identity under Manual values.");
 
-        return new ProviderRequirement(name, description, RequirementStatus.Satisfied,
-            $"Tenant {settings.TenantId}");
+        var probe = await azureDiscovery.CheckAccessAsync(ct);
+
+        return probe.Outcome switch
+        {
+            AzureProbeOutcome.Succeeded => new ProviderRequirement(name, description,
+                RequirementStatus.Satisfied, probe.Value),
+
+            AzureProbeOutcome.Denied => new ProviderRequirement(name, description,
+                RequirementStatus.Failed,
+                "Entra refused Connapse's credential, so Azure sources cannot sync. The certificate "
+                + "is not registered on the app, has expired, or the app no longer exists — set "
+                + $"access up again below. Entra said: {probe.Detail}"),
+
+            _ => new ProviderRequirement(name, description, RequirementStatus.Warning,
+                "Connapse could not reach Azure to confirm its identity, so this may or may not "
+                + $"work. Test a connection to be sure. The check reported: {probe.Detail}")
+        };
     }
 
     /// <summary>
@@ -128,18 +147,19 @@ public class ProviderSetupReader(
 
         if (!signIn.IsConfigured)
             return new ProviderRequirement(name, description, RequirementStatus.NotConfigured,
-                "Set the Identity:AzureAd sign-in application so people can connect their Entra identity.");
+                "Nobody can connect an Entra identity until the sign-in application is set up below.");
 
         if (string.IsNullOrWhiteSpace(provider.SubscriptionId))
             return new ProviderRequirement(name, description, RequirementStatus.Warning,
-                "Sign-in is set, but Providers:Azure SubscriptionId is missing — the RBAC resolver "
-                + "needs it, so Azure filtering fails closed until it is set.");
+                "Sign-in is set, but the Access step has no subscription ID. Per-user filtering reads "
+                + "role assignments from that subscription, so Azure searches return nothing for "
+                + "anyone until it is set.");
 
         if (signIn.AdminConsentPending)
             return new ProviderRequirement(name, description, RequirementStatus.Warning,
                 "Sign-in is set, but the access app's Microsoft Graph permissions still need an "
-                + "administrator's consent — directory lookups fail until then, so Azure filtering "
-                + "fails closed.");
+                + "administrator's consent. Until then Connapse cannot look people up, so Azure "
+                + "searches return nothing for anyone.");
 
         return new ProviderRequirement(name, description, RequirementStatus.Satisfied,
             $"Tenant {signIn.TenantId}, subscription {provider.SubscriptionId}");

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -102,8 +102,55 @@ public class AzureCloudShellSetupTests
     public void AccessScript_PrintsTheKeys_ParseAccessResultReads()
     {
         string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
-        foreach (string key in new[] { "tenantId=", "subscriptionId=", "accessAppClientId=" })
+        foreach (string key in new[] { "tenantId=", "subscriptionId=", "accessAppClientId=", "certificateThumbprint=" })
             s.Should().Contain(key);
+    }
+
+    [Fact]
+    public void Scripts_ReadTheThumbprintBeforeDeletingTheCertificateFile()
+    {
+        // The thumbprint is what lets the page refuse to keep a certificate other than the one the
+        // script registered; it has to be taken while the file still exists.
+        foreach (string s in new[]
+                 {
+                     AzureCloudShellSetup.GenerateAccessScript(AccessInput()),
+                     AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput()),
+                 })
+        {
+            int thumb = s.IndexOf("CERT_THUMBPRINT=$(openssl x509 -in \"$CERT_FILE\"", StringComparison.Ordinal);
+            int remove = s.IndexOf("rm -f \"$CERT_FILE\"", StringComparison.Ordinal);
+            thumb.Should().BeGreaterThan(0);
+            remove.Should().BeGreaterThan(thumb);
+        }
+    }
+
+    [Theory]
+    [InlineData("ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01", "ABCDEF0123456789ABCDEF0123456789ABCDEF01")]
+    [InlineData("ABCDEF0123456789ABCDEF0123456789ABCDEF01", "ABCDEF0123456789ABCDEF0123456789ABCDEF01")]
+    [InlineData("", null)]
+    [InlineData("not-a-thumbprint", null)]
+    public void ParseAccessResult_ReadsTheThumbprint_NormalisedOrNone(string printed, string? expected)
+    {
+        string block = AzureCloudShellSetup.AccessBeginMarker
+            + $"\ntenantId={Tenant}\nsubscriptionId={Sub}\naccessAppClientId={AccessId}\ncertificateThumbprint={printed}\n"
+            + AzureCloudShellSetup.AccessEndMarker;
+
+        AzureCloudShellSetup.ParseAccessResult(block)!.CertificateThumbprint.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseAccessResult_OlderPasteWithoutThumbprint_StillParses() =>
+        AzureCloudShellSetup.ParseAccessResult(AccessBlock())!.CertificateThumbprint.Should().BeNull();
+
+    [Fact]
+    public void ParsePermissionsResult_ReadsTheThumbprint()
+    {
+        string block = AzureCloudShellSetup.PermissionsBeginMarker
+            + $"\nsignInAppClientId={SignInId}\nconsentGranted=true\nconsentUrl=\ncertificateThumbprint=abcdef0123456789abcdef0123456789abcdef01\n"
+            + AzureCloudShellSetup.PermissionsEndMarker;
+
+        AzureCloudShellSetup.ParsePermissionsResult(block)!.CertificateThumbprint
+            .Should().Be("ABCDEF0123456789ABCDEF0123456789ABCDEF01");
     }
 
     // ---- Per-user permissions step ----

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -142,6 +142,111 @@ public class AzureCloudShellSetupTests
     public void ParseAccessResult_OlderPasteWithoutThumbprint_StillParses() =>
         AzureCloudShellSetup.ParseAccessResult(AccessBlock())!.CertificateThumbprint.Should().BeNull();
 
+    // ---- Access step on an Azure host: the managed identity ----
+
+    private const string MiPrincipal = "55555555-5555-5555-5555-555555555555";
+    private const string MiClient = "66666666-6666-6666-6666-666666666666";
+
+    private static AzureManagedIdentityAccessSetupInput ManagedIdentityInput(bool userAssigned = false) =>
+        new(MiPrincipal, MiClient, userAssigned);
+
+    [Fact]
+    public void ManagedIdentityAccessScript_AssignsByObjectId_AndNeverRegistersAnApp()
+    {
+        string s = AzureCloudShellSetup.GenerateManagedIdentityAccessScript(ManagedIdentityInput());
+
+        s.Should().Contain($"MI_PRINCIPAL_ID='{MiPrincipal}'");
+        s.Should().Contain("--assignee-object-id \"$MI_PRINCIPAL_ID\" --assignee-principal-type ServicePrincipal");
+        s.Should().Contain(AzureCloudShellSetup.BlobDataRoleName).And.Contain(AzureCloudShellSetup.RbacReadRoleName);
+        // No app registration, no certificate: that is the whole point of this path.
+        s.Should().NotContain("az ad app").And.NotContain("CERT_FILE").And.NotContain("BEGIN CERTIFICATE");
+        s.Should().Contain("MI_KIND='system-assigned'");
+        AzureCloudShellSetup.GenerateManagedIdentityAccessScript(ManagedIdentityInput(userAssigned: true))
+            .Should().Contain("MI_KIND='user-assigned'");
+    }
+
+    [Fact]
+    public void ManagedIdentityAccessScript_PrintsTheKeys_ParseReads()
+    {
+        string s = AzureCloudShellSetup.GenerateManagedIdentityAccessScript(ManagedIdentityInput());
+        foreach (string key in new[] { "tenantId=", "subscriptionId=", "managedIdentityPrincipalId=", "managedIdentityClientId=", "managedIdentityKind=" })
+            s.Should().Contain(key);
+        s.Should().Contain(AzureCloudShellSetup.ManagedIdentityBeginMarker).And.Contain(AzureCloudShellSetup.ManagedIdentityEndMarker);
+    }
+
+    [Fact]
+    public void ManagedIdentityAccessScript_RunsInASubshell_LikeTheOthers()
+    {
+        string s = AzureCloudShellSetup.GenerateManagedIdentityAccessScript(ManagedIdentityInput()).Replace("\r\n", "\n");
+        s.Should().Contain("\n(\nset -euo pipefail\ntrap 'echo; echo \"Connapse setup failed at: $BASH_COMMAND\" >&2' ERR");
+        s.Should().Contain(") || echo \"----- CONNAPSE SETUP FAILED");
+    }
+
+    private static string ManagedIdentityBlock(string principal = MiPrincipal, string kind = "system-assigned") =>
+        AzureCloudShellSetup.ManagedIdentityBeginMarker
+        + $"\ntenantId={Tenant}\nsubscriptionId={Sub}\nmanagedIdentityPrincipalId={principal}\nmanagedIdentityClientId={MiClient}\nmanagedIdentityKind={kind}\n"
+        + AzureCloudShellSetup.ManagedIdentityEndMarker;
+
+    [Fact]
+    public void ParseManagedIdentityAccessResult_WellFormed_ReturnsEverything()
+    {
+        AzureManagedIdentityAccessResult? r = AzureCloudShellSetup.ParseManagedIdentityAccessResult(ManagedIdentityBlock());
+
+        r.Should().NotBeNull();
+        r!.TenantId.Should().Be(Tenant);
+        r.SubscriptionId.Should().Be(Sub);
+        r.PrincipalId.Should().Be(MiPrincipal);
+        r.ClientId.Should().Be(MiClient);
+        r.IsUserAssigned.Should().BeFalse();
+        AzureCloudShellSetup.ParseManagedIdentityAccessResult(ManagedIdentityBlock(kind: "user-assigned"))!.IsUserAssigned.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseManagedIdentityAccessResult_NonGuid_ReturnsNull() =>
+        AzureCloudShellSetup.ParseManagedIdentityAccessResult(ManagedIdentityBlock(principal: "bad")).Should().BeNull();
+
+    [Fact]
+    public void ParseManagedIdentityAccessResult_DoesNotReadTheCertificateAppBlock() =>
+        AzureCloudShellSetup.ParseManagedIdentityAccessResult(AccessBlock()).Should().BeNull();
+
+    [Fact]
+    public void PermissionsScript_ForAManagedIdentity_GrantsAppRolesByRest_AndNeverConsentsAnApp()
+    {
+        string s = AzureCloudShellSetup.GeneratePermissionsScript(
+            PermissionsInput() with { AccessManagedIdentityPrincipalId = MiPrincipal });
+
+        s.Should().Contain($"ACCESS_MI_PRINCIPAL_ID='{MiPrincipal}'");
+        s.Should().Contain("/servicePrincipals/$ACCESS_MI_PRINCIPAL_ID/appRoleAssignments");
+        s.Should().Contain("\\\"principalId\\\":\\\"$ACCESS_MI_PRINCIPAL_ID\\\"")
+            .And.Contain("\\\"resourceId\\\":\\\"$GRAPH_SP_ID\\\"")
+            .And.Contain("\\\"appRoleId\\\":\\\"$1\\\"");
+        s.Should().NotContain("az ad app permission add").And.NotContain("admin-consent");
+        s.Should().Contain("CONSENT_URL=\"\"");
+        // The sign-in app is still a certificate app: people cannot sign in through a managed identity.
+        s.Should().Contain("register_cert \"$SIGNIN_APP_ID\"");
+    }
+
+    [Fact]
+    public void PermissionsScript_ForAnApp_StillAddsPermissionsAndConsents()
+    {
+        string s = AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput());
+
+        s.Should().Contain("az ad app permission add").And.Contain("admin-consent");
+        s.Should().NotContain("appRoleAssignments");
+        s.Should().NotContain("{{graphGrant}}");
+    }
+
+    [Fact]
+    public void GraphAppRoleGrantCommands_NameTheIdentity_AndBothRoles()
+    {
+        string s = AzureCloudShellSetup.GraphAppRoleGrantCommands(MiPrincipal);
+
+        s.Should().Contain($"MI='{MiPrincipal}'");
+        s.Should().Contain("User.Read.All GroupMember.Read.All");
+        s.Should().Contain("appRoleAssignments");
+        s.Should().NotContain("{{");
+    }
+
     [Fact]
     public void ParsePermissionsResult_ReadsTheThumbprint()
     {

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -207,12 +207,15 @@ public class AzureCloudShellSetupTests
     {
         // `set -e` pasted into an interactive shell closes the session on the first failure, taking
         // the error message with it. Both scripts wrap the body and print what failed.
-        foreach (string s in new[]
+        foreach (string script in new[]
                  {
                      AzureCloudShellSetup.GenerateAccessScript(AccessInput()),
                      AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput()),
                  })
         {
+            // The template is a raw string literal, so it carries the source file's line endings;
+            // a CRLF checkout must not fail an assertion about the script's structure.
+            string s = script.Replace("\r\n", "\n");
             s.Should().Contain("\n(\nset -euo pipefail\ntrap 'echo; echo \"Connapse setup failed at: $BASH_COMMAND\" >&2' ERR");
             s.Should().Contain(") || echo \"----- CONNAPSE SETUP FAILED");
         }

--- a/tests/Connapse.Integration.Tests/SettingsStoreUpdateIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SettingsStoreUpdateIntegrationTests.cs
@@ -1,0 +1,78 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// <see cref="ISettingsStore.UpdateAsync{T}"/> against PostgreSQL: a read-modify-write under a row
+/// lock, so concurrent updaters merge rather than overwrite. The enforcement latches depend on it —
+/// two administrators saving the AWS and Azure sign-in applications at once must end with both
+/// flags on, never one switched back off by the other's stale copy.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class SettingsStoreUpdateIntegrationTests(SharedWebAppFixture fixture)
+{
+    private const string Category = "integrationtest-update";
+
+    private ISettingsStore Store(AsyncServiceScope scope) => scope.ServiceProvider.GetRequiredService<ISettingsStore>();
+
+    [Fact]
+    public async Task UpdateAsync_ConcurrentMergesFromSeparateScopes_LoseNothing()
+    {
+        await using var setup = fixture.Factory.Services.CreateAsyncScope();
+        await Store(setup).ResetAsync(Category);
+
+        try
+        {
+            // Each task owns a scope (its own DbContext) and switches one flag on, ORing the rest.
+            var tasks = Enumerable.Range(0, 12).Select(async i =>
+            {
+                await using var scope = fixture.Factory.Services.CreateAsyncScope();
+                await Store(scope).UpdateAsync<PermissionEnforcementSettings>(Category, stored => new PermissionEnforcementSettings
+                {
+                    IsEnforcing = (stored?.IsEnforcing ?? false) || i % 2 == 0,
+                    AzureEnforcing = (stored?.AzureEnforcing ?? false) || i % 2 == 1,
+                });
+            });
+            await Task.WhenAll(tasks);
+
+            var final = await Store(setup).GetAsync<PermissionEnforcementSettings>(Category);
+            final.Should().NotBeNull();
+            final!.IsEnforcing.Should().BeTrue();
+            final.AzureEnforcing.Should().BeTrue();
+        }
+        finally
+        {
+            await Store(setup).ResetAsync(Category);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenNothingIsStored_HandsTheUpdaterNull_AndStoresItsResult()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        await Store(scope).ResetAsync(Category);
+
+        try
+        {
+            PermissionEnforcementSettings? seen = new();
+            var stored = await Store(scope).UpdateAsync<PermissionEnforcementSettings>(Category, current =>
+            {
+                seen = current;
+                return new PermissionEnforcementSettings { AzureEnforcing = true };
+            });
+
+            seen.Should().BeNull();
+            stored.AzureEnforcing.Should().BeTrue();
+            (await Store(scope).GetAsync<PermissionEnforcementSettings>(Category))!.AzureEnforcing.Should().BeTrue();
+        }
+        finally
+        {
+            await Store(scope).ResetAsync(Category);
+        }
+    }
+
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
@@ -71,14 +71,14 @@ public class AzureBlobDiscoveryTests
     }
 
     [Fact]
-    public async Task CheckAccess_CertificateFileMissing_Fails_WithTheReason()
+    public async Task CheckAccess_CertificateFileMissing_IsUnusable_WithTheReason()
     {
         // The credential chain refuses to build without a readable certificate, and refuses to
-        // fall through to a managed identity. That is a check that could not run, not Entra
-        // saying no — so Failed, carrying the message the operator needs.
+        // fall through to a managed identity. Azure was never asked: this host is what needs
+        // fixing, which is neither Entra saying no nor "could not confirm".
         var probe = await Build(Configured()).CheckAccessAsync();
 
-        probe.Outcome.Should().Be(AzureProbeOutcome.Failed);
+        probe.Outcome.Should().Be(AzureProbeOutcome.Unusable);
         probe.Detail.Should().Contain("certificate");
     }
 
@@ -89,7 +89,7 @@ public class AzureBlobDiscoveryTests
         // file is missing, so it is the candidate that produced the answer.
         var probe = await Build(new AzureProviderSettings()).CheckAccessAsync(Configured());
 
-        probe.Outcome.Should().Be(AzureProbeOutcome.Failed);
+        probe.Outcome.Should().Be(AzureProbeOutcome.Unusable);
         probe.Detail.Should().Contain("certificate");
     }
 

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
@@ -104,8 +104,16 @@ public class AzureBlobDiscoveryTests
     [Theory]
     [InlineData("AADSTS700027: Client assertion contains an invalid signature", true)]
     [InlineData("AADSTS7000215: Invalid client secret provided", true)]
+    [InlineData("AADSTS7000222: The provided client secret keys are expired", true)]
+    [InlineData("AADSTS7000229: The client application is missing service principal in the tenant", true)]
+    [InlineData("AADSTS700016: Application with identifier 'x' was not found in the directory", true)]
+    [InlineData("AADSTS90002: Tenant 'x' not found", true)]
+    // Entra answered, but about itself, not the credential: transient, throttled, or unavailable.
+    [InlineData("AADSTS90024: The request body must contain the following parameter", false)]
+    [InlineData("AADSTS90033: A transient error has occurred. Please try again.", false)]
+    [InlineData("AADSTS50196: The server terminated an operation because it encountered a client request loop", false)]
     [InlineData("No such host is known (login.microsoftonline.com:443)", false)]
-    public void IsCredentialRefusal_OnlyWhenEntraAnswered(string message, bool expected) =>
+    public void IsCredentialRefusal_OnlyForCodesThatMeanTheCredentialIsWrong(string message, bool expected) =>
         AzureBlobDiscovery.IsCredentialRefusal(new AuthenticationFailedException(message)).Should().Be(expected);
 
     [Fact]

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
@@ -140,5 +140,11 @@ public class AzureBlobDiscoveryTests
             TenantId = "t", UserAssignedManagedIdentityClientId = "mi",
         }).Should().BeTrue();
         AzureBlobDiscovery.IsConfigured(Configured() with { TenantId = null }).Should().BeFalse();
+        // The host's own managed identity, as the guided setup on an Azure host records it.
+        AzureBlobDiscovery.IsConfigured(new AzureProviderSettings
+        {
+            TenantId = "t", UseHostManagedIdentity = true,
+        }).Should().BeTrue();
+        AzureBlobDiscovery.IsConfigured(new AzureProviderSettings { UseHostManagedIdentity = true }).Should().BeFalse();
     }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
@@ -82,6 +82,25 @@ public class AzureBlobDiscoveryTests
         probe.Detail.Should().Contain("certificate");
     }
 
+    [Fact]
+    public async Task CheckAccess_Candidate_IsCheckedInsteadOfTheStoredSettings()
+    {
+        // Stored settings are blank (NotConfigured); the candidate is complete but its certificate
+        // file is missing, so it is the candidate that produced the answer.
+        var probe = await Build(new AzureProviderSettings()).CheckAccessAsync(Configured());
+
+        probe.Outcome.Should().Be(AzureProbeOutcome.Failed);
+        probe.Detail.Should().Contain("certificate");
+    }
+
+    [Fact]
+    public async Task CheckAccess_Candidate_NotConfigured_NeverCallsAzure()
+    {
+        var probe = await Build(Configured()).CheckAccessAsync(new AzureProviderSettings { TenantId = "t" });
+
+        probe.Outcome.Should().Be(AzureProbeOutcome.NotConfigured);
+    }
+
     [Theory]
     [InlineData("AADSTS700027: Client assertion contains an invalid signature", true)]
     [InlineData("AADSTS7000215: Invalid client secret provided", true)]

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
@@ -1,4 +1,5 @@
 using Azure;
+using Azure.Identity;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.CloudScope;
@@ -59,6 +60,39 @@ public class AzureBlobDiscoveryTests
         probe.Outcome.Should().Be(AzureProbeOutcome.Failed);
         probe.Detail.Should().Contain("No storage account");
     }
+
+    [Fact]
+    public async Task CheckAccess_NoIdentity_IsNotConfigured_WithoutCallingAzure()
+    {
+        var probe = await Build(new AzureProviderSettings()).CheckAccessAsync();
+
+        probe.Outcome.Should().Be(AzureProbeOutcome.NotConfigured);
+        probe.Detail.Should().Contain("provider page");
+    }
+
+    [Fact]
+    public async Task CheckAccess_CertificateFileMissing_Fails_WithTheReason()
+    {
+        // The credential chain refuses to build without a readable certificate, and refuses to
+        // fall through to a managed identity. That is a check that could not run, not Entra
+        // saying no — so Failed, carrying the message the operator needs.
+        var probe = await Build(Configured()).CheckAccessAsync();
+
+        probe.Outcome.Should().Be(AzureProbeOutcome.Failed);
+        probe.Detail.Should().Contain("certificate");
+    }
+
+    [Theory]
+    [InlineData("AADSTS700027: Client assertion contains an invalid signature", true)]
+    [InlineData("AADSTS7000215: Invalid client secret provided", true)]
+    [InlineData("No such host is known (login.microsoftonline.com:443)", false)]
+    public void IsCredentialRefusal_OnlyWhenEntraAnswered(string message, bool expected) =>
+        AzureBlobDiscovery.IsCredentialRefusal(new AuthenticationFailedException(message)).Should().Be(expected);
+
+    [Fact]
+    public void IsCredentialRefusal_ManagedIdentityUnavailable_IsNotARefusal() =>
+        AzureBlobDiscovery.IsCredentialRefusal(new CredentialUnavailableException("AADSTS-looking text from the IMDS probe"))
+            .Should().BeFalse();
 
     [Theory]
     [InlineData(401, true)]

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
@@ -106,6 +106,7 @@ public class AzureBlobDiscoveryTests
     [InlineData("AADSTS7000215: Invalid client secret provided", true)]
     [InlineData("AADSTS7000222: The provided client secret keys are expired", true)]
     [InlineData("AADSTS7000229: The client application is missing service principal in the tenant", true)]
+    [InlineData("AADSTS7000112: Application 'x' is disabled", true)]
     [InlineData("AADSTS700016: Application with identifier 'x' was not found in the directory", true)]
     [InlineData("AADSTS90002: Tenant 'x' not found", true)]
     // Entra answered, but about itself, not the credential: transient, throttled, or unavailable.

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCertificateFileTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCertificateFileTests.cs
@@ -1,0 +1,96 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+/// <summary>
+/// The one loader every reader of Connapse's Azure certificate files goes through. A file it cannot
+/// read is a fact for the provider page to show, never an exception that stops the page rendering.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AzureCertificateFileTests : IDisposable
+{
+    private readonly string directory = Path.Combine(Path.GetTempPath(), "connapse-cert-tests-" + Guid.NewGuid().ToString("N"));
+
+    public AzureCertificateFileTests() => Directory.CreateDirectory(directory);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(directory, recursive: true); } catch (IOException) { }
+    }
+
+    private string Write(string name, string content)
+    {
+        string path = Path.Combine(directory, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Fact]
+    public void Expiry_MissingFile_IsNull()
+    {
+        AzureCertificateFile.Expiry(Path.Combine(directory, "nope.pem"), null).Should().BeNull();
+        AzureCertificateFile.Expiry(null, null).Should().BeNull();
+        AzureCertificateFile.Expiry("   ", null).Should().BeNull();
+    }
+
+    [Fact]
+    public void Expiry_GeneratedPem_IsTheCertificatesNotAfter()
+    {
+        AzureCertificateMaterial material = AzureCertificateGenerator.Generate("connapse-test");
+        string path = Write("good.pem", material.CombinedPem);
+
+        DateTime? expiry = AzureCertificateFile.Expiry(path, null);
+
+        using var expected = X509Certificate2.CreateFromPem(material.PublicCertificatePem);
+        expiry.Should().Be(expected.NotAfter.ToUniversalTime());
+    }
+
+    [Fact]
+    public void Expiry_FileThatIsNotACertificate_IsNull_NotAnException()
+    {
+        string path = Write("junk.pem", "this is not a certificate");
+
+        AzureCertificateFile.Expiry(path, null).Should().BeNull();
+    }
+
+    [Fact]
+    public void Expiry_FileHeldOpenExclusively_IsNull_NotAnException()
+    {
+        AzureCertificateMaterial material = AzureCertificateGenerator.Generate("connapse-test");
+        string path = Write("locked.pem", material.CombinedPem);
+
+        using var _ = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+        AzureCertificateFile.Expiry(path, null).Should().BeNull();
+    }
+
+    [Fact]
+    public void Thumbprint_MatchesTheCertificatesOwn_UpperCaseNoSeparators()
+    {
+        AzureCertificateMaterial material = AzureCertificateGenerator.Generate("connapse-test");
+
+        string thumbprint = AzureCertificateFile.Thumbprint(material.PublicCertificatePem);
+
+        using var certificate = X509Certificate2.CreateFromPem(material.PublicCertificatePem);
+        thumbprint.Should().Be(certificate.Thumbprint.ToUpperInvariant());
+        thumbprint.Should().HaveLength(40).And.MatchRegex("^[0-9A-F]+$");
+    }
+
+    [Theory]
+    [InlineData(typeof(CryptographicException))]
+    [InlineData(typeof(IOException))]
+    [InlineData(typeof(UnauthorizedAccessException))]
+    [InlineData(typeof(ArgumentException))]
+    public void IsUnreadable_CoversTheWaysAFileFailsToRead(Type exceptionType)
+    {
+        var exception = (Exception)Activator.CreateInstance(exceptionType)!;
+        AzureCertificateFile.IsUnreadable(exception).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsUnreadable_DoesNotSwallowEverything() =>
+        AzureCertificateFile.IsUnreadable(new InvalidOperationException()).Should().BeFalse();
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
@@ -66,6 +66,16 @@ public class AzureCredentialChainFactoryTests
     }
 
     [Fact]
+    public void Create_HostFlagAndUserAssignedIdTogether_Throws_RatherThanChoosing()
+    {
+        // Neither side is picked: the flag and the id name different identities.
+        var settings = new AzureProviderSettings { UseHostManagedIdentity = true, UserAssignedManagedIdentityClientId = "mi" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => null);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*both*");
+        AzureCredentialChainFactory.IsManagedIdentity(settings).Should().BeFalse();
+    }
+
+    [Fact]
     public void IsHostManagedIdentity_FalseWhenACertificateOrUserAssignedFieldIsSet()
     {
         // The flag beside a certificate field is a mix the form can never produce; if it arrives

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
@@ -73,6 +73,11 @@ public class AzureCredentialChainFactoryTests
         var act = () => AzureCredentialChainFactory.Create(settings, _ => null);
         act.Should().Throw<InvalidOperationException>().WithMessage("*both*");
         AzureCredentialChainFactory.IsManagedIdentity(settings).Should().BeFalse();
+
+        // The same for the flag beside a certificate app: the certificate must not win silently.
+        var withApp = new AzureProviderSettings { TenantId = "t", UseHostManagedIdentity = true, ClientId = "c", ClientCertificatePath = "x.pem" };
+        var actApp = () => AzureCredentialChainFactory.Create(withApp, _ => SelfSigned());
+        actApp.Should().Throw<InvalidOperationException>().WithMessage("*both*");
     }
 
     [Fact]

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
@@ -44,6 +44,28 @@ public class AzureCredentialChainFactoryTests
     }
 
     [Fact]
+    public void Create_TenantAndUserAssignedManagedIdentity_UsesManagedIdentity()
+    {
+        // The provider page records the tenant for every identity. A tenant beside a managed
+        // identity id is not certificate intent, and must not be refused as a half-filled one.
+        var settings = new AzureProviderSettings { TenantId = "t", UserAssignedManagedIdentityClientId = "mi-client" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => null);
+        Sources(cred).Should().ContainSingle().Which.Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    [Fact]
+    public void IsUserAssignedManagedIdentity_FalseWhenAnyCertificateFieldIsSet()
+    {
+        AzureCredentialChainFactory.IsUserAssignedManagedIdentity(
+            new AzureProviderSettings { TenantId = "t", UserAssignedManagedIdentityClientId = "mi" }).Should().BeTrue();
+        AzureCredentialChainFactory.IsUserAssignedManagedIdentity(
+            new AzureProviderSettings { UserAssignedManagedIdentityClientId = "mi", ClientId = "c" }).Should().BeFalse();
+        AzureCredentialChainFactory.IsUserAssignedManagedIdentity(
+            new AzureProviderSettings { UserAssignedManagedIdentityClientId = "mi", ClientCertificatePath = "x.pem" }).Should().BeFalse();
+        AzureCredentialChainFactory.IsUserAssignedManagedIdentity(new AzureProviderSettings { TenantId = "t" }).Should().BeFalse();
+    }
+
+    [Fact]
     public void Create_ClientIdSetButCertMissing_Throws()
     {
         var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c" };

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
@@ -54,6 +54,30 @@ public class AzureCredentialChainFactoryTests
     }
 
     [Fact]
+    public void Create_HostManagedIdentityFlag_UsesTheSystemAssignedIdentity_TenantOrNot()
+    {
+        // The guided setup on an Azure host records only the flag (and the tenant, for display);
+        // that must be the host's own identity, never a refusal for a "half-filled" certificate.
+        var settings = new AzureProviderSettings { TenantId = "t", UseHostManagedIdentity = true, ManagedIdentityPrincipalId = "oid" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => null);
+        Sources(cred).Should().ContainSingle().Which.Should().BeOfType<ManagedIdentityCredential>();
+        AzureCredentialChainFactory.IsHostManagedIdentity(settings).Should().BeTrue();
+        AzureCredentialChainFactory.IsManagedIdentity(settings).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsHostManagedIdentity_FalseWhenACertificateOrUserAssignedFieldIsSet()
+    {
+        // The flag beside a certificate field is a mix the form can never produce; if it arrives
+        // from configuration it is certificate intent and must fail closed like any other mix.
+        AzureCredentialChainFactory.IsHostManagedIdentity(
+            new AzureProviderSettings { UseHostManagedIdentity = true, ClientId = "c" }).Should().BeFalse();
+        AzureCredentialChainFactory.IsHostManagedIdentity(
+            new AzureProviderSettings { UseHostManagedIdentity = true, UserAssignedManagedIdentityClientId = "mi" }).Should().BeFalse();
+        AzureCredentialChainFactory.IsHostManagedIdentity(new AzureProviderSettings { TenantId = "t" }).Should().BeFalse();
+    }
+
+    [Fact]
     public void IsUserAssignedManagedIdentity_FalseWhenAnyCertificateFieldIsSet()
     {
         AzureCredentialChainFactory.IsUserAssignedManagedIdentity(

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureHostIdentityTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureHostIdentityTests.cs
@@ -1,0 +1,123 @@
+using Azure.Identity;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+/// <summary>
+/// Detecting the host's managed identity from the token Azure issues it. The claims are what the
+/// guided setup names the identity by, so each one has to be read from where Azure puts it.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AzureHostIdentityTests
+{
+    private const string Tenant = "11111111-1111-1111-1111-111111111111";
+    private const string Principal = "22222222-2222-2222-2222-222222222222";
+    private const string Client = "33333333-3333-3333-3333-333333333333";
+    private const string Subscription = "44444444-4444-4444-4444-444444444444";
+
+    private static string SystemAssignedToken() => AzureHostIdentity.EncodePayload(new
+    {
+        tid = Tenant, oid = Principal, appid = Client,
+        xms_mirid = $"/subscriptions/{Subscription}/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
+    });
+
+    [Fact]
+    public void Describe_SystemAssignedToken_ReadsTenantPrincipalClientAndSubscription()
+    {
+        AzureHostIdentityInfo? info = AzureHostIdentity.Describe(SystemAssignedToken());
+
+        info.Should().NotBeNull();
+        info!.TenantId.Should().Be(Tenant);
+        info.PrincipalId.Should().Be(Principal);
+        info.ClientId.Should().Be(Client);
+        info.SubscriptionId.Should().Be(Subscription);
+        info.IsUserAssigned.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Describe_UserAssignedToken_IsMarkedUserAssigned()
+    {
+        string token = AzureHostIdentity.EncodePayload(new
+        {
+            tid = Tenant, oid = Principal, appid = Client,
+            xms_mirid = $"/subscriptions/{Subscription}/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/connapse",
+        });
+
+        AzureHostIdentity.Describe(token)!.IsUserAssigned.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Describe_WithoutTheNamingClaims_IsNull()
+    {
+        AzureHostIdentity.Describe(AzureHostIdentity.EncodePayload(new { tid = Tenant })).Should().BeNull();
+        AzureHostIdentity.Describe("not.a.token").Should().BeNull();
+        AzureHostIdentity.Describe("garbage").Should().BeNull();
+    }
+
+    [Fact]
+    public void Describe_WithoutAResourceId_StillNamesTheIdentity_WithoutASubscription()
+    {
+        AzureHostIdentityInfo? info = AzureHostIdentity.Describe(
+            AzureHostIdentity.EncodePayload(new { tid = Tenant, oid = Principal, appid = Client }));
+
+        info!.SubscriptionId.Should().BeNull();
+        info.ResourceId.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("/subscriptions/44444444-4444-4444-4444-444444444444/resourceGroups/rg/providers/x", "44444444-4444-4444-4444-444444444444")]
+    [InlineData("/SUBSCRIPTIONS/44444444-4444-4444-4444-444444444444/x", "44444444-4444-4444-4444-444444444444")]
+    [InlineData("/subscriptions/not-a-guid/x", null)]
+    [InlineData("", null)]
+    public void SubscriptionFrom_ReadsTheSegmentAfterSubscriptions(string resourceId, string? expected) =>
+        AzureHostIdentity.SubscriptionFrom(resourceId).Should().Be(expected);
+
+    [Fact]
+    public async Task DetectAsync_NoMetadataService_IsNull_NotAnException()
+    {
+        var probe = new AzureHostIdentity(NullLogger<AzureHostIdentity>.Instance)
+        {
+            AcquireToken = _ => throw new CredentialUnavailableException("ManagedIdentityCredential authentication unavailable"),
+        };
+
+        (await probe.DetectAsync()).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DetectAsync_FoundOnce_IsRememberedWithoutAskingAgain()
+    {
+        int calls = 0;
+        var probe = new AzureHostIdentity(NullLogger<AzureHostIdentity>.Instance)
+        {
+            AcquireToken = _ => { calls++; return Task.FromResult(SystemAssignedToken()); },
+        };
+
+        var first = await probe.DetectAsync();
+        var second = await probe.DetectAsync();
+
+        first.Should().NotBeNull();
+        second.Should().BeSameAs(first);
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DetectAsync_NotFound_AsksAgainNextTime()
+    {
+        // A host that had no identity may gain one (or the metadata service may have been slow);
+        // only a found identity is worth remembering.
+        int calls = 0;
+        var probe = new AzureHostIdentity(NullLogger<AzureHostIdentity>.Instance)
+        {
+            AcquireToken = _ => { calls++; throw new CredentialUnavailableException("none"); },
+        };
+
+        await probe.DetectAsync();
+        await probe.DetectAsync();
+
+        calls.Should().Be(2);
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureHostIdentityTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureHostIdentityTests.cs
@@ -105,6 +105,28 @@ public class AzureHostIdentityTests
     }
 
     [Fact]
+    public async Task DetectAsync_Refresh_AsksAgain_AndForgetsAnIdentityThatIsGone()
+    {
+        // Recheck asks with refresh: an identity re-created since the process cached it comes back
+        // new, and one that was removed is not handed out from the cache any more.
+        int calls = 0;
+        var probe = new AzureHostIdentity(NullLogger<AzureHostIdentity>.Instance)
+        {
+            AcquireToken = _ =>
+            {
+                calls++;
+                if (calls == 1) return Task.FromResult(SystemAssignedToken());
+                throw new CredentialUnavailableException("gone");
+            },
+        };
+
+        (await probe.DetectAsync()).Should().NotBeNull();
+        (await probe.DetectAsync(refresh: true)).Should().BeNull();
+        (await probe.DetectAsync()).Should().BeNull("the cache must not resurrect a removed identity");
+        calls.Should().Be(3);
+    }
+
+    [Fact]
     public async Task DetectAsync_NotFound_AsksAgainNextTime()
     {
         // A host that had no identity may gain one (or the metadata service may have been slow);

--- a/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
+++ b/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
@@ -183,7 +183,7 @@ public class ProvidersPageTests
 
         // Saving Azure sign-in must latch Azure enforcement at save time, like the SAML save does —
         // relying on the startup latch alone left azblob results unfiltered until the next restart.
-        int azureSave = markup.IndexOf("private async Task SaveAzureAdFromForm(", StringComparison.Ordinal);
+        int azureSave = markup.IndexOf("private async Task<bool> SaveAzureAdFromForm(", StringComparison.Ordinal);
         azureSave.Should().BeGreaterThan(0);
         markup[azureSave..].Should().Contain("AzureEnforcing = enforcing");
         markup.Should().NotContain("confirmResetAccess")

--- a/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
+++ b/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
@@ -185,7 +185,7 @@ public class ProvidersPageTests
         // relying on the startup latch alone left azblob results unfiltered until the next restart.
         int azureSave = markup.IndexOf("private async Task<bool?> SaveAzureAdFromForm(", StringComparison.Ordinal);
         azureSave.Should().BeGreaterThan(0);
-        markup[azureSave..].Should().Contain("AzureEnforcing = enforcing");
+        markup[azureSave..].Should().Contain("LatchEnforcementAsync(azure: true)");
         markup.Should().NotContain("confirmResetAccess")
             .And.NotContain("confirmResetIdentityCenter")
             .And.NotContain("confirmResetSamlApplication");

--- a/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
+++ b/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
@@ -186,6 +186,15 @@ public class ProvidersPageTests
         int azureSave = markup.IndexOf("private async Task<bool?> SaveAzureAdFromForm(", StringComparison.Ordinal);
         azureSave.Should().BeGreaterThan(0);
         markup[azureSave..].Should().Contain("LatchEnforcementAsync(azure: true)");
+
+        // Each Azure card renders what the reader found out — the reason Entra refused a credential
+        // and what to do, or what was verified — not the status word alone. A bare "Failed" on a
+        // revoked certificate would leave the administrator with nothing to act on.
+        int azureAccessCard = markup.IndexOf("Id=\"azure-access\"", StringComparison.Ordinal);
+        int azurePermissionsCard = markup.IndexOf("Id=\"azure-permissions\"", StringComparison.Ordinal);
+        markup[azureAccessCard..azurePermissionsCard].Should().Contain("@RequirementDetail(AccessRequirement)");
+        markup[azurePermissionsCard..].Should().Contain("@RequirementDetail(PermissionsRequirement)");
+        markup.Should().Contain("RequirementStatus.Failed => (\"alert alert-danger py-2 mb-2 small\", \"alert\"");
         markup.Should().NotContain("confirmResetAccess")
             .And.NotContain("confirmResetIdentityCenter")
             .And.NotContain("confirmResetSamlApplication");

--- a/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
+++ b/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
@@ -183,7 +183,7 @@ public class ProvidersPageTests
 
         // Saving Azure sign-in must latch Azure enforcement at save time, like the SAML save does —
         // relying on the startup latch alone left azblob results unfiltered until the next restart.
-        int azureSave = markup.IndexOf("private async Task<bool> SaveAzureAdFromForm(", StringComparison.Ordinal);
+        int azureSave = markup.IndexOf("private async Task<bool?> SaveAzureAdFromForm(", StringComparison.Ordinal);
         azureSave.Should().BeGreaterThan(0);
         markup[azureSave..].Should().Contain("AzureEnforcing = enforcing");
         markup.Should().NotContain("confirmResetAccess")

--- a/tests/Connapse.Web.Tests/Services/CloudEnforcementLatchTests.cs
+++ b/tests/Connapse.Web.Tests/Services/CloudEnforcementLatchTests.cs
@@ -80,15 +80,37 @@ public class CloudEnforcementLatchTests
             NullLogger<CloudEnforcementLatch>.Instance), migration);
     }
 
+    /// <summary>What the latch asked the store to hold, computed the way the store would: the merge
+    /// function it passed, applied to an empty row.</summary>
     private Task<PermissionEnforcementSettings?> SavedMarker()
     {
         var calls = store.ReceivedCalls()
-            .Where(c => c.GetMethodInfo().Name == nameof(ISettingsStore.SaveAsync))
-            .Select(c => c.GetArguments()[1] as PermissionEnforcementSettings)
-            .Where(v => v is not null)
+            .Where(c => c.GetMethodInfo().Name == nameof(ISettingsStore.UpdateAsync))
+            .Select(c => c.GetArguments()[1] as Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>)
+            .Where(f => f is not null)
+            .Select(f => f!(null))
             .ToList();
 
         return Task.FromResult(calls.LastOrDefault());
+    }
+
+    [Fact]
+    public async Task TheMarkerIsMerged_SoALatchAlreadyStoredIsNeverSwitchedOff()
+    {
+        // Azure was latched by somebody else — the Providers page, another process — and this
+        // deployment only configures SAML. Writing the record from this snapshot would turn Azure
+        // back off; the merge keeps whatever is already on.
+        var (latch, _) = Build(Complete());
+        await latch.StartAsync(CancellationToken.None);
+
+        var merge = store.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(ISettingsStore.UpdateAsync))
+            .Select(c => c.GetArguments()[1] as Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>)
+            .Single(f => f is not null)!;
+
+        var merged = merge(new PermissionEnforcementSettings { IsEnforcing = false, AzureEnforcing = true });
+        merged.IsEnforcing.Should().BeTrue();
+        merged.AzureEnforcing.Should().BeTrue();
     }
 
     [Fact]
@@ -238,8 +260,8 @@ public class CloudEnforcementLatchTests
     {
         // Which makes the resolver deny. The first version logged this and carried on with
         // enforcement off, so one transient database error at boot opened the whole corpus.
-        store.SaveAsync(Arg.Any<string>(), Arg.Any<PermissionEnforcementSettings>(), Arg.Any<CancellationToken>())
-            .Returns<Task>(_ => throw new InvalidOperationException("database unavailable"));
+        store.UpdateAsync(Arg.Any<string>(), Arg.Any<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(), Arg.Any<CancellationToken>())
+            .Returns<Task<PermissionEnforcementSettings>>(_ => throw new InvalidOperationException("database unavailable"));
 
         var (latch, migration) = Build(Complete());
         await latch.StartAsync(CancellationToken.None);
@@ -252,8 +274,8 @@ public class CloudEnforcementLatchTests
     {
         // Refusing to answer is the version of "never block startup" that does not fail open. The
         // deployment comes up, and searches deny until somebody looks.
-        store.SaveAsync(Arg.Any<string>(), Arg.Any<PermissionEnforcementSettings>(), Arg.Any<CancellationToken>())
-            .Returns<Task>(_ => throw new InvalidOperationException("database unavailable"));
+        store.UpdateAsync(Arg.Any<string>(), Arg.Any<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(), Arg.Any<CancellationToken>())
+            .Returns<Task<PermissionEnforcementSettings>>(_ => throw new InvalidOperationException("database unavailable"));
 
         var (latch, _) = Build(Complete());
 
@@ -270,10 +292,12 @@ public class CloudEnforcementLatchTests
 
         await store.DidNotReceive().SaveAsync(
             Arg.Any<string>(), Arg.Any<SamlSignInSettings>(), Arg.Any<CancellationToken>());
+        await store.DidNotReceive().UpdateAsync(
+            Arg.Any<string>(), Arg.Any<Func<SamlSignInSettings?, SamlSignInSettings>>(), Arg.Any<CancellationToken>());
 
-        await store.Received(1).SaveAsync(
+        await store.Received(1).UpdateAsync(
             PermissionEnforcementSettings.Category,
-            Arg.Any<PermissionEnforcementSettings>(),
+            Arg.Any<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Connapse.Web.Tests/Services/CloudEnforcementLatchTests.cs
+++ b/tests/Connapse.Web.Tests/Services/CloudEnforcementLatchTests.cs
@@ -29,6 +29,24 @@ public class CloudEnforcementLatchTests
     /// <summary>Reads the database successfully unless a test says otherwise.</summary>
     private readonly ISettingsReloader reloader = Substitute.For<ISettingsReloader>();
 
+    /// <summary>The live options the resolvers read. The store's reload after a commit is what
+    /// moves them; the default stub below plays that part, and a test can leave it out to stand
+    /// in for a reload that failed.</summary>
+    private readonly IOptionsMonitor<PermissionEnforcementSettings> enforcement =
+        Substitute.For<IOptionsMonitor<PermissionEnforcementSettings>>();
+
+    public CloudEnforcementLatchTests()
+    {
+        // Configured here, before any test's own stub, so a test that makes the store throw wins.
+        store.UpdateAsync(Arg.Any<string>(), Arg.Any<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var merged = call.ArgAt<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(1)(null);
+                enforcement.CurrentValue.Returns(merged);
+                return merged;
+            });
+    }
+
     private static SamlSignInSettings Complete() => new()
     {
         EntityId = "https://connapse.example.com/saml/connapse",
@@ -65,16 +83,17 @@ public class CloudEnforcementLatchTests
 
         var migration = new EnforcementMigration();
         reloader.Reload().Returns(settingsReadable);
+        enforcement.CurrentValue.Returns(new PermissionEnforcementSettings
+        {
+            IsEnforcing = alreadyEnforcing,
+            AzureEnforcing = azureAlreadyEnforcing,
+        });
 
         return (new CloudEnforcementLatch(
             services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
             Monitor(signIn),
             Monitor(azureAd ?? new AzureAdSignInSettings()),
-            Monitor(new PermissionEnforcementSettings
-            {
-                IsEnforcing = alreadyEnforcing,
-                AzureEnforcing = azureAlreadyEnforcing,
-            }),
+            enforcement,
             migration,
             reloader,
             NullLogger<CloudEnforcementLatch>.Instance), migration);
@@ -267,6 +286,22 @@ public class CloudEnforcementLatchTests
         await latch.StartAsync(CancellationToken.None);
 
         migration.Determined.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task WhenTheCommitSucceedsButTheReloadDoesNot_LeavesTheStateUndetermined()
+    {
+        // The store commits the marker and then fails to reload it into this process. The resolvers
+        // read the live options, which still say "not enforcing"; completing the migration would
+        // let them answer unfiltered. Undetermined denies until a later reload lands.
+        store.UpdateAsync(Arg.Any<string>(), Arg.Any<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(), Arg.Any<CancellationToken>())
+            .Returns(call => call.ArgAt<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(1)(null));
+
+        var (latch, migration) = Build(Complete());
+        await latch.StartAsync(CancellationToken.None);
+
+        (await SavedMarker())!.IsEnforcing.Should().BeTrue("the marker was committed");
+        migration.Determined.Should().BeFalse("the live options never showed it");
     }
 
     [Fact]

--- a/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
+++ b/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
@@ -615,6 +615,20 @@ public class ProviderSetupReaderTests
     }
 
     [Fact]
+    public async Task Azure_Access_WhenTheIdentityIsUnusableOnThisHost_IsFailed_AndNamesTheFile()
+    {
+        // A missing or unreadable certificate file is not "could not confirm": nothing was asked
+        // of Azure and nothing will work until the file is fixed. Failed, with the remedy.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(),
+            azureAccess: AzureProbe<string>.Unusable("no usable certificate was loaded (ClientCertificatePath='/certs/azure.pem')")));
+
+        var access = azure.Requirements.Single(r => r.Name == "Access");
+        access.Status.Should().Be(RequirementStatus.Failed);
+        access.Detail.Should().Contain("cannot be used from this host").And.Contain("/certs/azure.pem");
+    }
+
+    [Fact]
     public async Task Azure_Access_WhenTheCheckCannotComplete_Warns_RatherThanFails()
     {
         // A network fault says nothing about the credential, so it is a warning: "cannot confirm",
@@ -625,7 +639,7 @@ public class ProviderSetupReaderTests
 
         var access = azure.Requirements.Single(r => r.Name == "Access");
         access.Status.Should().Be(RequirementStatus.Warning);
-        access.Detail.Should().Contain("could not reach Azure").And.Contain("No such host");
+        access.Detail.Should().Contain("could not confirm").And.Contain("No such host");
     }
 
     [Fact]
@@ -698,7 +712,7 @@ public class ProviderSetupReaderTests
 
         var requirement = azure.Requirements.Single(r => r.Name == "Per-user permissions");
         requirement.Status.Should().Be(RequirementStatus.Warning);
-        requirement.Detail.Should().Contain("could not reach Azure");
+        requirement.Detail.Should().Contain("could not confirm");
     }
 
     [Fact]

--- a/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
+++ b/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
@@ -41,11 +41,18 @@ public class ProviderSetupReaderTests
         IdentityCenterSettings? identityCenter = null,
         AzureProviderSettings? azureProvider = null,
         AzureAdSignInSettings? azureAd = null,
-        IConnectionStore? connections = null)
+        IConnectionStore? connections = null,
+        AzureProbe<string>? azureAccess = null)
     {
         var discovery = Substitute.For<IS3Discovery>();
         discovery.WhoAmIAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(identity);
         discovery.ListBucketsAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(buckets);
+
+        // Defaults to Entra accepting the credential, so a test about anything else is not also
+        // silently a test about the live check.
+        var azureDiscovery = Substitute.For<IAzureBlobDiscovery>();
+        azureDiscovery.CheckAccessAsync(Arg.Any<CancellationToken>())
+            .Returns(azureAccess ?? AzureProbe<string>.Ok("Entra accepted the certificate."));
 
         if (credentials is null)
         {
@@ -67,7 +74,7 @@ public class ProviderSetupReaderTests
             Options.Create(identityCenter ?? LocatedInstance()).AsMonitor(),
             Options.Create(azureProvider ?? new AzureProviderSettings()).AsMonitor(),
             Options.Create(azureAd ?? new AzureAdSignInSettings()).AsMonitor(),
-            discovery, connections, credentials,
+            discovery, azureDiscovery, connections, credentials,
             new FixedClock(new DateTimeOffset(Created) + (sinceCreated ?? TimeSpan.Zero)),
             NullLogger<ProviderSetupReader>.Instance);
     }
@@ -309,7 +316,7 @@ public class ProviderSetupReaderTests
             Options.Create(new IdentityCenterSettings()).AsMonitor(),
             Options.Create(new AzureProviderSettings()).AsMonitor(),
             Options.Create(new AzureAdSignInSettings()).AsMonitor(),
-            Substitute.For<IS3Discovery>(), connections,
+            Substitute.For<IS3Discovery>(), Substitute.For<IAzureBlobDiscovery>(), connections,
             Substitute.For<IProviderCredentialStore>(),
             new FixedClock(new DateTimeOffset(Created)),
             NullLogger<ProviderSetupReader>.Instance);
@@ -532,7 +539,7 @@ public class ProviderSetupReaderTests
     {
         TenantId = "11111111-1111-1111-1111-111111111111",
         ClientId = "44444444-4444-4444-4444-444444444444",
-        RedirectUri = "https://connapse.example.com/api/v1/auth/cloud/azure/cb",
+        RedirectUri = "https://connapse.example.com/api/v1/auth/cloud/azure/callback",
         ClientCertificatePath = "/certs/azure-signin.pem",
     };
 
@@ -575,8 +582,58 @@ public class ProviderSetupReaderTests
         var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
             azureProvider: ConfiguredAzureProvider()));
 
-        azure.Requirements.Single(r => r.Name == "Access").Status
-            .Should().Be(RequirementStatus.Satisfied);
+        var access = azure.Requirements.Single(r => r.Name == "Access");
+        access.Status.Should().Be(RequirementStatus.Satisfied);
+        // A pass says what was verified, in the words the probe used.
+        access.Detail.Should().Contain("Entra accepted");
+    }
+
+    [Fact]
+    public async Task Azure_Access_WhenEntraRefusesTheCredential_IsFailed_AndSaysToSetUpAgain()
+    {
+        // An expired or unregistered certificate is the one thing settings alone cannot see, and
+        // the reason to ask Entra at all. It must read as Failed, not Ready.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(),
+            azureAccess: AzureProbe<string>.Denied("AADSTS700027: The certificate is not registered on application")));
+
+        var access = azure.Requirements.Single(r => r.Name == "Access");
+        access.Status.Should().Be(RequirementStatus.Failed);
+        access.Detail.Should().Contain("set access up again").And.Contain("AADSTS700027");
+    }
+
+    [Fact]
+    public async Task Azure_Access_WhenTheCheckCannotComplete_Warns_RatherThanFails()
+    {
+        // A network fault says nothing about the credential, so it is a warning: "cannot confirm",
+        // which the connection test can still answer.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(),
+            azureAccess: AzureProbe<string>.Failed("No such host is known")));
+
+        var access = azure.Requirements.Single(r => r.Name == "Access");
+        access.Status.Should().Be(RequirementStatus.Warning);
+        access.Detail.Should().Contain("could not reach Azure").And.Contain("No such host");
+    }
+
+    [Fact]
+    public async Task Azure_Access_WithNothingConfigured_NeverAsksEntra()
+    {
+        var azureDiscovery = Substitute.For<IAzureBlobDiscovery>();
+        var reader = new ProviderSetupReader(
+            Options.Create(new SamlSignInSettings()).AsMonitor(),
+            Options.Create(new IdentityCenterSettings()).AsMonitor(),
+            Options.Create(new AzureProviderSettings()).AsMonitor(),
+            Options.Create(new AzureAdSignInSettings()).AsMonitor(),
+            Substitute.For<IS3Discovery>(), azureDiscovery, ConnectionsWith(),
+            Substitute.For<IProviderCredentialStore>(),
+            new FixedClock(new DateTimeOffset(Created)),
+            NullLogger<ProviderSetupReader>.Instance);
+
+        var azure = await AzureAsync(reader);
+
+        azure.Requirements.Single(r => r.Name == "Access").Status.Should().Be(RequirementStatus.NotConfigured);
+        await azureDiscovery.DidNotReceive().CheckAccessAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
+++ b/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
@@ -43,7 +43,8 @@ public class ProviderSetupReaderTests
         AzureAdSignInSettings? azureAd = null,
         IConnectionStore? connections = null,
         AzureProbe<string>? azureAccess = null,
-        AzureProbe<string>? azureSignIn = null)
+        AzureProbe<string>? azureSignIn = null,
+        PermissionEnforcementSettings? enforcement = null)
     {
         var discovery = Substitute.For<IS3Discovery>();
         discovery.WhoAmIAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(identity);
@@ -80,7 +81,11 @@ public class ProviderSetupReaderTests
             Options.Create(identityCenter ?? LocatedInstance()).AsMonitor(),
             Options.Create(azureProvider ?? new AzureProviderSettings()).AsMonitor(),
             Options.Create(azureAd ?? new AzureAdSignInSettings()).AsMonitor(),
-            discovery, azureDiscovery, connections, credentials,
+            discovery, azureDiscovery,
+            // Latched by default: a sign-in test is about sign-in, not about the latch. The test
+            // that cares passes the open state explicitly.
+            Options.Create(enforcement ?? new PermissionEnforcementSettings { IsEnforcing = true, AzureEnforcing = true }).AsMonitor(),
+            connections, credentials,
             new FixedClock(new DateTimeOffset(Created) + (sinceCreated ?? TimeSpan.Zero)),
             NullLogger<ProviderSetupReader>.Instance);
     }
@@ -322,7 +327,8 @@ public class ProviderSetupReaderTests
             Options.Create(new IdentityCenterSettings()).AsMonitor(),
             Options.Create(new AzureProviderSettings()).AsMonitor(),
             Options.Create(new AzureAdSignInSettings()).AsMonitor(),
-            Substitute.For<IS3Discovery>(), Substitute.For<IAzureBlobDiscovery>(), connections,
+            Substitute.For<IS3Discovery>(), Substitute.For<IAzureBlobDiscovery>(),
+            Options.Create(new PermissionEnforcementSettings()).AsMonitor(), connections,
             Substitute.For<IProviderCredentialStore>(),
             new FixedClock(new DateTimeOffset(Created)),
             NullLogger<ProviderSetupReader>.Instance);
@@ -631,7 +637,8 @@ public class ProviderSetupReaderTests
             Options.Create(new IdentityCenterSettings()).AsMonitor(),
             Options.Create(new AzureProviderSettings()).AsMonitor(),
             Options.Create(new AzureAdSignInSettings()).AsMonitor(),
-            Substitute.For<IS3Discovery>(), azureDiscovery, ConnectionsWith(),
+            Substitute.For<IS3Discovery>(), azureDiscovery,
+            Options.Create(new PermissionEnforcementSettings()).AsMonitor(), ConnectionsWith(),
             Substitute.For<IProviderCredentialStore>(),
             new FixedClock(new DateTimeOffset(Created)),
             NullLogger<ProviderSetupReader>.Instance);
@@ -666,6 +673,20 @@ public class ProviderSetupReaderTests
         requirement.Detail.Should().Contain("sign-in application").And.Contain("AADSTS700027");
         // The access credential was fine; only the sign-in one was refused.
         azure.Requirements.Single(r => r.Name == "Access").Status.Should().Be(RequirementStatus.Satisfied);
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_SignInSetButEnforcementOff_IsFailed_BecauseThatStateIsOpen()
+    {
+        // The one combination that returns every Azure result to everyone: sign-in configured, latch
+        // off. It must never read as Ready, and the fix is named.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(), azureAd: ConfiguredAzureAd(),
+            enforcement: new PermissionEnforcementSettings { IsEnforcing = true, AzureEnforcing = false }));
+
+        var requirement = azure.Requirements.Single(r => r.Name == "Per-user permissions");
+        requirement.Status.Should().Be(RequirementStatus.Failed);
+        requirement.Detail.Should().Contain("not filtered").And.Contain("Save the sign-in application again");
     }
 
     [Fact]

--- a/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
+++ b/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
@@ -42,17 +42,23 @@ public class ProviderSetupReaderTests
         AzureProviderSettings? azureProvider = null,
         AzureAdSignInSettings? azureAd = null,
         IConnectionStore? connections = null,
-        AzureProbe<string>? azureAccess = null)
+        AzureProbe<string>? azureAccess = null,
+        AzureProbe<string>? azureSignIn = null)
     {
         var discovery = Substitute.For<IS3Discovery>();
         discovery.WhoAmIAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(identity);
         discovery.ListBucketsAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(buckets);
 
-        // Defaults to Entra accepting the credential, so a test about anything else is not also
-        // silently a test about the live check.
+        // Defaults to Entra accepting both credentials, so a test about anything else is not also
+        // silently a test about the live checks. The sign-in check is told apart from the access
+        // check by the candidate it is handed: the sign-in app's client id.
         var azureDiscovery = Substitute.For<IAzureBlobDiscovery>();
         azureDiscovery.CheckAccessAsync(Arg.Any<CancellationToken>())
             .Returns(azureAccess ?? AzureProbe<string>.Ok("Entra accepted the certificate."));
+        azureDiscovery.CheckAccessAsync(Arg.Any<AzureProviderSettings>(), Arg.Any<CancellationToken>())
+            .Returns(call => call.ArgAt<AzureProviderSettings>(0).ClientId == (azureAd ?? new AzureAdSignInSettings()).ClientId
+                ? azureSignIn ?? AzureProbe<string>.Ok("Entra accepted the sign-in certificate.")
+                : azureAccess ?? AzureProbe<string>.Ok("Entra accepted the certificate."));
 
         if (credentials is null)
         {
@@ -644,6 +650,46 @@ public class ProviderSetupReaderTests
 
         azure.Requirements.Single(r => r.Name == "Per-user permissions").Status
             .Should().Be(RequirementStatus.Satisfied);
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_WhenEntraRefusesTheSignInCredential_IsFailed()
+    {
+        // An expired or removed sign-in certificate is invisible to settings, and a Ready card over
+        // it would send people to a sign-in that fails. Failed, with the reason and the fix.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(), azureAd: ConfiguredAzureAd(),
+            azureSignIn: AzureProbe<string>.Denied("AADSTS700027: Client assertion contains an invalid signature")));
+
+        var requirement = azure.Requirements.Single(r => r.Name == "Per-user permissions");
+        requirement.Status.Should().Be(RequirementStatus.Failed);
+        requirement.Detail.Should().Contain("sign-in application").And.Contain("AADSTS700027");
+        // The access credential was fine; only the sign-in one was refused.
+        azure.Requirements.Single(r => r.Name == "Access").Status.Should().Be(RequirementStatus.Satisfied);
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_WhenTheSignInCheckCannotComplete_Warns()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(), azureAd: ConfiguredAzureAd(),
+            azureSignIn: AzureProbe<string>.Failed("No such host is known")));
+
+        var requirement = azure.Requirements.Single(r => r.Name == "Per-user permissions");
+        requirement.Status.Should().Be(RequirementStatus.Warning);
+        requirement.Detail.Should().Contain("could not reach Azure");
+    }
+
+    [Fact]
+    public void SignInIdentity_CarriesTheFourFieldsTheCredentialCheckNeeds()
+    {
+        var identity = ProviderSetupReader.SignInIdentity(ConfiguredAzureAd() with { ClientCertificatePassword = "pw" });
+
+        identity.TenantId.Should().Be(ConfiguredAzureAd().TenantId);
+        identity.ClientId.Should().Be(ConfiguredAzureAd().ClientId);
+        identity.ClientCertificatePath.Should().Be(ConfiguredAzureAd().ClientCertificatePath);
+        identity.ClientCertificatePassword.Should().Be("pw");
+        identity.UserAssignedManagedIdentityClientId.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #503.

Audits the Azure provider page (Access and Per-user permissions cards, easy Cloud Shell path and manual forms), the Azure Blob connection form, the Azure source branch, the Entra card on Integrations, and `docs/azure-setup.md` against the config-page rubric, and fixes what it found. All five rubric gates passed from the start; the dimension score moved from 1.93 to 2.51 of 3. Eight Codex adversarial review rounds and one Claude review followed; every finding was verified against the code and fixed. Full report with per-criterion scores and evidence: `docs/plans/azure-config-page-audit-report.md` (local, gitignored) — summary below.

## Certificate lifecycle

- **"New certificate" no longer overwrites the live private key.** Each save attempt writes its candidate to its own thumbprint-and-attempt-named file under `appdata/azure`, verifies it with Entra from there, and only then commits settings naming it. The key in use is never moved or overwritten.
- Superseded files are swept only when nothing stored names them (both Azure settings categories re-read from the store) and they are over an hour old, so two processes sharing a volume cannot delete each other's key. If the store cannot be read, nothing is deleted.
- Both Cloud Shell scripts print the registered certificate's thumbprint; Save refuses a paste whose thumbprint is not the material the page holds (a second tab made a new one). Writes are atomic (temp + move); interrupted-write temp files are swept.
- Both cards show certificate expiry with a 30-day warning and an expired state; a missing or unreadable certificate file is an alert on the card, never an exception from the page.

## Live health

- `IAzureBlobDiscovery.CheckAccessAsync` acquires an ARM-scope token with a fresh credential each time (no cached token can mask a revoked certificate). The reader reports Ready with what was verified, Failed with the AADSTS reason when Entra refuses the credential (allowlisted codes only — throttling and transient faults read as Unconfirmed), Failed when the identity is unusable on this host, and Unconfirmed when Azure cannot be reached. The sign-in application's credential is checked the same way, in parallel with Access.
- Every manual or script save is checked with Entra before it is stored; a refused, unusable, or unconfirmable candidate leaves the working settings untouched and keeps what was typed.
- Both Azure cards render the reader's detail text with alert/status semantics, not just a status word. The connection tester names the layer that failed (reached / Entra accepted / allowed / exists), distinguishes refusal from transport failure, validates the blob endpoint, and puts the raw error in `Details`.

## Fail-closed enforcement (pre-existing epic bugs)

- The AWS sign-in save rewrote the enforcement record with only its own flag, switching Azure filtering off. Enforcement latches now merge with a monotonic OR through a new row-locked `ISettingsStore.UpdateAsync` (`SELECT … FOR UPDATE` in one transaction), are written **before** the sign-in settings, and must be visible in the live options before sign-in saves or the startup migration completes. The reader reports Per-user permissions as Failed if sign-in is configured while the latch is off.
- A user-assigned managed identity with the tenant recorded was rejected by `AzureCredentialChainFactory`; it is now an explicit mode the form, factory, and discovery agree on.
- `SaveSettings` returns committed / not committed / unknown; an unknown outcome never rolls back a certificate. `PostgresSettingsStore` clears its change tracker on a failed write so a failed rotation cannot ride along with the next save in the same request.

## Forms and copy

- Access manual form: certificate-app vs user-assigned managed identity as a `fieldset` radio revealing one branch (the other cleared on save); prerequisites stated; a portal link on every field; gathering order (tenant → identity → subscription, optional); submit validation with `role="alert"` and `aria-invalid`.
- Sign-in manual form: tenant and redirect URI pre-filled, correct callback placeholder (`/api/v1/auth/cloud/azure/callback`), links, validation.
- One "(optional)" convention; config keys (`Providers:Azure`, `Identity:AzureAd`, "RBAC resolver") out of user copy; Graph permissions named at the consent step; "Recheck" and "Add a connection" parity with AWS; Integrations card names the page that exists; connection Name/probe help cover containers; stale developer notes removed; a checking indicator instead of unmounting the cards on refresh.
- `docs/azure-setup.md`: field tables for both cards and the connection, what Recheck verifies, certificate lifetime and rotation, and troubleshooting entries matching every new message.

## Tests

Unit: Web 134, Storage 264 (incl. new `AzureCertificateFileTests`, discovery candidate/classifier tests, factory managed-identity tests), Core 1,117 (Cloud Shell thumbprint parse tests; the CRLF-sensitive subshell assertion now normalises line endings), Identity 109, Ingestion 219, Background 18 — all green. Integration (Testcontainers PostgreSQL): new `SettingsStoreUpdateIntegrationTests` (twelve concurrent scopes merging end with both flags on), plus the settings, provider-page, and cloud-identity suites — green.

Manual checks still recommended: tab order and focus under the sticky header on `/admin/providers/azure`, `.form-text` contrast on both themes, 200% zoom, and the live Entra check against a real tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)