### PR TITLE
Azure Blob Storage as a per-object-permission provider

### DIFF
--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -1,0 +1,70 @@
+# Azure setup
+
+Connapse reads Azure Blob Storage (including Data Lake Gen2 accounts) as its own Entra app
+identity, authenticated with a certificate it generates on its host, or as a managed identity.
+No account keys, SAS tokens, client secrets, or connection strings are ever entered or stored.
+It only reads: it never writes a blob, a role assignment, an ACL, or a tag.
+
+## Setup
+
+Admin → Providers → Azure. Two steps, each with an **Easy setup** guide and **Manual values**.
+
+1. **Access.** Copy the script, run it in [Azure Cloud Shell](https://shell.azure.com) (Bash),
+   paste back what it prints, Save. It uses the subscription Cloud Shell is signed in to, creates
+   two custom roles and the access app, and uploads only the public certificate:
+   - *Connapse Blob Data + Tags Reader* — read blobs and blob index tags, list containers.
+   - *Connapse RBAC Authorization Reader* — read role and deny assignments and storage-account
+     metadata at subscription scope.
+   Whoever runs it needs Owner or User Access Administrator on the subscription and permission
+   to register applications. The script is safe to re-run: it finds existing apps by name and
+   updates the roles in place.
+2. **Per-user permissions.** A second script registers the sign-in app people link their Entra
+   identity through, grants the access app the two Microsoft Graph permissions
+   (`User.Read.All`, `GroupMember.Read.All`) it looks people and groups up with, and attempts
+   admin consent. Consent needs a Global Administrator or Privileged Role Administrator; if the
+   person running the script is not one, the page shows a consent link to send them. When
+   consent succeeds the script also pre-consents the sign-in app for everyone, so nobody sees a
+   consent prompt when linking.
+
+Then Admin → Connections → New → Azure Blob Storage: choose the storage account and containers
+from the lists (or type them), Test connection, Save. People link their Entra identity under
+Integrations → Microsoft Entra ID; their search results are then limited to what that identity
+may read.
+
+## Troubleshooting
+
+**`AADSTS700027: The certificate ... is not registered on application`** — the certificate
+Connapse signs with is not the one uploaded to that app. Open the step's guide on the Azure
+provider page (it embeds the certificate Connapse actually holds), re-run the script, paste back,
+Save. Use **New certificate** only if you want to replace the key.
+
+**`AADSTS500113: No reply address is registered`** on the admin-consent link — the access app
+had no reply URL. Re-run the Per-user permissions script; it registers the Providers page as
+the reply URL and the link works.
+
+**`AADSTS65001` / "admin consent pending"** — the Graph permissions have not been approved.
+Send the consent link from the Per-user permissions card to a Global Administrator.
+
+**"This identity may not list storage accounts / containers"** in the connection form — the
+access identity lacks a listing role. Roles created before container/account listing was added
+are upgraded by re-running the Access script; otherwise assign *Connapse Blob Data + Tags Reader*
+on the account and *Connapse RBAC Authorization Reader* on the subscription. Typing the names
+still works without the lists.
+
+**Test connection fails with 403 / `AuthorizationPermissionMismatch`** — the access app has no
+blob-read role on that account or container. Use the "Role assignments granting exactly this
+access" snippet on the connection form, or assign *Connapse Blob Data + Tags Reader* at the
+account scope. Role assignments can take a few minutes to propagate.
+
+**Test connection fails with 404** — the container name is wrong, or the account is not the one
+you think (check the resource group in the account picker). Azure accounts have no default
+container; the test needs one that exists.
+
+**Search returns nothing for a linked user** — per-user filtering is on and the identity lookup
+failed closed. Check that admin consent was granted, that the subscription is set on the Access
+step (the RBAC resolver needs it), and that the user still exists and is enabled in Entra. For
+Data Lake Gen2 accounts, the user also needs Read on the file and Execute on every ancestor
+directory in the POSIX ACLs.
+
+**"Could not connect your Entra identity"** — the container log names the cause:
+`docker logs connapse-web-1 | grep -A5 "Entra sign-in callback failed"`.

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -16,22 +16,173 @@ Admin → Providers → Azure. Two steps, each with an **Easy setup** guide and 
    - *Connapse RBAC Authorization Reader* — read role and deny assignments and storage-account
      metadata at subscription scope.
    Whoever runs it needs Owner or User Access Administrator on the subscription and permission
-   to register applications. The script is safe to re-run: it finds existing apps by name and
-   updates the roles in place.
+   to register applications. The script is safe to re-run: it reuses the app Connapse recorded
+   (never one found by display name) and updates the roles in place.
 2. **Per-user permissions.** A second script registers the sign-in app people link their Entra
    identity through, grants the access app the two Microsoft Graph permissions
-   (`User.Read.All`, `GroupMember.Read.All`) it looks people and groups up with, and attempts
-   admin consent. Consent needs a Global Administrator or Privileged Role Administrator; if the
-   person running the script is not one, the page shows a consent link to send them. When
-   consent succeeds the script also pre-consents the sign-in app for everyone, so nobody sees a
-   consent prompt when linking.
+   (`User.Read.All`, `GroupMember.Read.All` — read-only lookups of who a person is and which
+   groups they belong to) it looks people and groups up with, and attempts admin consent. Consent
+   needs a Global Administrator or Privileged Role Administrator; if the person running the
+   script is not one, the page shows a consent link to send them. When consent succeeds the
+   script also pre-consents the sign-in app for everyone, so nobody sees a consent prompt when
+   linking.
 
 Then Admin → Connections → New → Azure Blob Storage: choose the storage account and containers
 from the lists (or type them), Test connection, Save. People link their Entra identity under
 Integrations → Microsoft Entra ID; their search results are then limited to what that identity
 may read.
 
+### Connapse running on Azure
+
+If the Connapse host is an Azure VM, App Service, or container with a managed identity, the
+Access guide notices and switches to it: no app registration and no certificate. Its script
+creates the same two custom roles and assigns them to that identity by object id, and the
+paste-back records the identity (tenant, subscription, principal). Whoever runs it needs only
+Owner or User Access Administrator on the subscription. A link under the guide switches back to
+a certificate app if you prefer one; the manual form also offers "This host's managed identity"
+as a choice, needing only the tenant. Detection asks for the host's system-assigned identity; a
+host that has only user-assigned identities may report none — enter such an identity by hand
+under Manual values, by its client ID.
+
+The Per-user permissions guide then grants the identity its two Graph permissions as app roles
+(a REST call per permission) instead of consenting an app. If the person running it is not a
+Global Administrator or Privileged Role Administrator, the script reports that and the card
+shows the two commands to hand to one; press "The permissions have been granted" once they have.
+
+### Graph permissions for a managed identity
+
+A managed identity has no app registration to consent to, so its two Microsoft Graph
+permissions are app-role assignments on its service principal. The guided Per-user permissions
+script makes them; when it cannot (the runner is not a Global Administrator or Privileged Role
+Administrator), or when the access identity was entered by hand, a directory administrator runs
+these in Cloud Shell, with the identity's **Object (principal) ID** from its Overview page in
+the Azure portal (for a host's own identity, the host's **Identity** page):
+
+```bash
+GRAPH_API='00000003-0000-0000-c000-000000000000'
+MI='<managed-identity-object-id>'
+GRAPH_SP_ID=$(az ad sp show --id "$GRAPH_API" --query id -o tsv)
+for ROLE in User.Read.All GroupMember.Read.All; do
+  ROLE_ID=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='$ROLE'].id | [0]" -o tsv)
+  az rest -m POST -u "https://graph.microsoft.com/v1.0/servicePrincipals/$MI/appRoleAssignments" \
+    -b "{\"principalId\":\"$MI\",\"resourceId\":\"$GRAPH_SP_ID\",\"appRoleId\":\"$ROLE_ID\"}"
+done
+```
+
+"Permission being assigned already exists" means that grant was already in place. Once both are
+made, press **The permissions have been granted** on the Per-user permissions card (or, for a
+hand-entered identity, set the sign-in application up under Manual values).
+
+### What Recheck verifies
+
+**Recheck** on the Access card asks Entra for a token as Connapse's identity. *Ready* means Entra
+accepted the certificate (or issued a token to the managed identity); it does not prove any role
+is assigned — **Test connection** on a connection does that. *Failed* means Entra refused the
+credential and quotes the `AADSTS` reason; *Unconfirmed* means Azure could not be reached.
+
+### Certificates
+
+The certificates Connapse generates are valid for one year. Each card shows when its certificate
+expires and warns 30 days ahead. To renew, open the card's guide, choose **New certificate**, run
+the script it produces (which registers the new public certificate alongside the old one), paste
+back, Save. The old certificate keeps working until you save, and the private keys are stored
+only under `appdata/azure` on the Connapse host, readable by Connapse's own user.
+
+Save is a check first: Connapse writes the new certificate to a file of its own (named by its
+thumbprint), asks Entra for a token with it, and only then commits settings naming that file.
+The key in use is never moved or overwritten; it is removed only after the new settings are
+stored, and anything Entra rejects is deleted again with the working setup untouched. The script
+also prints the thumbprint of the certificate it registered; if it differs from the one the page
+holds (another tab made a new certificate in between), Save refuses and asks you to run the
+command shown now. The same Entra check runs when Manual values are saved.
+
+Only Entra errors that mean the credential itself is wrong — certificate not registered
+(`AADSTS700027`), keys expired (`AADSTS7000222`), app disabled (`AADSTS7000112`), app or tenant
+not found (`AADSTS700016`, `AADSTS90002`), missing service principal (`AADSTS7000229`) — count as
+a refusal. Throttling, transient faults, and outages read as *Unconfirmed* with a retry, never as
+a demand to set up again.
+
+Each save attempt writes its own file (`connapse-azure-access-<thumbprint>-<attempt>.pem`), so
+attempts never share one. Old certificate files are removed only once nothing stored names them
+and they are more than an hour old, so two Connapse processes sharing one volume cannot delete
+each other's key; if the settings store cannot be read, nothing is deleted at all. Saving the
+sign-in application switches per-user enforcement on *before* storing the application and
+requires the switch to be live in this process; if it cannot be written or applied, the
+application is not saved and the message says to restart and save again. The AWS sign-in save
+carries the Azure switch through unchanged. If enforcement is somehow off while sign-in is
+configured, the Per-user permissions card shows Failed and says how to switch it on. A save
+whose outcome cannot be confirmed (the store failed after committing and could not be read back)
+is reported as unconfirmed rather than as failed; check the card after a restart before retrying.
+
+## Manual values
+
+Use these when the identity already exists. Every value is read from the Azure portal or the
+Microsoft Entra admin center; nothing here is a secret except an optional PFX password.
+
+### Access
+
+| Field | Where to find it |
+|---|---|
+| Directory (tenant) ID | Entra admin center → Overview (the tenant overview). |
+| How Connapse signs in | *App registration with a certificate* — an app you registered and uploaded a certificate to. *This host's managed identity* — the system-assigned identity of the Azure host Connapse runs on; nothing else to enter. *A user-assigned managed identity* — an identity attached to the host, named by its client ID. |
+| Application (client) ID | Entra admin center → App registrations → the app → Overview. Certificate app only. |
+| Client certificate path | A path on the Connapse host to a PEM (certificate plus private key) or PFX. Its public certificate must be uploaded under the app's Certificates & secrets. Certificate app only. |
+| Certificate password | Optional; only for a password-protected PFX. Never shown again once stored; leave blank to keep it. |
+| Managed identity client ID | Azure portal → Managed Identities → the identity → Overview → Client ID. User-assigned identity only; the host's own identity needs no ID. |
+| Subscription ID | Optional. Azure portal → Subscriptions. Needed for per-user permissions (role assignments are read from it) and for the storage-account list on the connection form. |
+
+The identity needs a role that can read blobs on each storage account — Storage Blob Data
+Reader, or the *Connapse Blob Data + Tags Reader* role the script creates. For per-user
+permissions it also needs *Connapse RBAC Authorization Reader* (or Reader) on the subscription
+and the two Graph permissions above, with admin consent.
+
+### Per-user permissions (sign-in app)
+
+| Field | Where to find it |
+|---|---|
+| Directory (tenant) ID | Filled in from the Access step. Change it only if the sign-in app lives in another tenant. |
+| Application (client) ID | Entra admin center → App registrations → the sign-in app → Overview. |
+| Redirect URI | Filled in from the address you reached Connapse on, plus `/api/v1/auth/cloud/azure/callback`. Register the same value under the app's Authentication page as a Web redirect URI. |
+| Client certificate path | A path on the Connapse host to the sign-in app's PEM or PFX; its public certificate goes under that app's Certificates & secrets. |
+| Certificate password | Optional; PFX only. |
+
+### Connection
+
+| Field | Notes |
+|---|---|
+| Name | Filled in from the first container you choose if left blank. |
+| Storage account name | Pick from the accounts Connapse can see, or type it. Listing needs the Subscription ID on the Access step and *Connapse RBAC Authorization Reader* (or Reader) on the subscription. |
+| Blob endpoint | Optional. Only to point at Azurite or another emulator; otherwise the account's public endpoint is used. |
+| Allowed locations | The containers (optionally `container/prefix`) a source on this connection may name. Pick from the list or type them. |
+| Container to test against | Not saved; the first allowed location when blank. |
+
 ## Troubleshooting
+
+**Access card shows Failed** — Entra refused Connapse's credential; the card quotes the
+`AADSTS` code. `AADSTS700027` (certificate not registered on the application) or an expired
+certificate: open the guide, choose **New certificate**, run the script, paste back, Save.
+`AADSTS700016` (application not found): the app was deleted — Reset access and set it up again.
+
+**Access card shows Unconfirmed** — Azure could not be reached from this server. Check outbound
+access to `login.microsoftonline.com`, then Recheck. Test a connection to be sure.
+
+**Access card shows Failed: "cannot be used from this host"** — the certificate file is missing
+or unreadable, the settings are only partly filled in, or Access is set to a managed identity and
+this host has none (the identity was removed, or the settings came from another host). Fix the
+file or the identity, or set access up again.
+
+**Per-user permissions card shows Failed** — Entra refused the sign-in application's
+certificate; the card quotes the reason. Open the card's guide, choose **New certificate**, run
+the script, paste back, Save.
+
+**Save says "Entra refused the … credential, so nothing was changed"** — the certificate or
+identity you are about to store does not work, and the current one was left in place. Right
+after running a script, Entra can take up to a minute to register the certificate: wait, then
+Save again. If it persists, the certificate on the app is not the one Connapse holds — re-run the
+command shown on the page.
+
+**Test connection: "Could not reach Entra to sign Connapse in"** — the request never got an
+answer from Entra; the credential was not judged. Check outbound access, then try again.
 
 **`AADSTS700027: The certificate ... is not registered on application`** — the certificate
 Connapse signs with is not the one uploaded to that app. Open the step's guide on the Azure
@@ -51,20 +202,27 @@ are upgraded by re-running the Access script; otherwise assign *Connapse Blob Da
 on the account and *Connapse RBAC Authorization Reader* on the subscription. Typing the names
 still works without the lists.
 
-**Test connection fails with 403 / `AuthorizationPermissionMismatch`** — the access app has no
-blob-read role on that account or container. Use the "Role assignments granting exactly this
-access" snippet on the connection form, or assign *Connapse Blob Data + Tags Reader* at the
-account scope. Role assignments can take a few minutes to propagate.
+**Test connection: "not allowed to list container"** (403, `AuthorizationPermissionMismatch`) —
+the access app has no blob-read role on that account or container. Use the "Role assignments
+granting exactly this access" snippet on the connection form, or assign *Connapse Blob Data +
+Tags Reader* at the account scope. Role assignments can take a few minutes to propagate.
 
-**Test connection fails with 404** — the container name is wrong, or the account is not the one
-you think (check the resource group in the account picker). Azure accounts have no default
-container; the test needs one that exists.
+**Test connection: "no container ... exists"** (404) — the container name is wrong, or the
+account is not the one you think (check the resource group in the account picker). Azure
+accounts have no default container; the test needs one that exists.
+
+**Test connection: "Entra rejected Connapse's identity"** — the same fault as a Failed Access
+card; fix it there, not on the connection.
+
+**Test connection: "Could not reach ..."** — the account name does not resolve. Check the
+spelling, and the blob endpoint if one is set.
 
 **Search returns nothing for a linked user** — per-user filtering is on and the identity lookup
 failed closed. Check that admin consent was granted, that the subscription is set on the Access
-step (the RBAC resolver needs it), and that the user still exists and is enabled in Entra. For
-Data Lake Gen2 accounts, the user also needs Read on the file and Execute on every ancestor
-directory in the POSIX ACLs.
+step, and that the user still exists and is enabled in Entra. For Data Lake Gen2 accounts, the
+user also needs Read on the file and Execute on every ancestor directory in the POSIX ACLs.
 
 **"Could not connect your Entra identity"** — the container log names the cause:
-`docker logs connapse-web-1 | grep -A5 "Entra sign-in callback failed"`.
+`docker logs connapse-web-1 | grep -A5 "Entra sign-in callback failed"`. A redirect mismatch
+means the Redirect URI on the Per-user permissions card differs from the one registered on the
+sign-in app.

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -73,6 +73,17 @@ done
 made, press **The permissions have been granted** on the Per-user permissions card (or, for a
 hand-entered identity, set the sign-in application up under Manual values).
 
+### How quickly a permission change takes effect
+
+Per-user filtering is evaluated at query time against Azure, with short caches so a search
+does not pay for two or three control-plane calls every time: who a person is and which groups
+they belong to (5 minutes), their role and deny assignments (5 minutes), and, on Data Lake Gen2
+accounts, the directory traversals that grant recall (60 seconds). A grant or revocation in
+Azure is therefore reflected within that window — at most five minutes — never later, and a
+revoked user or removed role is refused on the next search after the cache expires. Blob
+tags and Gen2 file ACLs are read live for every result. If a shorter window matters more than
+per-query cost in your deployment, that is a tuning point rather than a redesign; open an issue.
+
 ### What Recheck verifies
 
 **Recheck** on the Access card asks Entra for a token as Connapse's identity. *Ready* means Entra

--- a/docs/research/azure-blob-connector-parity-2026-09-08.md
+++ b/docs/research/azure-blob-connector-parity-2026-09-08.md
@@ -1,0 +1,111 @@
+# Can the Azure Blob connector be as guided as the S3 one?
+**Date:** 2026-09-08
+**Status:** Reviewed
+**Built on:** azure-easy-setup-2026-09-08.md (the app-identity and custom-role design this extends)
+
+## Executive summary
+Yes — everything the S3 connection form automates has an Azure equivalent reachable with the
+certificate-authenticated access app Connapse already has, using only read-only operations:
+storage-account discovery (ARM), container discovery (blob data plane), hierarchical-namespace
+detection (ARM `isHnsEnabled`), and a real test-connection call. The one cost is two small
+control-plane **read** permissions the least-privilege custom roles currently omit
+(`Microsoft.Storage/storageAccounts/read` and `.../blobServices/containers/read`). Neither exposes
+keys or data; both are part of the built-in Storage Blob Data Reader / Reader roles. Microsoft's
+own Data Factory presents exactly this shape: "From Azure subscription" pickers or "Enter manually",
+plus Test connection.
+
+## Research brief
+**Question:** What can the Azure Blob connection form automate to match the S3 form, under
+Connapse's identity model (certificate app or managed identity; no keys, SAS, or connection strings)?
+
+**Sub-questions:** (1) What does the S3 form automate and how? (2) What does the Azure form have?
+(3) Which Azure operations and RBAC actions give account/container discovery and a test?
+(4) How do Microsoft's products present this?
+
+**Out of scope:** account keys / SAS / connection strings; write operations of any kind; changing
+the per-object permission engine.
+
+## Findings
+
+### What S3 automates today (Connections.razor, S3Discovery, S3ConnectionTester)
+Readiness banner from `IProviderSetupReader` (links to the AWS provider page when access is not set
+up); bucket picker ("Choose from buckets Connapse can see", `IS3Discovery.ListBucketsAsync`) that
+adds to the allowed-locations list and auto-fills the connection name; region auto-detect on pick
+(`GetBucketRegionAsync`); cross-account Role ARN behind a disclosure; a generated least-privilege IAM
+policy for exactly the chosen buckets (`S3SetupPolicy`); Test connection (lists ≤5 objects) with a
+troubleshooting link on failure. Discovery is a server-side service injected into the page, not a
+REST endpoint.
+
+### What Azure has today
+Two text fields (storage account name; optional blob endpoint for emulators), the shared
+allowed-locations list, and Test connection (`AzureBlobConnectionTester`, lists ≤5 blobs). No
+readiness banner, no account or container picker, no name auto-fill, no RBAC snippet, no
+troubleshooting link, and no discovery service at all (`ConnapseAzureCredentials` is only a
+`TokenCredential`).
+
+### Azure operations and the permissions they need (learn.microsoft.com, high confidence)
+| Need | Call | RBAC operation | In our roles today? |
+|---|---|---|---|
+| List storage accounts in the subscription | `Azure.ResourceManager.Storage` `SubscriptionResource.GetStorageAccountsAsync()` → `PrimaryEndpoints.BlobUri`, `IsHnsEnabled` | `Microsoft.Storage/storageAccounts/read` (Action) | **No** |
+| List containers in an account | `BlobServiceClient.GetBlobContainersAsync()` | `Microsoft.Storage/storageAccounts/blobServices/containers/read` (control-plane **Action**, even though the call is data-plane) | **No** → 403 today |
+| List blobs with a prefix / read blobs | `BlobContainerClient.GetBlobsAsync` | `.../containers/blobs/read` (DataAction) | Yes |
+| Read blob index tags | | `.../blobs/tags/read` (DataAction) | Yes |
+
+Storage Blob Data Reader's definition is Actions `containers/read` + `generateUserDelegationKey`,
+DataActions `blobs/read`; our blob role is that minus `containers/read` plus `tags/read`. The
+subscription-wide Reader role would also work for account listing but exposes every resource type,
+so a targeted action on our existing subscription-scoped role is tighter. `listKeys/action` is not
+needed for anything here and must stay out.
+
+There is no Azure "GetCallerIdentity" for an app. Token acquisition alone proves only that the
+certificate is valid, not that any role is assigned; the meaningful readiness probe is a scoped
+read that exercises the real permission (e.g. `GetBlobContainersAsync` on the chosen account, or
+`GET /subscriptions/{id}` for ARM reachability).
+
+### How Microsoft's products present it
+Azure Data Factory: "Account selection method" toggle — **From Azure subscription** (subscription →
+storage account dropdown, auto-fills the endpoint) or **Enter manually** (type the URL) — with a
+**Test connection** button; service-principal auth stores the service endpoint URL. Purview browses
+subscription → storage account and tests with the chosen identity (needs Storage Blob Data
+Reader). Fabric and Databricks take a URL (`https://…dfs.core.windows.net` / `abfss://`). All store
+a URL or endpoint, never a bare account name; HNS is implied by endpoint choice rather than shown,
+though ARM exposes `isHnsEnabled` directly — Connapse can do better by showing it.
+
+## Recommendation
+1. **Roles (needs the operator's OK — two read-only additions):** add
+   `Microsoft.Storage/storageAccounts/blobServices/containers/read` to the blob data role's
+   Actions, and `Microsoft.Storage/storageAccounts/read` to the subscription-scoped authorization
+   reader role. Both are read-only listing rights; no data or key access changes. The Access script
+   should create-or-update the role definitions so re-running upgrades existing roles.
+2. **`IAzureBlobDiscovery`** (Core interface, Storage implementation, mirroring `IS3Discovery`
+   with an `AzureProbe<T>` outcome type: not-configured / denied / failed / ok):
+   `ListStorageAccountsAsync` (name, blob endpoint, resource group, `IsHnsEnabled`),
+   `ListContainersAsync(accountName | endpoint)`, `ProbeAccessAsync`.
+3. **Connections form, Azure block, mirroring S3 line for line:** readiness banner (Azure Access
+   status, link to the Azure provider page); "From your subscription" account picker with an
+   "Enter manually" fallback (auto-fills account + endpoint; shows a "Data Lake Gen2 (hierarchical
+   namespace)" badge, which matters because Gen2 accounts are enforced via POSIX ACLs); container
+   picker feeding allowed locations and auto-filling the name; a generated `az role assignment`
+   snippet scoping the blob role to exactly the chosen account(s)/container(s); troubleshooting
+   link to `docs/azure-setup.md` on test failure.
+4. Package: `Azure.ResourceManager.Storage` (new, Storage project). Sovereign clouds: construct
+   `ArmClient` with the environment matching the credential's authority host.
+
+## Conflicts and uncertainties
+- The List Containers REST doc names Storage Blob Data Contributor as least-privileged although
+  Reader carries the same `containers/read` Action — treated as a docs inconsistency; Reader-level
+  rights suffice. Verify live after the role change.
+- `PrimaryEndpoints.BlobUri` vs `.Blob` depends on the SDK version; check the installed package.
+- ADF's exact Test-connection operation is not documented (community claim: a lightweight list).
+
+## Gaps
+No product documents surfacing `isHnsEnabled` in a picker; Connapse would be doing something the
+references don't. Managed-identity deployments get discovery the same way, but the Providers page
+still cannot see a system-assigned identity (known limitation).
+
+## Sources
+Primary: learn.microsoft.com — Azure built-in roles (Storage); List Containers and List Blobs REST
+authorization sections; `StorageAccountData.PrimaryEndpoints`; storage-blob-query-endpoint-srp;
+hierarchical-namespace (isHnsEnabled); Data Factory Azure Blob connector; Purview register/scan
+Azure Blob; Fabric ADLS shortcuts; Databricks external locations (ADLS). Secondary: Airbyte Azure
+Blob source docs; RBACMap role listing; a community Q&A on ADF test connection (410 Gone at fetch).

--- a/docs/research/azure-easy-setup-2026-09-08.md
+++ b/docs/research/azure-easy-setup-2026-09-08.md
@@ -1,0 +1,161 @@
+# Best "easy setup" (guided) flow for connecting Connapse to Azure
+**Date:** 2026-09-08
+**Status:** Reviewed
+**Built on:** no prior corpus material (Connapse knowledge MCP not available this session)
+
+## Executive summary
+The recommended Azure "easy setup" is the direct analog of Connapse's AWS CloudShell flow: **Connapse generates keypairs locally, emits an `az`-CLI Bash script the operator pastes into Azure Cloud Shell, and parses a delimited block the script prints back** (tenant, subscription, and two client IDs). Use **two separate Entra app registrations** (a low-privilege OIDC *sign-in* app and a certificate-authenticated *access* app) and **two least-privilege custom RBAC roles** (blob+tags data reader; authorization reader) rather than the over-broad built-ins. The one step that **cannot be guaranteed automatable** is granting admin consent to the access app's Microsoft Graph *application* permissions (`User.Read.All`, `GroupMember.Read.All`): **only Global Administrator or Privileged Role Administrator can do it**. The flow must therefore attempt consent, treat "insufficient privileges" as an expected branch, and fall back to surfacing a ready-to-send v1 `adminconsent` URL while marking per-user permissions "pending admin consent." Bicep/ARM is a non-starter (it cannot create Entra apps, service principals, or Graph grants).
+
+## Research brief
+**Question:** What is the best way to implement a low-friction guided ("easy") Azure setup for Connapse (self-hosted .NET), analogous to its AWS CloudShell + IAM Roles Anywhere flow, and what genuinely cannot be automated?
+
+**Sub-questions investigated:**
+1. Scripting approach & host (`az`/Cloud Shell vs Bicep vs Graph PowerShell vs portal) + the exact command sequence.
+2. The admin-consent constraint: exact role requirements, the out-of-band consent URL, graceful degradation.
+3. Identity & Azure RBAC model: one app vs two; built-in vs custom roles for blob+tags and for the RBAC read.
+4. Certificate handling, the paste-back handshake values, and common tenant blockers.
+
+**Out of scope:** the Blazor UI implementation itself; AWS specifics; non-Azure clouds.
+
+**Success criteria:** a concrete, implementable recommendation — approach + actual scripts/commands + how to handle the non-automatable admin-consent step + the recommended UX — grounded in current (2026) Azure/Entra behavior with citations.
+
+## Findings by sub-question
+
+### Sub-question 1 — Scripting approach & host: Azure Cloud Shell + discrete `az` commands
+**Claim:** Emit an `az`-CLI Bash script for Azure Cloud Shell; do not use Bicep, and do not use the `create-for-rbac` combo command.
+
+Azure Cloud Shell is the correct AWS-CloudShell analog: it is **pre-authenticated** ("Cloud Shell automatically securely authenticates for instant access to your resources through the Azure CLI" — [Cloud Shell overview](https://learn.microsoft.com/en-us/azure/cloud-shell/overview)) and runs **as the signed-in operator**, so its permissions match whatever rights the operator already holds — the same trust model as AWS CloudShell. **Bicep/ARM cannot create Entra app registrations, service principals, or Graph permission grants at all** — those are Microsoft Graph/Entra objects, not ARM resources — so Bicep is disqualified. `az ad sp create-for-rbac` can bundle app+SP+cert+role in one call but **cannot add Graph API permissions**, so the discrete command sequence is required regardless. Microsoft Graph PowerShell is workable but more verbose; portal click-through fails the "scriptable/low-friction" bar.
+
+Cloud Shell limitations to design around: it requires a one-time Azure Files (5 GB) mount prompt on first use, and times out after ~20 min of inactivity.
+
+**Verified command sequence** (current `az` syntax, Microsoft Learn CLI reference):
+```bash
+APP_ID=$(az ad app create --display-name "Connapse-Azure-Access" --query appId -o tsv)
+az ad app credential reset --id "$APP_ID" --cert "@connapse-access.pem" --append   # PUBLIC cert only
+az ad sp create --id "$APP_ID"
+az role assignment create --assignee "$APP_ID" --role "<data role>"  --scope "<storage account scope>"
+az role assignment create --assignee "$APP_ID" --role "<rbac-read role>" --scope "/subscriptions/<sub>"
+az ad app permission add --id "$APP_ID" --api 00000003-0000-0000-c000-000000000000 \
+  --api-permissions a154be20-db9c-4678-8ab7-66f6cc099a59=Role   # User.Read.All
+az ad app permission add --id "$APP_ID" --api 00000003-0000-0000-c000-000000000000 \
+  --api-permissions 98830695-27a2-44f7-8c18-0c3ebc9698f6=Role   # GroupMember.Read.All
+az ad app permission admin-consent --id "$APP_ID"               # may fail — see sub-question 2
+```
+**Corrections vs. common/older guidance** ([az ad app credential](https://learn.microsoft.com/en-us/cli/azure/ad/app/credential)): `az ad app credential add` does not exist — `az ad app credential reset` (with `--append`) is the unified command. `az ad app permission grant` activates **delegated** (`Scope`) permissions only; **application** (`Role`) permissions like these require `az ad app permission admin-consent`, a different command.
+
+*Confidence:* Commands and Cloud Shell pre-auth are **primary-source (Microsoft Learn)**. The two Graph app-role GUIDs were confirmed via a widely-cited third-party reference (graphpermissions.merill.net), **not** Microsoft directly — **verify live at build time** with `az ad sp show --id 00000003-0000-0000-c000-000000000000 --query "appRoles[?value=='User.Read.All'||value=='GroupMember.Read.All'].{v:value,id:id}"`.
+
+### Sub-question 2 — Admin consent is the one hard, non-automatable gate
+**Claim:** Only Global Administrator or Privileged Role Administrator can consent to the access app's Microsoft Graph *application* permissions; the flow must degrade gracefully.
+
+Per Microsoft's Graph permissions doc, **"Only Privileged Role Administrator and Global Administrator can consent to application permissions"** ([Permissions overview](https://learn.microsoft.com/en-us/graph/permissions-overview)). The Entra "Grant tenant-wide admin consent" prerequisites make the split explicit: **Privileged Role Administrator** can consent to any permission for any API; **Application Administrator / Cloud Application Administrator** can consent to any permission **except Microsoft Graph app roles (application permissions)** ([Grant tenant-wide admin consent](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent)). Global Administrator is a superset. So an operator who can *create* the app (Application/Cloud App Admin, or any member if the tenant allows self-service registration) **still cannot consent** to `User.Read.All`/`GroupMember.Read.All` unless they are Global Admin or Privileged Role Admin.
+
+Adjacent role requirements: **assigning Azure RBAC roles** (`Microsoft.Authorization/roleAssignments/write`) needs **Owner, User Access Administrator, or Role Based Access Control Administrator** at the target scope ([RBAC troubleshooting](https://learn.microsoft.com/en-us/azure/role-based-access-control/troubleshooting)) — Azure RBAC, distinct from Entra roles. **Creating custom roles** (`roleDefinitions/write`) needs the same Owner/User Access Admin level.
+
+**Out-of-band consent URL (verified, v1):**
+```
+https://login.microsoftonline.com/{tenant}/adminconsent?client_id={access-app-id}
+```
+`{tenant}` = tenant ID / a verified domain / the literal `organizations`. This grants **all permissions already configured** on the app's API-permissions blade — no scope enumeration, no redirect URI required ([Grant tenant-wide admin consent](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent)). The v2 form (`/v2.0/adminconsent?...&scope=https://graph.microsoft.com/.default&redirect_uri=...`) requires a registered redirect URI and is unnecessary here.
+
+**Recommended graceful degradation:** the script attempts `az ad app permission admin-consent` right after adding the permissions; treat `AADSTS650052`/"Insufficient privileges" as a **non-fatal expected branch**. On that branch: finish everything else (app + SP + RBAC assignments + emit the paste-back block), and have Connapse render the v1 consent URL with plain instructions ("send this to a Global Administrator or Privileged Role Administrator; they click Accept"). Connapse marks per-user Azure permissions **"pending admin consent"** (not "failed") with a re-check button, since consent completes out-of-band and takes a few minutes to propagate. This mirrors Microsoft's own SaaS deferred-admin-consent onboarding pattern.
+
+*Confidence:* **Primary-source (Microsoft Learn)** for the role split, the URL, and propagation delay.
+
+### Sub-question 3 — Two apps, and two custom least-privilege roles
+**Claim:** Use separate sign-in and access app registrations; build custom RBAC roles rather than the over-broad built-ins.
+
+**Two app registrations, not one.** Microsoft's Zero Trust guidance is explicit: "Use separate app registrations for apps that sign in users and apps that expose data and operations via API," to keep high-privilege API permissions and credentials "at a distance from user-facing components" ([Register applications – Zero Trust](https://learn.microsoft.com/en-us/security/zero-trust/develop/app-registration)). A combined app would make the public, every-user OIDC sign-in flow carry the same identity that holds subscription-wide reads and Graph app permissions. Separate apps also give independent credential rotation, independent consent, and clean audit separation (sign-ins vs. service reads under different app IDs).
+
+**Blob + tags data role — the built-in is insufficient; use a custom role.** `Microsoft.Storage/.../blobs/read` and `Microsoft.Storage/.../blobs/tags/read` are **distinct** actions in the Azure permissions reference, and **Storage Blob Data Reader's `dataActions` contains only `blobs/read`, not `blobs/tags/read`** ([storage permissions](https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/storage)). Storage Blob Data Owner/Contributor would add write/delete (far broader). A custom data role is the least-privilege fit — and it directly closes the `blobs/tags/read` prerequisite that Connapse's tag-ABAC verification needs (repo issue #498):
+```json
+{
+  "Name": "Connapse Blob Data + Tags Reader",
+  "IsCustom": true,
+  "Description": "Read blob content and blob index tags for ABAC-conditioned access verification.",
+  "Actions": [], "NotActions": [], "NotDataActions": [],
+  "DataActions": [
+    "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
+    "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read"
+  ],
+  "AssignableScopes": ["/subscriptions/{subscriptionId}"]
+}
+```
+Assign it at the storage-account (or container) scope; `AssignableScopes` can be narrowed to the specific account(s) if that fits Connapse's per-container model.
+
+**RBAC-read role — custom is more correct than built-in Reader.** Both `Microsoft.Authorization/roleAssignments/read` and `Microsoft.Authorization/denyAssignments/read` are confirmed read-only control-plane actions. Built-in **Reader** grants `*/read` across *every* resource type in scope (VMs, networking, SQL metadata, …) — far more than Connapse needs. Least-privilege custom role:
+```json
+{
+  "Name": "Connapse RBAC Authorization Reader",
+  "IsCustom": true,
+  "Description": "Read role and deny assignments at subscription scope for per-user permission filtering.",
+  "Actions": [
+    "Microsoft.Authorization/roleAssignments/read",
+    "Microsoft.Authorization/denyAssignments/read"
+  ],
+  "NotActions": [], "DataActions": [], "NotDataActions": [],
+  "AssignableScopes": ["/subscriptions/{subscriptionId}"]
+}
+```
+(Custom-role schema per [custom roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles).) **`Microsoft.Authorization/roleDefinitions/read` is NOT needed** — a research worker raised it as a possible dependency, but Connapse's `ArmRbacReader` matches assignments by the hard-coded Storage-Blob-Data role GUIDs (the last segment of `RoleDefinitionId`) and never fetches role *definitions*, so `roleAssignments/read` + `denyAssignments/read` suffice (resolved against this repo's code, not an external source). Built-in Reader remains a defensible one-line fallback if custom-role creation is undesirable.
+
+**Managed identity vs certificate app — split by topology.** A managed identity **cannot be used outside Azure** ("a managed identity can only be used by the Azure resource for which it was created"), so Connapse's self-hosted/Docker deployments **must** use a certificate-authenticated app registration + service principal — not optional, a hard platform constraint. On an Azure VM/AKS a managed identity is preferable (no cert to store/rotate), **but** its auto-created service principal still needs the same Graph application permissions granted and admin-consented and the same RBAC roles assigned — MI only removes credential management, not the permission grants. Design the access identity around the certificate app as the baseline; treat MI as an optional enhancement, applying the identical roles/consent to whichever service principal represents the access identity.
+
+*Confidence:* **Primary-source** for the built-in-role facts, the two-app guidance, and the MI constraint. The two custom-role recommendations are a least-privilege synthesis (well-documented principle) applied to confirmed read-only actions, not copied from a named MS example.
+
+### Sub-question 4 — Certificates, the paste-back handshake, and tenant blockers
+**Claim:** Upload only the public cert; return four values in a delimited block; detect the common tenant blockers.
+
+**Certificate (public only).** Entra accepts `.cer`/`.pem`/`.crt` public certificates; you upload the public key and sign the client-assertion JWT locally with the private key — the private key never leaves the host, matching the AWS flow ([Add and manage app credentials](https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials)). `az ad app credential reset --cert @cert.pem` takes a PEM/DER public cert (docs: "Do not include the private key"); **without `--append` it wipes existing credentials** (destructive default), so rotation and multi-cert use must pass `--append`. Known gotcha: re-running the same `--append` isn't idempotent (it imports a duplicate keyCredential) — the script should `az ad app credential list` first. **Rotation:** append the new cert before the old expires, switch local config to the new thumbprint, verify, then `az ad app credential delete --key-id <old>`. Some hardened tenants enforce an `appManagementPolicy` capping cert lifetime (e.g., `maxLifetime P180D`) — **disabled by default** but, when on, will reject a longer-lived cert; catch and surface that error ([Enforce secret/certificate standards](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/tutorial-enforce-secret-standards)).
+
+**Paste-back handshake — four values suffice:**
+```
+-----BEGIN CONNAPSE AZURE SETUP-----
+TENANT_ID=<guid>            # az account show --query tenantId -o tsv
+SUBSCRIPTION_ID=<guid>      # az account show --query id -o tsv
+ACCESS_APP_CLIENT_ID=<guid> # az ad app create (access) --query appId -o tsv
+SIGNIN_APP_CLIENT_ID=<guid> # az ad app create (sign-in) --query appId -o tsv
+-----END CONNAPSE AZURE SETUP-----
+```
+`appId` (client ID) is shared by an app and its SP; the separate *object* IDs aren't needed at paste-back (Connapse can derive the SP object id later via `az ad sp show --id <appId> --query id` if required). The delimited-block format is a **design recommendation** (mirroring Connapse's AWS `-----BEGIN…-----` marker), not an MS-documented convention.
+
+**Common tenant blockers** (script should detect the error and instruct):
+- **"Users can register applications" = No** (default is Yes): app creation then needs Application Developer / Application Administrator / Cloud Application Administrator / Global Administrator ([Delegate app roles](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/delegate-app-roles)).
+- **Guest (B2B) operator**: guests get restricted directory permissions by default and typically cannot register apps ([Default user permissions](https://learn.microsoft.com/en-us/entra/fundamentals/users-default-permissions)).
+- **PIM / Conditional Access / MFA**: a PIM-eligible privileged role must be *activated* (MFA/justification) before privileged `az` calls succeed — instruct the operator to activate then re-run. *(Inferred from PIM/CA docs, not a single Cloud-Shell-specific statement — lower confidence.)*
+- **Sovereign/national clouds** (Azure Government, China): different ARM/Graph/login endpoints — the script must `az cloud set --name <cloud>` and target the matching Graph endpoint. *(General pattern; needs a dedicated endpoint citation if launch targets these.)*
+
+## Conflicts and uncertainties
+- **No material conflicts** between workers. Both the admin-consent and blockers workers independently confirmed default self-service app registration is **Yes** and that consent is the gated step.
+- **Load-bearing single-source:** the Graph app-role GUIDs came from a third-party reference, not Microsoft directly. Mitigation: the script/Connapse should resolve them live via `az ad sp show` on the Graph SP at build/run time rather than hard-coding.
+- **Lower-confidence, inferred (not single-source MS):** the PIM→Cloud-Shell failure mode; sovereign-cloud endpoint specifics; the paste-back delimiter format (our design, not an MS convention).
+- **Resolved against this repo (not external):** the custom RBAC-read role does not need `roleDefinitions/read` (Connapse hard-codes the role GUIDs).
+
+## Gaps — what we did not find
+- No official Microsoft guidance on a "handshake" output format (expected — it's an app-specific design choice).
+- No single canonical Learn page enumerating all sovereign-cloud ARM/Graph/login endpoints was captured this pass.
+- Whether a client *secret* is acceptable in non-production self-host (vs. mandatory certificate) was out of scope; Connapse's design already mandates certificate/MI, so this doesn't block.
+- Not verified live: that the exact Graph app-role GUIDs above are current in every cloud — flagged for build-time verification.
+
+## Source quality assessment
+The load-bearing conclusions — Cloud Shell pre-auth and command semantics, the admin-consent role split, the v1 consent URL, the built-in-role dataActions, the certificate-public-key/`--append` behavior, and the MI-cannot-run-off-Azure constraint — rest on **primary sources (Microsoft Learn / Entra / Graph docs)**. The custom-role JSON recommendations are a **synthesis** of the (documented) least-privilege principle over confirmed read-only actions. Three items are explicitly lower-confidence/inferred (Graph GUIDs' provenance, PIM-in-Cloud-Shell, sovereign endpoints, and the handshake format) and are flagged inline.
+
+## Sources
+**Primary (Microsoft Learn / Entra / Graph):**
+- Cloud Shell overview — https://learn.microsoft.com/en-us/azure/cloud-shell/overview
+- az ad app credential — https://learn.microsoft.com/en-us/cli/azure/ad/app/credential
+- Add and manage app credentials — https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials
+- Permissions overview (who can consent) — https://learn.microsoft.com/en-us/graph/permissions-overview
+- Grant tenant-wide admin consent (role split + v1 URL) — https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent
+- v2 admin consent protocol — https://learn.microsoft.com/en-us/entra/identity-platform/v2-admin-consent
+- Azure RBAC troubleshooting (roleAssignments/write roles) — https://learn.microsoft.com/en-us/azure/role-based-access-control/troubleshooting
+- Storage permissions reference (blobs/read vs blobs/tags/read) — https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/storage
+- Azure custom roles — https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles
+- Register applications – Zero Trust (separate apps) — https://learn.microsoft.com/en-us/security/zero-trust/develop/app-registration
+- Delegate app registration permissions — https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/delegate-app-roles
+- Default user permissions (guest limits) — https://learn.microsoft.com/en-us/entra/fundamentals/users-default-permissions
+- Enforce secret/certificate standards (cert lifetime policy) — https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/tutorial-enforce-secret-standards
+
+**Secondary/tertiary (flagged, verify at build):**
+- graphpermissions.merill.net — Graph app-role GUIDs (User.Read.All, GroupMember.Read.All)
+- azure-cli GitHub issue #12797 — admin-consent propagation/failure modes

--- a/docs/superpowers/plans/2026-09-05-azure-phase2-app-identity-connector.md
+++ b/docs/superpowers/plans/2026-09-05-azure-phase2-app-identity-connector.md
@@ -1,0 +1,1050 @@
+# Azure Phase 2 — ConnapseAzureCredentials + Blob Connector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver Azure Blob ingestion end-to-end — Connapse's own Azure identity (ambient managed identity, or a configured service-principal certificate) plus a rebuilt read-only Azure Blob connector, creatable through the Connections/Sources UI.
+
+**Architecture:** Mirror the existing S3 path. A pure `AzureCredentialChainFactory` turns settings into a `TokenCredential` (unit-testable without Azure); `ConnapseAzureCredentials` wraps it with `IOptionsMonitor`. `AzureBlobConnector` implements `IConnector` and accepts an injectable `BlobServiceClient` so the Azurite integration test can use a shared-key client (Azurite cannot authenticate an AAD `TokenCredential`). `ConnectorFactory` recombines connection config + source scope, exactly as it does for S3.
+
+**Tech Stack:** .NET 10, `Azure.Storage.Blobs`, `Azure.Identity` (`TokenCredential`, `ChainedTokenCredential`, `ClientCertificateCredential`, `ManagedIdentityCredential`), xUnit + FluentAssertions + NSubstitute, Testcontainers.Azurite.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-azure-phase2-app-identity-connector-design.md` (parent: `docs/superpowers/specs/2026-09-05-azure-blob-provider-design.md`).
+
+## Global Constraints
+
+- **One credential story, two contexts** — configured **certificate** (off-Azure) → **ambient managed identity** (in-Azure) → **fail closed**. No client-secret, no workload-identity-federation, no credential-kind chooser.
+- **Credential config from the settings hierarchy only** (`AzureProviderSettings`), NOT `ProviderCredentialEntity`. No DB-stored/encrypted credential in this phase.
+- Use an explicit **`ChainedTokenCredential`**, never `DefaultAzureCredential`.
+- **No per-user permission logic** (Phase 4). **No guided Providers setup page.** **No live-watch** (`SupportsLiveWatch = false`).
+- Enum values: `ConnectorType.AzureBlob = 4`, `ConnectionProvider.AzureBlob = 4`, `CloudProvider.Azure = 1` — do not renumber existing members.
+- Don't touch Azure OpenAI / AI Foundry, JWT/SAML, or the AWS path.
+- .NET conventions (CLAUDE.md): file-scoped namespaces, records for DTOs/settings, primary constructors for DI, async all the way, no `var` for primitives, parameterized SQL only.
+- Build: `dotnet build`. Tests: `dotnet test --filter "Category=Unit"` (no Docker), `dotnet test --filter "Category=Integration"` (Docker). Tag tests with `[Trait("Category","Unit")]` or `[Trait("Category","Integration")]`.
+
+---
+
+### Task 1: `AzureProviderSettings` + `AzureCredentialChainFactory`
+
+The pure credential-selection logic — the novel core, unit-testable without Azure.
+
+**Files:**
+- Create: `src/Connapse.Core/Models/AzureProviderSettings.cs`
+- Create: `src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs`
+- Modify: `src/Connapse.Storage/Connapse.Storage.csproj` (add `Azure.Identity`)
+
+**Interfaces:**
+- Produces: `record AzureProviderSettings { string? TenantId; string? ClientId; string? ClientCertificatePath; string? ClientCertificatePassword; string? UserAssignedManagedIdentityClientId; const string SectionName = "Providers:Azure"; }`
+- Produces: `static class AzureCredentialChainFactory { static TokenCredential Create(AzureProviderSettings settings, Func<AzureProviderSettings, X509Certificate2?> certLoader); }` — returns a `ChainedTokenCredential`; **throws `InvalidOperationException`** when `ClientId` is set but `certLoader` returns null (misconfiguration must not silently fall through to ambient).
+
+- [ ] **Step 1: Add the `Azure.Identity` package**
+
+Add to `src/Connapse.Storage/Connapse.Storage.csproj` (version pinned to the latest 1.x the restore resolves, ≥ 1.16.0 for the resilient MI retry mode):
+```xml
+<PackageReference Include="Azure.Identity" Version="1.16.0" />
+```
+Run: `dotnet restore` — expect success.
+
+- [ ] **Step 2: Write `AzureProviderSettings`**
+
+```csharp
+namespace Connapse.Core;
+
+/// <summary>
+/// Connapse's own Azure app-credential configuration, bound from the settings hierarchy.
+/// When ClientId + a certificate are present, Connapse authenticates as that service principal;
+/// otherwise it uses the ambient managed identity. Never a client secret.
+/// </summary>
+public record AzureProviderSettings
+{
+    public const string SectionName = "Providers:Azure";
+
+    public string? TenantId { get; init; }
+    public string? ClientId { get; init; }
+    public string? ClientCertificatePath { get; init; }
+    public string? ClientCertificatePassword { get; init; }
+    public string? UserAssignedManagedIdentityClientId { get; init; }
+}
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+```csharp
+using Azure.Identity;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureCredentialChainFactoryTests
+{
+    private static X509Certificate2 SelfSigned() =>
+        new CertificateRequest("CN=connapse-test",
+            System.Security.Cryptography.ECDsa.Create(),
+            HashAlgorithmName.SHA256)
+            .CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
+
+    [Fact]
+    public void Create_WithClientIdAndCert_UsesCertificateCredential()
+    {
+        var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        cred.Should().BeOfType<ChainedTokenCredential>();
+        // First source is the cert credential when configured.
+        FirstSource(cred).Should().BeOfType<ClientCertificateCredential>();
+    }
+
+    [Fact]
+    public void Create_NoCert_SystemAssignedManagedIdentity()
+    {
+        var cred = AzureCredentialChainFactory.Create(new AzureProviderSettings(), _ => null);
+        FirstSource(cred).Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    [Fact]
+    public void Create_NoCert_UserAssignedManagedIdentity()
+    {
+        var settings = new AzureProviderSettings { UserAssignedManagedIdentityClientId = "mi-client" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => null);
+        FirstSource(cred).Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    [Fact]
+    public void Create_ClientIdSetButCertMissing_Throws()
+    {
+        var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => null);
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*certificate*");
+    }
+
+    // Reads the private _sources array ChainedTokenCredential stores, to assert ordering.
+    private static TokenCredential FirstSource(TokenCredential chain)
+    {
+        var field = typeof(ChainedTokenCredential)
+            .GetField("_sources", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var sources = (TokenCredential[])field.GetValue(chain)!;
+        return sources[0];
+    }
+}
+```
+> Note: if a future `Azure.Identity` renames the private `_sources` field, switch `FirstSource` to assert behavior via a stubbed `certLoader`/env instead. The public contract under test is "cert first when configured, else MI, else throw."
+
+- [ ] **Step 4: Run tests, verify they fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~AzureCredentialChainFactoryTests"`
+Expected: FAIL — `AzureCredentialChainFactory` does not exist.
+
+- [ ] **Step 5: Implement `AzureCredentialChainFactory`**
+
+```csharp
+using Azure.Core;
+using Azure.Identity;
+using Connapse.Core;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Pure selection of Connapse's Azure credential from settings: a configured
+/// service-principal certificate first, else the ambient managed identity, else fail closed.
+/// Deterministic (an explicit ChainedTokenCredential) — never DefaultAzureCredential.
+/// </summary>
+public static class AzureCredentialChainFactory
+{
+    public static TokenCredential Create(
+        AzureProviderSettings settings,
+        Func<AzureProviderSettings, X509Certificate2?> certLoader)
+    {
+        var sources = new List<TokenCredential>();
+
+        if (!string.IsNullOrWhiteSpace(settings.ClientId))
+        {
+            X509Certificate2 cert = certLoader(settings)
+                ?? throw new InvalidOperationException(
+                    "Azure ClientId is configured but no usable certificate was loaded "
+                    + $"(ClientCertificatePath='{settings.ClientCertificatePath}'). "
+                    + "Fix the certificate configuration; Connapse will not silently fall back to managed identity.");
+
+            sources.Add(new ClientCertificateCredential(
+                settings.TenantId, settings.ClientId, cert,
+                new ClientCertificateCredentialOptions { SendCertificateChain = true }));
+        }
+
+        sources.Add(string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+            ? new ManagedIdentityCredential()
+            : new ManagedIdentityCredential(
+                ManagedIdentityId.FromUserAssignedClientId(settings.UserAssignedManagedIdentityClientId)));
+
+        return new ChainedTokenCredential(sources.ToArray());
+    }
+}
+```
+
+- [ ] **Step 6: Run tests, verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~AzureCredentialChainFactoryTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Connapse.Core/Models/AzureProviderSettings.cs src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs src/Connapse.Storage/Connapse.Storage.csproj
+git commit -m "feat(azure): AzureProviderSettings + credential chain factory (#477)"
+```
+
+---
+
+### Task 2: `ConnapseAzureCredentials`
+
+The `TokenCredential` singleton every Azure SDK client consumes — wraps the factory with `IOptionsMonitor`, caching the chain and rebuilding on settings reload.
+
+**Files:**
+- Create: `src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs`
+
+**Interfaces:**
+- Consumes: `AzureCredentialChainFactory.Create`, `AzureProviderSettings`.
+- Produces: `class ConnapseAzureCredentials : TokenCredential { const string ProviderKey = "azure"; }` — overrides `GetToken`/`GetTokenAsync` to delegate to the current chain.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Azure.Core;
+using Azure.Identity;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class ConnapseAzureCredentialsTests
+{
+    [Fact]
+    public void ProviderKey_IsAzure() => ConnapseAzureCredentials.ProviderKey.Should().Be("azure");
+
+    [Fact]
+    public void GetToken_WithNoAzureEnvironment_FailsClosed()
+    {
+        // No cert, no managed-identity endpoint reachable in a unit-test host → the chain
+        // cannot produce a token and throws, rather than returning a bogus token.
+        var monitor = new TestOptionsMonitor<AzureProviderSettings>(new AzureProviderSettings());
+        var creds = new ConnapseAzureCredentials(monitor);
+        var act = () => creds.GetToken(
+            new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
+        act.Should().Throw<CredentialUnavailableException>();
+    }
+
+    private sealed class TestOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; private set; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}
+```
+> The fail-closed assertion runs in a host with no managed-identity endpoint; `ManagedIdentityCredential` throws `CredentialUnavailableException`, which the chain surfaces. If a CI runner ever exposes an MI endpoint, gate this test with the `AZURE_*`-absent precondition.
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~ConnapseAzureCredentialsTests"`
+Expected: FAIL — `ConnapseAzureCredentials` does not exist.
+
+- [ ] **Step 3: Implement `ConnapseAzureCredentials`**
+
+```csharp
+using Azure.Core;
+using Connapse.Core;
+using Microsoft.Extensions.Options;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Connapse's own Azure identity: an explicit certificate-or-ambient-managed-identity chain,
+/// rebuilt when settings reload. The single TokenCredential every Azure SDK client uses.
+/// </summary>
+public sealed class ConnapseAzureCredentials : TokenCredential, IDisposable
+{
+    public const string ProviderKey = "azure";
+
+    private readonly IOptionsMonitor<AzureProviderSettings> _options;
+    private readonly IDisposable? _reload;
+    private readonly object _gate = new();
+    private TokenCredential _current;
+
+    public ConnapseAzureCredentials(IOptionsMonitor<AzureProviderSettings> options)
+    {
+        _options = options;
+        _current = Build(options.CurrentValue);
+        _reload = options.OnChange(settings =>
+        {
+            lock (_gate) { _current = Build(settings); }
+        });
+    }
+
+    private TokenCredential Current { get { lock (_gate) { return _current; } } }
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken ct) =>
+        Current.GetToken(requestContext, ct);
+
+    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken ct) =>
+        Current.GetTokenAsync(requestContext, ct);
+
+    private static TokenCredential Build(AzureProviderSettings settings) =>
+        AzureCredentialChainFactory.Create(settings, LoadCertificate);
+
+    private static X509Certificate2? LoadCertificate(AzureProviderSettings s)
+    {
+        if (string.IsNullOrWhiteSpace(s.ClientCertificatePath)) return null;
+        if (!File.Exists(s.ClientCertificatePath)) return null;
+
+        string ext = Path.GetExtension(s.ClientCertificatePath).ToLowerInvariant();
+        return ext is ".pem" or ".crt"
+            ? X509Certificate2.CreateFromPemFile(s.ClientCertificatePath)
+            : X509CertificateLoader.LoadPkcs12FromFile(s.ClientCertificatePath, s.ClientCertificatePassword);
+    }
+
+    public void Dispose() => _reload?.Dispose();
+}
+```
+> `X509Certificate2.CreateFromPemFile` reads a PEM cert (with its key from the same file or a paired `.key`); `X509CertificateLoader.LoadPkcs12FromFile` is the .NET 9+ replacement for the obsolete `new X509Certificate2(path, password)` PFX ctor. If the target framework lacks `X509CertificateLoader`, use `new X509Certificate2(path, password)` and suppress the obsoletion locally.
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~ConnapseAzureCredentialsTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs
+git commit -m "feat(azure): ConnapseAzureCredentials TokenCredential singleton (#477)"
+```
+
+---
+
+### Task 3: Enum values + `ResourceUri.ForAzureBlob`
+
+Foundational identifiers the connector and factory consume.
+
+**Files:**
+- Modify: `src/Connapse.Core/Models/StorageModels.cs` (`ConnectorType`)
+- Modify: `src/Connapse.Core/Models/ConnectionModels.cs` (`ConnectionProvider`)
+- Modify: `src/Connapse.Core/Models/CloudProvider.cs`
+- Modify: `src/Connapse.Core/Utilities/ResourceUri.cs`
+- Test: `tests/Connapse.Core.Tests/Utilities/ResourceUriTests.cs`
+
+**Interfaces:**
+- Produces: `ConnectorType.AzureBlob = 4`, `ConnectionProvider.AzureBlob = 4`, `CloudProvider.Azure = 1`, `ResourceUri.ForAzureBlob(string account, string container, string path) → "azblob://{account}/{container}/{path}"`.
+
+- [ ] **Step 1: Write the failing test** (append to `ResourceUriTests.cs`)
+
+```csharp
+[Fact]
+[Trait("Category", "Unit")]
+public void ForAzureBlob_BuildsAzblobUri()
+{
+    ResourceUri.ForAzureBlob("acct", "docs", "reports/q1.pdf")
+        .Should().Be("azblob://acct/docs/reports/q1.pdf");
+}
+
+[Fact]
+[Trait("Category", "Unit")]
+public void ForAzureBlob_BlankAccount_Throws()
+{
+    var act = () => ResourceUri.ForAzureBlob("", "docs", "k");
+    act.Should().Throw<ArgumentException>();
+}
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~ResourceUriTests.ForAzureBlob"`
+Expected: FAIL — `ForAzureBlob` not defined.
+
+- [ ] **Step 3: Implement**
+
+In `ResourceUri.cs`, add beside `ForS3`:
+```csharp
+public static string ForAzureBlob(string account, string container, string path)
+{
+    ArgumentException.ThrowIfNullOrWhiteSpace(account);
+    ArgumentException.ThrowIfNullOrWhiteSpace(container);
+    return $"azblob://{account}/{container}/{path}";
+}
+```
+In the three enums, add the Azure member (do not renumber others):
+- `ConnectorType`: `... S3 = 3, AzureBlob = 4, Sftp = 5 }`
+- `ConnectionProvider`: `... S3 = 3, AzureBlob = 4, Sftp = 5 }`
+- `CloudProvider`: `{ AWS = 0, Azure = 1 }`
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~ResourceUriTests.ForAzureBlob"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Models/StorageModels.cs src/Connapse.Core/Models/ConnectionModels.cs src/Connapse.Core/Models/CloudProvider.cs src/Connapse.Core/Utilities/ResourceUri.cs tests/Connapse.Core.Tests/Utilities/ResourceUriTests.cs
+git commit -m "feat(azure): re-add AzureBlob/Azure enum values + ResourceUri.ForAzureBlob (#477)"
+```
+
+---
+
+### Task 4: `AzureBlobConnectorConfig` + `AzureBlobConnector`
+
+**Files:**
+- Create: `src/Connapse.Storage/Connectors/AzureBlobConnectorConfig.cs`
+- Create: `src/Connapse.Storage/Connectors/AzureBlobConnector.cs`
+- Modify: `src/Connapse.Storage/Connapse.Storage.csproj` (add `Azure.Storage.Blobs`)
+- Test: `tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs`
+
+**Interfaces:**
+- Consumes: `ResourceUri.ForAzureBlob`, `ConnectorType.AzureBlob`, `TokenCredential`.
+- Produces: `record AzureBlobConnectorConfig { string AccountName; string ContainerName; string? Prefix; string? BlobEndpoint; }`; `class AzureBlobConnector : IConnector, IDisposable` with a public ctor `(AzureBlobConnectorConfig config, TokenCredential credential)` and an `internal` ctor `(AzureBlobConnectorConfig config, BlobServiceClient client)` used by tests.
+
+- [ ] **Step 1: Add the `Azure.Storage.Blobs` package**
+
+Add to `Connapse.Storage.csproj`:
+```xml
+<PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
+```
+Run: `dotnet restore` — expect success.
+
+- [ ] **Step 2: Write the failing unit test** (network-free surface only: `Type`, `SupportsLiveWatch`, `ResolveJobPath`, `WatchAsync` throws)
+
+```csharp
+using Azure.Storage.Blobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Connectors;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Connectors;
+
+[Trait("Category", "Unit")]
+public class AzureBlobConnectorUnitTests
+{
+    private static AzureBlobConnector Make() =>
+        new(new AzureBlobConnectorConfig { AccountName = "acct", ContainerName = "docs", Prefix = "reports/" },
+            new BlobServiceClient(new Uri("http://127.0.0.1:10000/devstoreaccount1")));
+
+    [Fact] public void Type_IsAzureBlob() => Make().Type.Should().Be(ConnectorType.AzureBlob);
+    [Fact] public void SupportsLiveWatch_False() => Make().SupportsLiveWatch.Should().BeFalse();
+
+    [Fact]
+    public void ResolveJobPath_JoinsUnderPrefix()
+        => Make().ResolveJobPath("q1.pdf").Should().Be("reports/q1.pdf");
+
+    [Fact]
+    public async Task WatchAsync_Throws()
+    {
+        var act = async () => { await foreach (var _ in Make().WatchAsync()) { } };
+        await act.Should().ThrowAsync<NotSupportedException>();
+    }
+}
+```
+
+- [ ] **Step 3: Run test, verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~AzureBlobConnectorUnitTests"`
+Expected: FAIL — types not defined.
+
+- [ ] **Step 4: Implement config + connector**
+
+`AzureBlobConnectorConfig.cs`:
+```csharp
+namespace Connapse.Storage.Connectors;
+
+/// <summary>Recombined connection (account/endpoint) + source (container/prefix) config for the Azure Blob connector.</summary>
+public record AzureBlobConnectorConfig
+{
+    public string AccountName { get; init; } = "";
+    public string ContainerName { get; init; } = "";
+    public string? Prefix { get; init; }
+    /// <summary>Overrides https://{account}.blob.core.windows.net (Azurite/local).</summary>
+    public string? BlobEndpoint { get; init; }
+}
+```
+
+`AzureBlobConnector.cs`:
+```csharp
+using Azure.Core;
+using Azure.Storage.Blobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
+using System.Runtime.CompilerServices;
+
+namespace Connapse.Storage.Connectors;
+
+/// <summary>
+/// Read-only Azure Blob Storage connector. Builds a BlobServiceClient from the account +
+/// Connapse's TokenCredential; the internal ctor accepts a prebuilt client for tests
+/// (Azurite cannot authenticate an AAD TokenCredential). SupportsLiveWatch = false.
+/// </summary>
+public sealed class AzureBlobConnector : IConnector, IDisposable
+{
+    private readonly AzureBlobConnectorConfig _config;
+    private readonly BlobContainerClient _container;
+
+    public AzureBlobConnector(AzureBlobConnectorConfig config, TokenCredential credential)
+        : this(config, new BlobServiceClient(
+            new Uri(config.BlobEndpoint ?? $"https://{config.AccountName}.blob.core.windows.net"),
+            credential))
+    { }
+
+    internal AzureBlobConnector(AzureBlobConnectorConfig config, BlobServiceClient client)
+    {
+        _config = config;
+        _container = client.GetBlobContainerClient(config.ContainerName);
+    }
+
+    public ConnectorType Type => ConnectorType.AzureBlob;
+    public bool SupportsLiveWatch => false;
+
+    public string ResolveJobPath(string relativePath) => CombinePrefix(relativePath);
+
+    public async Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
+    {
+        string effective = CombinePrefix(prefix ?? "");
+        var files = new List<ConnectorFile>();
+        await foreach (var item in _container.GetBlobsAsync(prefix: effective, cancellationToken: ct))
+        {
+            files.Add(new ConnectorFile(
+                item.Name,
+                item.Properties.ContentLength ?? 0,
+                (item.Properties.LastModified ?? DateTimeOffset.MinValue).UtcDateTime,
+                item.Properties.ContentType,
+                ResourceUri.ForAzureBlob(_config.AccountName, _config.ContainerName, item.Name)));
+        }
+        return files;
+    }
+
+    public async Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
+    {
+        var download = await _container.GetBlobClient(path).DownloadStreamingAsync(cancellationToken: ct);
+        return download.Value.Content;
+    }
+
+    public async Task<bool> ExistsAsync(string path, CancellationToken ct = default)
+        => await _container.GetBlobClient(path).ExistsAsync(ct);
+
+    public async IAsyncEnumerable<ConnectorFileEvent> WatchAsync([EnumeratorCancellation] CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Azure Blob connector does not support live watch.");
+#pragma warning disable CS0162
+        yield break;
+#pragma warning restore CS0162
+    }
+
+    private string CombinePrefix(string tail)
+    {
+        string p = _config.Prefix?.Trim('/') ?? "";
+        string t = tail.TrimStart('/');
+        return string.IsNullOrEmpty(p) ? t : string.IsNullOrEmpty(t) ? p + "/" : $"{p}/{t}";
+    }
+
+    public void Dispose() { }
+}
+```
+> `ListFilesAsync` correctness (real enumeration, prefix scoping, streaming reads) is covered by the Azurite integration test in Task 8; this unit test covers only the network-free surface.
+
+- [ ] **Step 5: Run test, verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~AzureBlobConnectorUnitTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Connapse.Storage/Connectors/AzureBlobConnectorConfig.cs src/Connapse.Storage/Connectors/AzureBlobConnector.cs src/Connapse.Storage/Connapse.Storage.csproj tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
+git commit -m "feat(azure): AzureBlobConnector + config (#477)"
+```
+
+---
+
+### Task 5: `ConnectorFactory` Azure arm
+
+**Files:**
+- Modify: `src/Connapse.Storage/Connectors/ConnectorFactory.cs` (add `ConnapseAzureCredentials` to the primary ctor; add the `ConnectionProvider.AzureBlob` switch arm)
+- Test: `tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs` (add the Azure case)
+
+**Interfaces:**
+- Consumes: `ConnapseAzureCredentials` (as `TokenCredential`), `AzureBlobConnector`, `AzureBlobConnectorConfig`, `ConnectionProvider.AzureBlob`.
+- Produces: `IConnectorFactory.Create(source, connection, secret)` returns an `AzureBlobConnector` for `ConnectionProvider.AzureBlob`, reading `accountName`/`blobEndpoint` from the connection config and `containerName`/`prefix` from the source scope.
+
+- [ ] **Step 1: Write the failing test** (mirror the existing S3 factory test in the same file)
+
+```csharp
+[Fact]
+[Trait("Category", "Unit")]
+public void Create_AzureBlob_BuildsConnectorFromSplitConfig()
+{
+    var connection = TestConnection(ConnectionProvider.AzureBlob,
+        configJson: """{"accountName":"acct"}""");
+    var source = TestSource(connection.Id,
+        scopeJson: """{"containerName":"docs","prefix":"reports/"}""");
+
+    var connector = Factory().Create(source, connection);
+
+    connector.Should().BeOfType<AzureBlobConnector>();
+    connector.Type.Should().Be(ConnectorType.AzureBlob);
+}
+```
+> Reuse the file's existing `TestConnection`/`TestSource`/`Factory` helpers (as the S3 case does). If `Factory()` needs the new ctor arg, pass a `ConnapseAzureCredentials` built with a `TestOptionsMonitor<AzureProviderSettings>(new())` — no network is touched because `Create` does not call the connector.
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~SourceConnectorFactoryTests.Create_AzureBlob"`
+Expected: FAIL — no AzureBlob arm / ctor arg missing.
+
+- [ ] **Step 3: Implement the arm**
+
+Add `ConnapseAzureCredentials azureCredentials` to `ConnectorFactory`'s constructor (beside the existing `awsCredentials`), store it, and add the switch arm after the S3 arm:
+```csharp
+ConnectionProvider.AzureBlob => new AzureBlobConnector(new AzureBlobConnectorConfig
+{
+    AccountName = Str(credential, "accountName")
+        ?? throw new InvalidOperationException(
+            $"Connection '{connection.Name}' has no accountName."),
+    BlobEndpoint = Str(credential, "blobEndpoint"),
+    ContainerName = RequirePermittedLocation(
+        StorageLocationPolicy.ReadAllowedLocations(credential.RootElement),
+        Str(scope, "containerName")
+            ?? throw new InvalidOperationException(
+                $"Source '{source.Name}' has no containerName in its scope."),
+        Str(scope, "prefix"),
+        connection.Name, source.Name),
+    Prefix = Str(scope, "prefix"),
+}, azureCredentials),
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~SourceConnectorFactoryTests"`
+Expected: PASS (the new case + existing S3/Filesystem/Sftp cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/Connectors/ConnectorFactory.cs tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
+git commit -m "feat(azure): ConnectorFactory AzureBlob arm (#477)"
+```
+
+---
+
+### Task 6: `AzureBlobConnectionTester`
+
+**Files:**
+- Create: `src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs`
+- Test: `tests/Connapse.Core.Tests/ConnectionTesterTests.cs` (add Azure settings-shaping cases)
+
+**Interfaces:**
+- Consumes: `ConnapseAzureCredentials`, `AzureBlobConnectorConfig`, `ConnectionTestResult`.
+- Produces: `class AzureBlobConnectionTester : IConnectionTester` — `TestConnectionAsync(object settings, …)` where `settings` is an `AzureBlobConnectorConfig`; lists ≤5 blobs; returns `ConnectionTestResult.CreateSuccess`/`CreateFailure`.
+
+- [ ] **Step 1: Write the failing test** (settings-shaping + failure mapping, no network)
+
+```csharp
+[Fact]
+[Trait("Category", "Unit")]
+public async Task AzureBlobTester_WrongSettingsType_Fails()
+{
+    var tester = new AzureBlobConnectionTester(
+        new ConnapseAzureCredentials(new TestOptionsMonitor<AzureProviderSettings>(new())));
+    var result = await tester.TestConnectionAsync("not-a-config", TimeSpan.FromSeconds(1));
+    result.Success.Should().BeFalse();
+    result.Message.Should().Contain("AzureBlobConnectorConfig");
+}
+```
+> `TestOptionsMonitor<T>` is the small stub from Task 2's test; extract it to a shared test helper (`tests/Connapse.Core.Tests/TestOptionsMonitor.cs`) if both projects need it, or duplicate the 5-line stub — do not add a production seam for it.
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~ConnectionTesterTests.AzureBlobTester"`
+Expected: FAIL — `AzureBlobConnectionTester` not defined.
+
+- [ ] **Step 3: Implement** (mirror `S3ConnectionTester` structure)
+
+```csharp
+using Azure;
+using Azure.Storage.Blobs;
+using Connapse.Core.Interfaces;
+using Connapse.Core.Models;
+using Connapse.Storage.CloudScope;
+using Connapse.Storage.Connectors;
+
+namespace Connapse.Storage.ConnectionTesters;
+
+/// <summary>Validates an Azure Blob connection by listing a few blobs with Connapse's identity.</summary>
+public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentials) : IConnectionTester
+{
+    public async Task<ConnectionTestResult> TestConnectionAsync(
+        object settings, TimeSpan? timeout = null, CancellationToken ct = default)
+    {
+        if (settings is not AzureBlobConnectorConfig cfg)
+            return ConnectionTestResult.CreateFailure(
+                "Invalid settings: expected AzureBlobConnectorConfig.");
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(timeout ?? TimeSpan.FromSeconds(10));
+
+        try
+        {
+            var service = new BlobServiceClient(
+                new Uri(cfg.BlobEndpoint ?? $"https://{cfg.AccountName}.blob.core.windows.net"),
+                credentials);
+            var container = service.GetBlobContainerClient(cfg.ContainerName);
+
+            int seen = 0;
+            await foreach (var _ in container.GetBlobsAsync(prefix: cfg.Prefix, cancellationToken: cts.Token))
+                if (++seen >= 5) break;
+
+            return ConnectionTestResult.CreateSuccess(
+                $"Connected to container '{cfg.ContainerName}' on account '{cfg.AccountName}'.");
+        }
+        catch (RequestFailedException ex) when (ex.Status == 403)
+        {
+            return ConnectionTestResult.CreateFailure(
+                "Authorization failed — Connapse's identity lacks read access to this container "
+                + "(needs Storage Blob Data Reader).");
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return ConnectionTestResult.CreateFailure(
+                $"Container '{cfg.ContainerName}' or account '{cfg.AccountName}' not found.");
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return ConnectionTestResult.CreateFailure("Connection test timed out.");
+        }
+        catch (Exception ex)
+        {
+            return ConnectionTestResult.CreateFailure($"Connection test failed: {ex.Message}");
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~ConnectionTesterTests.AzureBlobTester"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs tests/Connapse.Core.Tests/ConnectionTesterTests.cs
+git commit -m "feat(azure): AzureBlobConnectionTester (#477)"
+```
+
+---
+
+### Task 7: DI + settings wiring
+
+**Files:**
+- Modify: `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs`
+- Modify: `src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs` (`CategoryPrefixMap`)
+- Modify: `src/Connapse.Web/appsettings.json` (empty `Providers:Azure` section as documentation)
+- Test: `tests/Connapse.Integration.Tests/` — add a DI-resolution assertion to an existing startup/integration fixture test (a clean container start proves the DI graph)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `ConnapseAzureCredentials` (singleton), `AzureBlobConnectionTester` (scoped), `Configure<AzureProviderSettings>` bound to `"Providers:Azure"`, and the `ConnectorFactory` ctor's new arg satisfied.
+
+- [ ] **Step 1: Write the failing test** — add to the existing DI/host integration test (find the one that resolves `IConnectorFactory`/testers; e.g. in `Connapse.Integration.Tests`):
+
+```csharp
+[Fact]
+[Trait("Category", "Integration")]
+public void Di_Resolves_AzureCredentialsAndTester()
+{
+    using var scope = _fixture.Services.CreateScope();
+    scope.ServiceProvider.GetRequiredService<ConnapseAzureCredentials>().Should().NotBeNull();
+    scope.ServiceProvider.GetServices<IConnectionTester>()
+        .Should().Contain(t => t is AzureBlobConnectionTester);
+    scope.ServiceProvider.GetRequiredService<IConnectorFactory>().Should().NotBeNull();
+}
+```
+> Use the collection's shared `SharedWebAppFixture` (per CLAUDE.md) rather than a new host. If no such DI-resolution test exists yet, add this one to the existing integration collection.
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~Di_Resolves_AzureCredentials"`
+Expected: FAIL — `ConnapseAzureCredentials`/tester not registered (or `ConnectorFactory` ctor unsatisfied).
+
+- [ ] **Step 3: Implement the registrations**
+
+In `AddConnapseStorage` (`ServiceCollectionExtensions.cs`), beside the AWS credential + S3 tester registrations:
+```csharp
+services.Configure<AzureProviderSettings>(configuration.GetSection(AzureProviderSettings.SectionName));
+services.AddSingleton<ConnapseAzureCredentials>();
+services.AddScoped<IConnectionTester, AzureBlobConnectionTester>();
+```
+In `DatabaseSettingsProvider.CategoryPrefixMap`, add:
+```csharp
+["azure"] = "Providers:Azure",
+```
+In `appsettings.json`, add a documented empty section:
+```json
+"Providers": { "Azure": { "TenantId": "", "ClientId": "", "ClientCertificatePath": "", "UserAssignedManagedIdentityClientId": "" } }
+```
+(If `ConnectorFactory` is a singleton consuming `ConnapseAzureCredentials`, the new ctor arg is satisfied automatically once the singleton is registered.)
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~Di_Resolves_AzureCredentials"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs src/Connapse.Web/appsettings.json tests/Connapse.Integration.Tests/
+git commit -m "feat(azure): DI + settings wiring for Azure provider (#477)"
+```
+
+---
+
+### Task 8: Azurite integration tests
+
+**Files:**
+- Modify: `tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj` (add `Testcontainers.Azurite`)
+- Create: `tests/Connapse.Integration.Tests/AzuriteFixture.cs`
+- Create: `tests/Connapse.Integration.Tests/AzureBlobConnectorIntegrationTests.cs`
+- Modify: `tests/Connapse.Integration.Tests/CloudConnectorTestCollection.cs` (add `AzureBlobConnectorTestCollection`)
+
+**Interfaces:**
+- Consumes: `AzureBlobConnector` (internal `BlobServiceClient` ctor), `AzureBlobConnectorConfig`.
+- Produces: end-to-end coverage of list/read/exists/prefix/ResourceUri against Azurite.
+
+- [ ] **Step 1: Add the package**
+
+```xml
+<PackageReference Include="Testcontainers.Azurite" Version="4.3.0" />
+```
+Run: `dotnet restore` — expect success.
+
+- [ ] **Step 2: Write `AzuriteFixture`**
+
+```csharp
+using Testcontainers.Azurite;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+public sealed class AzuriteFixture : IAsyncLifetime
+{
+    private readonly AzuriteContainer _container = new AzuriteBuilder().Build();
+    public string ConnectionString => _container.GetConnectionString();
+    public Task InitializeAsync() => _container.StartAsync();
+    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+}
+```
+
+- [ ] **Step 3: Write the failing integration test** (drives the connector via the shared-key client — Azurite can't auth AAD)
+
+```csharp
+using Azure.Storage.Blobs;
+using Connapse.Storage.Connectors;
+using FluentAssertions;
+using System.Text;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("AzureBlobConnector")]
+public class AzureBlobConnectorIntegrationTests(AzuriteFixture fixture)
+{
+    [Fact]
+    public async Task ListAndRead_ScopedToPrefix()
+    {
+        var service = new BlobServiceClient(fixture.ConnectionString); // shared-key, Azurite
+        var container = service.GetBlobContainerClient("docs");
+        await container.CreateIfNotExistsAsync();
+        await container.UploadBlobAsync("reports/q1.pdf", new BinaryData("hello"));
+        await container.UploadBlobAsync("other/skip.txt", new BinaryData("nope"));
+
+        var connector = new AzureBlobConnector(
+            new AzureBlobConnectorConfig { AccountName = "devstoreaccount1", ContainerName = "docs", Prefix = "reports/" },
+            service); // internal test ctor
+
+        var files = await connector.ListFilesAsync();
+        files.Should().ContainSingle();
+        files[0].Path.Should().Be("reports/q1.pdf");
+        files[0].ResourceUri.Should().Be("azblob://devstoreaccount1/docs/reports/q1.pdf");
+
+        (await connector.ExistsAsync("reports/q1.pdf")).Should().BeTrue();
+        using var stream = await connector.ReadFileAsync("reports/q1.pdf");
+        (await new StreamReader(stream).ReadToEndAsync()).Should().Be("hello");
+    }
+}
+```
+> The internal ctor requires `[assembly: InternalsVisibleTo("Connapse.Integration.Tests")]` on `Connapse.Storage` — add it to that project's `AssemblyInfo`/csproj if not already present (the S3 tests' access pattern shows whether it is).
+
+- [ ] **Step 4: Add the test collection** in `CloudConnectorTestCollection.cs`:
+```csharp
+[CollectionDefinition("AzureBlobConnector")]
+public class AzureBlobConnectorTestCollection : ICollectionFixture<AzuriteFixture> { }
+```
+
+- [ ] **Step 5: Run test, verify it fails then passes**
+
+Run (fails first if run before Task 4 wiring, else drives real behavior): `dotnet test --filter "FullyQualifiedName~AzureBlobConnectorIntegrationTests"`
+Expected: PASS (needs Docker).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/Connapse.Integration.Tests/
+git commit -m "test(azure): Azurite integration tests for AzureBlobConnector (#477)"
+```
+
+---
+
+### Task 9: Connection/Source form UI
+
+**Files:**
+- Modify: `src/Connapse.Web/Components/Settings/ConnectionForm.cs`
+- Modify: `src/Connapse.Web/Components/Settings/SourceForm.cs`
+- Modify: `src/Connapse.Web/Components/Pages/Connections.razor`
+- Modify: `src/Connapse.Web/Components/Pages/Sources.razor`
+- Test: `tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs`, `tests/Connapse.Core.Tests/Sources/SourceFormTests.cs`
+
+**Interfaces:**
+- Consumes: `ConnectionProvider.AzureBlob`, `AzureBlobConnectionTester`.
+- Produces: `ConnectionForm` emits `{"accountName":...,"blobEndpoint"?:...}` for AzureBlob; `SourceForm` emits `{"containerName":...,"prefix"?:...}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`ConnectionFormTests.cs`:
+```csharp
+[Fact]
+[Trait("Category", "Unit")]
+public void ConnectionForm_AzureBlob_BuildsConfigJson()
+{
+    var form = new ConnectionForm { Provider = ConnectionProvider.AzureBlob, StorageAccountName = "acct" };
+    form.Validate().Should().BeNull();               // valid
+    form.ToConfigJson().Should().Contain("\"accountName\":\"acct\"");
+}
+
+[Fact]
+[Trait("Category", "Unit")]
+public void ConnectionForm_AzureBlob_MissingAccount_FailsValidation()
+{
+    var form = new ConnectionForm { Provider = ConnectionProvider.AzureBlob };
+    form.Validate().Should().NotBeNull();
+}
+```
+`SourceFormTests.cs`:
+```csharp
+[Fact]
+[Trait("Category", "Unit")]
+public void SourceForm_AzureBlob_BuildsScopeJson()
+{
+    var form = new SourceForm { Container = "docs", Prefix = "reports/" };
+    form.ToScopeJson(ConnectionProvider.AzureBlob)
+        .Should().Contain("\"containerName\":\"docs\"").And.Contain("\"prefix\":\"reports/\"");
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~ConnectionForm_AzureBlob|FullyQualifiedName~SourceForm_AzureBlob"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the form logic**
+
+`ConnectionForm.cs`:
+- Add `public string? StorageAccountName { get; set; }` and `public string? BlobEndpoint { get; set; }`.
+- In `IsCloudProvider` (or the cloud-branching property), include `ConnectionProvider.AzureBlob`.
+- In `ToConfigJson()`, add the case: for `AzureBlob`, serialize `{ accountName = StorageAccountName, blobEndpoint = string.IsNullOrWhiteSpace(BlobEndpoint) ? null : BlobEndpoint }` (omit null endpoint).
+- In `Validate()`, add: `AzureBlob` requires non-blank `StorageAccountName` (else return a message).
+
+`SourceForm.cs`:
+- In `ToScopeJson(provider)`, add the `ConnectionProvider.AzureBlob` case building `{ containerName = Container, prefix = Prefix (if non-blank) }` (mirror the S3 case that uses `Container` as bucketName).
+- In `Validate()`, require `Container` for `AzureBlob`.
+
+`Connections.razor`:
+- Add `@inject AzureBlobConnectionTester AzureBlobTester`.
+- Add `<option value="AzureBlob">Azure Blob Storage</option>` to the provider select.
+- Add the Azure form branch (Storage Account Name input, optional Blob Endpoint).
+- Wire the test button for AzureBlob to call `AzureBlobTester.TestConnectionAsync(new AzureBlobConnectorConfig { AccountName = form.StorageAccountName, BlobEndpoint = form.BlobEndpoint, ContainerName = "$root" })` — test at account level; use a probe container name only if the form has one, else test service-level reachability.
+- Add the summary/`DescribeScope` arm for AzureBlob.
+
+`Sources.razor`:
+- Add the `ConnectionProvider.AzureBlob` branch rendering the container + prefix fields (mirror S3's bucket + prefix).
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~ConnectionForm_AzureBlob|FullyQualifiedName~SourceForm_AzureBlob"`
+Expected: PASS.
+
+- [ ] **Step 5: Build (Blazor components compile)**
+
+Run: `dotnet build`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Connapse.Web/Components/Settings/ConnectionForm.cs src/Connapse.Web/Components/Settings/SourceForm.cs src/Connapse.Web/Components/Pages/Connections.razor src/Connapse.Web/Components/Pages/Sources.razor tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
+git commit -m "feat(azure): connection/source form UI for Azure Blob (#477)"
+```
+
+---
+
+### Task 10: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full build**
+
+Run: `dotnet build`
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 2: Unit tests**
+
+Run: `dotnet test --filter "Category=Unit"`
+Expected: PASS (all, including the new Azure unit tests).
+
+- [ ] **Step 3: Integration tests (Docker)**
+
+Run: `dotnet test --filter "Category=Integration"`
+Expected: the Azure integration + DI-resolution tests PASS. (Pre-existing Ollama-dependent ingestion tests may fail if no local Ollama — that is the known environmental gap from Phase 1, not introduced here; confirm any failures are only those.)
+
+- [ ] **Step 4: Confirm Azure OpenAI untouched**
+
+Run: `rg -ln "AzureOpenAi|AzureAIFoundry" src/`
+Expected: the AI-provider files still present.
+
+- [ ] **Step 5: Push + open PR**
+
+```bash
+git push -u origin feature/477-azure-app-identity-connector
+gh pr create --repo Destrayon/Connapse --base main \
+  --title "feat: Azure Blob connector + ConnapseAzureCredentials (#477)" \
+  --body "Closes #477. Part of epic #475. Adds Connapse's Azure identity (ambient managed identity, or a configured service-principal certificate) and a read-only Azure Blob connector, creatable via the Connections/Sources UI. No per-user permission filtering (Phase 4); no guided Providers page or DB-stored credentials (deferred). See docs/superpowers/specs/2026-09-05-azure-phase2-app-identity-connector-design.md."
+```
+(Push/PR is an outward action — perform in the finishing step after the whole-branch review, with the user's go-ahead.)
+
+---
+
+## Self-Review
+
+**Spec coverage:** §A credential (Tasks 1–2, chain factory + wrapper, cert-or-MI-or-fail-closed, `AzureProviderSettings` from config), §B connector (Tasks 3–4, `ResourceUri.ForAzureBlob`, config, connector with injectable client), §C enums + factory (Tasks 3, 5), §D UI (Task 9, forms only), §E DI/packages/settings (Tasks 1/4/7/8 add the three packages; Task 7 DI + category map), testing (Tasks 1–2 unit chain, 8 Azurite seam, 7 DI-resolution). Non-goals (Providers page, DB creds, federation/secret, per-user perms, live-watch) are respected — no task implements them.
+
+**Placeholder scan:** UI Task 9's razor steps describe exact fields/JSON/validation rather than pasting full markup — that is the one place the plan gives precise instructions over verbatim code, because Blazor markup mirrors the existing S3 branch in the same files; every data shape (`accountName`/`blobEndpoint`/`containerName`/`prefix`) and validation rule is stated explicitly. No "TBD"/"handle edge cases"/"similar to Task N" remain.
+
+**Type consistency:** `AzureProviderSettings` fields, `AzureBlobConnectorConfig { AccountName, ContainerName, Prefix, BlobEndpoint }`, `AzureCredentialChainFactory.Create(settings, certLoader)`, `ConnapseAzureCredentials.ProviderKey = "azure"`, and `ResourceUri.ForAzureBlob(account, container, path)` are used identically across tasks. The connection-config keys (`accountName`/`blobEndpoint`) and source-scope keys (`containerName`/`prefix`) match between the factory (Task 5), the forms (Task 9), and the integration test (Task 8).

--- a/docs/superpowers/plans/2026-09-06-azure-phase3-entra-user-link.md
+++ b/docs/superpowers/plans/2026-09-06-azure-phase3-entra-user-link.md
@@ -1,0 +1,330 @@
+# Azure Phase 3 — Entra User Identity Link Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a signed-in Connapse user link their Microsoft Entra identity — a one-time OIDC (auth-code + PKCE + certificate) proof that captures `oid` + `tid`, stores only those, and is user-revocable.
+
+**Architecture:** Mirror the AWS SAML link (`UserAwsIdentityLinkEntity` / `AwsIdentityLinkStore` / `AwsIdentityLinkService` / the `CloudIdentityEndpoints` `/aws/connect`+`/aws/acs` flow / `SamlSignInRequests` / the `ProfileIntegrations.razor` AWS card), but with OIDC instead of SAML. It is a **secondary account-link** inside the user's existing Connapse session — NOT app login — so no `Microsoft.Identity.Web`, no second ASP.NET auth scheme. The Entra token-endpoint call is isolated behind `IOidcTokenExchanger` so the callback's state/PKCE/id_token-validation/store logic is testable without live Entra.
+
+**Tech Stack:** .NET 10, EF Core (`ConnapseIdentityDbContext`), `Microsoft.IdentityModel.Tokens`/`.JsonWebTokens` (already present via ITfoxtec — id_token validation + JWKS), `System.Security.Cryptography` (PKCE + client-assertion signing), `HttpClient`, xUnit + FluentAssertions + NSubstitute.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-azure-phase3-entra-user-link-design.md` (parent: `docs/superpowers/specs/2026-09-05-azure-blob-provider-design.md` §B).
+
+## Global Constraints
+
+- **Link only.** Establish/store/revoke the link. Do NOT build the Graph `accountEnabled` deprovisioning check, transitive group resolution, or any search filtering — those are Phase 4 (#479).
+- **Permanent key = `oid` + `tid`** (both stored). Display name is display-only (mutable), never a key. Discard all tokens after extracting claims.
+- **Explicit endpoints, auth-code + PKCE (S256) + certificate client-assertion.** PKCE does NOT replace the client credential (confidential client) — a certificate signs the client assertion. NO `Microsoft.Identity.Web`, NO second auth scheme, NO OIDC implicit flow.
+- **No new NuGet package** for id_token validation/JWKS — use `Microsoft.IdentityModel.Tokens`/`.JsonWebTokens` (present via ITfoxtec). Only add `Microsoft.IdentityModel.Protocols.OpenIdConnect` if it is ALREADY transitively available; otherwise fetch JWKS manually with `HttpClient` + `JsonWebKeySet` (see Task 5).
+- **Fail closed:** any state/PKCE/signature/issuer/audience/nonce/expiry failure stores nothing and surfaces an error.
+- Config in a dedicated `Identity:AzureAd` settings record — separate from Phase 2's `Providers:Azure`.
+- .NET conventions (CLAUDE.md): file-scoped namespaces, records for DTOs/settings, primary constructors for DI, `IDbContextFactory<T>` short-lived contexts, no `var` for primitives, parameterized SQL. Never touch Azure OpenAI/AI Foundry or the AWS path except to mirror it. Tag tests `[Trait("Category","Unit")]` / `[Trait("Category","Integration")]`.
+- Build: `dotnet build`. Tests: `dotnet test --filter "Category=Unit"` / `"Category=Integration"` (Docker). Migrations: `dotnet ef migrations add <Name> --project src/Connapse.Identity`.
+
+---
+
+### Task 1: `UserAzureIdentityLinkEntity` + DTOs + migration
+
+**Files:**
+- Create: `src/Connapse.Identity/Data/Entities/UserAzureIdentityLinkEntity.cs`
+- Modify: `src/Connapse.Core/Models/AuthModels.cs` (add `AzureIdentityLinkDto`, `AzureIdentityRef`)
+- Modify: `src/Connapse.Identity/Data/ConnapseIdentityDbContext.cs` (DbSet + mapping)
+- Modify: `src/Connapse.Identity/Data/Entities/ConnapseUser.cs` (navigation)
+- Migration: `AddUserAzureIdentityLinks`
+
+**Interfaces:**
+- Produces: `UserAzureIdentityLinkEntity { Guid Id; Guid UserId; string ObjectId; string TenantId; string DisplayName; DateTime ConnectedAt; ConnapseUser User; }`; `record AzureIdentityLinkDto(string ObjectId, string TenantId, string DisplayName, DateTime ConnectedAt)`; `record AzureIdentityRef(string ObjectId, string TenantId)`.
+
+- [ ] **Step 1: Write the entity** (mirror `UserAwsIdentityLinkEntity`'s shape/remarks)
+
+```csharp
+namespace Connapse.Identity.Data.Entities;
+
+/// <summary>A Connapse user's linked Microsoft Entra identity (oid + tid). Holds no token —
+/// Entra attests the identity once at link time; permissions are later read with Connapse's own
+/// identity. One row per user (unique index); connecting again replaces the row.</summary>
+public class UserAzureIdentityLinkEntity
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    /// <summary>Entra object id (oid) — immutable per-tenant user identifier; the permanent key.</summary>
+    public string ObjectId { get; set; } = string.Empty;
+    /// <summary>Entra tenant id (tid). Stored with ObjectId as the fully-qualified key.</summary>
+    public string TenantId { get; set; } = string.Empty;
+    /// <summary>Display name/UPN from the id_token — display only, mutable, never a key.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+    public DateTime ConnectedAt { get; set; }
+    public ConnapseUser User { get; set; } = null!;
+}
+```
+
+- [ ] **Step 2: Add the DTOs** to `AuthModels.cs` (beside `AwsIdentityLinkDto`):
+
+```csharp
+public record AzureIdentityLinkDto(string ObjectId, string TenantId, string DisplayName, DateTime ConnectedAt);
+public record AzureIdentityRef(string ObjectId, string TenantId);
+```
+
+- [ ] **Step 3: Map it** — in `ConnapseIdentityDbContext`, add `public DbSet<UserAzureIdentityLinkEntity> UserAzureIdentityLinks => Set<...>();`, and in `OnModelCreating` configure the table + a UNIQUE index on `UserId` + the FK to `ConnapseUser` (cascade), mirroring the `UserAwsIdentityLinkEntity` mapping. Add a `ICollection<UserAzureIdentityLinkEntity>` navigation to `ConnapseUser` mirroring the AWS one.
+
+- [ ] **Step 4: Create the migration**
+
+Run: `dotnet ef migrations add AddUserAzureIdentityLinks --project src/Connapse.Identity`
+Open it: confirm `Up()` creates `user_azure_identity_links` with the columns + unique `UserId` index + FK, `Down()` drops it, and the snapshot includes the entity. Do not hand-edit beyond what EF generates.
+
+- [ ] **Step 5: Build + commit**
+
+Run: `dotnet build` → 0 errors.
+```bash
+git add -A
+git commit -m "feat(azure): UserAzureIdentityLinkEntity + DTOs + migration (#478)"
+```
+
+---
+
+### Task 2: Link store, reader, and service
+
+**Files:**
+- Create: `src/Connapse.Identity/Services/AzureIdentityLinkStore.cs`
+- Create: `src/Connapse.Core/Interfaces/IAzureIdentityLinkReader.cs`
+- Create: `src/Connapse.Identity/Services/IAzureIdentityLinkService.cs` + `AzureIdentityLinkService.cs`
+- Test: `tests/Connapse.Identity.Tests/AzureIdentityLinkServiceTests.cs` (or an integration test using the shared Postgres fixture if the store needs a real DbContext)
+
+**Interfaces:**
+- Consumes: `UserAzureIdentityLinkEntity`, `AzureIdentityLinkDto`, `AzureIdentityRef`, `IDbContextFactory<ConnapseIdentityDbContext>`.
+- Produces:
+  - `interface IAzureIdentityLinkReader { Task<AzureIdentityRef?> GetLinkAsync(Guid userId, CancellationToken ct = default); }` (Core — what Phase 4 will consume)
+  - `class AzureIdentityLinkStore : IAzureIdentityLinkReader` with `Task SaveAsync(Guid userId, string oid, string tid, string displayName, CancellationToken ct)`, `Task<UserAzureIdentityLinkEntity?> GetAsync(Guid userId, CancellationToken ct)`, `Task<bool> DeleteAsync(Guid userId, CancellationToken ct)` — mirror `AwsIdentityLinkStore`'s `IDbContextFactory` pattern; `SaveAsync` upserts (replace the existing row for the user).
+  - `interface IAzureIdentityLinkService { Task<AzureIdentityLinkDto?> GetAsync(Guid, CancellationToken); Task StoreAsync(Guid userId, string oid, string tid, string displayName, CancellationToken); Task<bool> DisconnectAsync(Guid, CancellationToken); }` + `AzureIdentityLinkService` delegating to the store.
+
+- [ ] **Step 1: Write the failing test** (round-trip; use the pattern the AWS link store tests use — if they're integration tests against the shared Postgres fixture, mirror that)
+
+```csharp
+[Trait("Category", "Integration")]
+public class AzureIdentityLinkServiceTests(SharedWebAppFixture fx) : IClassFixture<SharedWebAppFixture>
+{
+    [Fact]
+    public async Task Store_Get_Disconnect_RoundTrips()
+    {
+        using var scope = fx.Services.CreateScope();
+        var svc = scope.ServiceProvider.GetRequiredService<IAzureIdentityLinkService>();
+        var userId = /* seed or use an existing test user id */ Guid.NewGuid();
+        await svc.StoreAsync(userId, "oid-1", "tid-1", "Ada Lovelace", default);
+
+        var dto = await svc.GetAsync(userId, default);
+        dto!.ObjectId.Should().Be("oid-1"); dto.TenantId.Should().Be("tid-1"); dto.DisplayName.Should().Be("Ada Lovelace");
+
+        var reader = scope.ServiceProvider.GetRequiredService<IAzureIdentityLinkReader>();
+        (await reader.GetLinkAsync(userId, default))!.Should().Be(new AzureIdentityRef("oid-1", "tid-1"));
+
+        (await svc.DisconnectAsync(userId, default)).Should().BeTrue();
+        (await svc.GetAsync(userId, default)).Should().BeNull();
+    }
+}
+```
+> Match the AWS link tests' fixture/user-seeding approach exactly (read `AwsIdentityLinkStoreTests`/`AwsIdentityLinkServiceTests` first). If those are unit tests with an in-memory/factory double, mirror that instead.
+
+- [ ] **Step 2: Run → FAIL** (`dotnet test --filter "FullyQualifiedName~AzureIdentityLinkServiceTests"`).
+- [ ] **Step 3: Implement** the reader, store (mirror `AwsIdentityLinkStore` — `IDbContextFactory`, short-lived contexts, upsert in `SaveAsync`, `DeleteAsync` returns whether a row was removed), and service.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(azure): Entra identity link store + reader + service (#478)`
+
+---
+
+### Task 3: `AzureAdSignInSettings`
+
+**Files:**
+- Create: `src/Connapse.Core/Models/AzureAdSignInSettings.cs`
+- Test: `tests/Connapse.Core.Tests/Settings/AzureAdSignInSettingsTests.cs`
+
+**Interfaces:**
+- Produces: `record AzureAdSignInSettings { const string SectionName = "Identity:AzureAd"; string? TenantId; string? ClientId; string? RedirectUri; string? ClientCertificatePath; string? ClientCertificatePassword; bool IsConfigured; }` where `IsConfigured` is true iff `TenantId`, `ClientId`, `RedirectUri`, and `ClientCertificatePath` are all non-blank.
+
+- [ ] **Step 1: Failing test** — `IsConfigured` true only when all four required fields are set; false when any is blank. (4-5 cases.)
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** the record + `IsConfigured` computed property.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(azure): AzureAdSignInSettings (#478)`
+
+---
+
+### Task 4: PKCE + pending-request store + authorization-URL builder
+
+**Files:**
+- Create: `src/Connapse.Identity/Services/OidcPkce.cs` (pure helpers), `src/Connapse.Identity/Services/AzureSignInRequests.cs` (in-memory pending store), `src/Connapse.Identity/Services/AzureAuthorizationUrl.cs` (URL builder)
+- Test: `tests/Connapse.Identity.Tests/OidcPkceTests.cs`, `AzureAuthorizationUrlTests.cs`, `AzureSignInRequestsTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `static class OidcPkce { static (string verifier, string challenge) Create(); }` — verifier = base64url(32 random bytes); challenge = base64url(SHA256(ASCII(verifier))).
+  - `record AzurePendingSignIn(string State, string CodeVerifier, string Nonce, Guid UserId, DateTime ExpiresAtUtc);` and `class AzureSignInRequests { void Add(AzurePendingSignIn p); AzurePendingSignIn? TakeByState(string state); }` (thread-safe dictionary; `TakeByState` removes-and-returns, dropping expired) — mirror `SamlSignInRequests`.
+  - `static class AzureAuthorizationUrl { static string Build(AzureAdSignInSettings s, string state, string nonce, string codeChallenge); }` → `https://login.microsoftonline.com/{tid}/oauth2/v2.0/authorize?client_id=..&response_type=code&redirect_uri=..&response_mode=query&scope=openid%20profile&state=..&nonce=..&code_challenge=..&code_challenge_method=S256` (all values URL-encoded).
+
+- [ ] **Step 1: Failing tests**
+
+```csharp
+[Fact][Trait("Category","Unit")]
+public void Pkce_ChallengeIsBase64UrlSha256OfVerifier()
+{
+    var (verifier, challenge) = OidcPkce.Create();
+    using var sha = System.Security.Cryptography.SHA256.Create();
+    var expected = Base64Url(sha.ComputeHash(System.Text.Encoding.ASCII.GetBytes(verifier)));
+    challenge.Should().Be(expected);
+    challenge.Should().NotContain("+").And.NotContain("/").And.NotContain("=");
+}
+
+[Fact][Trait("Category","Unit")]
+public void AuthUrl_ContainsRequiredParams()
+{
+    var s = new AzureAdSignInSettings { TenantId = "t", ClientId = "c", RedirectUri = "https://app/azure/callback" };
+    var url = AzureAuthorizationUrl.Build(s, "st", "no", "ch");
+    url.Should().StartWith("https://login.microsoftonline.com/t/oauth2/v2.0/authorize?");
+    url.Should().Contain("client_id=c").And.Contain("response_type=code")
+       .And.Contain("code_challenge=ch").And.Contain("code_challenge_method=S256")
+       .And.Contain("state=st").And.Contain("nonce=no")
+       .And.Contain("redirect_uri=https%3A%2F%2Fapp%2Fazure%2Fcallback")
+       .And.Contain("scope=openid%20profile");
+}
+
+[Fact][Trait("Category","Unit")]
+public void Pending_TakeByState_RemovesAndDropsExpired()
+{
+    var store = new AzureSignInRequests();
+    store.Add(new AzurePendingSignIn("s1","v","n",Guid.NewGuid(), DateTime.UtcNow.AddMinutes(5)));
+    store.TakeByState("s1").Should().NotBeNull();
+    store.TakeByState("s1").Should().BeNull(); // removed
+    store.Add(new AzurePendingSignIn("s2","v","n",Guid.NewGuid(), DateTime.UtcNow.AddMinutes(-1)));
+    store.TakeByState("s2").Should().BeNull(); // expired
+}
+```
+(`Base64Url` helper in the test: `Convert.ToBase64String(bytes).TrimEnd('=').Replace('+','-').Replace('/','_')`.)
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** the three helpers. `OidcPkce.Create`: `RandomNumberGenerator.GetBytes(32)` → base64url = verifier; challenge = base64url(SHA256). `AzureSignInRequests`: `ConcurrentDictionary<string,AzurePendingSignIn>`; `TakeByState` `TryRemove` then null-if-expired.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(azure): OIDC PKCE + pending-request store + auth-URL builder (#478)`
+
+---
+
+### Task 5: id_token validation + `IOidcTokenExchanger`
+
+**Files:**
+- Create: `src/Connapse.Identity/Services/IOidcTokenExchanger.cs` + `AzureOidcTokenExchanger.cs` (real impl), `src/Connapse.Identity/Services/AzureIdTokenValidator.cs`
+- Modify: `src/Connapse.Identity/Connapse.Identity.csproj` ONLY if `Microsoft.IdentityModel.Protocols.OpenIdConnect` is not already available (see Step 3)
+- Test: `tests/Connapse.Identity.Tests/AzureIdTokenValidatorTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `interface IOidcTokenExchanger { Task<string> ExchangeAsync(string code, string codeVerifier, CancellationToken ct); }` — returns the raw id_token JWT. Real impl POSTs to `https://login.microsoftonline.com/{tid}/oauth2/v2.0/token` with form: `grant_type=authorization_code`, `code`, `redirect_uri`, `client_id`, `code_verifier`, `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`, `client_assertion=<signed JWT>`; reads `id_token` from the JSON response. The client-assertion JWT is signed with the cert (RS256): claims `aud`=token endpoint, `iss`=`sub`=client_id, `jti`=guid, `nbf`/`exp` (±minutes), header `x5t`/`kid` from the cert.
+  - `class AzureIdTokenValidator { Task<AzureIdTokenResult> ValidateAsync(string idToken, string expectedNonce, CancellationToken ct); }` returning `record AzureIdTokenResult(bool Ok, string? ObjectId, string? TenantId, string? DisplayName, string? Error)`.
+
+- [ ] **Step 1: Failing tests** — sign a test id_token with an in-test RSA key, validate against a `TokenValidationParameters` whose `IssuerSigningKeys` is that key, asserting: valid token with matching `aud`/`iss`/`nonce` → `Ok`, oid/tid extracted; wrong `nonce` → not Ok; wrong `aud` → not Ok; expired → not Ok. (Inject the signing key / a metadata stub so the validator doesn't hit the network in tests — see Step 3's seam.)
+
+```csharp
+[Trait("Category","Unit")]
+public class AzureIdTokenValidatorTests
+{
+    [Fact] public async Task ValidToken_ExtractsOidTid() { /* build signed JWT w/ oid,tid,nonce,aud,iss; assert Ok + values */ }
+    [Fact] public async Task WrongNonce_Fails() { /* ... */ }
+    [Fact] public async Task WrongAudience_Fails() { /* ... */ }
+    [Fact] public async Task Expired_Fails() { /* ... */ }
+}
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement.** For validation use `Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler.ValidateTokenAsync` with `TokenValidationParameters { ValidIssuer = $"https://login.microsoftonline.com/{tid}/v2.0", ValidAudience = clientId, IssuerSigningKeys = <Entra JWKS keys>, ValidateLifetime = true }`, then read the `nonce` claim and compare; extract `oid`, `tid`, and a display name (`name` ?? `preferred_username`).
+  - **JWKS without a new package:** make the signing-key source injectable so tests pass keys directly. For production, fetch keys manually: GET `https://login.microsoftonline.com/{tid}/v2.0/.well-known/openid-configuration` → `jwks_uri` → GET it → `new Microsoft.IdentityModel.Tokens.JsonWebKeySet(json).GetSigningKeys()`. Cache per tenant with a short TTL. (`JsonWebKeySet` is in `Microsoft.IdentityModel.Tokens`, already present — no new package.) ONLY if `Microsoft.IdentityModel.Protocols.OpenIdConnect` is already transitively present (check `dotnet list src/Connapse.Identity package --include-transitive`) may you use `ConfigurationManager<OpenIdConnectConfiguration>` instead; do not add it as a new dependency.
+  - The client-assertion signer: `RsaSecurityKey`/`X509SigningCredentials` from the cert (reuse Phase 2's cert loader for loading the `X509Certificate2`); build the JWT with `JsonWebTokenHandler.CreateToken`.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(azure): id_token validator + OIDC token exchanger seam (#478)`
+
+---
+
+### Task 6: `/azure/connect` + `/azure/callback` endpoints + disconnect branch
+
+**Files:**
+- Modify: `src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs` (add the two Azure routes to the existing group; add the `Azure` branch to `MapDelete("/{provider}")`)
+- Test: `tests/Connapse.Integration.Tests/CloudIdentityEndpointTests.cs` (add Azure cases)
+
+**Interfaces:**
+- Consumes: `AzureAdSignInSettings`, `AzureSignInRequests`, `AzureAuthorizationUrl`, `OidcPkce`, `IOidcTokenExchanger`, `AzureIdTokenValidator`, `IAzureIdentityLinkService`, `GetUserId(httpContext)`.
+- Produces: `GET /api/v1/auth/cloud/azure/connect`, `GET /api/v1/auth/cloud/azure/callback`, and `DELETE /{provider}` accepting `Azure`.
+
+- [ ] **Step 1: Failing integration tests**
+
+```csharp
+[Trait("Category","Integration")]
+// /azure/connect (configured) → 302 to login.microsoftonline.com with code_challenge + state; a pending entry exists.
+// /azure/callback?state=unknown → redirect to integrations page with an error; NO link row.
+// /azure/callback happy path with a FAKE IOidcTokenExchanger (registered in the test host) returning a
+//   test-signed id_token whose nonce matches the pending entry → link row stored (oid/tid), redirect success.
+// DELETE /Azure → deletes the row, 200.
+```
+> Register a fake `IOidcTokenExchanger` + an injectable signing key in the test `WebApplicationFactory` so the callback runs end-to-end without Entra. Seed a pending entry by first calling `/azure/connect` (capture `state` from the redirect) or by injecting `AzureSignInRequests` directly.
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** the endpoints, mirroring the AWS `/aws/connect` + `/aws/acs` structure:
+  - `connect`: require `GetUserId`; if `!settings.IsConfigured` → 400/redirect error; `var (v,ch)=OidcPkce.Create(); var state=rand; var nonce=rand;` `pending.Add(new(state,v,nonce,userId,ExpiresAtUtc));` redirect to `AzureAuthorizationUrl.Build(settings,state,nonce,ch)`.
+  - `callback`: read `code`,`state`; `var p = pending.TakeByState(state)` → null → error redirect; `var raw = await exchanger.ExchangeAsync(code, p.CodeVerifier, ct);` `var r = await validator.ValidateAsync(raw, p.Nonce, ct);` `!r.Ok` → error redirect (store nothing); `await linkService.StoreAsync(p.UserId, r.ObjectId!, r.TenantId!, r.DisplayName ?? "", ct);` redirect to the integrations page success. Wrap in try/catch → error redirect (fail closed).
+  - `MapDelete("/{provider}")`: add `Azure` to the accepted providers; for `Azure`, `await azureLinks.DisconnectAsync(userId.Value, ct)` and return the same success shape as AWS. Update the "Valid values: AWS." message to "AWS, Azure." (do NOT add scope-cache invalidation — that's Phase 4).
+- [ ] **Step 4: Run → PASS** (needs Docker for the integration host).
+- [ ] **Step 5: Commit** `feat(azure): Entra link connect/callback endpoints + disconnect (#478)`
+
+---
+
+### Task 7: DI + settings wiring
+
+**Files:**
+- Modify: `src/Connapse.Identity/IdentityServiceExtensions.cs` (registrations), `src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs` (category map), `src/Connapse.Web/appsettings.json` (doc section)
+- Test: add a DI-resolution assertion to the integration host test.
+
+**Interfaces:** Produces the resolvable graph: `AzureIdentityLinkStore`, `IAzureIdentityLinkReader`, `IAzureIdentityLinkService`, `AzureSignInRequests` (singleton), `IOidcTokenExchanger`→`AzureOidcTokenExchanger`, `AzureIdTokenValidator`, `Configure<AzureAdSignInSettings>`, a named `HttpClient` for the exchanger.
+
+- [ ] **Step 1: Failing test** — `GetRequiredService<IAzureIdentityLinkService>()`, `GetRequiredService<IAzureIdentityLinkReader>()`, and `GetRequiredService<IOidcTokenExchanger>()` all resolve from a scope of the shared host.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — mirror the AWS link registrations (`AwsIdentityLinkStore` scoped; reader forwards to it; service scoped) at `IdentityServiceExtensions.cs:72-74`; add `services.AddSingleton<AzureSignInRequests>()` (beside `SamlSignInRequests`), `services.Configure<AzureAdSignInSettings>(configuration.GetSection(AzureAdSignInSettings.SectionName))` (beside the `SamlSignInSettings` Configure), `services.AddScoped<AzureIdTokenValidator>()`, and `services.AddHttpClient<IOidcTokenExchanger, AzureOidcTokenExchanger>()`. Add `["azuread"] = "Identity:AzureAd"` to `DatabaseSettingsProvider.CategoryPrefixMap`. Add a documented empty `Identity:AzureAd` block to `appsettings.json`.
+- [ ] **Step 4: Run → PASS** (Docker).
+- [ ] **Step 5: Commit** `feat(azure): DI + settings wiring for Entra user link (#478)`
+
+---
+
+### Task 8: Integrations-page Azure card
+
+**Files:**
+- Modify: `src/Connapse.Web/Components/Pages/ProfileIntegrations.razor`
+- Test: none new required (Blazor handler; the AWS card isn't component-tested either) — build is the gate.
+
+**Interfaces:** Consumes `IAzureIdentityLinkService`.
+
+- [ ] **Step 1: Implement** an Azure card mirroring the AWS card: `@inject IAzureIdentityLinkService AzureIdentityLinkService`; in the load path call `GetAsync(currentUserId)` to populate an `azureIdentity` field; show connected state (display name, tenant, `ConnectedAt`) or a **Connect** button that navigates to `/api/v1/auth/cloud/azure/connect`; a **Disconnect** button (with a `confirmDisconnectAzure` toggle) that calls `DELETE /api/v1/auth/cloud/Azure`; surface `?error=` from the callback like `ApplyAwsErrorFromQuery` does. Reuse the AWS card's markup/styling.
+- [ ] **Step 2: Build** — `dotnet build` → 0 errors.
+- [ ] **Step 3: Unit tests still green** — `dotnet test --filter "Category=Unit"`.
+- [ ] **Step 4: Commit** `feat(azure): integrations-page Entra link card (#478)`
+
+---
+
+### Task 9: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1:** `dotnet build` → 0 errors, 0 warnings.
+- [ ] **Step 2:** `dotnet test --filter "Category=Unit"` → all pass.
+- [ ] **Step 3:** `dotnet test --filter "Category=Integration"` → the Azure link + DI-resolution + migration tests pass (Docker). Pre-existing Ollama-dependent failures (no local Ollama) are the known environmental gap — confirm any failures are only those.
+- [ ] **Step 4:** Confirm scope discipline: `rg -n "getMemberGroups|transitiveMemberOf|accountEnabled|ISearchScopeResolver" src/` shows NO Phase-4 code was added; Azure OpenAI/AI Foundry + AWS path untouched (`git diff --stat epic/azure-blob-provider..HEAD` touches only Identity/Web/Core Azure-link files + the migration).
+- [ ] **Step 5: Push + open PR to the epic branch** (outward action — perform in the finishing step after the whole-branch review, with the user's go-ahead):
+```bash
+git push -u origin feature/478-entra-user-link
+gh pr create --repo Destrayon/Connapse --base epic/azure-blob-provider \
+  --title "feat: Entra user identity link (#478)" \
+  --body "Closes #478. Part of epic #475. Link-only: OIDC auth-code+PKCE+certificate captures oid/tid, stored + user-revocable; Graph checks deferred to Phase 4. Targets the epic branch. See docs/superpowers/specs/2026-09-06-azure-phase3-entra-user-link-design.md."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** §A link storage → Tasks 1–2 (entity/DTOs/migration, store/reader/service). §B settings → Task 3. §C endpoints → Tasks 4–6 (PKCE/pending/URL, id_token validation + exchanger seam, the two endpoints + disconnect). §D UI → Task 8. §E DI/settings → Task 7. Testing (incl. the `IOidcTokenExchanger` seam and fail-closed matrix) → Tasks 5–6. Non-goals (Graph deprovisioning/groups, filtering, Microsoft.Identity.Web, second scheme, implicit flow, guided Providers page) are respected — no task builds them (Task 9 Step 4 asserts it).
+
+**Placeholder scan:** the endpoint markup (Task 6) and razor card (Task 8) are described as exact params/flow + mirror-the-AWS-structure rather than pasted verbatim, because they clone existing files in-repo; every data shape (oid/tid/display name, the auth-URL params, the token-endpoint form fields) and the fail-closed branches are stated explicitly. The JWKS-package decision (Task 5) is a concrete conditional with a no-new-package default, not a "figure it out."
+
+**Type consistency:** `AzureIdentityRef(ObjectId, TenantId)`, `AzureIdentityLinkDto(ObjectId, TenantId, DisplayName, ConnectedAt)`, `IAzureIdentityLinkReader.GetLinkAsync`, `IAzureIdentityLinkService.{GetAsync,StoreAsync,DisconnectAsync}`, `AzureAdSignInSettings` (SectionName `Identity:AzureAd`), `IOidcTokenExchanger.ExchangeAsync(code, codeVerifier, ct)`, `AzureIdTokenValidator.ValidateAsync(idToken, expectedNonce, ct) → AzureIdTokenResult`, `AzurePendingSignIn(State, CodeVerifier, Nonce, UserId, ExpiresAtUtc)`, and `AzureSignInRequests.{Add,TakeByState}` are used identically across tasks.

--- a/docs/superpowers/plans/2026-09-06-azure-phase4a-graph-identity.md
+++ b/docs/superpowers/plans/2026-09-06-azure-phase4a-graph-identity.md
@@ -1,0 +1,619 @@
+# Azure Phase 4a — Searcher identity resolution (Graph) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve a linked Entra searcher (oid) into an identity set **P** = {oid} ∪ {transitive security-group oids}, gated by a live deprovisioning check, in one Microsoft Graph `$batch`, cached ~5 min, failing closed.
+
+**Architecture:** A Core contract (`IAzureDirectoryReader` → `AzureIdentitySet`) and a Storage implementation (`GraphDirectoryReader`) that authenticates to Graph with Connapse's own `TokenCredential` (`ConnapseAzureCredentials`), issues one `$batch` (deprovisioning gate + `getMemberGroups`), and caches confident answers. Library only — nothing wires it into search yet (that is 4c). Mirrors the AWS `IDirectoryUserLookup`/`IdentityStoreUserLookup` split and `AwsSearchScopeResolver`'s fail-closed caching discipline.
+
+**Tech Stack:** .NET 10, `Azure.Core` (`TokenCredential`), `System.Net.Http.Json`, `System.Text.Json`, `IMemoryCache`, xUnit + FluentAssertions.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md` (§A, and the governing sound/complete + fail-closed principle).
+
+## Global Constraints
+
+- **Fail closed.** Any missing/absent value, non-200, deprovisioned account, or exception → deny (`Enabled=false`, empty `PrincipalOids`), never a populated set. Only `Resolved` and `Deprovisioned` are cacheable; `Failed` is never cached.
+- **Never trust the token `groups` claim** — groups come only from Graph `getMemberGroups`.
+- **Live only, no new persistence** — the only state is the in-memory cache (freshness = TTL).
+- **Read-only**, cert-based auth via `ConnapseAzureCredentials`; no client secrets, no writes.
+- **.NET 10 conventions:** file-scoped namespaces, records for DTOs, primary constructors, async all the way, no `var` for primitive types, no `dynamic`.
+- **Consumes** Phase 3's `AzureIdentityRef(string ObjectId, string TenantId)` (namespace `Connapse.Core`). Single-tenant: use `ObjectId`; `TenantId` is not needed for the Graph calls (the app queries its own tenant).
+
+---
+
+## File Structure
+
+- Create `src/Connapse.Core/Models/AzureIdentitySet.cs` — `AzureIdentitySet` record + `AzureIdentityOutcome` enum (namespace `Connapse.Core`).
+- Create `src/Connapse.Core/Interfaces/IAzureDirectoryReader.cs` — the contract (namespace `Connapse.Core.Interfaces`).
+- Create `src/Connapse.Storage/CloudScope/GraphDirectoryReader.cs` — the Graph implementation (namespace `Connapse.Storage.CloudScope`).
+- Modify `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs` — register the `TokenCredential` mapping + the typed HttpClient.
+- Create `tests/Connapse.Core.Tests/Models/AzureIdentitySetTests.cs`
+- Create `tests/Connapse.Storage.Tests/CloudScope/GraphDirectoryReaderTests.cs`
+- Create `tests/Connapse.Integration.Tests/AzureDirectoryReaderDiIntegrationTests.cs`
+
+---
+
+## Task 1: Core contract — `AzureIdentitySet` + `IAzureDirectoryReader`
+
+**Files:**
+- Create: `src/Connapse.Core/Models/AzureIdentitySet.cs`
+- Create: `src/Connapse.Core/Interfaces/IAzureDirectoryReader.cs`
+- Test: `tests/Connapse.Core.Tests/Models/AzureIdentitySetTests.cs`
+
+**Interfaces:**
+- Consumes: `AzureIdentityRef(string ObjectId, string TenantId)` (namespace `Connapse.Core`).
+- Produces: `AzureIdentityOutcome { Resolved, Deprovisioned, Failed }`; `AzureIdentitySet(bool Enabled, IReadOnlyList<string> PrincipalOids, AzureIdentityOutcome Outcome)` with static factories `Resolved(IReadOnlyList<string>)`, `Deprovisioned()`, `Failed()`; `IAzureDirectoryReader.ResolveAsync(AzureIdentityRef link, CancellationToken ct = default) → Task<AzureIdentitySet>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// tests/Connapse.Core.Tests/Models/AzureIdentitySetTests.cs
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Models;
+
+[Trait("Category", "Unit")]
+public class AzureIdentitySetTests
+{
+    [Fact]
+    public void Resolved_IsEnabled_AndCarriesPrincipals()
+    {
+        AzureIdentitySet set = AzureIdentitySet.Resolved(["oid-1", "group-a"]);
+
+        set.Enabled.Should().BeTrue();
+        set.Outcome.Should().Be(AzureIdentityOutcome.Resolved);
+        set.PrincipalOids.Should().Equal("oid-1", "group-a");
+    }
+
+    [Fact]
+    public void Deprovisioned_And_Failed_DenyWithNoPrincipals()
+    {
+        AzureIdentitySet.Deprovisioned().Enabled.Should().BeFalse();
+        AzureIdentitySet.Deprovisioned().Outcome.Should().Be(AzureIdentityOutcome.Deprovisioned);
+        AzureIdentitySet.Deprovisioned().PrincipalOids.Should().BeEmpty();
+
+        AzureIdentitySet.Failed().Enabled.Should().BeFalse();
+        AzureIdentitySet.Failed().Outcome.Should().Be(AzureIdentityOutcome.Failed);
+        AzureIdentitySet.Failed().PrincipalOids.Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~AzureIdentitySetTests"`
+Expected: FAIL — `AzureIdentitySet` / `AzureIdentityOutcome` do not exist (compile error).
+
+- [ ] **Step 3: Write the types**
+
+```csharp
+// src/Connapse.Core/Models/AzureIdentitySet.cs
+namespace Connapse.Core;
+
+/// <summary>What the directory said about a searcher when their identity set was resolved.</summary>
+public enum AzureIdentityOutcome
+{
+    /// <summary>A confident answer: the account is enabled and its group set is known.</summary>
+    Resolved,
+
+    /// <summary>The directory says the account is gone (404) or disabled — deny, and cacheable.</summary>
+    Deprovisioned,
+
+    /// <summary>The directory could not be asked (error/timeout/partial). Deny, and never cached.</summary>
+    Failed,
+}
+
+/// <summary>
+/// A searcher's Entra identity set: the object id plus the transitive security-group object ids
+/// permissions may be held against. Fails closed — unless <see cref="Enabled"/> is true,
+/// <see cref="PrincipalOids"/> is empty and nothing may be authorized from it.
+/// </summary>
+public record AzureIdentitySet(bool Enabled, IReadOnlyList<string> PrincipalOids, AzureIdentityOutcome Outcome)
+{
+    /// <summary>P = {oid} ∪ {group oids}, from a confident directory answer.</summary>
+    public static AzureIdentitySet Resolved(IReadOnlyList<string> principalOids) =>
+        new(true, principalOids, AzureIdentityOutcome.Resolved);
+
+    /// <summary>The account is gone or disabled. Deny; cacheable.</summary>
+    public static AzureIdentitySet Deprovisioned() => new(false, [], AzureIdentityOutcome.Deprovisioned);
+
+    /// <summary>The directory could not be asked. Deny; never cache.</summary>
+    public static AzureIdentitySet Failed() => new(false, [], AzureIdentityOutcome.Failed);
+}
+```
+
+```csharp
+// src/Connapse.Core/Interfaces/IAzureDirectoryReader.cs
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Resolves a linked Entra searcher into their identity set, reading the directory with Connapse's
+/// own Azure identity. Mirrors <c>IDirectoryUserLookup</c> for AWS: rather than acting as the user,
+/// Connapse asks the directory about them.
+/// </summary>
+public interface IAzureDirectoryReader
+{
+    /// <summary>
+    /// The searcher's identity set (object id ∪ transitive security-group object ids), or a
+    /// fail-closed denial. Applies the deprovisioning gate first — a gone/disabled account resolves
+    /// to <see cref="AzureIdentityOutcome.Deprovisioned"/>.
+    /// </summary>
+    Task<AzureIdentitySet> ResolveAsync(AzureIdentityRef link, CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~AzureIdentitySetTests"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Models/AzureIdentitySet.cs src/Connapse.Core/Interfaces/IAzureDirectoryReader.cs tests/Connapse.Core.Tests/Models/AzureIdentitySetTests.cs
+git commit -m "feat(azure): AzureIdentitySet + IAzureDirectoryReader contract (#486)"
+```
+
+---
+
+## Task 2: `GraphDirectoryReader` — `$batch` request + happy-path resolve
+
+**Files:**
+- Create: `src/Connapse.Storage/CloudScope/GraphDirectoryReader.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/GraphDirectoryReaderTests.cs`
+
+**Interfaces:**
+- Consumes: `IAzureDirectoryReader`, `AzureIdentitySet`, `AzureIdentityRef` (Task 1); `Azure.Core.TokenCredential`; `IMemoryCache`.
+- Produces: `GraphDirectoryReader(HttpClient httpClient, TokenCredential azureCredential, IMemoryCache cache) : IAzureDirectoryReader`; `public static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(5)`.
+
+Ctor takes `TokenCredential` (the base type `ConnapseAzureCredentials` extends) so a unit test can inject a stub without real Azure; DI maps it to `ConnapseAzureCredentials` in Task 5.
+
+- [ ] **Step 1: Write the failing test** (happy path + shared test helpers)
+
+```csharp
+// tests/Connapse.Storage.Tests/CloudScope/GraphDirectoryReaderTests.cs
+using System.Net;
+using System.Text;
+using Azure.Core;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class GraphDirectoryReaderTests
+{
+    private static readonly AzureIdentityRef Link = new("11111111-1111-1111-1111-111111111111", "tenant-1");
+
+    // A minimal stub that returns a queued response and counts how many sends it saw, so caching
+    // tests can assert the network was hit exactly once.
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        public int Sends { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Sends++;
+            return Task.FromResult(respond(request));
+        }
+    }
+
+    private sealed class StubTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext c, CancellationToken ct) =>
+            new("stub-token", DateTimeOffset.UtcNow.AddHours(1));
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext c, CancellationToken ct) =>
+            new(GetToken(c, ct));
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
+        new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    // A well-formed $batch response: user enabled, two group oids.
+    private static HttpResponseMessage BatchOk(bool accountEnabled, params string[] groups)
+    {
+        string groupJson = string.Join(",", groups.Select(g => $"\"{g}\""));
+        return Json(HttpStatusCode.OK, $$"""
+        {"responses":[
+          {"id":"user","status":200,"body":{"id":"oid","accountEnabled":{{(accountEnabled ? "true" : "false")}}}},
+          {"id":"groups","status":200,"body":{"value":[{{groupJson}}]}}
+        ]}
+        """);
+    }
+
+    private static GraphDirectoryReader NewReader(StubHandler handler, IMemoryCache? cache = null) =>
+        new(new HttpClient(handler), new StubTokenCredential(),
+            cache ?? new MemoryCache(new MemoryCacheOptions()));
+
+    [Fact]
+    public async Task Resolve_EnabledUser_ReturnsPrincipalSet_OidPlusGroups()
+    {
+        var handler = new StubHandler(_ => BatchOk(true, "group-a", "group-b"));
+        GraphDirectoryReader reader = NewReader(handler);
+
+        AzureIdentitySet set = await reader.ResolveAsync(Link, CancellationToken.None);
+
+        set.Outcome.Should().Be(AzureIdentityOutcome.Resolved);
+        set.Enabled.Should().BeTrue();
+        set.PrincipalOids.Should().BeEquivalentTo(Link.ObjectId, "group-a", "group-b");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~GraphDirectoryReaderTests"`
+Expected: FAIL — `GraphDirectoryReader` does not exist (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+```csharp
+// src/Connapse.Storage/CloudScope/GraphDirectoryReader.cs
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Azure.Core;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Resolves a searcher's Entra identity set in one Microsoft Graph <c>$batch</c>: the deprovisioning
+/// gate (<c>GET /users/{oid}?$select=id,accountEnabled</c>) and transitive security groups
+/// (<c>POST /users/{oid}/getMemberGroups {securityEnabledOnly:true}</c>). Authenticates with
+/// Connapse's own <see cref="TokenCredential"/>. Fails closed; caches only confident answers.
+/// </summary>
+public sealed class GraphDirectoryReader(
+    HttpClient httpClient,
+    TokenCredential azureCredential,
+    IMemoryCache cache) : IAzureDirectoryReader
+{
+    private const string GraphBatchUrl = "https://graph.microsoft.com/v1.0/$batch";
+    private static readonly string[] GraphScopes = ["https://graph.microsoft.com/.default"];
+
+    /// <summary>Cache window for a confident answer; also the revocation-propagation delay.</summary>
+    public static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(5);
+
+    public async Task<AzureIdentitySet> ResolveAsync(AzureIdentityRef link, CancellationToken ct = default)
+    {
+        string oid = link.ObjectId;
+        string cacheKey = "azure-identity:" + oid;
+        if (cache.TryGetValue(cacheKey, out AzureIdentitySet? cached) && cached is not null)
+            return cached;
+
+        AzureIdentitySet result;
+        try
+        {
+            result = await ResolveUncachedAsync(oid, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // Any transport/parse failure fails closed and is never cached.
+            return AzureIdentitySet.Failed();
+        }
+
+        // Only confident answers are cached; a failure must be retried on the next search.
+        if (result.Outcome is not AzureIdentityOutcome.Failed)
+            cache.Set(cacheKey, result, CacheLifetime);
+        return result;
+    }
+
+    private async Task<AzureIdentitySet> ResolveUncachedAsync(string oid, CancellationToken ct)
+    {
+        AccessToken token = await azureCredential.GetTokenAsync(new TokenRequestContext(GraphScopes), ct);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, GraphBatchUrl);
+        request.Headers.Authorization = new("Bearer", token.Token);
+        request.Content = JsonContent.Create(new BatchRequest(
+        [
+            new("user", "GET", $"/users/{oid}?$select=id,accountEnabled", null, null),
+            new("groups", "POST", $"/users/{oid}/getMemberGroups",
+                new GetMemberGroupsBody(true),
+                new Dictionary<string, string> { ["Content-Type"] = "application/json" }),
+        ]));
+
+        using HttpResponseMessage response = await httpClient.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+            return AzureIdentitySet.Failed();   // whole-batch failure (e.g. 401 bad token)
+
+        BatchResponse? batch = await response.Content.ReadFromJsonAsync<BatchResponse>(ct);
+        return Interpret(oid, batch);
+    }
+
+    /// <summary>
+    /// The fail-closed decision, isolated from transport so it is exhaustively unit-testable:
+    /// deprovisioning gate first, then the group set. Missing/partial responses fail closed.
+    /// </summary>
+    internal static AzureIdentitySet Interpret(string oid, BatchResponse? batch)
+    {
+        SubResponse? user = batch?.Responses?.FirstOrDefault(r => r.Id == "user");
+        SubResponse? groups = batch?.Responses?.FirstOrDefault(r => r.Id == "groups");
+        if (user is null || groups is null)
+            return AzureIdentitySet.Failed();
+
+        // Deprovisioning gate.
+        if (user.Status == 404)
+            return AzureIdentitySet.Deprovisioned();
+        if (user.Status != 200)
+            return AzureIdentitySet.Failed();
+        if (user.Body?.AccountEnabled != true)
+            return AzureIdentitySet.Deprovisioned();
+
+        // Groups must resolve, or the identity set is unknown — fail closed.
+        if (groups.Status != 200 || groups.Body?.Value is null)
+            return AzureIdentitySet.Failed();
+
+        var principals = new List<string>(1 + groups.Body.Value.Count) { oid };
+        principals.AddRange(groups.Body.Value);
+        return AzureIdentitySet.Resolved(principals);
+    }
+
+    // ---- Graph $batch DTOs ----
+    private sealed record BatchRequest([property: JsonPropertyName("requests")] IReadOnlyList<SubRequest> Requests);
+    private sealed record SubRequest(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("method")] string Method,
+        [property: JsonPropertyName("url")] string Url,
+        [property: JsonPropertyName("body")] object? Body,
+        [property: JsonPropertyName("headers")] IReadOnlyDictionary<string, string>? Headers);
+    private sealed record GetMemberGroupsBody([property: JsonPropertyName("securityEnabledOnly")] bool SecurityEnabledOnly);
+
+    internal sealed record BatchResponse([property: JsonPropertyName("responses")] IReadOnlyList<SubResponse>? Responses);
+    internal sealed record SubResponse(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("status")] int Status,
+        [property: JsonPropertyName("body")] SubBody? Body);
+    internal sealed record SubBody(
+        [property: JsonPropertyName("accountEnabled")] bool? AccountEnabled,
+        [property: JsonPropertyName("value")] IReadOnlyList<string>? Value);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~GraphDirectoryReaderTests"`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/GraphDirectoryReader.cs tests/Connapse.Storage.Tests/CloudScope/GraphDirectoryReaderTests.cs
+git commit -m "feat(azure): GraphDirectoryReader resolves identity set via Graph \$batch (#486)"
+```
+
+---
+
+## Task 3: Fail-closed matrix
+
+**Files:**
+- Modify: `tests/Connapse.Storage.Tests/CloudScope/GraphDirectoryReaderTests.cs` (add cases)
+
+**Interfaces:**
+- Consumes: `GraphDirectoryReader`, `AzureIdentitySet` (Task 2). No production change expected — `Interpret` and `ResolveAsync` from Task 2 already encode these paths; this task proves them and adds any missing guard.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// append to GraphDirectoryReaderTests
+[Fact]
+public async Task Resolve_UserNotFound_IsDeprovisioned()
+{
+    var handler = new StubHandler(_ => Json(System.Net.HttpStatusCode.OK, """
+    {"responses":[
+      {"id":"user","status":404,"body":null},
+      {"id":"groups","status":200,"body":{"value":[]}}
+    ]}
+    """));
+    (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+        .Outcome.Should().Be(AzureIdentityOutcome.Deprovisioned);
+}
+
+[Fact]
+public async Task Resolve_AccountDisabled_IsDeprovisioned()
+{
+    var handler = new StubHandler(_ => BatchOk(accountEnabled: false, "group-a"));
+    (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+        .Outcome.Should().Be(AzureIdentityOutcome.Deprovisioned);
+}
+
+[Fact]
+public async Task Resolve_GroupsCallFailed_FailsClosed()
+{
+    var handler = new StubHandler(_ => Json(System.Net.HttpStatusCode.OK, """
+    {"responses":[
+      {"id":"user","status":200,"body":{"id":"oid","accountEnabled":true}},
+      {"id":"groups","status":403,"body":null}
+    ]}
+    """));
+    AzureIdentitySet set = await NewReader(handler).ResolveAsync(Link, CancellationToken.None);
+    set.Outcome.Should().Be(AzureIdentityOutcome.Failed);
+    set.PrincipalOids.Should().BeEmpty();
+}
+
+[Fact]
+public async Task Resolve_WholeBatchUnauthorized_FailsClosed()
+{
+    var handler = new StubHandler(_ => Json(System.Net.HttpStatusCode.Unauthorized, "{}"));
+    (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+        .Outcome.Should().Be(AzureIdentityOutcome.Failed);
+}
+
+[Fact]
+public async Task Resolve_TransportThrows_FailsClosed()
+{
+    var handler = new StubHandler(_ => throw new HttpRequestException("network down"));
+    (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+        .Outcome.Should().Be(AzureIdentityOutcome.Failed);
+}
+
+[Fact]
+public async Task Resolve_MissingSubResponse_FailsClosed()
+{
+    var handler = new StubHandler(_ => Json(System.Net.HttpStatusCode.OK,
+        """{"responses":[{"id":"user","status":200,"body":{"accountEnabled":true}}]}"""));
+    (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+        .Outcome.Should().Be(AzureIdentityOutcome.Failed);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass (Task 2 logic already covers them)**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~GraphDirectoryReaderTests"`
+Expected: PASS. If any case fails, fix the guard in `GraphDirectoryReader.Interpret`/`ResolveUncachedAsync` (do not weaken any deny path) and re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Connapse.Storage.Tests/CloudScope/GraphDirectoryReaderTests.cs
+git commit -m "test(azure): GraphDirectoryReader fail-closed matrix (#486)"
+```
+
+---
+
+## Task 4: Caching — 5 minutes, confident answers only
+
+**Files:**
+- Modify: `tests/Connapse.Storage.Tests/CloudScope/GraphDirectoryReaderTests.cs` (add cases)
+
+**Interfaces:**
+- Consumes: `GraphDirectoryReader.CacheLifetime`, the `StubHandler.Sends` counter (Task 2). Caching logic is already in Task 2's `ResolveAsync`; this task proves it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// append to GraphDirectoryReaderTests
+[Fact]
+public async Task Resolve_ConfidentAnswer_IsCached_SecondCallDoesNotHitNetwork()
+{
+    var handler = new StubHandler(_ => BatchOk(true, "group-a"));
+    var cache = new MemoryCache(new MemoryCacheOptions());
+    GraphDirectoryReader reader = NewReader(handler, cache);
+
+    await reader.ResolveAsync(Link, CancellationToken.None);
+    await reader.ResolveAsync(Link, CancellationToken.None);
+
+    handler.Sends.Should().Be(1); // second answer served from cache
+}
+
+[Fact]
+public async Task Resolve_Failure_IsNotCached_NextCallRetries()
+{
+    bool first = true;
+    var handler = new StubHandler(_ =>
+    {
+        if (first) { first = false; return Json(System.Net.HttpStatusCode.Unauthorized, "{}"); }
+        return BatchOk(true, "group-a");
+    });
+    GraphDirectoryReader reader = NewReader(handler);
+
+    (await reader.ResolveAsync(Link, CancellationToken.None)).Outcome.Should().Be(AzureIdentityOutcome.Failed);
+    AzureIdentitySet second = await reader.ResolveAsync(Link, CancellationToken.None);
+
+    second.Outcome.Should().Be(AzureIdentityOutcome.Resolved); // failure was retried, not cached
+    handler.Sends.Should().Be(2);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~GraphDirectoryReaderTests"`
+Expected: PASS. If the failure case is cached, fix `ResolveAsync` so only non-`Failed` outcomes call `cache.Set`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Connapse.Storage.Tests/CloudScope/GraphDirectoryReaderTests.cs
+git commit -m "test(azure): GraphDirectoryReader caches confident answers only (#486)"
+```
+
+---
+
+## Task 5: DI wiring + resolution test
+
+**Files:**
+- Modify: `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs`
+- Create: `tests/Connapse.Integration.Tests/AzureDirectoryReaderDiIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: `IAzureDirectoryReader`/`GraphDirectoryReader` (Tasks 1-2), `ConnapseAzureCredentials` (already a singleton). Registers a bare `TokenCredential` → `ConnapseAzureCredentials` mapping and the typed HttpClient.
+
+- [ ] **Step 1: Add the DI registration**
+
+In `AddConnapseStorage`, immediately after the existing `services.AddSingleton<CloudScope.ConnapseAzureCredentials>();` block (around line 225), add:
+
+```csharp
+        // Expose Connapse's Azure identity as the ambient TokenCredential for Azure control-plane
+        // readers (Graph, and ARM in 4b). Nothing else resolves a bare TokenCredential today —
+        // connectors take ConnapseAzureCredentials directly — so this mapping is unambiguous.
+        services.TryAddSingleton<Azure.Core.TokenCredential>(
+            sp => sp.GetRequiredService<CloudScope.ConnapseAzureCredentials>());
+
+        // Reads the Entra directory (deprovisioning gate + transitive groups) over Graph $batch.
+        // Typed HttpClient; the 5-minute decision cache is the shared IMemoryCache singleton, so a
+        // transient reader instance per resolve still shares one cache across the process.
+        services.AddHttpClient<Connapse.Core.Interfaces.IAzureDirectoryReader, CloudScope.GraphDirectoryReader>();
+```
+
+Confirm `using Microsoft.Extensions.DependencyInjection.Extensions;` is present (it is — `TryAddSingleton` is already used for `EnforcementMigration`). `AddMemoryCache()` is already called in this method.
+
+- [ ] **Step 2: Write the failing DI resolution test**
+
+```csharp
+// tests/Connapse.Integration.Tests/AzureDirectoryReaderDiIntegrationTests.cs
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Proves the Phase 4a Graph identity-reader DI graph resolves from a real host — a clean container
+/// start does not catch a missing registration, only constructing the service does. Guards the
+/// TokenCredential mapping + typed HttpClient landing together.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureDirectoryReaderDiIntegrationTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public void Di_Resolves_AzureDirectoryReader()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IAzureDirectoryReader>().Should().NotBeNull();
+    }
+}
+```
+
+- [ ] **Step 3: Run the DI test to verify it fails, then passes**
+
+Run: `dotnet test tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj --filter "FullyQualifiedName~AzureDirectoryReaderDiIntegrationTests"`
+Expected before Step 1: FAIL (cannot resolve `IAzureDirectoryReader`). After Step 1: PASS.
+(Requires Docker for the shared fixture; the 23 pre-existing Ollama-dependent failures elsewhere are unrelated.)
+
+- [ ] **Step 4: Build the solution and run the full unit suite**
+
+Run: `dotnet build` then `dotnet test --filter "Category=Unit"`
+Expected: build clean; unit tests green (new `AzureIdentitySetTests` + `GraphDirectoryReaderTests` included).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs tests/Connapse.Integration.Tests/AzureDirectoryReaderDiIntegrationTests.cs
+git commit -m "feat(azure): register GraphDirectoryReader + TokenCredential mapping (#486)"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec §A coverage:** deprovisioning gate (Task 2/3), transitive `getMemberGroups` (Task 2), identity set P = {oid} ∪ groups (Task 2), one `$batch` (Task 2), ~5-min cache confident-only (Task 4), never trust token `groups` claim (groups come only from Graph — no token parsing anywhere here), fail-closed matrix (Task 3). ✅
+- **Not in 4a (deferred):** RBAC/ARM (4b), any search wiring or resolver (4c), Gen2 (4d/4e). This task ships a library + DI only.
+- **Type consistency:** `AzureIdentitySet`/`AzureIdentityOutcome`/`IAzureDirectoryReader.ResolveAsync(AzureIdentityRef, ct)` used identically across tasks; `CacheLifetime` and `StubHandler.Sends` referenced in Task 4 are defined in Task 2.
+- **Namespaces:** `Connapse.Core` (AzureIdentitySet), `Connapse.Core.Interfaces` (IAzureDirectoryReader), `Connapse.Storage.CloudScope` (GraphDirectoryReader) — matching existing files in each location.

--- a/docs/superpowers/plans/2026-09-06-azure-phase4b-rbac-resolver.md
+++ b/docs/superpowers/plans/2026-09-06-azure-phase4b-rbac-resolver.md
@@ -1,0 +1,1041 @@
+# Azure Phase 4b — RBAC scope resolver (ARM) + ABAC Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve a searcher (oid) into the set of `azblob://` prefixes they may read via Azure RBAC — one ARM `roleAssignments` call (transitive over groups) minus a parallel `denyAssignments` call, matched against the three Storage-Blob-Data read roles, with ABAC conditions translated to prefixes or tag residue — cached ~5 min, failing closed.
+
+**Architecture:** A Core contract (`IAzureRbacReader` → `AzureRbacScopes`) and a Storage implementation (`ArmRbacReader`) that authenticates to ARM with Connapse's own `TokenCredential`, queries at the configured subscription scope, and returns readable `azblob://` prefixes plus tag-conditioned residue (verified live in 4e). Two pure, exhaustively-tested translators do the bug-prone work: ARM-scope→`azblob://` prefix, and ABAC-condition→(path prefix | container | tag | drop). Library only — no search wiring (that is 4c).
+
+**Tech Stack:** .NET 10, `Azure.Core` (`TokenCredential`), `System.Net.Http.Json`, `System.Text.Json`, `IMemoryCache`, xUnit + FluentAssertions.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md` (§B).
+
+## Global Constraints
+
+- **Fail closed.** A missing `SubscriptionId`, a failed/timed-out `roleAssignments` OR `denyAssignments` call, or any exception → `AzureRbacScopes.Failed()` (empty, `Outcome=Failed`), never a populated set. Only `Resolved` is cacheable; `Failed` is never cached. (Follow 4a's `GraphDirectoryReader` caching + cancellation discipline exactly, including `catch (OperationCanceledException) when (ct.IsCancellationRequested)` rethrow vs. internal-timeout → Failed.)
+- **Deny wins, and never fails open.** `effective = grants − denies`; a failed deny call → `Failed` (never "assume none"). A deny of uncertain applicability drops the overlapping grant (under-grant, never over-grant).
+- **Only the three built-in blob-data-read roles count** (Reader `2a2b9908-6ea1-4ae2-8e65-a410df84e7d1`, Contributor `ba92f5b4-2d11-453d-a403-e96b0029c9fe`, Owner `b7e6dc6d-f1e8-4753-8033-0f276bb0955b`); every other `roleDefinitionId` is ignored.
+- **Query subscription scope WITHOUT `atScope()`** (`$filter=assignedTo('{oid}')`, api-version `2022-04-01`), so account- and container-scoped (descendant) assignments are included; `assignedTo` is transitive over groups. Follow the `nextLink` paging chain to completion (dropping a page = under-grant).
+- **Unparseable ABAC condition → drop that one assignment** (not the whole resolution).
+- **.NET 10 conventions:** file-scoped namespaces, records, primary constructors, async all the way, no `var` for primitive types, no `dynamic`, parameterized only.
+- Cert-based ARM auth via `ConnapseAzureCredentials` (scope `https://management.azure.com/.default`), read-only.
+
+## File Structure
+
+- Create `src/Connapse.Core/Models/AzureRbacScopes.cs` — `AzureRbacScopes`, `AzureScope`, `AzureTagCondition`, `RbacOutcome` (namespace `Connapse.Core`).
+- Create `src/Connapse.Core/Interfaces/IAzureRbacReader.cs` — the contract (namespace `Connapse.Core.Interfaces`).
+- Modify `src/Connapse.Core/Models/AzureProviderSettings.cs` — add `SubscriptionId`.
+- Create `src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs` — pure ARM-scope→`azblob://` prefix.
+- Create `src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs` — pure ABAC-condition classifier.
+- Create `src/Connapse.Storage/CloudScope/ArmRbacReader.cs` — the ARM implementation.
+- Modify `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs` — register the typed HttpClient.
+- Tests: `tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs`, `AzureAbacConditionParserTests.cs`, `ArmRbacReaderTests.cs`; `tests/Connapse.Integration.Tests/AzureRbacReaderDiIntegrationTests.cs`.
+
+The internal translator/parser types live in `Connapse.Storage.CloudScope` and are exercised through the reader's public `ResolveAsync` where possible; the two pure helpers are `internal static` and unit-tested directly (they need no InternalsVisibleTo if the tests call them via the reader — but because their matrices are large, expose them `public static` on `internal`-free classes in `Connapse.Storage.CloudScope`, which `Connapse.Storage.Tests` already references).
+
+---
+
+## Task 1: Core contract + `SubscriptionId`
+
+**Files:**
+- Create: `src/Connapse.Core/Models/AzureRbacScopes.cs`
+- Create: `src/Connapse.Core/Interfaces/IAzureRbacReader.cs`
+- Modify: `src/Connapse.Core/Models/AzureProviderSettings.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs` (created here with a placeholder contract test; real cases land in Task 2)
+
+**Interfaces:**
+- Produces: `RbacOutcome { Resolved, Failed }`; `AzureScope(string Prefix)`; `AzureTagCondition(string Scope, string TagKey, string TagValue, bool KeyCaseSensitive)`; `AzureRbacScopes(IReadOnlyList<AzureScope> ReadablePrefixes, IReadOnlyList<AzureTagCondition> TagConditioned, RbacOutcome Outcome)` with `Resolved(prefixes, tags)` / `Failed()`; `IAzureRbacReader.ResolveAsync(string primaryOid, CancellationToken) → Task<AzureRbacScopes>`; `AzureProviderSettings.SubscriptionId`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureRbacScopeTranslatorTests
+{
+    [Fact]
+    public void RbacScopes_Failed_IsEmptyAndFailed()
+    {
+        AzureRbacScopes f = AzureRbacScopes.Failed();
+        f.Outcome.Should().Be(RbacOutcome.Failed);
+        f.ReadablePrefixes.Should().BeEmpty();
+        f.TagConditioned.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RbacScopes_Resolved_CarriesPrefixesAndTags()
+    {
+        AzureRbacScopes r = AzureRbacScopes.Resolved(
+            [new AzureScope("azblob://acct/c/")],
+            [new AzureTagCondition("azblob://acct/c/", "Project", "Cascade", true)]);
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().ContainSingle().Which.Prefix.Should().Be("azblob://acct/c/");
+        r.TagConditioned.Should().ContainSingle();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureRbacScopeTranslatorTests"`
+Expected: FAIL — types do not exist.
+
+- [ ] **Step 3: Write the types**
+
+```csharp
+// src/Connapse.Core/Models/AzureRbacScopes.cs
+namespace Connapse.Core;
+
+/// <summary>Whether the RBAC scope set was resolved confidently or must fail closed.</summary>
+public enum RbacOutcome { Resolved, Failed }
+
+/// <summary>An <c>azblob://</c> prefix the searcher may read via an RBAC grant. A whole-account
+/// grant is <c>azblob://{account}/</c>; a grant broader than an account (RG/subscription/management
+/// group) is <c>azblob://</c> (matches every account).</summary>
+public record AzureScope(string Prefix);
+
+/// <summary>An RBAC grant gated on a blob index-tag condition that cannot reduce to a prefix. The
+/// <see cref="Scope"/> is the broad candidate prefix; the tag predicate is verified live per hit
+/// (Phase 4e). Never excluded here.</summary>
+public record AzureTagCondition(string Scope, string TagKey, string TagValue, bool KeyCaseSensitive);
+
+/// <summary>The searcher's effective RBAC-readable scope set. Fails closed: unless
+/// <see cref="Outcome"/> is <see cref="RbacOutcome.Resolved"/>, both lists are empty.</summary>
+public record AzureRbacScopes(
+    IReadOnlyList<AzureScope> ReadablePrefixes,
+    IReadOnlyList<AzureTagCondition> TagConditioned,
+    RbacOutcome Outcome)
+{
+    public static AzureRbacScopes Resolved(
+        IReadOnlyList<AzureScope> readablePrefixes, IReadOnlyList<AzureTagCondition> tagConditioned) =>
+        new(readablePrefixes, tagConditioned, RbacOutcome.Resolved);
+
+    public static AzureRbacScopes Failed() => new([], [], RbacOutcome.Failed);
+}
+```
+
+```csharp
+// src/Connapse.Core/Interfaces/IAzureRbacReader.cs
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Resolves a searcher's effective RBAC-readable <c>azblob://</c> scope set from Azure Resource
+/// Manager, reading with Connapse's own Azure identity. Fails closed.
+/// </summary>
+public interface IAzureRbacReader
+{
+    /// <summary>
+    /// The <c>azblob://</c> prefixes <paramref name="primaryOid"/> may read via Storage Blob Data
+    /// roles (transitive over groups, minus deny assignments), plus any tag-conditioned residue.
+    /// </summary>
+    Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct = default);
+}
+```
+
+Add to `src/Connapse.Core/Models/AzureProviderSettings.cs` (after `UserAssignedManagedIdentityClientId`):
+
+```csharp
+    /// <summary>The subscription whose role/deny assignments the RBAC resolver queries. Required
+    /// for per-user Azure permission filtering; absent → the resolver fails closed.</summary>
+    public string? SubscriptionId { get; init; }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureRbacScopeTranslatorTests"`
+Expected: PASS (2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Models/AzureRbacScopes.cs src/Connapse.Core/Interfaces/IAzureRbacReader.cs src/Connapse.Core/Models/AzureProviderSettings.cs tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs
+git commit -m "feat(azure): AzureRbacScopes + IAzureRbacReader contract + SubscriptionId (#487)"
+```
+
+---
+
+## Task 2: ARM scope → `azblob://` prefix translator (pure)
+
+**Files:**
+- Create: `src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs` (extend)
+
+**Interfaces:**
+- Consumes: nothing (pure).
+- Produces: `AzureRbacScopeTranslator.ToAzblobPrefix(string armScope) → string` — the `azblob://` prefix an ARM assignment scope governs.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// append to AzureRbacScopeTranslatorTests
+using Connapse.Storage.CloudScope;
+
+[Theory]
+[InlineData(
+    "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs",
+    "azblob://acct/docs/")]
+[InlineData(
+    "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct",
+    "azblob://acct/")]
+[InlineData(
+    "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default",
+    "azblob://acct/")]
+[InlineData("/subscriptions/s/resourceGroups/rg", "azblob://")]
+[InlineData("/subscriptions/s", "azblob://")]
+[InlineData("/providers/Microsoft.Management/managementGroups/mg", "azblob://")]
+public void ToAzblobPrefix_MapsScopeToPrefix(string armScope, string expected) =>
+    AzureRbacScopeTranslator.ToAzblobPrefix(armScope).Should().Be(expected);
+
+[Fact]
+public void ToAzblobPrefix_IsCaseInsensitiveOnResourceProviderSegments() =>
+    AzureRbacScopeTranslator.ToAzblobPrefix(
+        "/subscriptions/s/resourceGroups/rg/providers/microsoft.storage/STORAGEACCOUNTS/Acct/blobservices/default/CONTAINERS/Docs")
+        .Should().Be("azblob://Acct/Docs/");
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureRbacScopeTranslatorTests"`
+Expected: FAIL — `AzureRbacScopeTranslator` does not exist.
+
+- [ ] **Step 3: Write the translator**
+
+```csharp
+// src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Translates an ARM role-assignment scope into the <c>azblob://</c> prefix it governs. Resource
+/// provider and type segments are matched case-insensitively (ARM is case-insensitive on them);
+/// the account and container names keep their original case (they are the resource_uri content).
+/// </summary>
+public static class AzureRbacScopeTranslator
+{
+    public static string ToAzblobPrefix(string armScope)
+    {
+        string[] parts = armScope.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        int acctIdx = Array.FindIndex(parts,
+            p => string.Equals(p, "storageAccounts", StringComparison.OrdinalIgnoreCase));
+        if (acctIdx < 0 || acctIdx + 1 >= parts.Length)
+            return "azblob://"; // broader than an account (RG / subscription / management group)
+
+        string account = parts[acctIdx + 1];
+
+        int containersIdx = Array.FindIndex(parts, acctIdx + 1,
+            p => string.Equals(p, "containers", StringComparison.OrdinalIgnoreCase));
+        if (containersIdx >= 0 && containersIdx + 1 < parts.Length)
+            return $"azblob://{account}/{parts[containersIdx + 1]}/";
+
+        return $"azblob://{account}/";
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureRbacScopeTranslatorTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs
+git commit -m "feat(azure): ARM scope to azblob prefix translator (#487)"
+```
+
+---
+
+## Task 3: ABAC condition parser (pure)
+
+**Files:**
+- Create: `src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs`
+
+**Interfaces:**
+- Produces: `AbacResult` record `{ AbacKind Kind, string? PathPrefix, string? ContainerName, string? TagKey, string? TagValue, bool TagKeyCaseSensitive }`; `AbacKind { None, PathPrefix, ContainerName, Tag, Unparseable }`; `AzureAbacConditionParser.Parse(string? condition) → AbacResult` (null/blank condition → `None`).
+
+**Interpretation:** A null/empty condition is an unconditional grant (`None`). Otherwise classify by the single resource attribute the condition references. This parser only understands the canonical read templates (per the spec's non-goals: anything else → `Unparseable` → the caller drops that grant). Recognized attribute tokens (case-insensitive on the attribute path, value in single quotes):
+- `blobs:path]` with `StringStartsWith`/`StringLike` `'<p>'` → `PathPrefix` = `<p>` with a single trailing `*` stripped.
+- `containers:name]` with `StringEquals` `'<c>'` → `ContainerName` = `<c>`.
+- `blobs/tags:<Key><$key_case_sensitive$>]` or `blobs/tags:<Key><$key_case_insensitive$>]` with `StringEquals` `'<v>'` → `Tag`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureAbacConditionParserTests
+{
+    private const string PathCond =
+        "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'} AND NOT SubOperationMatches{'Blob.List'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*'))";
+    private const string NameCond =
+        "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'reports'))";
+    private const string TagCond =
+        "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Project<$key_case_sensitive$>] StringEquals 'Cascade'))";
+
+    [Fact]
+    public void Parse_Null_IsNone() =>
+        AzureAbacConditionParser.Parse(null).Kind.Should().Be(AbacKind.None);
+
+    [Fact]
+    public void Parse_Path_ReturnsPrefix_TrailingStarStripped()
+    {
+        AbacResult r = AzureAbacConditionParser.Parse(PathCond);
+        r.Kind.Should().Be(AbacKind.PathPrefix);
+        r.PathPrefix.Should().Be("readonly/");
+    }
+
+    [Fact]
+    public void Parse_ContainerName_ReturnsName()
+    {
+        AbacResult r = AzureAbacConditionParser.Parse(NameCond);
+        r.Kind.Should().Be(AbacKind.ContainerName);
+        r.ContainerName.Should().Be("reports");
+    }
+
+    [Fact]
+    public void Parse_Tag_ReturnsKeyValue()
+    {
+        AbacResult r = AzureAbacConditionParser.Parse(TagCond);
+        r.Kind.Should().Be(AbacKind.Tag);
+        r.TagKey.Should().Be("Project");
+        r.TagValue.Should().Be("Cascade");
+        r.TagKeyCaseSensitive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_UnknownExpression_IsUnparseable() =>
+        AzureAbacConditionParser.Parse("@Request[...] DateTimeGreaterThan '2024-01-01'")
+            .Kind.Should().Be(AbacKind.Unparseable);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureAbacConditionParserTests"`
+Expected: FAIL — parser does not exist.
+
+- [ ] **Step 3: Write the parser**
+
+```csharp
+// src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs
+using System.Text.RegularExpressions;
+
+namespace Connapse.Storage.CloudScope;
+
+public enum AbacKind { None, PathPrefix, ContainerName, Tag, Unparseable }
+
+public record AbacResult(
+    AbacKind Kind,
+    string? PathPrefix = null,
+    string? ContainerName = null,
+    string? TagKey = null,
+    string? TagValue = null,
+    bool TagKeyCaseSensitive = false);
+
+/// <summary>
+/// Classifies the canonical Azure Blob ABAC read conditions into a prefix, a container name, a tag
+/// predicate, or Unparseable. Only the documented read templates are understood; anything else is
+/// Unparseable and the caller drops that grant (fail closed). A null/blank condition is None (an
+/// unconditional grant).
+/// </summary>
+public static partial class AzureAbacConditionParser
+{
+    [GeneratedRegex(@"blobServices/containers/blobs:path\]\s+String(?:Like|StartsWith)\s+'([^']*)'",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex PathRegex();
+
+    [GeneratedRegex(@"blobServices/containers:name\]\s+StringEquals\s+'([^']*)'",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex NameRegex();
+
+    [GeneratedRegex(@"blobServices/containers/blobs/tags:([^<\]]+)<\$key_(case_sensitive|case_insensitive)\$>\]\s+StringEquals\s+'([^']*)'",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex TagRegex();
+
+    public static AbacResult Parse(string? condition)
+    {
+        if (string.IsNullOrWhiteSpace(condition))
+            return new AbacResult(AbacKind.None);
+
+        Match tag = TagRegex().Match(condition);
+        if (tag.Success)
+            return new AbacResult(AbacKind.Tag,
+                TagKey: tag.Groups[1].Value,
+                TagValue: tag.Groups[3].Value,
+                TagKeyCaseSensitive: string.Equals(tag.Groups[2].Value, "case_sensitive", StringComparison.OrdinalIgnoreCase));
+
+        Match path = PathRegex().Match(condition);
+        if (path.Success)
+        {
+            string p = path.Groups[1].Value;
+            if (p.EndsWith('*')) p = p[..^1];
+            return new AbacResult(AbacKind.PathPrefix, PathPrefix: p);
+        }
+
+        Match name = NameRegex().Match(condition);
+        if (name.Success)
+            return new AbacResult(AbacKind.ContainerName, ContainerName: name.Groups[1].Value);
+
+        return new AbacResult(AbacKind.Unparseable);
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureAbacConditionParserTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs
+git commit -m "feat(azure): ABAC blob condition parser (path/name/tag) (#487)"
+```
+
+---
+
+## Task 4: `ArmRbacReader` — role assignments → readable scopes (grants only)
+
+**Files:**
+- Create: `src/Connapse.Storage/CloudScope/ArmRbacReader.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs`
+
+**Interfaces:**
+- Consumes: `IAzureRbacReader`, `AzureRbacScopes`, `AzureScope`, `AzureTagCondition` (Task 1); `AzureRbacScopeTranslator` (Task 2); `AzureAbacConditionParser`/`AbacKind`/`AbacResult` (Task 3); `TokenCredential`; `IMemoryCache`; `IOptionsMonitor<AzureProviderSettings>`.
+- Produces: `ArmRbacReader(HttpClient httpClient, TokenCredential azureCredential, IMemoryCache cache, IOptionsMonitor<AzureProviderSettings> options) : IAzureRbacReader`; `public static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(5)`.
+
+This task builds the grants path (roleAssignments only); Task 5 adds deny subtraction; Task 6 adds caching + DI. The internal apply-condition logic maps each grant `(azblobPrefix, condition)` → prefix / tag-residue / drop.
+
+- [ ] **Step 1: Write the failing tests** (happy path + role filtering + ABAC application + subscription-missing)
+
+```csharp
+// tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+using System.Net;
+using System.Text;
+using Azure.Core;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class ArmRbacReaderTests
+{
+    private const string Oid = "11111111-1111-1111-1111-111111111111";
+    private const string Sub = "22222222-2222-2222-2222-222222222222";
+    private const string ReaderRole = "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1";
+
+    // Records every request URL so tests can assert which ARM endpoints were called.
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        public List<string> Urls { get; } = [];
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Urls.Add(request.RequestUri!.ToString());
+            return Task.FromResult(respond(request));
+        }
+    }
+
+    private sealed class StubTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext c, CancellationToken ct) =>
+            new("stub", DateTimeOffset.UtcNow.AddHours(1));
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext c, CancellationToken ct) =>
+            new(GetToken(c, ct));
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode s, string body) =>
+        new(s) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    private static string RoleAssignmentsBody(params (string roleGuid, string scope, string? condition)[] rows)
+    {
+        string items = string.Join(",", rows.Select(r =>
+        {
+            string cond = r.condition is null ? "null" : $"\"{r.condition.Replace("\"", "\\\"")}\"";
+            return $$"""
+            {"properties":{"roleDefinitionId":"/subscriptions/{{Sub}}/providers/Microsoft.Authorization/roleDefinitions/{{r.roleGuid}}","principalId":"{{Oid}}","scope":"{{r.scope}}","condition":{{cond}},"conditionVersion":null}}
+            """;
+        }));
+        return $$"""{"value":[{{items}}]}""";
+    }
+
+    private static readonly string EmptyDeny = """{"value":[]}""";
+
+    // A reader whose roleAssignments call returns `roles` and whose denyAssignments call returns empty.
+    private static ArmRbacReader NewReader(string rolesBody, string? subId = Sub, IMemoryCache? cache = null)
+    {
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.OK, EmptyDeny)
+                : Json(HttpStatusCode.OK, rolesBody));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = subId });
+        return new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            cache ?? new MemoryCache(new MemoryCacheOptions()), opts);
+    }
+
+    [Fact]
+    public async Task Resolve_AccountScopedReaderRole_NoCondition_YieldsAccountPrefix()
+    {
+        string body = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().Contain("azblob://acct/");
+    }
+
+    [Fact]
+    public async Task Resolve_IgnoresNonBlobDataRoles()
+    {
+        // Owner of the *control plane* role "Contributor" for ARM is a different GUID; use a random one.
+        string body = RoleAssignmentsBody(("00000000-0000-0000-0000-000000000000",
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_PathCondition_NarrowsPrefix()
+    {
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'} AND NOT SubOperationMatches{'Blob.List'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*'))";
+        string body = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", cond));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().Contain("azblob://acct/docs/readonly/");
+    }
+
+    [Fact]
+    public async Task Resolve_TagCondition_GoesToTagResidue_NotPrefix()
+    {
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Project<$key_case_sensitive$>] StringEquals 'Cascade'))";
+        string body = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", cond));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Should().BeEmpty();
+        r.TagConditioned.Should().ContainSingle().Which.TagValue.Should().Be("Cascade");
+    }
+
+    [Fact]
+    public async Task Resolve_UnparseableCondition_DropsThatGrantOnly()
+    {
+        string bad = "((!(ActionMatches{'x'})) OR (@Request[foo] DateTimeGreaterThan '2024-01-01'))";
+        string body = RoleAssignmentsBody(
+            (ReaderRole, "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/bad", bad),
+            (ReaderRole, "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/good", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/good/");
+    }
+
+    [Fact]
+    public async Task Resolve_NoSubscriptionConfigured_FailsClosed()
+    {
+        AzureRbacScopes r = await NewReader(RoleAssignmentsBody(), subId: null).ResolveAsync(Oid, CancellationToken.None);
+        r.Outcome.Should().Be(RbacOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_QueriesSubscriptionScope_WithoutAtScope()
+    {
+        var reader = NewReader(RoleAssignmentsBody());
+        await reader.ResolveAsync(Oid, CancellationToken.None);
+        // (assert via a handler that captured URLs — see StubHandler.Urls; validated in Task 6's DI test
+        //  and here by constructing the reader with a capturing handler if needed)
+    }
+}
+```
+
+Note: add `using NSubstitute;` — the test project already references NSubstitute (see CLAUDE.md). The final URL-assertion test is fleshed out in Task 6 where the capturing handler is wired; keep the placeholder body compiling (it simply resolves).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~ArmRbacReaderTests"`
+Expected: FAIL — `ArmRbacReader` does not exist.
+
+- [ ] **Step 3: Write the reader (grants path)**
+
+```csharp
+// src/Connapse.Storage/CloudScope/ArmRbacReader.cs
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Azure.Core;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Resolves a searcher's effective RBAC-readable azblob scopes from ARM: one roleAssignments call
+/// at the subscription scope (transitive over groups, WITHOUT atScope so account/container
+/// assignments are included) minus a parallel denyAssignments call. Fails closed; caches only
+/// confident answers. Mirrors <see cref="GraphDirectoryReader"/>'s transport/caching discipline.
+/// </summary>
+public sealed class ArmRbacReader(
+    HttpClient httpClient,
+    TokenCredential azureCredential,
+    IMemoryCache cache,
+    IOptionsMonitor<AzureProviderSettings> options) : IAzureRbacReader
+{
+    private const string ArmBase = "https://management.azure.com";
+    private const string ApiVersion = "2022-04-01";
+    private static readonly string[] ArmScopes = ["https://management.azure.com/.default"];
+
+    private static readonly HashSet<string> BlobDataReadRoles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1", // Storage Blob Data Reader
+        "ba92f5b4-2d11-453d-a403-e96b0029c9fe", // Storage Blob Data Contributor
+        "b7e6dc6d-f1e8-4753-8033-0f276bb0955b", // Storage Blob Data Owner
+    };
+
+    public static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(5);
+
+    public async Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct = default)
+    {
+        string? sub = options.CurrentValue.SubscriptionId;
+        if (string.IsNullOrWhiteSpace(sub))
+            return AzureRbacScopes.Failed(); // cannot query without a subscription — fail closed
+
+        try
+        {
+            return await ResolveUncachedAsync(sub, primaryOid, ct); // Task 5/6 add deny + cache
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return AzureRbacScopes.Failed();
+        }
+    }
+
+    private async Task<AzureRbacScopes> ResolveUncachedAsync(string sub, string oid, CancellationToken ct)
+    {
+        AccessToken token = await azureCredential.GetTokenAsync(new TokenRequestContext(ArmScopes), ct);
+
+        IReadOnlyList<Assignment> grants = await ListAllAsync(
+            $"{ArmBase}/subscriptions/{sub}/providers/Microsoft.Authorization/roleAssignments" +
+            $"?api-version={ApiVersion}&$filter=assignedTo('{oid}')", token, ct);
+
+        var prefixes = new List<AzureScope>();
+        var tags = new List<AzureTagCondition>();
+        foreach (Assignment a in grants)
+        {
+            string? roleGuid = LastSegment(a.Properties?.RoleDefinitionId);
+            if (roleGuid is null || !BlobDataReadRoles.Contains(roleGuid) || a.Properties?.Scope is null)
+                continue;
+
+            ApplyGrant(a.Properties.Scope, a.Properties.Condition, prefixes, tags);
+        }
+
+        return AzureRbacScopes.Resolved(prefixes, tags);
+    }
+
+    /// <summary>Maps one matched grant (scope + ABAC condition) into a prefix, a tag residue, or a drop.</summary>
+    internal static void ApplyGrant(string armScope, string? condition, List<AzureScope> prefixes, List<AzureTagCondition> tags)
+    {
+        string basePrefix = AzureRbacScopeTranslator.ToAzblobPrefix(armScope);
+        AbacResult abac = AzureAbacConditionParser.Parse(condition);
+        switch (abac.Kind)
+        {
+            case AbacKind.None:
+                prefixes.Add(new AzureScope(basePrefix));
+                break;
+            case AbacKind.PathPrefix:
+                prefixes.Add(new AzureScope(basePrefix + abac.PathPrefix));
+                break;
+            case AbacKind.ContainerName:
+                // Narrow an account/broader scope to the named container.
+                prefixes.Add(new AzureScope(NarrowToContainer(basePrefix, abac.ContainerName!)));
+                break;
+            case AbacKind.Tag:
+                tags.Add(new AzureTagCondition(basePrefix, abac.TagKey!, abac.TagValue!, abac.TagKeyCaseSensitive));
+                break;
+            case AbacKind.Unparseable:
+            default:
+                break; // drop this grant only (fail closed)
+        }
+    }
+
+    private static string NarrowToContainer(string basePrefix, string container)
+    {
+        // basePrefix is "azblob://", "azblob://{acct}/", or "azblob://{acct}/{c}/". A container-name
+        // condition names the container within the account; only meaningful when the account is known.
+        if (basePrefix == "azblob://")
+            return basePrefix; // account unknown — leave broad; the condition can't be tightened here
+        // basePrefix ends with "/"; strip any existing container and append the named one.
+        string acct = basePrefix["azblob://".Length..].TrimEnd('/').Split('/')[0];
+        return $"azblob://{acct}/{container}/";
+    }
+
+    private static string? LastSegment(string? id) =>
+        string.IsNullOrEmpty(id) ? null : id.Split('/', StringSplitOptions.RemoveEmptyEntries)[^1];
+
+    private async Task<IReadOnlyList<Assignment>> ListAllAsync(string url, AccessToken token, CancellationToken ct)
+    {
+        var all = new List<Assignment>();
+        string? next = url;
+        while (next is not null)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, next);
+            request.Headers.Authorization = new("Bearer", token.Token);
+            using HttpResponseMessage response = await httpClient.SendAsync(request, ct);
+            response.EnsureSuccessStatusCode(); // non-2xx → throw → caller fails closed
+            ArmList? page = await response.Content.ReadFromJsonAsync<ArmList>(ct);
+            if (page?.Value is { } v) all.AddRange(v);
+            next = page?.NextLink;
+        }
+        return all;
+    }
+
+    // ---- ARM DTOs ----
+    internal sealed record ArmList(
+        [property: JsonPropertyName("value")] IReadOnlyList<Assignment>? Value,
+        [property: JsonPropertyName("nextLink")] string? NextLink);
+    internal sealed record Assignment([property: JsonPropertyName("properties")] AssignmentProps? Properties);
+    internal sealed record AssignmentProps(
+        [property: JsonPropertyName("roleDefinitionId")] string? RoleDefinitionId,
+        [property: JsonPropertyName("scope")] string? Scope,
+        [property: JsonPropertyName("condition")] string? Condition);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~ArmRbacReaderTests"`
+Expected: PASS (the URL-assertion placeholder test resolves; deny/cache tests come in 5/6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/ArmRbacReader.cs tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+git commit -m "feat(azure): ArmRbacReader resolves readable scopes from role assignments (#487)"
+```
+
+---
+
+## Task 5: Deny assignments — effective = grants − denies
+
+**Files:**
+- Modify: `src/Connapse.Storage/CloudScope/ArmRbacReader.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs` (extend)
+
+**Interfaces:**
+- Consumes: the grants path (Task 4). Adds a parallel deny fetch and a conservative subtraction.
+
+**Deny model (conservative, sound):** fetch `denyAssignments` at the same subscription scope with `assignedTo('{oid}')`. A deny assignment carries `properties.scope` and `properties.permissions[].dataActions`/`notDataActions`. Treat a deny as applicable to blob read when any `dataActions` entry is the blob read action or a wildcard covering it (`Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read`, or `.../blobs/*`, or `*`). For each applicable deny, remove any grant prefix that the deny's scope **covers** — i.e. the deny's azblob prefix (via `AzureRbacScopeTranslator`) is a prefix of, or equal to, the grant prefix. (Deny scope broader than grant ⇒ grant removed; this is deny-wins. Tag-conditioned residue whose scope is covered is likewise dropped.) A failed deny call throws → the outer catch returns `Failed` (never assume none).
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// append to ArmRbacReaderTests
+
+// Build a reader whose deny call returns `denyBody`.
+private static ArmRbacReader NewReaderWithDeny(string rolesBody, string denyBody, string? subId = Sub)
+{
+    var handler = new StubHandler(req =>
+        req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+            ? Json(HttpStatusCode.OK, denyBody)
+            : Json(HttpStatusCode.OK, rolesBody));
+    var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+    opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = subId });
+    return new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+        new MemoryCache(new MemoryCacheOptions()), opts);
+}
+
+private static string DenyBody(string scope) => $$"""
+{"value":[{"properties":{"scope":"{{scope}}","permissions":[{"dataActions":["Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"],"notDataActions":[]}]}}]}
+""";
+
+[Fact]
+public async Task Resolve_DenyCoveringGrant_RemovesIt()
+{
+    string acctScope = "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+    string roles = RoleAssignmentsBody((ReaderRole, acctScope + "/blobServices/default/containers/docs", null));
+    // Deny at the whole account covers the container grant.
+    AzureRbacScopes r = await NewReaderWithDeny(roles, DenyBody(acctScope)).ResolveAsync(Oid, CancellationToken.None);
+
+    r.Outcome.Should().Be(RbacOutcome.Resolved);
+    r.ReadablePrefixes.Should().BeEmpty(); // deny wins
+}
+
+[Fact]
+public async Task Resolve_DenyElsewhere_DoesNotRemoveUnrelatedGrant()
+{
+    string roles = RoleAssignmentsBody((ReaderRole,
+        "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", null));
+    string denyOther = DenyBody("/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/other");
+    AzureRbacScopes r = await NewReaderWithDeny(roles, denyOther).ResolveAsync(Oid, CancellationToken.None);
+
+    r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/docs/");
+}
+
+[Fact]
+public async Task Resolve_DenyCallFails_FailsClosed()
+{
+    var handler = new StubHandler(req =>
+        req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+            ? Json(HttpStatusCode.InternalServerError, "{}")
+            : Json(HttpStatusCode.OK, RoleAssignmentsBody((ReaderRole,
+                "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null))));
+    var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+    opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+    var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+        new MemoryCache(new MemoryCacheOptions()), opts);
+
+    (await reader.ResolveAsync(Oid, CancellationToken.None)).Outcome.Should().Be(RbacOutcome.Failed);
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~ArmRbacReaderTests"`
+Expected: FAIL (deny not yet fetched/subtracted).
+
+- [ ] **Step 3: Add deny fetch + subtraction**
+
+Replace `ResolveUncachedAsync` so it fetches deny in parallel and subtracts, and add the helpers:
+
+```csharp
+    private async Task<AzureRbacScopes> ResolveUncachedAsync(string sub, string oid, CancellationToken ct)
+    {
+        AccessToken token = await azureCredential.GetTokenAsync(new TokenRequestContext(ArmScopes), ct);
+
+        Task<IReadOnlyList<Assignment>> grantsTask = ListAllAsync(
+            $"{ArmBase}/subscriptions/{sub}/providers/Microsoft.Authorization/roleAssignments" +
+            $"?api-version={ApiVersion}&$filter=assignedTo('{oid}')", token, ct);
+        Task<IReadOnlyList<Assignment>> denyTask = ListAllAsync(
+            $"{ArmBase}/subscriptions/{sub}/providers/Microsoft.Authorization/denyAssignments" +
+            $"?api-version={ApiVersion}&$filter=assignedTo('{oid}')", token, ct);
+        await Task.WhenAll(grantsTask, denyTask); // a failure in either throws → caller fails closed
+
+        var prefixes = new List<AzureScope>();
+        var tags = new List<AzureTagCondition>();
+        foreach (Assignment a in grantsTask.Result)
+        {
+            string? roleGuid = LastSegment(a.Properties?.RoleDefinitionId);
+            if (roleGuid is null || !BlobDataReadRoles.Contains(roleGuid) || a.Properties?.Scope is null)
+                continue;
+            ApplyGrant(a.Properties.Scope, a.Properties.Condition, prefixes, tags);
+        }
+
+        IReadOnlyList<string> denyPrefixes = DenyPrefixes(denyTask.Result);
+        if (denyPrefixes.Count > 0)
+        {
+            prefixes = prefixes.Where(p => !CoveredByAnyDeny(p.Prefix, denyPrefixes)).ToList();
+            tags = tags.Where(t => !CoveredByAnyDeny(t.Scope, denyPrefixes)).ToList();
+        }
+
+        return AzureRbacScopes.Resolved(prefixes, tags);
+    }
+
+    /// <summary>Deny scopes (as azblob prefixes) that apply to blob read for this searcher.</summary>
+    private static IReadOnlyList<string> DenyPrefixes(IReadOnlyList<Assignment> denies)
+    {
+        var result = new List<string>();
+        foreach (Assignment d in denies)
+        {
+            if (d.Properties?.Scope is null) continue;
+            if (AppliesToBlobRead(d.Properties.Permissions))
+                result.Add(AzureRbacScopeTranslator.ToAzblobPrefix(d.Properties.Scope));
+        }
+        return result;
+    }
+
+    private static bool AppliesToBlobRead(IReadOnlyList<Permission>? permissions)
+    {
+        if (permissions is null) return false;
+        foreach (Permission p in permissions)
+        {
+            foreach (string a in p.DataActions ?? [])
+            {
+                if (a == "*"
+                    || a.Equals("Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read", StringComparison.OrdinalIgnoreCase)
+                    || (a.EndsWith('*') && "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"
+                            .StartsWith(a[..^1], StringComparison.OrdinalIgnoreCase)))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    // A grant is denied when a deny prefix is equal to, or an ancestor of, the grant prefix
+    // (deny-wins over a broader-or-equal scope). "azblob://" as a deny prefix covers everything.
+    private static bool CoveredByAnyDeny(string grantPrefix, IReadOnlyList<string> denyPrefixes) =>
+        denyPrefixes.Any(d => grantPrefix.StartsWith(d, StringComparison.Ordinal));
+```
+
+Add the deny DTO fields to `AssignmentProps` and a `Permission` record:
+
+```csharp
+    internal sealed record AssignmentProps(
+        [property: JsonPropertyName("roleDefinitionId")] string? RoleDefinitionId,
+        [property: JsonPropertyName("scope")] string? Scope,
+        [property: JsonPropertyName("condition")] string? Condition,
+        [property: JsonPropertyName("permissions")] IReadOnlyList<Permission>? Permissions);
+    internal sealed record Permission(
+        [property: JsonPropertyName("dataActions")] IReadOnlyList<string>? DataActions,
+        [property: JsonPropertyName("notDataActions")] IReadOnlyList<string>? NotDataActions);
+```
+
+(`roleAssignments` responses simply have no `permissions` field → null → ignored. `denyAssignments` responses have no `roleDefinitionId` → not matched as a grant.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~ArmRbacReaderTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/ArmRbacReader.cs tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+git commit -m "feat(azure): subtract deny assignments from RBAC grants (deny wins) (#487)"
+```
+
+---
+
+## Task 6: Caching + DI wiring + resolution test
+
+**Files:**
+- Modify: `src/Connapse.Storage/CloudScope/ArmRbacReader.cs` (add caching)
+- Modify: `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs` (caching + URL assertion), `tests/Connapse.Integration.Tests/AzureRbacReaderDiIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: everything above; `ConnapseAzureCredentials` (already a singleton, mapped to `TokenCredential` in 4a).
+
+- [ ] **Step 1: Add caching to `ResolveAsync`**
+
+Wrap the resolve in a per-oid cache (confident answers only), mirroring `GraphDirectoryReader`:
+
+```csharp
+    public async Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct = default)
+    {
+        string? sub = options.CurrentValue.SubscriptionId;
+        if (string.IsNullOrWhiteSpace(sub))
+            return AzureRbacScopes.Failed();
+
+        string cacheKey = "azure-rbac:" + primaryOid;
+        if (cache.TryGetValue(cacheKey, out AzureRbacScopes? cached) && cached is not null)
+            return cached;
+
+        AzureRbacScopes result;
+        try
+        {
+            result = await ResolveUncachedAsync(sub, primaryOid, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return AzureRbacScopes.Failed();
+        }
+
+        if (result.Outcome is RbacOutcome.Resolved)
+            cache.Set(cacheKey, result, CacheLifetime);
+        return result;
+    }
+```
+
+- [ ] **Step 2: Write caching + URL-assertion tests**
+
+```csharp
+// append to ArmRbacReaderTests
+[Fact]
+public async Task Resolve_Resolved_IsCached_SecondCallDoesNotHitArm()
+{
+    string roles = RoleAssignmentsBody((ReaderRole,
+        "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+    var handler = new StubHandler(req =>
+        req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+            ? Json(HttpStatusCode.OK, EmptyDeny) : Json(HttpStatusCode.OK, roles));
+    var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+    opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+    var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+        new MemoryCache(new MemoryCacheOptions()), opts);
+
+    await reader.ResolveAsync(Oid, CancellationToken.None);
+    int after = handler.Urls.Count;
+    await reader.ResolveAsync(Oid, CancellationToken.None);
+
+    handler.Urls.Count.Should().Be(after); // served from cache
+    handler.Urls.Should().Contain(u => u.Contains("/roleAssignments") && u.Contains("assignedTo") && !u.Contains("atScope"));
+    handler.Urls.Should().Contain(u => u.Contains("/subscriptions/" + Sub + "/"));
+}
+```
+
+- [ ] **Step 3: DI registration** — after the 4a `IAzureDirectoryReader` registration in `AddConnapseStorage`, add:
+
+```csharp
+        // Reads the searcher's effective RBAC-readable azblob scopes from ARM (role assignments
+        // minus deny assignments). Typed HttpClient; the 5-minute decision cache is the shared
+        // IMemoryCache singleton. TokenCredential is already mapped to ConnapseAzureCredentials (4a).
+        services.AddHttpClient<Connapse.Core.Interfaces.IAzureRbacReader, CloudScope.ArmRbacReader>();
+```
+
+- [ ] **Step 4: Write the DI resolution test**
+
+```csharp
+// tests/Connapse.Integration.Tests/AzureRbacReaderDiIntegrationTests.cs
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureRbacReaderDiIntegrationTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public void Di_Resolves_AzureRbacReader()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IAzureRbacReader>().Should().NotBeNull();
+    }
+}
+```
+
+- [ ] **Step 5: Build, run tests, commit**
+
+Run: `dotnet build` then `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~ArmRbacReaderTests|FullyQualifiedName~AzureRbacScopeTranslatorTests|FullyQualifiedName~AzureAbacConditionParserTests"` and the DI test `dotnet test tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj --filter "FullyQualifiedName~AzureRbacReaderDiIntegrationTests"` (needs Docker).
+Expected: all green.
+
+```bash
+git add src/Connapse.Storage/CloudScope/ArmRbacReader.cs src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs tests/Connapse.Integration.Tests/AzureRbacReaderDiIntegrationTests.cs
+git commit -m "feat(azure): cache RBAC scopes + register ArmRbacReader (#487)"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec §B coverage:** subscription-scope query without `atScope()` + transitive `assignedTo` (Task 4, corrects the parent design); nextLink paging (Task 4); 3 role GUIDs (Task 4); scope→azblob translation incl. broader→`azblob://` (Task 2); ABAC path/name/tag/unparseable (Task 3, applied Task 4); deny in parallel, effective = grants − denies, deny-call-fail → Failed (Task 5); cache ~5 min confident-only + `azure-rbac:{oid}` (Task 6); fail-closed on no-subscription/HTTP-fail/timeout (Tasks 4, 6). ✅
+- **Not in 4b (deferred):** search wiring / composite / enforcement (4c); Gen2 (4d/4e); the settings-based tenant-match guard (4a follow-up).
+- **Type consistency:** `AzureRbacScopes`/`AzureScope`/`AzureTagCondition`/`RbacOutcome`/`IAzureRbacReader.ResolveAsync(string, ct)` identical across tasks; `AzureRbacScopeTranslator.ToAzblobPrefix`, `AzureAbacConditionParser.Parse`, `AbacResult`/`AbacKind` referenced consistently; `ArmRbacReader` ctor and `CacheLifetime` stable.
+- **Fail-closed:** every non-Resolved path returns `Failed()` (empty); deny-call failure fails closed; unparseable condition drops one grant, not the resolution.

--- a/docs/superpowers/plans/2026-09-06-azure-phase4c-composite-resolver.md
+++ b/docs/superpowers/plans/2026-09-06-azure-phase4c-composite-resolver.md
@@ -1,0 +1,812 @@
+# Azure Phase 4c — flat resolver + composite + per-cloud enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire Azure into search: an `AzureSearchScopeResolver` that turns a searcher into `azblob://` prefixes (flat accounts), a `CompositeSearchScopeResolver` that unions AWS + Azure per-cloud/per-scheme (fail-closed per cloud), and a generalized enforcement latch so Azure AD configuration also enables filtering — leaving the shared SQL filter and the AWS path behavior-identical.
+
+**Architecture:** The existing SQL filter (`resource_uri IS NULL OR <OR of matches>`) is provider-agnostic and non-cloud docs have `resource_uri = NULL`, so per-cloud/per-scheme enforcement is expressed **by construction** in a composite `SearchScopes`: each cloud contributes its prefixes when enforcing-and-granted, a scheme wildcard (`s3://` / `azblob://`) when that cloud is not enforcing, and nothing when it denies/fails — the SQL layer is untouched. Enforcement stays a single global opt-in latch, broadened to latch on SAML **or** Azure AD; each cloud's resolver gates on its own provider's config via an additive `StateFor(bool)` overload so the AWS resolver, its `StateFor` call, and its tests are unchanged.
+
+**Tech Stack:** .NET 10, `IMemoryCache`, `IOptionsMonitor<T>`, xUnit + FluentAssertions + NSubstitute, Testcontainers (integration).
+
+**Spec:** `docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md` (§C, §D).
+
+## Global Constraints
+
+- **AWS behavior is unchanged.** `AwsSearchScopeResolver`, its `StateFor(SamlSignInSettings, bool)` call, and `SamlEnforcementStateTests` are not modified; the enforcement generalization is an *additive* `StateFor(bool, bool)` overload plus a broadened latch. The AWS resolver becomes one inner resolver of the composite with its logic intact.
+- **The shared SQL filter is not touched.** `PgVectorStore`/`KeywordSearchService` stay as-is; correctness comes entirely from the `SearchScopes` the composite produces. Non-cloud docs (`resource_uri = NULL`) remain always-visible via the existing `resource_uri IS NULL` fallback.
+- **Fail closed, per cloud.** Any error/deny/no-principal from one cloud contributes no matches for that cloud's scheme (its docs hidden), never a global failure that hides the other cloud or non-cloud docs. A cloud not enforcing contributes its scheme wildcard (its docs visible). Global `Unrestricted` only when **both** clouds are unrestricted.
+- **No over-grant of Azure content.** A deployment in enforcing mode with Azure AD unconfigured denies `azblob://` docs (never shows them unfiltered).
+- **Flat only.** This phase resolves flat (non-HNS) accounts via RBAC prefixes. Tag-conditioned RBAC residue and Gen2 ACLs are **not** admitted here (they need 4e's live verifier) — omitting them is a temporary under-grant on the epic branch that 4e closes before the epic reaches main.
+- **.NET 10 conventions:** file-scoped namespaces, records, primary constructors, async all the way, no `var` for primitives, no `dynamic`.
+- Azure resolver caches per-user (`azure-scopes:{userId}`, ~60 s, confident answers only), mirroring `AwsSearchScopeResolver`.
+
+## File Structure
+
+- Modify `src/Connapse.Core/Models/PermissionEnforcementSettings.cs` — add `StateFor(bool providerConfigured, bool determined = true)`; keep the `SamlSignInSettings` overload delegating to it.
+- Create `src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs` — the flat Azure resolver.
+- Create `src/Connapse.Storage/CloudScope/CompositeSearchScopeResolver.cs` — AWS ∪ Azure, per-cloud/per-scheme.
+- Rename/broaden `src/Connapse.Web/Services/SamlEnforcementLatch.cs` → `CloudEnforcementLatch.cs` — latch on SAML **or** Azure AD.
+- Modify `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs` — register Aws + Azure resolvers as concrete types and the composite as `ISearchScopeResolver`.
+- Modify the `CloudEnforcementLatch` registration in `src/Connapse.Web` (wherever `SamlEnforcementLatch` is registered as an `IHostedService`).
+- Tests: `tests/Connapse.Core.Tests/Models/PermissionEnforcementStateTests.cs` (add bool-overload cases — new file or extend), `tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs`, `tests/Connapse.Storage.Tests/CloudScope/CompositeSearchScopeResolverTests.cs`, `tests/Connapse.Integration.Tests/AzureFlatEnforcementTests.cs`, and the DI resolution guard in `tests/Connapse.Integration.Tests/` (extend an existing Azure DI test or add one).
+
+---
+
+## Task 1: `StateFor(bool)` overload (additive; AWS untouched)
+
+**Files:**
+- Modify: `src/Connapse.Core/Models/PermissionEnforcementSettings.cs`
+- Test: `tests/Connapse.Core.Tests/Models/PermissionEnforcementBoolStateTests.cs`
+
+**Interfaces:**
+- Consumes: `EnforcementState`, `IsEnforcing`.
+- Produces: `EnforcementState StateFor(bool providerConfigured, bool determined = true)`. The existing `StateFor(SamlSignInSettings, bool)` now delegates: `StateFor(signIn.IsConfigured, determined)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// tests/Connapse.Core.Tests/Models/PermissionEnforcementBoolStateTests.cs
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Models;
+
+[Trait("Category", "Unit")]
+public class PermissionEnforcementBoolStateTests
+{
+    [Fact]
+    public void Undetermined_IsEnforcingButUnusable()
+    {
+        var s = new PermissionEnforcementSettings { IsEnforcing = true };
+        s.StateFor(providerConfigured: true, determined: false).Should().Be(EnforcementState.EnforcingButUnusable);
+    }
+
+    [Fact]
+    public void NotLatched_IsNotEnforcing()
+    {
+        var s = new PermissionEnforcementSettings { IsEnforcing = false };
+        s.StateFor(providerConfigured: true).Should().Be(EnforcementState.NotEnforcing);
+    }
+
+    [Fact]
+    public void Latched_ProviderConfigured_IsEnforcing()
+    {
+        var s = new PermissionEnforcementSettings { IsEnforcing = true };
+        s.StateFor(providerConfigured: true).Should().Be(EnforcementState.Enforcing);
+    }
+
+    [Fact]
+    public void Latched_ProviderNotConfigured_IsEnforcingButUnusable()
+    {
+        var s = new PermissionEnforcementSettings { IsEnforcing = true };
+        s.StateFor(providerConfigured: false).Should().Be(EnforcementState.EnforcingButUnusable);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~PermissionEnforcementBoolStateTests"`
+Expected: FAIL — the bool overload does not exist.
+
+- [ ] **Step 3: Add the overload**
+
+In `PermissionEnforcementSettings`, replace the existing `StateFor(SamlSignInSettings, bool)` body with a delegation and add the bool overload:
+
+```csharp
+    /// <summary>What a resolver should do, given whether its own sign-in provider is configured.</summary>
+    /// <param name="providerConfigured">True when the resolver's identity provider (SAML, Azure AD)
+    /// has a complete sign-in configuration.</param>
+    /// <param name="determined">
+    /// False when the startup migration could not establish whether this deployment was already
+    /// enforcing. An undetermined deployment enforces: not knowing is not permission to open.
+    /// </param>
+    public EnforcementState StateFor(bool providerConfigured, bool determined = true)
+    {
+        if (!determined)
+            return EnforcementState.EnforcingButUnusable;
+
+        if (!IsEnforcing)
+            return EnforcementState.NotEnforcing;
+
+        return providerConfigured
+            ? EnforcementState.Enforcing
+            : EnforcementState.EnforcingButUnusable;
+    }
+
+    /// <summary>What a resolver should do, given the SAML sign-in settings it has. Delegates to the
+    /// provider-agnostic overload — kept so the AWS resolver and its tests are unchanged.</summary>
+    public EnforcementState StateFor(SamlSignInSettings signIn, bool determined = true)
+    {
+        ArgumentNullException.ThrowIfNull(signIn);
+        return StateFor(signIn.IsConfigured, determined);
+    }
+```
+
+- [ ] **Step 4: Run both the new test and the existing AWS enforcement tests**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~PermissionEnforcementBoolStateTests|FullyQualifiedName~SamlEnforcementStateTests"`
+Expected: PASS — the new bool cases and the unchanged `SamlEnforcementStateTests` (which exercise the delegating overload) both green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Models/PermissionEnforcementSettings.cs tests/Connapse.Core.Tests/Models/PermissionEnforcementBoolStateTests.cs
+git commit -m "feat(azure): add provider-agnostic PermissionEnforcementSettings.StateFor(bool) overload (#488)"
+```
+
+---
+
+## Task 2: `AzureSearchScopeResolver` (flat)
+
+**Files:**
+- Create: `src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs`
+
+**Interfaces:**
+- Consumes: `ISearchScopeResolver`/`SearchScopes` (Core); `IAzureIdentityLinkReader`→`AzureIdentityRef` (Phase 3); `IAzureDirectoryReader`→`AzureIdentitySet` (4a); `IAzureRbacReader`→`AzureRbacScopes` (4b); `AzureAdSignInSettings` (Phase 3, has `IsConfigured`); `PermissionEnforcementSettings`; `EnforcementMigration`; `IMemoryCache`.
+- Produces: `AzureSearchScopeResolver(...) : ISearchScopeResolver`; `public static readonly TimeSpan CacheLifetime = TimeSpan.FromSeconds(60)`.
+
+Mirrors `AwsSearchScopeResolver`: enforcement gate first, then link → deprovision gate → RBAC prefixes. **Only RBAC `ReadablePrefixes` are used** (tag residue and Gen2 are deferred to 4e). Fails closed on every uncertain path; caches only confident answers.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureSearchScopeResolverTests
+{
+    private static readonly Guid User = Guid.NewGuid();
+    private static readonly AzureIdentityRef Link = new("oid-1", "tid-1");
+
+    private static IOptionsMonitor<T> Opt<T>(T value) where T : class
+    {
+        var m = Substitute.For<IOptionsMonitor<T>>();
+        m.CurrentValue.Returns(value);
+        return m;
+    }
+
+    private static AzureSearchScopeResolver Build(
+        IAzureIdentityLinkReader? links = null,
+        IAzureDirectoryReader? directory = null,
+        IAzureRbacReader? rbac = null,
+        bool azureAdConfigured = true,
+        bool isEnforcing = true,
+        bool determined = true)
+    {
+        var azureAd = Opt(new AzureAdSignInSettings
+        {
+            TenantId = azureAdConfigured ? "t" : null,
+            ClientId = azureAdConfigured ? "c" : null,
+            RedirectUri = azureAdConfigured ? "https://x/cb" : null,
+            ClientCertificatePath = azureAdConfigured ? "cert.pem" : null,
+        });
+        var enforcement = Opt(new PermissionEnforcementSettings { IsEnforcing = isEnforcing });
+        EnforcementMigration migration = determined ? EnforcementMigration.Completed() : new EnforcementMigration();
+
+        return new AzureSearchScopeResolver(
+            links ?? Substitute.For<IAzureIdentityLinkReader>(),
+            directory ?? Substitute.For<IAzureDirectoryReader>(),
+            rbac ?? Substitute.For<IAzureRbacReader>(),
+            azureAd, enforcement, migration,
+            new MemoryCache(new MemoryCacheOptions()),
+            NullLogger<AzureSearchScopeResolver>.Instance);
+    }
+
+    [Fact]
+    public async Task NotEnforcing_IsUnrestricted()
+    {
+        var r = Build(isEnforcing: false);
+        (await r.ResolveAsync(User)).IsUnrestricted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Enforcing_ButAzureAdNotConfigured_Fails()
+    {
+        var r = Build(azureAdConfigured: false);
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.ResolverFailed);
+    }
+
+    [Fact]
+    public async Task Undetermined_Fails()
+    {
+        var r = Build(determined: false);
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.ResolverFailed);
+    }
+
+    [Fact]
+    public async Task NullUser_IsNoPrincipal()
+    {
+        var r = Build();
+        (await r.ResolveAsync(null)).Outcome.Should().Be(ScopeOutcome.NoPrincipal);
+    }
+
+    [Fact]
+    public async Task NoLink_IsNoPrincipal()
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns((AzureIdentityRef?)null);
+        var r = Build(links: links);
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.NoPrincipal);
+    }
+
+    [Fact]
+    public async Task Deprovisioned_IsNoPrincipal()
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+        var directory = Substitute.For<IAzureDirectoryReader>();
+        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Deprovisioned());
+        var r = Build(links: links, directory: directory);
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.NoPrincipal);
+    }
+
+    [Fact]
+    public async Task IdentityResolutionFailed_Fails()
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+        var directory = Substitute.For<IAzureDirectoryReader>();
+        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Failed());
+        var r = Build(links: links, directory: directory);
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.ResolverFailed);
+    }
+
+    [Fact]
+    public async Task RbacFailed_Fails()
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+        var directory = Substitute.For<IAzureDirectoryReader>();
+        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
+        var rbac = Substitute.For<IAzureRbacReader>();
+        rbac.ResolveAsync("oid-1", Arg.Any<CancellationToken>()).Returns(AzureRbacScopes.Failed());
+        var r = Build(links: links, directory: directory, rbac: rbac);
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.ResolverFailed);
+    }
+
+    [Fact]
+    public async Task Enabled_WithRbacPrefixes_ReturnsGrantedAzblobMatches()
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+        var directory = Substitute.For<IAzureDirectoryReader>();
+        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
+        var rbac = Substitute.For<IAzureRbacReader>();
+        rbac.ResolveAsync("oid-1", Arg.Any<CancellationToken>()).Returns(
+            AzureRbacScopes.Resolved([new AzureScope("azblob://acct/docs/")], []));
+        var r = Build(links: links, directory: directory, rbac: rbac);
+
+        SearchScopes s = await r.ResolveAsync(User);
+        s.Outcome.Should().Be(ScopeOutcome.Granted);
+        s.Matches.Should().ContainSingle().Which.Value.Should().Be("azblob://acct/docs/");
+        s.Matches[0].IsExact.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Enabled_NoRbacPrefixes_IsNoGrants()
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+        var directory = Substitute.For<IAzureDirectoryReader>();
+        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
+        var rbac = Substitute.For<IAzureRbacReader>();
+        rbac.ResolveAsync("oid-1", Arg.Any<CancellationToken>()).Returns(AzureRbacScopes.Resolved([], []));
+        var r = Build(links: links, directory: directory, rbac: rbac);
+
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.NoGrants);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureSearchScopeResolverTests"`
+Expected: FAIL — `AzureSearchScopeResolver` does not exist.
+
+- [ ] **Step 3: Write the resolver**
+
+```csharp
+// src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Answers what a Connapse user may search in Azure Blob, from the Storage-Blob-Data role
+/// assignments held against the Entra identity they linked. Flat accounts only: the RBAC prefix set
+/// is exact and complete. Mirrors <see cref="AwsSearchScopeResolver"/> — enforcement gate first,
+/// then link → deprovisioning gate → RBAC — and fails closed on every uncertain path.
+/// </summary>
+public sealed class AzureSearchScopeResolver(
+    IAzureIdentityLinkReader links,
+    IAzureDirectoryReader directory,
+    IAzureRbacReader rbac,
+    IOptionsMonitor<AzureAdSignInSettings> azureAd,
+    IOptionsMonitor<PermissionEnforcementSettings> enforcement,
+    EnforcementMigration migration,
+    IMemoryCache cache,
+    ILogger<AzureSearchScopeResolver> logger) : ISearchScopeResolver
+{
+    public static readonly TimeSpan CacheLifetime = TimeSpan.FromSeconds(60);
+    private const string KeyPrefix = "azure-scopes:";
+
+    public async Task<SearchScopes> ResolveAsync(Guid? userId, CancellationToken ct = default)
+    {
+        switch (enforcement.CurrentValue.StateFor(azureAd.CurrentValue.IsConfigured, migration.Determined))
+        {
+            case EnforcementState.NotEnforcing:
+                return SearchScopes.Unrestricted;
+            case EnforcementState.EnforcingButUnusable:
+                logger.LogError(
+                    "Azure per-user permissions cannot be determined — Azure AD sign-in is incomplete or the startup migration did not complete; denying rather than widening");
+                return SearchScopes.Failed;
+        }
+
+        if (userId is null)
+            return SearchScopes.NoPrincipal;
+
+        string key = KeyPrefix + userId.Value;
+        if (cache.TryGetValue(key, out SearchScopes? cached) && cached is not null)
+            return cached;
+
+        SearchScopes resolved;
+        try
+        {
+            resolved = await ResolveUncachedAsync(userId.Value, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Could not resolve Azure search scopes; denying rather than widening");
+            return SearchScopes.Failed;
+        }
+
+        if (resolved.Outcome is ScopeOutcome.Granted or ScopeOutcome.NoGrants)
+            cache.Set(key, resolved, CacheLifetime);
+        return resolved;
+    }
+
+    private async Task<SearchScopes> ResolveUncachedAsync(Guid userId, CancellationToken ct)
+    {
+        AzureIdentityRef? link = await links.GetLinkAsync(userId, ct);
+        if (link is null)
+            return SearchScopes.NoPrincipal;
+
+        // Deprovisioning gate: a disabled/deleted Entra account is denied even if role assignments
+        // still exist. A Failed identity lookup is an uncertain answer → deny.
+        AzureIdentitySet identity = await directory.ResolveAsync(link, ct);
+        if (identity.Outcome is AzureIdentityOutcome.Deprovisioned)
+        {
+            logger.LogInformation("A linked Entra identity is disabled or gone; denying");
+            return SearchScopes.NoPrincipal;
+        }
+        if (identity.Outcome is AzureIdentityOutcome.Failed)
+            return SearchScopes.Failed;
+
+        AzureRbacScopes scopes = await rbac.ResolveAsync(link.ObjectId, ct);
+        if (scopes.Outcome is RbacOutcome.Failed)
+            return SearchScopes.Failed;
+
+        // Flat accounts: RBAC readable prefixes are the answer. Tag-conditioned residue and Gen2
+        // ACLs are NOT admitted here — they require Phase 4e's live per-hit verifier; omitting them
+        // is a temporary under-grant on the epic branch that 4e closes before the epic reaches main.
+        var matches = scopes.ReadablePrefixes
+            .Select(s => new GrantMatch(s.Prefix, IsExact: false))
+            .ToList();
+
+        return SearchScopes.Of(matches);
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureSearchScopeResolverTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs
+git commit -m "feat(azure): AzureSearchScopeResolver (flat) resolves azblob scopes from RBAC (#488)"
+```
+
+---
+
+## Task 3: `CompositeSearchScopeResolver`
+
+**Files:**
+- Create: `src/Connapse.Storage/CloudScope/CompositeSearchScopeResolver.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/CompositeSearchScopeResolverTests.cs`
+
+**Interfaces:**
+- Consumes: `AwsSearchScopeResolver`, `AzureSearchScopeResolver` (concrete), `SearchScopes`, `GrantMatch`, `ScopeOutcome`.
+- Produces: `CompositeSearchScopeResolver(AwsSearchScopeResolver aws, AzureSearchScopeResolver azure) : ISearchScopeResolver`.
+
+Combine rule (per-cloud fail-closed, per-scheme): each cloud → contribution (Unrestricted → its scheme wildcard; Granted → its matches; None/NoPrincipal/Failed → nothing). Both Unrestricted → global `Unrestricted`. Else → `SearchScopes.Of(union)`. Each inner resolve is wrapped so one cloud throwing/denying never affects the other.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// tests/Connapse.Storage.Tests/CloudScope/CompositeSearchScopeResolverTests.cs
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class CompositeSearchScopeResolverTests
+{
+    // The composite composes two ISearchScopeResolver results; drive it through a tiny fake for each
+    // cloud rather than the concrete resolvers (those have their own tests).
+    private sealed class FakeResolver(SearchScopes result) : ISearchScopeResolver
+    {
+        public Task<SearchScopes> ResolveAsync(Guid? userId, CancellationToken ct = default) =>
+            Task.FromResult(result);
+    }
+
+    private static SearchScopes S3(params string[] prefixes) =>
+        SearchScopes.OfPrefixes(prefixes.Select(p => p).ToList());
+
+    private static async Task<SearchScopes> Combine(SearchScopes aws, SearchScopes azure)
+    {
+        var c = new CompositeSearchScopeResolver.Combiner();
+        return await Task.FromResult(c.Combine(aws, azure));
+    }
+
+    [Fact]
+    public async Task BothUnrestricted_IsUnrestricted() =>
+        (await Combine(SearchScopes.Unrestricted, SearchScopes.Unrestricted)).IsUnrestricted.Should().BeTrue();
+
+    [Fact]
+    public async Task AwsGranted_AzureUnrestricted_UnionsPrefixesAndAzureWildcard()
+    {
+        SearchScopes r = await Combine(SearchScopes.OfPrefixes(["s3://bucket/team/"]), SearchScopes.Unrestricted);
+        r.IsUnrestricted.Should().BeFalse();
+        r.Matches.Select(m => m.Value).Should().BeEquivalentTo("s3://bucket/team/", "azblob://");
+    }
+
+    [Fact]
+    public async Task AwsUnrestricted_AzureGranted_UnionsAwsWildcardAndAzurePrefixes()
+    {
+        SearchScopes r = await Combine(SearchScopes.Unrestricted, SearchScopes.OfPrefixes(["azblob://acct/docs/"]));
+        r.Matches.Select(m => m.Value).Should().BeEquivalentTo("s3://", "azblob://acct/docs/");
+    }
+
+    [Fact]
+    public async Task OneCloudFailed_DoesNotDenyTheOther()
+    {
+        SearchScopes r = await Combine(SearchScopes.Failed, SearchScopes.OfPrefixes(["azblob://acct/"]));
+        r.Matches.Select(m => m.Value).Should().BeEquivalentTo("azblob://acct/"); // AWS failed → no s3 matches
+    }
+
+    [Fact]
+    public async Task BothDeny_IsEmpty()
+    {
+        SearchScopes r = await Combine(SearchScopes.Failed, SearchScopes.None);
+        r.IsEmpty.Should().BeTrue(); // only non-cloud (resource_uri IS NULL) will survive in SQL
+    }
+
+    [Fact]
+    public async Task AwsGranted_AzureFailed_KeepsAwsHidesAzure()
+    {
+        SearchScopes r = await Combine(SearchScopes.OfPrefixes(["s3://b/"]), SearchScopes.Failed);
+        r.Matches.Select(m => m.Value).Should().BeEquivalentTo("s3://b/");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~CompositeSearchScopeResolverTests"`
+Expected: FAIL — `CompositeSearchScopeResolver` does not exist.
+
+- [ ] **Step 3: Write the composite**
+
+```csharp
+// src/Connapse.Storage/CloudScope/CompositeSearchScopeResolver.cs
+using Connapse.Core;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Unions the AWS and Azure scope resolvers into one, per cloud and per URI scheme. Each cloud
+/// governs its own scheme (<c>s3://</c>, <c>azblob://</c>); non-cloud documents (resource_uri NULL)
+/// are always admitted by the store's existing fallback. A cloud that is not enforcing contributes
+/// its scheme wildcard (its docs visible); a cloud that denies or fails contributes nothing (its
+/// docs hidden), and one cloud's failure never denies the other's or non-cloud docs. Only when both
+/// clouds are unrestricted is the result globally unrestricted.
+/// </summary>
+public sealed class CompositeSearchScopeResolver(
+    AwsSearchScopeResolver aws,
+    AzureSearchScopeResolver azure) : ISearchScopeResolver
+{
+    private static readonly Combiner Combine = new();
+
+    public async Task<SearchScopes> ResolveAsync(Guid? userId, CancellationToken ct = default)
+    {
+        SearchScopes awsScopes = await SafeResolveAsync(aws, userId, ct);
+        SearchScopes azureScopes = await SafeResolveAsync(azure, userId, ct);
+        return Combine.Combine(awsScopes, azureScopes);
+    }
+
+    // A throw from one cloud fails only that cloud closed; cancellation still propagates.
+    private static async Task<SearchScopes> SafeResolveAsync(ISearchScopeResolver inner, Guid? userId, CancellationToken ct)
+    {
+        try
+        {
+            return await inner.ResolveAsync(userId, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return SearchScopes.Failed;
+        }
+    }
+
+    /// <summary>The pure combine rule, separated so it can be unit-tested without resolvers.</summary>
+    public sealed class Combiner
+    {
+        private const string S3Scheme = "s3://";
+        private const string AzureScheme = "azblob://";
+
+        public SearchScopes Combine(SearchScopes awsScopes, SearchScopes azureScopes)
+        {
+            if (awsScopes.IsUnrestricted && azureScopes.IsUnrestricted)
+                return SearchScopes.Unrestricted;
+
+            var matches = new List<GrantMatch>();
+            matches.AddRange(ContributionFor(awsScopes, S3Scheme));
+            matches.AddRange(ContributionFor(azureScopes, AzureScheme));
+            return SearchScopes.Of(matches);
+        }
+
+        // Unrestricted → the scheme wildcard (all of that cloud's docs). Granted → its own matches.
+        // Any denial/failure/no-principal → nothing (that scheme's docs are hidden — fail closed).
+        private static IReadOnlyList<GrantMatch> ContributionFor(SearchScopes scopes, string schemeWildcard)
+        {
+            if (scopes.IsUnrestricted)
+                return [new GrantMatch(schemeWildcard, IsExact: false)];
+            if (scopes.Outcome is ScopeOutcome.Granted)
+                return scopes.Matches;
+            return [];
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~CompositeSearchScopeResolverTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/CompositeSearchScopeResolver.cs tests/Connapse.Storage.Tests/CloudScope/CompositeSearchScopeResolverTests.cs
+git commit -m "feat(azure): CompositeSearchScopeResolver unions AWS + Azure per-scheme (#488)"
+```
+
+---
+
+## Task 4: Broaden the enforcement latch to Azure AD
+
+**Files:**
+- Rename: `src/Connapse.Web/Services/SamlEnforcementLatch.cs` → `src/Connapse.Web/Services/CloudEnforcementLatch.cs` (class `SamlEnforcementLatch` → `CloudEnforcementLatch`)
+- Modify: its `IHostedService` registration (grep `SamlEnforcementLatch` under `src/Connapse.Web`)
+- Test: `tests/Connapse.Web.Tests/Services/CloudEnforcementLatchTests.cs` (rename/extend the existing `SamlEnforcementLatchTests`)
+
+**Interfaces:**
+- Consumes: `IOptionsMonitor<SamlSignInSettings>`, and **newly** `IOptionsMonitor<AzureAdSignInSettings>`; `PermissionEnforcementSettings`; `EnforcementMigration`.
+- Produces: the deployment latches `IsEnforcing` when SAML **or** Azure AD is configured.
+
+- [ ] **Step 1: Rename the class + file, inject Azure AD settings, broaden the "never configured" check**
+
+Rename the file and type to `CloudEnforcementLatch`. Add `IOptionsMonitor<AzureAdSignInSettings> azureAd` to the constructor. Change the "never configured" short-circuit from:
+
+```csharp
+if (!signIn.CurrentValue.IsConfigured)
+{
+    migration.Complete();
+    return;
+}
+```
+
+to:
+
+```csharp
+// Enforcement is opt-in via ANY cloud identity provider. Once SAML OR Azure AD is configured,
+// the deployment latches into enforcing mode; before that, searches are unfiltered.
+if (!signIn.CurrentValue.IsConfigured && !azureAd.CurrentValue.IsConfigured)
+{
+    migration.Complete();
+    return;
+}
+```
+
+Leave every other line (reload-or-refuse, already-enforcing short-circuit, the save that sets `IsEnforcing = true`, `migration.Complete()` placement, and the catch that deliberately does not complete) unchanged. Update the class XML doc to say "SAML or Azure AD".
+
+- [ ] **Step 2: Update the registration**
+
+Grep: `grep -rn "SamlEnforcementLatch" src/Connapse.Web` — update the `AddHostedService<SamlEnforcementLatch>()` (or equivalent) to `AddHostedService<CloudEnforcementLatch>()`. Confirm `AzureAdSignInSettings` is `Configure`d in the app (Phase 3 registered `services.Configure<AzureAdSignInSettings>(...)` in Identity) so `IOptionsMonitor<AzureAdSignInSettings>` resolves.
+
+- [ ] **Step 3: Rename/extend the latch tests**
+
+Rename `tests/Connapse.Web.Tests/Services/SamlEnforcementLatchTests.cs` → `CloudEnforcementLatchTests.cs` and the class accordingly; update construction to pass an `IOptionsMonitor<AzureAdSignInSettings>` (default: not configured, so all existing SAML-only cases behave exactly as before). Add one case:
+
+```csharp
+[Fact]
+public async Task Latches_When_OnlyAzureAd_Configured()
+{
+    // SAML not configured, Azure AD configured, not yet marked → the latch turns enforcement on.
+    // (Mirror the existing "configured-but-unmarked → saves IsEnforcing = true" test, but with the
+    // Azure AD settings configured and SAML blank.)
+}
+```
+
+Fill the body by mirroring the existing configured-but-unmarked test (assert `ISettingsStore.SaveAsync` was called with `IsEnforcing = true` and `migration.Complete()` ran), swapping which provider is configured.
+
+- [ ] **Step 4: Run the latch tests**
+
+Run: `dotnet test tests/Connapse.Web.Tests/Connapse.Web.Tests.csproj --filter "FullyQualifiedName~CloudEnforcementLatchTests"`
+Expected: PASS — all prior SAML cases plus the Azure-AD-only latch case.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Web/Services/CloudEnforcementLatch.cs tests/Connapse.Web.Tests/Services/CloudEnforcementLatchTests.cs
+git rm src/Connapse.Web/Services/SamlEnforcementLatch.cs tests/Connapse.Web.Tests/Services/SamlEnforcementLatchTests.cs 2>/dev/null; true
+git add -A src/Connapse.Web
+git commit -m "feat(azure): latch enforcement on SAML or Azure AD (CloudEnforcementLatch) (#488)"
+```
+
+---
+
+## Task 5: DI rewiring — register the composite
+
+**Files:**
+- Modify: `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs`
+- Test: `tests/Connapse.Integration.Tests/AzureCompositeResolverDiIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: `AwsSearchScopeResolver`, `AzureSearchScopeResolver`, `CompositeSearchScopeResolver`.
+
+- [ ] **Step 1: Change the registration**
+
+Replace the single line `services.AddScoped<ISearchScopeResolver, CloudScope.AwsSearchScopeResolver>();` with:
+
+```csharp
+        // The composite is THE resolver; it consumes the AWS and Azure resolvers as concrete types
+        // and unions them per cloud/scheme. AWS keeps its exact behavior as one inner resolver.
+        services.AddScoped<CloudScope.AwsSearchScopeResolver>();
+        services.AddScoped<CloudScope.AzureSearchScopeResolver>();
+        services.AddScoped<ISearchScopeResolver, CloudScope.CompositeSearchScopeResolver>();
+```
+
+Confirm the Azure resolver's dependencies resolve: `IAzureIdentityLinkReader` (Identity), `IAzureDirectoryReader` (4a, Storage), `IAzureRbacReader` (4b, Storage), `IOptionsMonitor<AzureAdSignInSettings>` (Configured in Identity), `IOptionsMonitor<PermissionEnforcementSettings>`, `EnforcementMigration`, `IMemoryCache` — all already registered.
+
+- [ ] **Step 2: Write the DI resolution test**
+
+```csharp
+// tests/Connapse.Integration.Tests/AzureCompositeResolverDiIntegrationTests.cs
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureCompositeResolverDiIntegrationTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public void Di_Resolves_CompositeAsTheScopeResolver()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        ISearchScopeResolver resolver = scope.ServiceProvider.GetRequiredService<ISearchScopeResolver>();
+        resolver.Should().BeOfType<CompositeSearchScopeResolver>();
+        scope.ServiceProvider.GetRequiredService<AzureSearchScopeResolver>().Should().NotBeNull();
+        scope.ServiceProvider.GetRequiredService<AwsSearchScopeResolver>().Should().NotBeNull();
+    }
+}
+```
+
+- [ ] **Step 3: Run it (fails before Step 1's rebuild, passes after)**
+
+Run: `dotnet test tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj --filter "FullyQualifiedName~AzureCompositeResolverDiIntegrationTests"` (needs Docker)
+Expected: PASS — the composite is resolved as `ISearchScopeResolver` and both inner resolvers resolve.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs tests/Connapse.Integration.Tests/AzureCompositeResolverDiIntegrationTests.cs
+git commit -m "feat(azure): register CompositeSearchScopeResolver as the scope resolver (#488)"
+```
+
+---
+
+## Task 6: Flat end-to-end enforcement integration test
+
+**Files:**
+- Test: `tests/Connapse.Integration.Tests/AzureFlatEnforcementTests.cs`
+
+**Interfaces:**
+- Consumes: the full stack (composite + Azure resolver + the SQL filter). Follows `SearchScopeEnforcementTests` (AWS) as the template — seed documents with `resource_uri` values, resolve scopes, assert the SQL filter admits/excludes correctly.
+
+- [ ] **Step 1: Read the AWS template**
+
+Read `tests/Connapse.Integration.Tests/SearchScopeEnforcementTests.cs` to reuse its fixture pattern (how it seeds `DocumentEntity` rows with `resource_uri`, builds a `SearchScopes`, and asserts which rows a store search returns). Mirror it for Azure.
+
+- [ ] **Step 2: Write the tests**
+
+Seed four documents: `azblob://acct/docs/a` (Azure, in scope), `azblob://acct/secret/b` (Azure, out of scope), `s3://bucket/x` (AWS), and one with `resource_uri = NULL` (non-cloud). Then, using a `SearchScopes` equal to what the composite yields for an Azure-granted / AWS-unrestricted user (`azblob://acct/docs/` prefix + `s3://` wildcard), assert a store query returns: the in-scope Azure doc, the AWS doc, and the NULL doc — but **not** the out-of-scope Azure doc. Add a second case where Azure is `Failed` (no azblob matches): assert **no** Azure docs are returned but the NULL doc still is. Use the same store-level assertion mechanism `SearchScopeEnforcementTests` uses (do not re-implement the SQL).
+
+```csharp
+// tests/Connapse.Integration.Tests/AzureFlatEnforcementTests.cs — shape (fill bodies from the AWS template)
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureFlatEnforcementTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public async Task AzurePrefixPlusAwsWildcard_AdmitsInScopeAzure_AwsAndNonCloud_ExcludesOutOfScopeAzure()
+    {
+        // scopes = Of([ GrantMatch("azblob://acct/docs/", false), GrantMatch("s3://", false) ])
+        // Seed the four docs above; run the store search with these scopes; assert the returned
+        // resource_uris are exactly { azblob://acct/docs/a, s3://bucket/x, <null doc> }.
+    }
+
+    [Fact]
+    public async Task AzureFailed_HidesAllAzure_ButKeepsNonCloud()
+    {
+        // scopes = Of([ GrantMatch("s3://", false) ])  // Azure contributed nothing
+        // Assert no azblob:// doc is returned; the null-resource_uri doc still is.
+    }
+}
+```
+
+- [ ] **Step 3: Run + full build + suite, commit**
+
+Run: `dotnet build`, then `dotnet test --filter "Category=Unit"` (all green incl. new resolver/composite/enforcement tests), then the two Azure integration tests (Docker). Expected: green (23 pre-existing Ollama integration failures remain, unrelated).
+
+```bash
+git add tests/Connapse.Integration.Tests/AzureFlatEnforcementTests.cs
+git commit -m "test(azure): flat end-to-end enforcement — Azure prefixes filter, non-cloud survives (#488)"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec §C/§D coverage:** flat resolver from 4a identity + 4b RBAC (Task 2, tag/Gen2 deferred to 4e); composite per-cloud/per-scheme with fail-closed isolation + scheme wildcards + both-unrestricted→Unrestricted (Task 3); enforcement generalized to SAML-or-Azure-AD via additive `StateFor(bool)` + broadened latch (Tasks 1, 4); DI drop-in with AWS untouched (Task 5); flat end-to-end proof + non-cloud always-visible (Task 6). The shared SQL and AWS resolver are unmodified. ✅
+- **AWS unchanged:** `StateFor(bool)` is additive (the `SamlSignInSettings` overload delegates); `AwsSearchScopeResolver` and `SamlEnforcementStateTests` are not edited; `PgVectorStore`/`KeywordSearchService` are not edited; the latch broadening only adds Azure AD as an alternative trigger.
+- **Deferred to 4e:** tag-conditioned RBAC residue, Gen2 Phase-A/B, the post-retrieval verifier and over-fetch. 4c ships flat correctness; Gen2/tag completeness lands in 4d/4e before the epic reaches main.
+- **Type consistency:** `StateFor(bool,bool)`, `AzureSearchScopeResolver`, `CompositeSearchScopeResolver`(+`Combiner`), `CloudEnforcementLatch` referenced consistently; the composite consumes the two concrete resolvers; `AzureRbacScopes.ReadablePrefixes`/`AzureScope.Prefix` and `AzureIdentitySet.Outcome` used as defined in 4a/4b.

--- a/docs/superpowers/plans/2026-09-07-azure-phase4d-gen2-acl-engine.md
+++ b/docs/superpowers/plans/2026-09-07-azure-phase4d-gen2-acl-engine.md
@@ -1,0 +1,1019 @@
+# Azure Phase 4d — Gen2 POSIX ACL engine + ancestor-traverse resolver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the pure, unit-testable Gen2 (ADLS HNS) permission engine — a POSIX first-match ACL evaluator and a lazily-cached ancestor-traverse resolver — that Phase 4e's live per-hit verifier will consume.
+
+**Architecture:** Two pure pieces plus a thin SDK adapter. `PosixAclEvaluator` (Core, static) decides read/traverse for an identity set against one directory's ACL using the documented POSIX first-match rules. `AncestorTraverseResolver` (Storage) confirms the identity set holds traverse-`X` on **every** ancestor directory of a candidate file, resolving lazily and caching per directory behind an `IGen2DirectoryReader` seam. `DataLakeGen2DirectoryReader` (Storage) is the live seam implementation over `Azure.Storage.Files.DataLake`, with all mapping logic in `internal static` methods so the SDK-touching shell stays trivial. **Nothing here is wired into search** — that is Phase 4e.
+
+**Tech Stack:** .NET 10, C# (file-scoped namespaces, records, primary constructors, nullable enabled), `Azure.Storage.Files.DataLake`, `Microsoft.Extensions.Caching.Memory`; xUnit + FluentAssertions + NSubstitute.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md` (§D; governing principle and §E give the consumer's contract)
+
+## Global Constraints
+
+- **Live only.** No ingestion-time permission capture; no new persistence surface. Freshness = cache TTL.
+- **Fail closed everywhere.** Any unreadable directory, fetch error, or uncertain answer → deny (no traverse), never a grant.
+- **Reuse the provider-agnostic enforcement half.** 4d adds a library only; it does not touch `ISearchScopeResolver`, `SearchScopes`, `PgVectorStore`, `KeywordSearchService`, or `HybridSearchService`.
+- **AWS behavior unchanged.** No file under `RolesAnywhere/`, `AwsSearchScopeResolver.cs`, `S3*`, or the SAML/JWT path is touched.
+- **App identity is `Storage Blob Data Reader`** — read-only. Connapse reads ACL data to evaluate the *user's* access; it never writes a grant, role, or ACL.
+- **Folder access is never trusted as file access.** ADLS ACLs are copy-at-create, not live-inherited. 4d resolves traverse-`X` on ancestor **directories** only; it never decides a file's own read (that is 4e's file-ACL check), never skip-verifies a file from a readable folder, and never excludes a file because of a folder.
+- **Cache only confident answers.** A definitive ACL decision (grant/deny) is cacheable ~60 s; an unreadable/uncertain directory is never cached (fail closed and retried).
+- **Cert-based auth via `ConnapseAzureCredentials`** (a `TokenCredential`); no client secrets. The DataLake client is built from the account URI + that credential.
+
+---
+
+## File Structure
+
+**Create (Core — `src/Connapse.Core/`):**
+- `Models/Gen2Acl.cs` — `Gen2Permission` (flags), `Gen2NamedAce`, `Gen2Acl`, `Gen2ModeBits` (+ `ToAcl()`), `Gen2Path`, and the `Gen2Permissions` symbolic-string parser. Pure data + parsing, no I/O.
+- `CloudScope/PosixAclEvaluator.cs` — the static first-match evaluator.
+- `Interfaces/IGen2DirectoryReader.cs` — the directory-ACL read seam.
+
+**Create (Storage — `src/Connapse.Storage/`):**
+- `CloudScope/AncestorTraverseResolver.cs` — the cached ancestor-traverse walk.
+- `CloudScope/DataLakeGen2DirectoryReader.cs` — the live `IGen2DirectoryReader` over the DataLake SDK.
+
+**Modify:**
+- `src/Connapse.Storage/Connapse.Storage.csproj` — add the `Azure.Storage.Files.DataLake` package.
+- `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs` — register `IGen2DirectoryReader` and `AncestorTraverseResolver` (consumed by 4e; not wired to search).
+
+**Create (tests):**
+- `tests/Connapse.Core.Tests/Models/Gen2AclTests.cs`
+- `tests/Connapse.Core.Tests/CloudScope/PosixAclEvaluatorTests.cs`
+- `tests/Connapse.Storage.Tests/CloudScope/AncestorTraverseResolverTests.cs`
+- `tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs`
+
+`Connapse.Core.Tests` and `Connapse.Storage.Tests` already have `InternalsVisibleTo`, so `internal static` mappers are directly testable.
+
+---
+
+### Task 1: Gen2 ACL types + directory-reader seam (Core)
+
+Pure type declarations, a symbolic-permission parser, and the read seam. No logic beyond parsing.
+
+**Files:**
+- Create: `src/Connapse.Core/Models/Gen2Acl.cs`
+- Create: `src/Connapse.Core/Interfaces/IGen2DirectoryReader.cs`
+- Test: `tests/Connapse.Core.Tests/Models/Gen2AclTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `enum Gen2Permission { None=0, Execute=1, Write=2, Read=4 }` (`[Flags]`).
+  - `record Gen2NamedAce(string Oid, Gen2Permission Permissions)`.
+  - `record Gen2Acl(string? OwnerOid, string? OwningGroupOid, Gen2Permission OwnerPermissions, Gen2Permission OwningGroupPermissions, Gen2Permission OtherPermissions, Gen2Permission? Mask, IReadOnlyList<Gen2NamedAce> NamedUsers, IReadOnlyList<Gen2NamedAce> NamedGroups)`.
+  - `record Gen2ModeBits(string? OwnerOid, string? OwningGroupOid, Gen2Permission Owner, Gen2Permission OwningGroup, Gen2Permission Other, bool HasExtendedAcl)` with `Gen2Acl ToAcl()`.
+  - `record Gen2Path(string Account, string FileSystem, string Path)` — `Path` is the blob path relative to the filesystem, no leading slash; the filesystem root is `Path == ""`.
+  - `static class Gen2Permissions { static Gen2Permission FromRwx(char r, char w, char x); static (Gen2Permission Owner, Gen2Permission Group, Gen2Permission Other, bool Extended) ParseSymbolic(string symbolic); }`.
+  - `interface IGen2DirectoryReader` (see step 6).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// tests/Connapse.Core.Tests/Models/Gen2AclTests.cs
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Models;
+
+[Trait("Category", "Unit")]
+public class Gen2AclTests
+{
+    [Theory]
+    [InlineData('r', '-', 'x', Gen2Permission.Read | Gen2Permission.Execute)]
+    [InlineData('r', 'w', 'x', Gen2Permission.Read | Gen2Permission.Write | Gen2Permission.Execute)]
+    [InlineData('-', '-', '-', Gen2Permission.None)]
+    [InlineData('-', '-', 'x', Gen2Permission.Execute)]
+    public void FromRwx_MapsEachBit(char r, char w, char x, Gen2Permission expected) =>
+        Gen2Permissions.FromRwx(r, w, x).Should().Be(expected);
+
+    [Fact]
+    public void ParseSymbolic_NineChars_SplitsOwnerGroupOther()
+    {
+        var (owner, group, other, extended) = Gen2Permissions.ParseSymbolic("rwxr-x---");
+        owner.Should().Be(Gen2Permission.Read | Gen2Permission.Write | Gen2Permission.Execute);
+        group.Should().Be(Gen2Permission.Read | Gen2Permission.Execute);
+        other.Should().Be(Gen2Permission.None);
+        extended.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseSymbolic_TrailingPlus_MarksExtendedAcl()
+    {
+        var (_, _, _, extended) = Gen2Permissions.ParseSymbolic("rwxr-x---+");
+        extended.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseSymbolic_TenCharLeadingType_IgnoresTypeChar()
+    {
+        // Some listings prefix a file-type char (e.g. 'd' for directory): "drwxr-x---".
+        var (owner, _, _, _) = Gen2Permissions.ParseSymbolic("drwxr-x---");
+        owner.Should().Be(Gen2Permission.Read | Gen2Permission.Write | Gen2Permission.Execute);
+    }
+
+    [Fact]
+    public void ModeBits_ToAcl_CarriesOwnerGroupOther_NoNamedNoMask()
+    {
+        var bits = new Gen2ModeBits("owner-oid", "group-oid",
+            Gen2Permission.Read | Gen2Permission.Execute, Gen2Permission.Execute, Gen2Permission.None,
+            HasExtendedAcl: false);
+
+        Gen2Acl acl = bits.ToAcl();
+
+        acl.OwnerOid.Should().Be("owner-oid");
+        acl.OwningGroupOid.Should().Be("group-oid");
+        acl.OwnerPermissions.Should().Be(Gen2Permission.Read | Gen2Permission.Execute);
+        acl.OwningGroupPermissions.Should().Be(Gen2Permission.Execute);
+        acl.OtherPermissions.Should().Be(Gen2Permission.None);
+        acl.Mask.Should().BeNull();
+        acl.NamedUsers.Should().BeEmpty();
+        acl.NamedGroups.Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~Gen2AclTests"`
+Expected: FAIL — `Gen2Permission`, `Gen2Permissions`, `Gen2ModeBits` do not exist (compile error).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```csharp
+// src/Connapse.Core/Models/Gen2Acl.cs
+namespace Connapse.Core;
+
+/// <summary>POSIX permission bits, as flags so a permission set is one value.</summary>
+[Flags]
+public enum Gen2Permission
+{
+    None = 0,
+    Execute = 1,
+    Write = 2,
+    Read = 4,
+}
+
+/// <summary>A named ADLS ACL entry: a user or group principal object id and its permissions.</summary>
+public record Gen2NamedAce(string Oid, Gen2Permission Permissions);
+
+/// <summary>
+/// One directory's <b>access</b> ACL (never the default/inheritance ACL), as the POSIX evaluator
+/// needs it: the owner and owning-group principals and their permissions, the mask (present only
+/// when the ACL is extended), the named user/group entries, and the "other" permissions.
+/// </summary>
+public record Gen2Acl(
+    string? OwnerOid,
+    string? OwningGroupOid,
+    Gen2Permission OwnerPermissions,
+    Gen2Permission OwningGroupPermissions,
+    Gen2Permission OtherPermissions,
+    Gen2Permission? Mask,
+    IReadOnlyList<Gen2NamedAce> NamedUsers,
+    IReadOnlyList<Gen2NamedAce> NamedGroups);
+
+/// <summary>
+/// The cheap "mode bits" view of a directory — owner/group principals plus the owner/group/other
+/// rwx triples — from a listing (<c>GetPaths</c>) or properties read. <see cref="HasExtendedAcl"/>
+/// is the POSIX '+' marker: when false there are no named entries and no mask, so these bits alone
+/// decide access; when true a named entry could be decisive and the full ACL must be read.
+/// </summary>
+public record Gen2ModeBits(
+    string? OwnerOid,
+    string? OwningGroupOid,
+    Gen2Permission Owner,
+    Gen2Permission OwningGroup,
+    Gen2Permission Other,
+    bool HasExtendedAcl)
+{
+    /// <summary>The equivalent <see cref="Gen2Acl"/> with no named entries and no mask. Correct to
+    /// evaluate against only when the requester owns the directory or when there is no extended ACL;
+    /// the resolver enforces that precondition.</summary>
+    public Gen2Acl ToAcl() =>
+        new(OwnerOid, OwningGroupOid, Owner, OwningGroup, Other, Mask: null, NamedUsers: [], NamedGroups: []);
+}
+
+/// <summary>An ADLS path: the storage account, filesystem (container), and the path within it
+/// (no leading slash; the filesystem root is the empty string).</summary>
+public record Gen2Path(string Account, string FileSystem, string Path);
+
+/// <summary>Parses ADLS symbolic permission strings into <see cref="Gen2Permission"/> triples.</summary>
+public static class Gen2Permissions
+{
+    /// <summary>Maps one rwx triple (e.g. 'r','-','x') to a permission set.</summary>
+    public static Gen2Permission FromRwx(char r, char w, char x)
+    {
+        Gen2Permission p = Gen2Permission.None;
+        if (r == 'r') p |= Gen2Permission.Read;
+        if (w == 'w') p |= Gen2Permission.Write;
+        if (x is 'x' or 's' or 't') p |= Gen2Permission.Execute; // setuid/sticky imply the x slot
+        return p;
+    }
+
+    /// <summary>
+    /// Parses a symbolic permission string into owner/group/other triples plus the extended-ACL
+    /// flag. Accepts a 9-char body ("rwxr-x---"), an optional trailing '+' (extended ACL), and an
+    /// optional leading file-type char ("drwx...").
+    /// </summary>
+    public static (Gen2Permission Owner, Gen2Permission Group, Gen2Permission Other, bool Extended) ParseSymbolic(string symbolic)
+    {
+        ArgumentNullException.ThrowIfNull(symbolic);
+        bool extended = symbolic.EndsWith('+');
+        string s = extended ? symbolic[..^1] : symbolic;
+        if (s.Length == 10) s = s[1..];           // drop a leading file-type char
+        if (s.Length != 9)
+            throw new FormatException($"Unexpected ADLS permission string '{symbolic}'.");
+        return (
+            FromRwx(s[0], s[1], s[2]),
+            FromRwx(s[3], s[4], s[5]),
+            FromRwx(s[6], s[7], s[8]),
+            extended);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~Gen2AclTests"`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Add the reader seam**
+
+```csharp
+// src/Connapse.Core/Interfaces/IGen2DirectoryReader.cs
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Reads a single ADLS Gen2 directory's <b>access</b> ACL, with Connapse's own (Data Reader)
+/// identity, to evaluate a searcher's traverse rights. Two calls so the resolver can short-circuit:
+/// the cheap mode-bits read decides on its own whenever the requester owns the directory or the ACL
+/// is not extended; only otherwise is the full ACL fetched. Both return <c>null</c> when the
+/// directory cannot be read — an uncertain answer the caller treats as fail-closed.
+/// </summary>
+public interface IGen2DirectoryReader
+{
+    Task<Gen2ModeBits?> ReadModeBitsAsync(Gen2Path directory, CancellationToken ct = default);
+    Task<Gen2Acl?> ReadAccessAclAsync(Gen2Path directory, CancellationToken ct = default);
+}
+```
+
+(`Gen2ModeBits`, `Gen2Acl`, `Gen2Path` live in namespace `Connapse.Core`; add the `using Connapse.Core;` the interface needs.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Connapse.Core/Models/Gen2Acl.cs src/Connapse.Core/Interfaces/IGen2DirectoryReader.cs tests/Connapse.Core.Tests/Models/Gen2AclTests.cs
+git commit -m "feat(azure): Gen2 ACL model + directory-reader seam (#489)"
+```
+
+---
+
+### Task 2: POSIX first-match evaluator (Core)
+
+The pure decision. This is the correctness heart of 4d — the matrix test is exhaustive.
+
+**Files:**
+- Create: `src/Connapse.Core/CloudScope/PosixAclEvaluator.cs`
+- Test: `tests/Connapse.Core.Tests/CloudScope/PosixAclEvaluatorTests.cs`
+
+**Interfaces:**
+- Consumes: `Gen2Acl`, `Gen2NamedAce`, `Gen2Permission` (Task 1).
+- Produces: `static bool PosixAclEvaluator.Grants(Gen2Acl acl, IReadOnlySet<string> principals, Gen2Permission requested)`.
+
+**Algorithm (documented POSIX first-match; class precedence owner > named-user > group-union > other):**
+1. **Owner** — if any principal is the owner, the owner permissions decide; the mask does **not** apply. Terminal.
+2. **Named user** — else if any principal matches a named-user entry, that entry (capped by the mask) decides. Terminal even if it denies.
+3. **Group class** — else gather the owning group (if a principal is in it) and every named-group entry a principal matches; if **any** of them, masked, grants the permission, allow; if there is at least one group match but none grants, deny (do not fall through). 
+4. **Other** — else the "other" permissions decide.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// tests/Connapse.Core.Tests/CloudScope/PosixAclEvaluatorTests.cs
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class PosixAclEvaluatorTests
+{
+    private const Gen2Permission RX = Gen2Permission.Read | Gen2Permission.Execute;
+
+    private static Gen2Acl Acl(
+        string? owner = "owner", string? group = "group",
+        Gen2Permission ownerPerms = RX, Gen2Permission groupPerms = RX, Gen2Permission other = Gen2Permission.None,
+        Gen2Permission? mask = null,
+        IReadOnlyList<Gen2NamedAce>? namedUsers = null, IReadOnlyList<Gen2NamedAce>? namedGroups = null) =>
+        new(owner, group, ownerPerms, groupPerms, other, mask, namedUsers ?? [], namedGroups ?? []);
+
+    private static IReadOnlySet<string> P(params string[] oids) => new HashSet<string>(oids);
+
+    [Fact]
+    public void Owner_Decides_AndIgnoresMask()
+    {
+        // Owner has X; a restrictive mask must NOT cut the owner down.
+        var acl = Acl(ownerPerms: RX, mask: Gen2Permission.None);
+        PosixAclEvaluator.Grants(acl, P("owner"), Gen2Permission.Execute).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Owner_WithoutTheBit_IsDenied_NotFallingThroughToGroup()
+    {
+        // Requester owns the dir (owner has no X) AND is in the owning group (group has X). Owner is
+        // terminal: no X for the owner means denied, group never consulted.
+        var acl = Acl(ownerPerms: Gen2Permission.Read, groupPerms: RX);
+        PosixAclEvaluator.Grants(acl, P("owner", "group"), Gen2Permission.Execute).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NamedUser_Matched_IsCappedByMask()
+    {
+        var acl = Acl(other: RX,
+            mask: Gen2Permission.Read, // mask strips X from named entries
+            namedUsers: [new Gen2NamedAce("alice", RX)]);
+        // Named-user match is terminal and masked → no X, even though "other" would have granted it.
+        PosixAclEvaluator.Grants(acl, P("alice"), Gen2Permission.Execute).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NamedUser_Matched_Grants_WhenMaskAllows()
+    {
+        var acl = Acl(mask: RX, namedUsers: [new Gen2NamedAce("alice", RX)]);
+        PosixAclEvaluator.Grants(acl, P("alice"), Gen2Permission.Execute).Should().BeTrue();
+    }
+
+    [Fact]
+    public void OwningGroup_Grants_WhenMaskAllows()
+    {
+        var acl = Acl(owner: "someone-else", groupPerms: RX, mask: RX);
+        PosixAclEvaluator.Grants(acl, P("group"), Gen2Permission.Execute).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnyNamedGroup_Granting_Suffices()
+    {
+        // Two group matches: one denies X, one grants it. Any one granting → allow.
+        var acl = Acl(owner: "someone-else", group: "not-mine",
+            mask: RX,
+            namedGroups: [new Gen2NamedAce("g1", Gen2Permission.Read), new Gen2NamedAce("g2", RX)]);
+        PosixAclEvaluator.Grants(acl, P("g1", "g2"), Gen2Permission.Execute).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GroupMatch_ButNoneGrant_IsDenied_NotFallingThroughToOther()
+    {
+        var acl = Acl(owner: "someone-else", group: "not-mine", other: RX,
+            mask: RX, namedGroups: [new Gen2NamedAce("g1", Gen2Permission.Read)]);
+        PosixAclEvaluator.Grants(acl, P("g1"), Gen2Permission.Execute).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GroupClass_CappedByMask()
+    {
+        var acl = Acl(owner: "someone-else", group: "g", groupPerms: RX, mask: Gen2Permission.Read);
+        PosixAclEvaluator.Grants(acl, P("g"), Gen2Permission.Execute).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Other_Decides_WhenNoOwnerNamedOrGroupMatch()
+    {
+        var acl = Acl(owner: "someone-else", group: "not-mine", other: RX);
+        PosixAclEvaluator.Grants(acl, P("stranger"), Gen2Permission.Execute).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Other_WithoutTheBit_IsDenied()
+    {
+        var acl = Acl(owner: "someone-else", group: "not-mine", other: Gen2Permission.Read);
+        PosixAclEvaluator.Grants(acl, P("stranger"), Gen2Permission.Execute).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Owner_TakesPrecedence_OverANamedUserEntryForTheSamePrincipal()
+    {
+        // Same principal is both owner and a named user; owner class wins (terminal, unmasked).
+        var acl = Acl(ownerPerms: RX, mask: Gen2Permission.None,
+            namedUsers: [new Gen2NamedAce("owner", Gen2Permission.None)]);
+        PosixAclEvaluator.Grants(acl, P("owner"), Gen2Permission.Execute).Should().BeTrue();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~PosixAclEvaluatorTests"`
+Expected: FAIL — `PosixAclEvaluator` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```csharp
+// src/Connapse.Core/CloudScope/PosixAclEvaluator.cs
+namespace Connapse.Core;
+
+/// <summary>
+/// The documented POSIX ACL first-match check, as ADLS Gen2 applies it: class precedence
+/// owner &gt; named-user &gt; group-union &gt; other. The mask caps named users, the owning group,
+/// and named groups — never the owner or "other". A matched owner or named-user class is terminal
+/// (even when it denies); in the group class, any one matching entry that (masked) grants suffices.
+/// Pure and side-effect-free so it is exhaustively unit-testable.
+/// </summary>
+public static class PosixAclEvaluator
+{
+    public static bool Grants(Gen2Acl acl, IReadOnlySet<string> principals, Gen2Permission requested)
+    {
+        ArgumentNullException.ThrowIfNull(acl);
+        ArgumentNullException.ThrowIfNull(principals);
+
+        // 1. Owner class — terminal, mask does not apply.
+        if (acl.OwnerOid is not null && principals.Contains(acl.OwnerOid))
+            return Has(acl.OwnerPermissions, requested);
+
+        // 2. Named-user class — terminal if matched, capped by the mask.
+        foreach (Gen2NamedAce entry in acl.NamedUsers)
+        {
+            if (principals.Contains(entry.Oid))
+                return Has(Capped(entry.Permissions, acl.Mask), requested);
+        }
+
+        // 3. Group class — owning group ∪ named groups. Any one that (masked) grants suffices; a
+        //    match that grants nothing denies rather than falling through to "other".
+        bool anyGroupMatch = false;
+        if (acl.OwningGroupOid is not null && principals.Contains(acl.OwningGroupOid))
+        {
+            anyGroupMatch = true;
+            if (Has(Capped(acl.OwningGroupPermissions, acl.Mask), requested))
+                return true;
+        }
+        foreach (Gen2NamedAce entry in acl.NamedGroups)
+        {
+            if (!principals.Contains(entry.Oid)) continue;
+            anyGroupMatch = true;
+            if (Has(Capped(entry.Permissions, acl.Mask), requested))
+                return true;
+        }
+        if (anyGroupMatch)
+            return false;
+
+        // 4. Other class.
+        return Has(acl.OtherPermissions, requested);
+    }
+
+    private static Gen2Permission Capped(Gen2Permission perms, Gen2Permission? mask) =>
+        mask is null ? perms : perms & mask.Value;
+
+    private static bool Has(Gen2Permission perms, Gen2Permission requested) =>
+        (perms & requested) == requested;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~PosixAclEvaluatorTests"`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/CloudScope/PosixAclEvaluator.cs tests/Connapse.Core.Tests/CloudScope/PosixAclEvaluatorTests.cs
+git commit -m "feat(azure): POSIX first-match ACL evaluator (#489)"
+```
+
+---
+
+### Task 3: Ancestor-traverse resolver (Storage)
+
+Walks a candidate file's ancestor directories, confirms traverse-`X` on **every** one, resolves lazily with the mode-bits short-circuit, and caches confident per-directory decisions. Fails closed.
+
+**Files:**
+- Create: `src/Connapse.Storage/CloudScope/AncestorTraverseResolver.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AncestorTraverseResolverTests.cs`
+
+**Interfaces:**
+- Consumes: `IGen2DirectoryReader` (Task 1), `PosixAclEvaluator.Grants` (Task 2), `Gen2Path`, `Gen2ModeBits`, `Gen2Acl`, `Gen2Permission` (Task 1), `Microsoft.Extensions.Caching.Memory.IMemoryCache`.
+- Produces: `Task<bool> AncestorTraverseResolver.HoldsTraverseOnAllAncestorsAsync(Gen2Path file, IReadOnlySet<string> principals, CancellationToken ct = default)`.
+
+**Ancestor set:** the filesystem root plus every directory prefix of the file, excluding the file itself. For `dir1/dir2/file.txt` → `""` (root), `"dir1"`, `"dir1/dir2"`. For a root-level `file.txt` → just `""`.
+
+**Short-circuit + fail-closed per directory:** read mode bits; if the requester owns the directory **or** the ACL is not extended, decide from the mode bits alone; otherwise read the full ACL. Either read returning `null` is uncertain → the whole traverse is denied (and nothing is cached for that directory). Any ancestor lacking `X` denies immediately.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// tests/Connapse.Storage.Tests/CloudScope/AncestorTraverseResolverTests.cs
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using NSubstitute;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AncestorTraverseResolverTests
+{
+    private const Gen2Permission RX = Gen2Permission.Read | Gen2Permission.Execute;
+    private static readonly IReadOnlySet<string> Me = new HashSet<string> { "me" };
+
+    private static Gen2Path File(string path) => new("acct", "fs", path);
+
+    // Mode bits where "other" carries X (so anyone traverses), no extended ACL.
+    private static Gen2ModeBits OpenDir() =>
+        new("owner", "group", RX, RX, RX, HasExtendedAcl: false);
+
+    // Mode bits where nobody but owner/group traverses (other has no X), no extended ACL.
+    private static Gen2ModeBits ClosedDir() =>
+        new("owner", "group", RX, RX, Gen2Permission.None, HasExtendedAcl: false);
+
+    private static AncestorTraverseResolver Build(IGen2DirectoryReader reader) =>
+        new(reader, new MemoryCache(new MemoryCacheOptions()));
+
+    [Fact]
+    public async Task AllAncestorsGrantX_IsReadable()
+    {
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns(OpenDir());
+
+        bool ok = await Build(reader).HoldsTraverseOnAllAncestorsAsync(File("a/b/file.txt"), Me);
+
+        ok.Should().BeTrue();
+        // root, "a", "a/b" — three ancestor directories, file excluded.
+        await reader.Received(3).ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task LosingXOnOneAncestor_IsNotReadable()
+    {
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Is<Gen2Path>(p => p.Path == "a"), Arg.Any<CancellationToken>()).Returns(ClosedDir());
+        reader.ReadModeBitsAsync(Arg.Is<Gen2Path>(p => p.Path != "a"), Arg.Any<CancellationToken>()).Returns(OpenDir());
+
+        bool ok = await Build(reader).HoldsTraverseOnAllAncestorsAsync(File("a/b/file.txt"), Me);
+
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExtendedAcl_AndNotOwner_ReadsFullAcl_ForTheTieBreak()
+    {
+        // Mode bits say "other" has no X and the ACL is extended → a named entry could grant X, so
+        // the full ACL is consulted; a named group grants X.
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, Gen2Permission.None, HasExtendedAcl: true));
+        reader.ReadAccessAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, Gen2Permission.None, Gen2Permission.None,
+                Mask: RX, NamedUsers: [], NamedGroups: [new Gen2NamedAce("me", RX)]));
+
+        bool ok = await Build(reader).HoldsTraverseOnAllAncestorsAsync(File("file.txt"), Me);
+
+        ok.Should().BeTrue();
+        await reader.Received(1).ReadAccessAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Owner_ShortCircuits_WithoutReadingFullAcl_EvenWhenExtended()
+    {
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("me", "group", RX, Gen2Permission.None, Gen2Permission.None, HasExtendedAcl: true));
+
+        bool ok = await Build(reader).HoldsTraverseOnAllAncestorsAsync(File("file.txt"), Me);
+
+        ok.Should().BeTrue();
+        await reader.DidNotReceive().ReadAccessAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UnreadableAncestor_FailsClosed_AndIsNotCached()
+    {
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns((Gen2ModeBits?)null);
+
+        var resolver = Build(reader);
+        (await resolver.HoldsTraverseOnAllAncestorsAsync(File("file.txt"), Me)).Should().BeFalse();
+        (await resolver.HoldsTraverseOnAllAncestorsAsync(File("file.txt"), Me)).Should().BeFalse();
+
+        // Not cached → read attempted again on the second call (root only, one dir).
+        await reader.Received(2).ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ConfidentDecision_IsCached_SecondCallDoesNotReRead()
+    {
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns(OpenDir());
+
+        var resolver = Build(reader);
+        await resolver.HoldsTraverseOnAllAncestorsAsync(File("a/file.txt"), Me); // root + "a" = 2 reads
+        await resolver.HoldsTraverseOnAllAncestorsAsync(File("a/file.txt"), Me); // served from cache
+
+        await reader.Received(2).ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DifferentPrincipalSet_IsNotServedFromAnotherSetsCache()
+    {
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        // "other" has no X and not extended → decision depends purely on group membership.
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, Gen2Permission.None, HasExtendedAcl: false));
+
+        var resolver = Build(reader);
+        (await resolver.HoldsTraverseOnAllAncestorsAsync(File("file.txt"), new HashSet<string> { "group" })).Should().BeTrue();
+        (await resolver.HoldsTraverseOnAllAncestorsAsync(File("file.txt"), new HashSet<string> { "stranger" })).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CallerCancellation_IsRethrown()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns<Gen2ModeBits?>(_ => throw new OperationCanceledException());
+
+        Func<Task> act = () => Build(reader).HoldsTraverseOnAllAncestorsAsync(File("file.txt"), Me, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AncestorTraverseResolverTests"`
+Expected: FAIL — `AncestorTraverseResolver` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```csharp
+// src/Connapse.Storage/CloudScope/AncestorTraverseResolver.cs
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Decides whether an identity set holds traverse-<c>X</c> on <b>every</b> ancestor directory of a
+/// candidate Gen2 file — the necessary condition (with the file's own read, checked by Phase 4e's
+/// verifier) for the file to be readable. Resolves lazily per directory with the mode-bits
+/// short-circuit and caches confident per-directory decisions, so candidates that share ancestors
+/// share the work. Fails closed: any directory that cannot be read denies the whole traverse and is
+/// never cached.
+/// </summary>
+public sealed class AncestorTraverseResolver(IGen2DirectoryReader reader, IMemoryCache cache)
+{
+    /// <summary>Cache window for a confident per-directory traverse decision; also its revocation
+    /// delay. Kept short (the spec's ~30–120 s) so a changed ACL takes effect quickly.</summary>
+    public static readonly TimeSpan CacheLifetime = TimeSpan.FromSeconds(60);
+
+    private const string KeyPrefix = "gen2-traverse:";
+
+    public async Task<bool> HoldsTraverseOnAllAncestorsAsync(
+        Gen2Path file, IReadOnlySet<string> principals, CancellationToken ct = default)
+    {
+        string principalKey = string.Join(",", principals.OrderBy(p => p, StringComparer.Ordinal));
+
+        foreach (Gen2Path dir in Ancestors(file))
+        {
+            string key = $"{KeyPrefix}{dir.Account}:{dir.FileSystem}:{dir.Path}:{principalKey}";
+            if (cache.TryGetValue(key, out bool cached))
+            {
+                if (!cached) return false; // a cached definitive deny short-circuits the whole walk
+                continue;
+            }
+
+            bool? decision = await ResolveDirectoryExecuteAsync(dir, principals, ct);
+            if (decision is null)
+                return false; // uncertain → fail closed, uncached (retried next time)
+
+            cache.Set(key, decision.Value, CacheLifetime);
+            if (!decision.Value)
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>Whether <paramref name="principals"/> hold traverse-<c>X</c> on one directory.
+    /// <c>null</c> means the directory could not be read (uncertain → the caller denies).</summary>
+    private async Task<bool?> ResolveDirectoryExecuteAsync(
+        Gen2Path dir, IReadOnlySet<string> principals, CancellationToken ct)
+    {
+        Gen2ModeBits? bits = await reader.ReadModeBitsAsync(dir, ct);
+        if (bits is null)
+            return null;
+
+        // Mode bits alone are authoritative when the requester owns the directory (owner is terminal)
+        // or the ACL is not extended (no named entries, no mask). Otherwise a named entry could be
+        // decisive, so the full access ACL is read.
+        bool ownsDir = bits.OwnerOid is not null && principals.Contains(bits.OwnerOid);
+        if (ownsDir || !bits.HasExtendedAcl)
+            return PosixAclEvaluator.Grants(bits.ToAcl(), principals, Gen2Permission.Execute);
+
+        Gen2Acl? full = await reader.ReadAccessAclAsync(dir, ct);
+        if (full is null)
+            return null;
+        return PosixAclEvaluator.Grants(full, principals, Gen2Permission.Execute);
+    }
+
+    /// <summary>The filesystem root and every directory prefix of the file, file itself excluded.</summary>
+    private static IEnumerable<Gen2Path> Ancestors(Gen2Path file)
+    {
+        yield return file with { Path = "" }; // filesystem root
+
+        string[] segments = file.Path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (int i = 1; i < segments.Length; i++) // exclude the last segment (the file)
+            yield return file with { Path = string.Join('/', segments[..i]) };
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AncestorTraverseResolverTests"`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/AncestorTraverseResolver.cs tests/Connapse.Storage.Tests/CloudScope/AncestorTraverseResolverTests.cs
+git commit -m "feat(azure): ancestor-traverse resolver with mode-bits short-circuit (#489)"
+```
+
+---
+
+### Task 4: DataLake directory reader + package + DI (Storage)
+
+The live `IGen2DirectoryReader` over the ADLS SDK. All translation lives in `internal static` mappers that are unit-tested with plain inputs; the client-calling shell stays trivial.
+
+**Files:**
+- Modify: `src/Connapse.Storage/Connapse.Storage.csproj` (add package)
+- Create: `src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs`
+- Modify: `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs` (register reader + resolver)
+- Test: `tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs`
+
+**Interfaces:**
+- Consumes: `IGen2DirectoryReader`, `Gen2Acl`, `Gen2ModeBits`, `Gen2Path`, `Gen2Permission`, `Gen2Permissions` (Tasks 1–3); `Azure.Core.TokenCredential` (already registered — `ConnapseAzureCredentials` maps to a bare `TokenCredential` in DI, added in 4a); `Azure.Storage.Files.DataLake` SDK types (`DataLakeServiceClient`, `DataLakeDirectoryClient`, `PathAccessControl`, `PathAccessControlItem`, `AccessControlType`).
+- Produces: `DataLakeGen2DirectoryReader : IGen2DirectoryReader`; DI registration of `IGen2DirectoryReader` and `AncestorTraverseResolver`.
+
+- [ ] **Step 1: Add the package**
+
+Add to `src/Connapse.Storage/Connapse.Storage.csproj` (in the `<ItemGroup>` with the other `Azure.Storage.*` references):
+
+```xml
+<PackageReference Include="Azure.Storage.Files.DataLake" Version="12.22.0" />
+```
+
+Run: `dotnet restore src/Connapse.Storage/Connapse.Storage.csproj`
+Expected: restores cleanly. If the version conflicts with `Azure.Storage.Blobs` 12.24.0's transitive `Azure.Storage.Common`, bump to the newest `12.x` that restores without a downgrade warning (DataLake ships in lockstep with Blobs), and note the chosen version in the commit.
+
+- [ ] **Step 2: Write the failing mapping test**
+
+```csharp
+// tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs
+using Azure.Storage.Files.DataLake.Models;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class DataLakeGen2DirectoryReaderMappingTests
+{
+    private const Gen2Permission RX = Gen2Permission.Read | Gen2Permission.Execute;
+
+    [Fact]
+    public void MapModeBits_ParsesOwnerGroupOther_AndExtendedFlag()
+    {
+        Gen2ModeBits bits = DataLakeGen2DirectoryReader.MapModeBits("owner-oid", "group-oid", "rwxr-x---+");
+
+        bits.OwnerOid.Should().Be("owner-oid");
+        bits.OwningGroupOid.Should().Be("group-oid");
+        bits.Owner.Should().Be(Gen2Permission.Read | Gen2Permission.Write | Gen2Permission.Execute);
+        bits.OwningGroup.Should().Be(RX);
+        bits.Other.Should().Be(Gen2Permission.None);
+        bits.HasExtendedAcl.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MapAccessControl_SplitsEntriesByType_AccessScopeOnly()
+    {
+        var items = new List<PathAccessControlItem>
+        {
+            new(AccessControlType.User,  RolePermissions.Read | RolePermissions.Execute, defaultScope: false, entityId: null),
+            new(AccessControlType.User,  RolePermissions.Read, defaultScope: false, entityId: "alice"),
+            new(AccessControlType.Group, RolePermissions.Execute, defaultScope: false, entityId: null),
+            new(AccessControlType.Group, RolePermissions.Read | RolePermissions.Execute, defaultScope: false, entityId: "devs"),
+            new(AccessControlType.Mask,  RolePermissions.Read | RolePermissions.Execute, defaultScope: false, entityId: null),
+            new(AccessControlType.Other, RolePermissions.None, defaultScope: false, entityId: null),
+            // A default-scope entry must be ignored (inheritance ACL, not the access ACL).
+            new(AccessControlType.User,  RolePermissions.Read | RolePermissions.Write | RolePermissions.Execute, defaultScope: true, entityId: "should-be-ignored"),
+        };
+
+        Gen2Acl acl = DataLakeGen2DirectoryReader.MapAccessControl("owner-oid", "group-oid", items);
+
+        acl.OwnerOid.Should().Be("owner-oid");
+        acl.OwningGroupOid.Should().Be("group-oid");
+        acl.OwnerPermissions.Should().Be(RX);
+        acl.OwningGroupPermissions.Should().Be(Gen2Permission.Execute);
+        acl.OtherPermissions.Should().Be(Gen2Permission.None);
+        acl.Mask.Should().Be(RX);
+        acl.NamedUsers.Should().ContainSingle().Which.Should().BeEquivalentTo(new Gen2NamedAce("alice", Gen2Permission.Read));
+        acl.NamedGroups.Should().ContainSingle().Which.Should().BeEquivalentTo(new Gen2NamedAce("devs", RX));
+    }
+
+    [Fact]
+    public void MapAccessControl_NoMaskEntry_LeavesMaskNull()
+    {
+        var items = new List<PathAccessControlItem>
+        {
+            new(AccessControlType.User,  RolePermissions.Read | RolePermissions.Execute, defaultScope: false, entityId: null),
+            new(AccessControlType.Group, RolePermissions.Read | RolePermissions.Execute, defaultScope: false, entityId: null),
+            new(AccessControlType.Other, RolePermissions.None, defaultScope: false, entityId: null),
+        };
+
+        DataLakeGen2DirectoryReader.MapAccessControl("o", "g", items).Mask.Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~DataLakeGen2DirectoryReaderMappingTests"`
+Expected: FAIL — `DataLakeGen2DirectoryReader` does not exist.
+
+- [ ] **Step 4: Write minimal implementation**
+
+```csharp
+// src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs
+using Azure;
+using Azure.Core;
+using Azure.Storage.Files.DataLake;
+using Azure.Storage.Files.DataLake.Models;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Reads a Gen2 directory's access ACL live over the ADLS SDK, with Connapse's own
+/// <see cref="TokenCredential"/> (Storage Blob Data Reader). A thin shell over the SDK: every
+/// translation lives in the <c>internal static</c> mappers, which are unit-tested directly. Any SDK
+/// failure returns <c>null</c> (the resolver treats that as fail-closed); genuine caller
+/// cancellation propagates.
+/// </summary>
+public sealed class DataLakeGen2DirectoryReader(TokenCredential credential) : IGen2DirectoryReader
+{
+    public async Task<Gen2ModeBits?> ReadModeBitsAsync(Gen2Path directory, CancellationToken ct = default)
+    {
+        try
+        {
+            DataLakeDirectoryClient dir = DirectoryClient(directory);
+            Response<PathAccessControl> ac = await dir.GetAccessControlAsync(cancellationToken: ct);
+            // GetAccessControl returns the full ACL; derive the cheap mode-bits view from it. (The
+            // GetPaths-listing optimization is a Phase-4e pre-warm concern; correctness does not
+            // depend on it.) The extended flag is "any named entry or mask present".
+            Gen2Acl acl = MapAccessControl(ac.Value.Owner, ac.Value.Group, ac.Value.AccessControlList);
+            bool extended = acl.NamedUsers.Count > 0 || acl.NamedGroups.Count > 0 || acl.Mask is not null;
+            return new Gen2ModeBits(acl.OwnerOid, acl.OwningGroupOid,
+                acl.OwnerPermissions, acl.OwningGroupPermissions, acl.OtherPermissions, extended);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task<Gen2Acl?> ReadAccessAclAsync(Gen2Path directory, CancellationToken ct = default)
+    {
+        try
+        {
+            DataLakeDirectoryClient dir = DirectoryClient(directory);
+            Response<PathAccessControl> ac = await dir.GetAccessControlAsync(cancellationToken: ct);
+            return MapAccessControl(ac.Value.Owner, ac.Value.Group, ac.Value.AccessControlList);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private DataLakeDirectoryClient DirectoryClient(Gen2Path directory)
+    {
+        var service = new DataLakeServiceClient(
+            new Uri($"https://{directory.Account}.dfs.core.windows.net"), credential);
+        DataLakeFileSystemClient fs = service.GetFileSystemClient(directory.FileSystem);
+        return directory.Path.Length == 0
+            ? fs.GetDirectoryClient("/")
+            : fs.GetDirectoryClient(directory.Path);
+    }
+
+    /// <summary>Parses an SDK owner/group/symbolic-permissions triple into mode bits.</summary>
+    internal static Gen2ModeBits MapModeBits(string? owner, string? group, string symbolicPermissions)
+    {
+        var (o, g, other, extended) = Gen2Permissions.ParseSymbolic(symbolicPermissions);
+        return new Gen2ModeBits(owner, group, o, g, other, extended);
+    }
+
+    /// <summary>Builds a <see cref="Gen2Acl"/> from the SDK access-control list, ignoring default
+    /// (inheritance) entries and keeping only the access-scope ones.</summary>
+    internal static Gen2Acl MapAccessControl(string? owner, string? group, IEnumerable<PathAccessControlItem> items)
+    {
+        Gen2Permission ownerPerms = Gen2Permission.None, groupPerms = Gen2Permission.None, other = Gen2Permission.None;
+        Gen2Permission? mask = null;
+        var namedUsers = new List<Gen2NamedAce>();
+        var namedGroups = new List<Gen2NamedAce>();
+
+        foreach (PathAccessControlItem item in items)
+        {
+            if (item.DefaultScope) continue; // inheritance ACL, not evaluated
+            Gen2Permission perms = FromRolePermissions(item.Permissions);
+            bool named = !string.IsNullOrEmpty(item.EntityId);
+            switch (item.AccessControlType)
+            {
+                case AccessControlType.User when named: namedUsers.Add(new Gen2NamedAce(item.EntityId!, perms)); break;
+                case AccessControlType.User: ownerPerms = perms; break;
+                case AccessControlType.Group when named: namedGroups.Add(new Gen2NamedAce(item.EntityId!, perms)); break;
+                case AccessControlType.Group: groupPerms = perms; break;
+                case AccessControlType.Mask: mask = perms; break;
+                case AccessControlType.Other: other = perms; break;
+            }
+        }
+
+        return new Gen2Acl(owner, group, ownerPerms, groupPerms, other, mask, namedUsers, namedGroups);
+    }
+
+    private static Gen2Permission FromRolePermissions(RolePermissions p)
+    {
+        Gen2Permission result = Gen2Permission.None;
+        if (p.HasFlag(RolePermissions.Read)) result |= Gen2Permission.Read;
+        if (p.HasFlag(RolePermissions.Write)) result |= Gen2Permission.Write;
+        if (p.HasFlag(RolePermissions.Execute)) result |= Gen2Permission.Execute;
+        return result;
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~DataLakeGen2DirectoryReaderMappingTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Register in DI (consumed by 4e; not wired to search)**
+
+In `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs`, alongside the other CloudScope registrations (`AzureSearchScopeResolver`, `ArmRbacReader`, etc.), add:
+
+```csharp
+// Gen2 permission engine (Phase 4d). A pure library the Phase 4e verifier consumes; nothing here
+// is wired into the search pipeline yet.
+services.AddSingleton<IGen2DirectoryReader, DataLakeGen2DirectoryReader>();
+services.AddSingleton<AncestorTraverseResolver>();
+```
+
+Confirm the file already has `using Connapse.Core.Interfaces;` and `using Connapse.Storage.CloudScope;` (add whichever is missing). `DataLakeGen2DirectoryReader` resolves its `TokenCredential` from the existing 4a registration; `AncestorTraverseResolver` gets `IGen2DirectoryReader` + the already-registered `IMemoryCache`.
+
+- [ ] **Step 7: Build and run the full Storage + Core unit suites**
+
+Run:
+```bash
+dotnet build -clp:ErrorsOnly
+dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --no-build --filter "Category=Unit"
+dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --no-build --filter "Category=Unit"
+```
+Expected: build clean (0 warnings); both suites green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Connapse.Storage/Connapse.Storage.csproj src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs
+git commit -m "feat(azure): live DataLake Gen2 directory reader + DI (#489)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (§D):**
+- "POSIX first-match evaluator: owner bypasses mask; named user/group capped by mask; any one group granting suffices; owning-group; other" → Task 2 (`PosixAclEvaluator`), matrix test covers each clause including owner-ignores-mask and any-named-group-suffices.
+- "Read (R) and traverse (X) decisions" → `Grants(..., Gen2Permission requested)` takes either bit; 4d exercises `Execute`, 4e will pass `Read` for the file's own ACL.
+- "Ancestor-traverse resolver … resolve whether P holds X on every ancestor directory; resolve lazily and cache per directory" → Task 3.
+- "mode bits via GetPaths/properties; GetAccessControl only for named-entry tie-breaks" → the `HasExtendedAcl` / owner short-circuit in Task 3, backed by mode-bits vs full-ACL reads in Task 4.
+- "folder access never proves file access; never excludes and never skip-verifies from folders" → 4d only decides ancestor **traverse**; it exposes no file-read decision and no exclusion API. Documented in the resolver/interface XML docs and the Global Constraints.
+- "Optional bulk pre-warm (one recursive directories-only GetPaths) — perf only, not required" → explicitly a non-goal for 4d (a 4e performance option); the reader's correctness path is per-directory. Noted here so a reviewer does not flag its absence.
+
+**2. Placeholder scan:** No TBD/TODO; every code step has full code; every test asserts concrete values. The one version caveat (DataLake package) gives an exact value to try plus a deterministic fallback rule, not a placeholder.
+
+**3. Type consistency:** `Gen2Permission`, `Gen2Acl`, `Gen2NamedAce`, `Gen2ModeBits` (+ `ToAcl`), `Gen2Path`, `Gen2Permissions.ParseSymbolic/FromRwx`, `IGen2DirectoryReader.ReadModeBitsAsync/ReadAccessAclAsync`, `PosixAclEvaluator.Grants`, `AncestorTraverseResolver.HoldsTraverseOnAllAncestorsAsync`, `DataLakeGen2DirectoryReader.MapModeBits/MapAccessControl` — names and signatures are identical across the task that defines each and every task that consumes it. `RolePermissions` / `PathAccessControlItem` / `AccessControlType` are the real `Azure.Storage.Files.DataLake.Models` types (verify the `PathAccessControlItem` constructor arg order on the pinned package version during Task 4; adjust the test's object construction if the SDK exposes a factory instead).
+
+**Note for the implementer:** the `PathAccessControlItem` constructor signature can vary slightly by SDK version. If the pinned version does not expose the `(AccessControlType, RolePermissions, bool defaultScope, string entityId)` constructor used in the Task 4 test, construct the items via whatever the package provides (constructor or `DataLakeModelFactory`) — the mapper under test is unaffected.

--- a/docs/superpowers/plans/2026-09-07-azure-phase4d-gen2-acl-engine.md
+++ b/docs/superpowers/plans/2026-09-07-azure-phase4d-gen2-acl-engine.md
@@ -283,7 +283,7 @@ The pure decision. This is the correctness heart of 4d — the matrix test is ex
 **Algorithm (documented POSIX first-match; class precedence owner > named-user > group-union > other):**
 1. **Owner** — if any principal is the owner, the owner permissions decide; the mask does **not** apply. Terminal.
 2. **Named user** — else if any principal matches a named-user entry, that entry (capped by the mask) decides. Terminal even if it denies.
-3. **Group class** — else gather the owning group (if a principal is in it) and every named-group entry a principal matches; if **any** of them, masked, grants the permission, allow; if there is at least one group match but none grants, deny (do not fall through). 
+3. **Group class** — else gather the owning group (if a principal is in it) and every named-group entry a principal matches; if **any** of them, masked, grants the permission, allow; if there is at least one group match but none grants, deny (do not fall through).
 4. **Other** — else the "other" permissions decide.
 
 - [ ] **Step 1: Write the failing test**

--- a/docs/superpowers/plans/2026-09-07-azure-phase4e-verify-seam.md
+++ b/docs/superpowers/plans/2026-09-07-azure-phase4e-verify-seam.md
@@ -1,0 +1,1159 @@
+# Azure Phase 4e — Gen2 live per-hit verify seam + tag verify Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the Azure permission engine into live search: a post-retrieval `ISearchResultVerifier` that admits every readable Azure hit and drops every unreadable one, completing Phase 4 (on merge, the epic → `main`).
+
+**Architecture:** `AzureSearchScopeResolver` broadens Azure retrieval to the scheme wildcard `azblob://` (retrieve every candidate by relevance) for a valid enforcing identity. After retrieval + rerank, `HybridSearchService` calls `ISearchResultVerifier`, which routes each `azblob://` hit: covered by an RBAC prefix → pass (in-memory, RBAC supersedes ACLs); under a tag condition → live blob-tag verify; otherwise → live Gen2 file-ACL (Read) + 4d ancestor-traverse (Execute). Fail closed; `s3://` and non-cloud hits pass untouched. Over-fetch + backfill keeps the page full; bounded parallelism bounds cost.
+
+**Tech Stack:** .NET 10, C#; `Azure.Storage.Blobs` (tags), `Azure.Storage.Files.DataLake` (file ACL); `Microsoft.Extensions.Caching.Memory`; xUnit + FluentAssertions + NSubstitute.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md` (§E and its 2026-09-07 amendment)
+
+## Global Constraints
+
+- **Broad retrieve-then-verify (§E amendment).** For a valid enforcing Azure identity, `AzureSearchScopeResolver` emits the single broad match `azblob://`; all Azure tightening is the verifier's job. No HNS detection, **no new Azure permission** (app stays `Storage Blob Data Reader` + the existing RBAC-read).
+- **The verifier acts ONLY on `azblob://` hits.** `s3://` and non-cloud (`resource_uri` NULL) hits pass through untouched — the AWS path is unchanged.
+- **Fail closed everywhere.** Any unreadable directory/file, tag-read failure, SDK error, missing link, deprovisioned/uncertain identity → drop that hit (never admit). A flat-account Gen2 ACL read fails → drop.
+- **Live only.** No permission persistence. RBAC/identity are resolved live and cached (~5 min, existing readers); per-hit ACL/tag reads cached for the query and ~30–120 s. Freshness = cache TTL.
+- **Routing precedence per `azblob://` hit:** (1) covered by any RBAC `ReadablePrefix` (exact or prefix) → **pass**, no live call; (2) else under a `TagConditioned` scope → **tag verify**; (3) else → **Gen2 verify** file ACL Read + ancestor-traverse Execute. Reading a Gen2 file requires **both** the file's own Read AND traverse-X on every ancestor (4d) — folder access is never trusted.
+- **Connapse reads only** — never writes a grant/role/ACL/tag.
+- **AWS unchanged:** no file under `AwsSearchScopeResolver`, `S3*`, `RolesAnywhere/`, or the SAML/JWT path is modified. `PgVectorStore`/`KeywordSearchService` SQL filters are not modified (retrieval breadth changes only via the resolver's `SearchScopes`).
+
+## File Structure
+
+**Create (Core):**
+- `Models/AzblobUri.cs` — parse `azblob://account/container/path` → components / `Gen2Path`.
+- `CloudScope/AzureTagConditionEvaluator.cs` — pure blob-tag ↔ `AzureTagCondition` match.
+- `Interfaces/IGen2FileAclReader.cs`, `Interfaces/IBlobTagReader.cs`, `Interfaces/ISearchResultVerifier.cs`.
+
+**Create (Storage):**
+- `CloudScope/BlobTagReader.cs` — `IBlobTagReader` over `Azure.Storage.Blobs`.
+- `CloudScope/AzureSearchResultVerifier.cs` — the routing verifier.
+- `CloudScope/NoOpSearchResultVerifier.cs` — pass-through default.
+
+**Modify:**
+- `src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs` — also implement `IGen2FileAclReader` (file-ACL read).
+- `src/Connapse.Core/Interfaces/IDocumentStore.cs` + its implementation — add `GetResourceUrisAsync`.
+- `src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs` — emit broad `azblob://` for a valid enforcing identity.
+- `src/Connapse.Search/Hybrid/HybridSearchService.cs` — over-fetch, call the verifier, backfill.
+- `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs` — register the verifier + new seams.
+
+**Create (tests):** one test file per new type under the mirroring `tests/*` path, plus an integration test `tests/Connapse.Integration.Tests/AzureVerifyEnforcementTests.cs`.
+
+---
+
+### Task 1: Azblob URI parsing (Core)
+
+**Files:**
+- Create: `src/Connapse.Core/Models/AzblobUri.cs`
+- Test: `tests/Connapse.Core.Tests/Models/AzblobUriTests.cs`
+
+**Interfaces:**
+- Produces: `static bool AzblobUri.TryParse(string? resourceUri, out Gen2Path path)` — true only for a well-formed `azblob://account/container/blobpath` (account + container + non-empty path); `path` = `Gen2Path(account, container, blobpath)`. `static bool AzblobUri.IsAzblob(string? resourceUri)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Models;
+
+[Trait("Category", "Unit")]
+public class AzblobUriTests
+{
+    [Theory]
+    [InlineData("azblob://acct/docs/a/b/file.txt", "acct", "docs", "a/b/file.txt")]
+    [InlineData("azblob://acct/docs/file.txt", "acct", "docs", "file.txt")]
+    public void TryParse_WellFormed_ReturnsComponents(string uri, string acct, string fs, string path)
+    {
+        AzblobUri.TryParse(uri, out Gen2Path p).Should().BeTrue();
+        p.Account.Should().Be(acct);
+        p.FileSystem.Should().Be(fs);
+        p.Path.Should().Be(path);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("s3://bucket/key")]
+    [InlineData("azblob://acct")]          // no container or path
+    [InlineData("azblob://acct/docs")]     // no blob path
+    [InlineData("azblob://acct/docs/")]    // empty blob path
+    public void TryParse_MalformedOrNonAzblob_ReturnsFalse(string? uri) =>
+        AzblobUri.TryParse(uri, out _).Should().BeFalse();
+
+    [Fact]
+    public void IsAzblob_MatchesSchemeOnly()
+    {
+        AzblobUri.IsAzblob("azblob://a/c/x").Should().BeTrue();
+        AzblobUri.IsAzblob("s3://b/k").Should().BeFalse();
+        AzblobUri.IsAzblob(null).Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~AzblobUriTests"`
+Expected: FAIL — `AzblobUri` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```csharp
+namespace Connapse.Core;
+
+/// <summary>Parses <c>azblob://account/container/blobpath</c> resource URIs into a
+/// <see cref="Gen2Path"/> (container = filesystem). The blob path is required and kept verbatim.</summary>
+public static class AzblobUri
+{
+    private const string Scheme = "azblob://";
+
+    public static bool IsAzblob(string? resourceUri) =>
+        resourceUri is not null && resourceUri.StartsWith(Scheme, StringComparison.Ordinal);
+
+    public static bool TryParse(string? resourceUri, out Gen2Path path)
+    {
+        path = new Gen2Path("", "", "");
+        if (!IsAzblob(resourceUri))
+            return false;
+
+        string rest = resourceUri![Scheme.Length..];
+        int firstSlash = rest.IndexOf('/');
+        if (firstSlash <= 0)
+            return false; // no container
+        int secondSlash = rest.IndexOf('/', firstSlash + 1);
+        if (secondSlash < 0 || secondSlash == rest.Length - 1)
+            return false; // no container/path boundary, or empty blob path
+
+        string account = rest[..firstSlash];
+        string container = rest[(firstSlash + 1)..secondSlash];
+        string blobPath = rest[(secondSlash + 1)..];
+        if (account.Length == 0 || container.Length == 0 || blobPath.Length == 0)
+            return false;
+
+        path = new Gen2Path(account, container, blobPath);
+        return true;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~AzblobUriTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Models/AzblobUri.cs tests/Connapse.Core.Tests/Models/AzblobUriTests.cs
+git commit -m "feat(azure): azblob:// URI parser (#490)"
+```
+
+---
+
+### Task 2: Tag-condition evaluator (Core)
+
+**Files:**
+- Create: `src/Connapse.Core/CloudScope/AzureTagConditionEvaluator.cs`
+- Test: `tests/Connapse.Core.Tests/CloudScope/AzureTagConditionEvaluatorTests.cs`
+
+**Interfaces:**
+- Consumes: `AzureTagCondition(string Scope, string TagKey, string TagValue, bool KeyCaseSensitive, bool ValueCaseSensitive)` (Connapse.Core, from 4b).
+- Produces: `static bool AzureTagConditionEvaluator.Matches(AzureTagCondition condition, IReadOnlyDictionary<string,string> blobTags)` — the blob's index tags satisfy the condition. Key match honors `KeyCaseSensitive`; value match honors `ValueCaseSensitive`. A missing key → false (fail closed).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureTagConditionEvaluatorTests
+{
+    private static AzureTagCondition Cond(bool keyCase = true, bool valueCase = false) =>
+        new("azblob://acct/docs/", "Project", "Cascade", keyCase, valueCase);
+
+    [Fact]
+    public void Matches_KeyAndValuePresent_True() =>
+        AzureTagConditionEvaluator.Matches(Cond(), new Dictionary<string, string> { ["Project"] = "Cascade" })
+            .Should().BeTrue();
+
+    [Fact]
+    public void Matches_MissingKey_False() =>
+        AzureTagConditionEvaluator.Matches(Cond(), new Dictionary<string, string> { ["Other"] = "Cascade" })
+            .Should().BeFalse();
+
+    [Fact]
+    public void Matches_KeyCaseSensitive_DoesNotMatchDifferentCaseKey() =>
+        AzureTagConditionEvaluator.Matches(Cond(keyCase: true), new Dictionary<string, string> { ["project"] = "Cascade" })
+            .Should().BeFalse();
+
+    [Fact]
+    public void Matches_ValueCaseInsensitive_MatchesDifferentCaseValue() =>
+        AzureTagConditionEvaluator.Matches(Cond(valueCase: false), new Dictionary<string, string> { ["Project"] = "cascade" })
+            .Should().BeTrue();
+
+    [Fact]
+    public void Matches_ValueCaseSensitive_DoesNotMatchDifferentCaseValue() =>
+        AzureTagConditionEvaluator.Matches(Cond(valueCase: true), new Dictionary<string, string> { ["Project"] = "cascade" })
+            .Should().BeFalse();
+
+    [Fact]
+    public void Matches_WrongValue_False() =>
+        AzureTagConditionEvaluator.Matches(Cond(), new Dictionary<string, string> { ["Project"] = "Other" })
+            .Should().BeFalse();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~AzureTagConditionEvaluatorTests"`
+Expected: FAIL — type does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```csharp
+namespace Connapse.Core;
+
+/// <summary>
+/// Evaluates a blob's index tags against an <see cref="AzureTagCondition"/> (an RBAC ABAC grant that
+/// could not reduce to a prefix, carried as residue by 4b). Pure; used by the Phase 4e verifier per
+/// hit. A missing key fails closed.
+/// </summary>
+public static class AzureTagConditionEvaluator
+{
+    public static bool Matches(AzureTagCondition condition, IReadOnlyDictionary<string, string> blobTags)
+    {
+        ArgumentNullException.ThrowIfNull(condition);
+        ArgumentNullException.ThrowIfNull(blobTags);
+
+        string? value = FindValue(condition.TagKey, condition.KeyCaseSensitive, blobTags);
+        if (value is null)
+            return false;
+
+        StringComparison valueCmp = condition.ValueCaseSensitive
+            ? StringComparison.Ordinal
+            : StringComparison.OrdinalIgnoreCase;
+        return string.Equals(value, condition.TagValue, valueCmp);
+    }
+
+    private static string? FindValue(string key, bool keyCaseSensitive, IReadOnlyDictionary<string, string> tags)
+    {
+        if (keyCaseSensitive)
+            return tags.TryGetValue(key, out string? v) ? v : null;
+
+        foreach (KeyValuePair<string, string> t in tags)
+            if (string.Equals(t.Key, key, StringComparison.OrdinalIgnoreCase))
+                return t.Value;
+        return null;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --filter "FullyQualifiedName~AzureTagConditionEvaluatorTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/CloudScope/AzureTagConditionEvaluator.cs tests/Connapse.Core.Tests/CloudScope/AzureTagConditionEvaluatorTests.cs
+git commit -m "feat(azure): blob-tag condition evaluator (#490)"
+```
+
+---
+
+### Task 3: Gen2 file-ACL read seam (Core interface + Storage)
+
+**Files:**
+- Create: `src/Connapse.Core/Interfaces/IGen2FileAclReader.cs`
+- Modify: `src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs` (also implement the new interface)
+- Test: `tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs` (the mapper is already covered; no new mapper logic — the file path reuses `MapAccessControl` + `IsStructurallyComplete`).
+
+**Interfaces:**
+- Consumes: `Gen2Acl`, `Gen2Path` (Core); the existing `MapAccessControl`/`IsStructurallyComplete` (4d).
+- Produces: `interface IGen2FileAclReader { Task<Gen2Acl?> ReadFileAclAsync(Gen2Path file, CancellationToken ct = default); }`; `DataLakeGen2DirectoryReader` implements it too.
+
+- [ ] **Step 1: Add the interface**
+
+```csharp
+// src/Connapse.Core/Interfaces/IGen2FileAclReader.cs
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Reads a single ADLS Gen2 <b>file's own</b> access ACL, with Connapse's Data-Reader identity, to
+/// evaluate a searcher's Read on the leaf (the ancestor-traverse resolver checks only directories).
+/// Returns <c>null</c> when the file cannot be read or the ACL is structurally incomplete — an
+/// uncertain answer the caller treats as fail-closed. On a non-HNS (flat) account the underlying
+/// call fails and this returns <c>null</c>, which is the correct drop for a flat blob reached only
+/// by the broad retrieval over-approximation.
+/// </summary>
+public interface IGen2FileAclReader
+{
+    Task<Gen2Acl?> ReadFileAclAsync(Gen2Path file, CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 2: Write the failing test (interface implemented by the reader)**
+
+Add to `tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs`:
+
+```csharp
+[Fact]
+public void Reader_Implements_FileAclReader() =>
+    typeof(Connapse.Core.Interfaces.IGen2FileAclReader)
+        .IsAssignableFrom(typeof(DataLakeGen2DirectoryReader)).Should().BeTrue();
+```
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~DataLakeGen2DirectoryReaderMappingTests"`
+Expected: FAIL — the reader does not implement `IGen2FileAclReader` yet (compile error).
+
+- [ ] **Step 3: Implement `ReadFileAclAsync` on `DataLakeGen2DirectoryReader`**
+
+Change the class declaration to also implement the interface, and add the method (mirrors `ReadAccessAclAsync` but uses a `DataLakeFileClient`):
+
+```csharp
+public sealed class DataLakeGen2DirectoryReader(TokenCredential credential)
+    : IGen2DirectoryReader, IGen2FileAclReader
+{
+    // ... existing members ...
+
+    public async Task<Gen2Acl?> ReadFileAclAsync(Gen2Path file, CancellationToken ct = default)
+    {
+        try
+        {
+            var service = new DataLakeServiceClient(
+                new Uri($"https://{file.Account}.dfs.core.windows.net"), credential);
+            DataLakeFileSystemClient fs = service.GetFileSystemClient(file.FileSystem);
+            DataLakeFileClient fileClient = fs.GetFileClient(file.Path);
+            Response<PathAccessControl> ac = await fileClient.GetAccessControlAsync(cancellationToken: ct);
+            Gen2Acl acl = MapAccessControl(ac.Value.Owner, ac.Value.Group, ac.Value.AccessControlList);
+            return IsStructurallyComplete(acl) ? acl : null;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~DataLakeGen2DirectoryReaderMappingTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Core/Interfaces/IGen2FileAclReader.cs src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs
+git commit -m "feat(azure): Gen2 file-ACL read seam (#490)"
+```
+
+---
+
+### Task 4: Blob-tag read seam (Core interface + Storage)
+
+**Files:**
+- Create: `src/Connapse.Core/Interfaces/IBlobTagReader.cs`
+- Create: `src/Connapse.Storage/CloudScope/BlobTagReader.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/BlobTagReaderTests.cs`
+
+**Interfaces:**
+- Consumes: `Gen2Path` (account/container/path is the same shape for a flat blob), `Azure.Core.TokenCredential`.
+- Produces: `interface IBlobTagReader { Task<IReadOnlyDictionary<string,string>?> ReadTagsAsync(Gen2Path blob, CancellationToken ct = default); }`; `BlobTagReader : IBlobTagReader`. Returns `null` on failure (fail closed); an empty dictionary means "no tags" (a valid answer → tag conditions won't match → drop).
+
+- [ ] **Step 1: Add the interface**
+
+```csharp
+// src/Connapse.Core/Interfaces/IBlobTagReader.cs
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>Reads a blob's index tags (with Connapse's Data-Reader identity) for live ABAC tag
+/// verification. <c>null</c> on any read failure (fail closed); an empty map is a valid "no tags".</summary>
+public interface IBlobTagReader
+{
+    Task<IReadOnlyDictionary<string, string>?> ReadTagsAsync(Gen2Path blob, CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+The `BlobClient` is sealed-ish but its calls can be stubbed via a custom `BlobClientOptions.Transport`. To keep the test a pure unit test, isolate the mapping in an `internal static` helper and test that; the thin client shell is exercised by the integration test in Task 8.
+
+```csharp
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class BlobTagReaderTests
+{
+    [Fact]
+    public void MapTags_CopiesAllPairs()
+    {
+        IReadOnlyDictionary<string, string> result = BlobTagReader.MapTags(
+            new Dictionary<string, string> { ["Project"] = "Cascade", ["Env"] = "prod" });
+        result.Should().HaveCount(2);
+        result["Project"].Should().Be("Cascade");
+        result["Env"].Should().Be("prod");
+    }
+
+    [Fact]
+    public void MapTags_Null_ReturnsEmpty() =>
+        BlobTagReader.MapTags(null).Should().BeEmpty();
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~BlobTagReaderTests"`
+Expected: FAIL — `BlobTagReader` does not exist.
+
+- [ ] **Step 4: Write minimal implementation**
+
+```csharp
+// src/Connapse.Storage/CloudScope/BlobTagReader.cs
+using Azure;
+using Azure.Core;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>Reads a blob's index tags over <c>Azure.Storage.Blobs</c>. Thin shell; fail-closed
+/// (<c>null</c>) on any error, genuine caller cancellation propagates.</summary>
+public sealed class BlobTagReader(TokenCredential credential) : IBlobTagReader
+{
+    public async Task<IReadOnlyDictionary<string, string>?> ReadTagsAsync(Gen2Path blob, CancellationToken ct = default)
+    {
+        try
+        {
+            var service = new BlobServiceClient(
+                new Uri($"https://{blob.Account}.blob.core.windows.net"), credential);
+            BlobClient client = service.GetBlobContainerClient(blob.FileSystem).GetBlobClient(blob.Path);
+            Response<GetBlobTagResult> tags = await client.GetTagsAsync(cancellationToken: ct);
+            return MapTags(tags.Value?.Tags);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    internal static IReadOnlyDictionary<string, string> MapTags(IDictionary<string, string>? tags) =>
+        tags is null ? new Dictionary<string, string>() : new Dictionary<string, string>(tags);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~BlobTagReaderTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Connapse.Core/Interfaces/IBlobTagReader.cs src/Connapse.Storage/CloudScope/BlobTagReader.cs tests/Connapse.Storage.Tests/CloudScope/BlobTagReaderTests.cs
+git commit -m "feat(azure): blob-tag read seam (#490)"
+```
+
+---
+
+### Task 5: Bulk resource_uri lookup (Core interface + Storage)
+
+**Files:**
+- Modify: `src/Connapse.Core/Interfaces/IDocumentStore.cs` (add the method)
+- Modify: the `IDocumentStore` implementation (find it: `grep -rl "class .*DocumentStore" src/Connapse.Storage`)
+- Test: `tests/Connapse.Storage.Tests/...` (an integration-tagged test if the impl needs a DbContext; otherwise a focused unit test). Because this needs the real store, put the covering test in `tests/Connapse.Integration.Tests/` tagged `Category=Integration`, OR — preferred — verify it in Task 8's integration test and here add only the interface + a mapping check. Follow whichever the existing `IDocumentStore` tests do.
+
+**Interfaces:**
+- Produces: `Task<IReadOnlyDictionary<string, string?>> GetResourceUrisAsync(IReadOnlyCollection<string> documentIds, CancellationToken ct = default)` — maps each requested document id to its `resource_uri` (null when the document has none or is not found). One query, not N.
+
+- [ ] **Step 1: Add the interface method**
+
+In `src/Connapse.Core/Interfaces/IDocumentStore.cs`:
+
+```csharp
+/// <summary>
+/// The <c>resource_uri</c> of each requested document (null when it has none — uploads and non-cloud
+/// connectors — or the id is unknown). One batched lookup, for the search verifier which must map
+/// ranked hits back to their governing URIs.
+/// </summary>
+Task<IReadOnlyDictionary<string, string?>> GetResourceUrisAsync(
+    IReadOnlyCollection<string> documentIds, CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Match the existing `IDocumentStore` test style. If the store is EF/Npgsql-backed (integration), add to a suitable integration test class; assert that for a set of document ids the returned map has the seeded `resource_uri`s and `null` for an unknown id. (Concrete seeding mirrors `AzureFlatEnforcementTests.SeedAsync` — a document with `ResourceUri = "azblob://acct/docs/a"` and one with `ResourceUri = null`.) Run it and confirm it fails to compile (method missing) then fails red.
+
+- [ ] **Step 3: Implement in the store**
+
+Use a single parameterized query. Example shape (adapt to the store's EF context / raw-SQL idiom already used in `PgVectorStore`):
+
+```csharp
+public async Task<IReadOnlyDictionary<string, string?>> GetResourceUrisAsync(
+    IReadOnlyCollection<string> documentIds, CancellationToken ct = default)
+{
+    var result = new Dictionary<string, string?>();
+    if (documentIds.Count == 0) return result;
+
+    Guid[] ids = documentIds.Select(Guid.Parse).ToArray();
+    await using var db = await _factory.CreateDbContextAsync(ct);
+    var rows = await db.Documents
+        .Where(d => ids.Contains(d.Id))
+        .Select(d => new { d.Id, d.ResourceUri })
+        .ToListAsync(ct);
+    foreach (var r in rows)
+        result[r.Id.ToString()] = r.ResourceUri;
+    return result;
+}
+```
+
+(Use the exact `DbContext`/entity names the store already uses — `KnowledgeDbContext`, `Documents`, `DocumentEntity.ResourceUri`, `Id`. Never string-interpolate SQL.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run the added test's filter. Expected: PASS (seeded URIs returned; unknown id → null/absent).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(search): bulk resource_uri lookup on the document store (#490)"
+```
+
+---
+
+### Task 6: The search-result verifier (Core interface + Storage impl + no-op)
+
+**Files:**
+- Create: `src/Connapse.Core/Interfaces/ISearchResultVerifier.cs`
+- Create: `src/Connapse.Storage/CloudScope/NoOpSearchResultVerifier.cs`
+- Create: `src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs`
+
+**Interfaces:**
+- Consumes: `SearchHit(ChunkId, DocumentId, Content, Score, Metadata)` (Core); `IDocumentStore.GetResourceUrisAsync` (Task 5); `IAzureIdentityLinkReader`→`AzureIdentityRef(ObjectId, TenantId)`; `IAzureDirectoryReader`→`AzureIdentitySet(PrincipalOids, Outcome)`; `IAzureRbacReader`→`AzureRbacScopes(ReadablePrefixes[AzureScope(Prefix)], TagConditioned[AzureTagCondition], Outcome)`; `IGen2FileAclReader.ReadFileAclAsync`; `AncestorTraverseResolver.HoldsTraverseOnAllAncestorsAsync(Gen2Path, string userOid, IReadOnlySet<string> groupOids, ct)`; `IBlobTagReader.ReadTagsAsync`; `PosixAclEvaluator.Grants(Gen2Acl, string userOid, IReadOnlySet<string> groupOids, Gen2Permission)`; `AzureTagConditionEvaluator.Matches`; `AzblobUri.TryParse`; `PermissionEnforcementSettings.StateForAzure`; `AzureAdSignInSettings.IsConfigured`; `EnforcementMigration.Determined`.
+- Produces: `interface ISearchResultVerifier { int CandidateMultiplier { get; } Task<IReadOnlyList<SearchHit>> VerifyAsync(IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default); }`. `VerifyAsync` returns the rank-ordered surviving hits, at most `topK` (backfill). `NoOpSearchResultVerifier`: `CandidateMultiplier => 1`, returns `rankedCandidates.Take(topK)`.
+
+**Routing (per candidate, in rank order; azblob only):**
+1. `resource_uri` not azblob (s3/null/unknown) → **pass**.
+2. Azure enforcement not active (StateForAzure ≠ Enforcing) → **pass** all (no-op; the resolver didn't broaden either).
+3. Identity: no link / deprovisioned / directory-failed → **drop** every azblob hit (fail closed).
+4. Covered by an RBAC `ReadablePrefix` (hit URI starts with the prefix) → **pass**.
+5. Under a `TagConditioned` scope (hit URI starts with its `Scope`) → **tag verify**: read tags; if any covering tag condition matches → pass, else drop.
+6. Else → **Gen2 verify**: `ReadFileAclAsync` → `PosixAclEvaluator.Grants(fileAcl, userOid, groupOids, Read)` AND `HoldsTraverseOnAllAncestorsAsync(path, userOid, groupOids)`; both true → pass, else drop.
+
+Bounded parallelism (`SemaphoreSlim`, degree from settings, default 16) over the candidate pool; preserve input rank order in the output; stop-collecting at `topK` survivors is unnecessary because the pool is already bounded by the over-fetch — verify the whole pool concurrently and take the first `topK` survivors by original rank.
+
+- [ ] **Step 1: Add the interface + no-op**
+
+```csharp
+// src/Connapse.Core/Interfaces/ISearchResultVerifier.cs
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Post-retrieval per-hit permission verify. Given ranked candidates, returns the subset the searcher
+/// may actually read, in rank order, at most <paramref name="topK"/> (dropping unreadable hits and
+/// backfilling from lower-ranked survivors). <see cref="CandidateMultiplier"/> tells the pipeline how
+/// much to over-fetch so backfill has material.
+/// </summary>
+public interface ISearchResultVerifier
+{
+    int CandidateMultiplier { get; }
+
+    Task<IReadOnlyList<SearchHit>> VerifyAsync(
+        IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default);
+}
+```
+
+```csharp
+// src/Connapse.Storage/CloudScope/NoOpSearchResultVerifier.cs
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>The default: no Azure verification. Returns the top <c>topK</c> unchanged.</summary>
+public sealed class NoOpSearchResultVerifier : ISearchResultVerifier
+{
+    public int CandidateMultiplier => 1;
+
+    public Task<IReadOnlyList<SearchHit>> VerifyAsync(
+        IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<SearchHit>>(rankedCandidates.Take(topK).ToList());
+}
+```
+
+- [ ] **Step 2: Write the failing tests (fakes for every seam)**
+
+```csharp
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureSearchResultVerifierTests
+{
+    private const Gen2Permission RX = Gen2Permission.Read | Gen2Permission.Execute;
+    private static readonly Guid User = Guid.NewGuid();
+    private static readonly AzureIdentityRef Link = new("user-oid", "tid");
+
+    private static SearchHit Hit(string docId, double score) =>
+        new($"chunk-{docId}", docId, "content", (float)score, new Dictionary<string, string>());
+
+    private static IOptionsMonitor<T> Opt<T>(T v) where T : class
+    {
+        var m = Substitute.For<IOptionsMonitor<T>>();
+        m.CurrentValue.Returns(v);
+        return m;
+    }
+
+    // Builds a verifier with all seams faked; each test overrides what it needs.
+    private sealed class Harness
+    {
+        public IDocumentStore Docs = Substitute.For<IDocumentStore>();
+        public IAzureIdentityLinkReader Links = Substitute.For<IAzureIdentityLinkReader>();
+        public IAzureDirectoryReader Directory = Substitute.For<IAzureDirectoryReader>();
+        public IAzureRbacReader Rbac = Substitute.For<IAzureRbacReader>();
+        public IGen2FileAclReader FileAcl = Substitute.For<IGen2FileAclReader>();
+        public IBlobTagReader Tags = Substitute.For<IBlobTagReader>();
+        public IGen2DirectoryReader DirReader = Substitute.For<IGen2DirectoryReader>();
+        public bool AzureConfigured = true;
+        public bool AzureEnforcing = true;
+
+        public AzureSearchResultVerifier Build()
+        {
+            Links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+            Directory.ResolveAsync(Link, Arg.Any<CancellationToken>())
+                .Returns(AzureIdentitySet.Resolved(["user-oid", "group-1"]));
+            Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+                .Returns(AzureRbacScopes.Resolved([], []));
+            var azureAd = Opt(AzureConfigured
+                ? new AzureAdSignInSettings { TenantId = "t", ClientId = "c", RedirectUri = "https://x/cb", ClientCertificatePath = "p.pem" }
+                : new AzureAdSignInSettings());
+            var enf = Opt(new PermissionEnforcementSettings { AzureEnforcing = AzureEnforcing });
+            var traverse = new AncestorTraverseResolver(DirReader, new MemoryCache(new MemoryCacheOptions()));
+            return new AzureSearchResultVerifier(
+                Docs, Links, Directory, Rbac, FileAcl, Tags, traverse,
+                azureAd, enf, EnforcementMigration.Completed(),
+                Options.Create(new AzureVerifierSettings { MaxParallelism = 16, CandidateMultiplier = 5 }),
+                NullLogger<AzureSearchResultVerifier>.Instance);
+        }
+    }
+
+    private void ResourceUris(Harness h, params (string doc, string? uri)[] map) =>
+        h.Docs.GetResourceUrisAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
+            .Returns(map.ToDictionary(m => m.doc, m => m.uri));
+
+    [Fact]
+    public async Task NonAzureHits_PassUntouched()
+    {
+        var h = new Harness();
+        ResourceUris(h, ("d1", "s3://b/k"), ("d2", null));
+        var hits = new[] { Hit("d1", 0.9), Hit("d2", 0.8) };
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync(hits, User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("d1", "d2");
+    }
+
+    [Fact]
+    public async Task AzureNotEnforcing_PassesEverything()
+    {
+        var h = new Harness { AzureEnforcing = false };
+        ResourceUris(h, ("d1", "azblob://acct/docs/secret"));
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+        r.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RbacCoveredHit_Passes_WithoutAnyLiveAclOrTagRead()
+    {
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+            .Returns(AzureRbacScopes.Resolved([new AzureScope("azblob://acct/docs/")], []));
+        ResourceUris(h, ("d1", "azblob://acct/docs/a/file.txt"));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().ContainSingle();
+        await h.FileAcl.DidNotReceive().ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+        await h.Tags.DidNotReceive().ReadTagsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task LockedFileBeneathReadableFolder_IsDropped()
+    {
+        // Soundness: no RBAC/tag; file's own ACL denies Read → drop, even if ancestors traverse.
+        var h = new Harness();
+        ResourceUris(h, ("d1", "azblob://acct/docs/locked.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, RX, Gen2Permission.None, null, [], [])); // other = no read
+        h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, RX, HasExtendedAcl: false)); // ancestors traverse
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CaseC_PerFileGrantBeneathUnreadableFolder_IsReturned()
+    {
+        // Completeness: file's own ACL grants Read to the user AND ancestors are traversable (X),
+        // even though the folder is not readable as a listing (R). No RBAC. → pass.
+        var h = new Harness();
+        ResourceUris(h, ("d1", "azblob://acct/docs/secret/case-c.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, Gen2Permission.None, Gen2Permission.None,
+                Mask: RX, NamedUsers: [new Gen2NamedAce("user-oid", RX)], NamedGroups: []));
+        h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, Gen2Permission.Execute, HasExtendedAcl: false));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Gen2FileAclUnreadable_IsDropped_FailClosed()
+    {
+        var h = new Harness();
+        ResourceUris(h, ("d1", "azblob://acct/docs/x.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns((Gen2Acl?)null);
+
+        (await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TagConditioned_MatchingTag_Passes_And_NonMatching_Drops()
+    {
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>()).Returns(
+            AzureRbacScopes.Resolved([], [new AzureTagCondition("azblob://acct/docs/", "Project", "Cascade", true, false)]));
+        ResourceUris(h, ("hit-ok", "azblob://acct/docs/a.txt"), ("hit-no", "azblob://acct/docs/b.txt"));
+        h.Tags.ReadTagsAsync(Arg.Is<Gen2Path>(p => p.Path == "a.txt"), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, string> { ["Project"] = "Cascade" });
+        h.Tags.ReadTagsAsync(Arg.Is<Gen2Path>(p => p.Path == "b.txt"), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, string> { ["Project"] = "Other" });
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("hit-ok", 0.9), Hit("hit-no", 0.8)], User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("hit-ok");
+    }
+
+    [Fact]
+    public async Task DeprovisionedIdentity_DropsAllAzure_ButKeepsNonCloud()
+    {
+        var h = new Harness();
+        h.Directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Deprovisioned());
+        ResourceUris(h, ("az", "azblob://acct/docs/x"), ("nc", null));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("az", 0.9), Hit("nc", 0.8)], User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("nc");
+    }
+
+    [Fact]
+    public async Task Backfill_KeepsTopKInRankOrder_AfterDroppingUnreadable()
+    {
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+            .Returns(AzureRbacScopes.Resolved([new AzureScope("azblob://acct/ok/")], []));
+        ResourceUris(h,
+            ("d1", "azblob://acct/no/1"),  // dropped (not covered, file acl null)
+            ("d2", "azblob://acct/ok/2"),  // pass
+            ("d3", "azblob://acct/ok/3")); // pass
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns((Gen2Acl?)null);
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync(
+            [Hit("d1", 0.9), Hit("d2", 0.8), Hit("d3", 0.7)], User, 2);
+
+        r.Select(x => x.DocumentId).Should().Equal("d2", "d3"); // rank order preserved, d1 backfilled out
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureSearchResultVerifierTests"`
+Expected: FAIL — `AzureSearchResultVerifier` / `AzureVerifierSettings` do not exist.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `src/Connapse.Core/Models/AzureVerifierSettings.cs`:
+
+```csharp
+namespace Connapse.Core;
+
+/// <summary>Tuning for the Phase 4e verifier.</summary>
+public sealed class AzureVerifierSettings
+{
+    public const string SectionName = "Azure:Verifier";
+    /// <summary>Bounded per-hit verify concurrency.</summary>
+    public int MaxParallelism { get; set; } = 16;
+    /// <summary>How many candidates to over-fetch per requested result, so backfill has material.</summary>
+    public int CandidateMultiplier { get; set; } = 5;
+}
+```
+
+Create `src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs`:
+
+```csharp
+using System.Collections.Concurrent;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Live per-hit Azure permission verify (Phase 4e). Passes non-Azure hits untouched; for each
+/// azblob hit, admits it only if covered by an RBAC prefix (in-memory), or a matching blob-tag
+/// condition, or the file's own ACL grants Read AND every ancestor directory grants traverse-X
+/// (4d). Fails closed on every uncertain read. Preserves rank order and returns at most topK.
+/// </summary>
+public sealed class AzureSearchResultVerifier(
+    IDocumentStore documents,
+    IAzureIdentityLinkReader links,
+    IAzureDirectoryReader directory,
+    IAzureRbacReader rbac,
+    IGen2FileAclReader fileAcl,
+    IBlobTagReader blobTags,
+    AncestorTraverseResolver traverse,
+    IOptionsMonitor<AzureAdSignInSettings> azureAd,
+    IOptionsMonitor<PermissionEnforcementSettings> enforcement,
+    EnforcementMigration migration,
+    IOptions<AzureVerifierSettings> settings,
+    ILogger<AzureSearchResultVerifier> logger) : ISearchResultVerifier
+{
+    public int CandidateMultiplier =>
+        Math.Max(1, settings.Value.CandidateMultiplier);
+
+    public async Task<IReadOnlyList<SearchHit>> VerifyAsync(
+        IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default)
+    {
+        // No Azure enforcement → the resolver did not broaden; nothing to tighten.
+        if (enforcement.CurrentValue.StateForAzure(azureAd.CurrentValue.IsConfigured, migration.Determined)
+            != EnforcementState.Enforcing)
+            return rankedCandidates.Take(topK).ToList();
+
+        // Map hits to their governing URIs (one batched query).
+        IReadOnlyDictionary<string, string?> uris =
+            await documents.GetResourceUrisAsync(rankedCandidates.Select(h => h.DocumentId).ToList(), ct);
+
+        // Resolve the searcher's Azure context once. Any failure/deprovision → drop every azblob hit.
+        AzureContext? azure = await ResolveContextAsync(userId, ct);
+
+        // Verify azblob hits concurrently (bounded); non-azblob pass; decision keyed by index so we
+        // can re-assemble in rank order.
+        var verdicts = new ConcurrentDictionary<int, bool>();
+        using var gate = new SemaphoreSlim(Math.Max(1, settings.Value.MaxParallelism));
+
+        await Task.WhenAll(rankedCandidates.Select(async (hit, i) =>
+        {
+            string? uri = uris.GetValueOrDefault(hit.DocumentId);
+            if (!AzblobUri.TryParse(uri, out Gen2Path path))
+            {
+                verdicts[i] = true; // s3:// or non-cloud → pass untouched
+                return;
+            }
+            if (azure is null)
+            {
+                verdicts[i] = false; // enforcing but no usable identity → drop azblob
+                return;
+            }
+            await gate.WaitAsync(ct);
+            try { verdicts[i] = await AdmitAzureHitAsync(uri!, path, azure, ct); }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+            catch (Exception ex) { logger.LogError(ex, "Azure hit verify failed; dropping"); verdicts[i] = false; }
+            finally { gate.Release(); }
+        }));
+
+        var survivors = new List<SearchHit>(topK);
+        for (int i = 0; i < rankedCandidates.Count && survivors.Count < topK; i++)
+            if (verdicts.GetValueOrDefault(i)) survivors.Add(rankedCandidates[i]);
+        return survivors;
+    }
+
+    private async Task<bool> AdmitAzureHitAsync(string uri, Gen2Path path, AzureContext azure, CancellationToken ct)
+    {
+        // 1. RBAC read supersedes ACLs — covered by any readable prefix → pass, no live call.
+        if (azure.ReadablePrefixes.Any(p => uri.StartsWith(p, StringComparison.Ordinal)))
+            return true;
+
+        // 2. Tag-conditioned residue → live tag verify against every covering condition.
+        AzureTagCondition[] covering =
+            azure.TagConditions.Where(t => uri.StartsWith(t.Scope, StringComparison.Ordinal)).ToArray();
+        if (covering.Length > 0)
+        {
+            IReadOnlyDictionary<string, string>? tags = await blobTags.ReadTagsAsync(path, ct);
+            if (tags is null) return false; // fail closed
+            return covering.Any(c => AzureTagConditionEvaluator.Matches(c, tags));
+        }
+
+        // 3. Gen2 ACL: file's own Read AND traverse-X on every ancestor. Folder access never trusted.
+        Gen2Acl? acl = await fileAcl.ReadFileAclAsync(path, ct);
+        if (acl is null) return false; // unreadable / flat account / incomplete → drop
+        if (!PosixAclEvaluator.Grants(acl, azure.UserOid, azure.GroupOids, Gen2Permission.Read))
+            return false;
+        return await traverse.HoldsTraverseOnAllAncestorsAsync(path, azure.UserOid, azure.GroupOids, ct);
+    }
+
+    private async Task<AzureContext?> ResolveContextAsync(Guid? userId, CancellationToken ct)
+    {
+        if (userId is null) return null;
+        AzureIdentityRef? link = await links.GetLinkAsync(userId.Value, ct);
+        if (link is null) return null;
+
+        AzureIdentitySet identity = await directory.ResolveAsync(link, ct);
+        if (identity.Outcome != AzureIdentityOutcome.Resolved) return null; // deprovisioned/failed → drop azblob
+
+        AzureRbacScopes scopes = await rbac.ResolveAsync(link.ObjectId, ct);
+        if (scopes.Outcome != RbacOutcome.Resolved) return null; // RBAC uncertain → fail closed
+
+        var groups = identity.PrincipalOids.Where(o => o != link.ObjectId).ToHashSet(StringComparer.Ordinal);
+        return new AzureContext(
+            link.ObjectId, groups,
+            scopes.ReadablePrefixes.Select(s => s.Prefix).ToArray(),
+            scopes.TagConditioned.ToArray());
+    }
+
+    private sealed record AzureContext(
+        string UserOid, IReadOnlySet<string> GroupOids,
+        IReadOnlyList<string> ReadablePrefixes, IReadOnlyList<AzureTagCondition> TagConditions);
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureSearchResultVerifierTests"`
+Expected: PASS (all 9 cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Connapse.Core/Interfaces/ISearchResultVerifier.cs src/Connapse.Core/Models/AzureVerifierSettings.cs src/Connapse.Storage/CloudScope/NoOpSearchResultVerifier.cs src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
+git commit -m "feat(azure): live per-hit search-result verifier + no-op default (#490)"
+```
+
+---
+
+### Task 7: Broaden Azure retrieval (Storage)
+
+**Files:**
+- Modify: `src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs`
+- Test: `tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs`
+
+**Interfaces:**
+- Produces (change): for a valid enforcing identity (link present, not deprovisioned, directory not failed), `ResolveAsync` returns `SearchScopes.Of([new GrantMatch("azblob://", IsExact: false)])` — retrieve every Azure candidate. The enforcement gate, null-user `NoPrincipal`, no-link `NoPrincipal`, deprovisioned `NoPrincipal`, and directory-failed `Failed` paths are unchanged. **The RBAC call is removed from retrieval** (RBAC now lives in the verifier); drop the `IAzureRbacReader` dependency if it becomes unused.
+
+- [ ] **Step 1: Update the tests to the broadened contract**
+
+In `AzureSearchScopeResolverTests.cs`, the "enabled with RBAC prefixes → granted azblob matches" and "no RBAC prefixes → no-grants" cases are replaced: a valid enforcing identity now yields the single broad `azblob://` match. Keep every fail-closed case (`NotEnforcing`→Unrestricted, `EnforcingButAzureAdNotConfigured`→Failed, `Undetermined`→Failed, null user→NoPrincipal, no link→NoPrincipal, deprovisioned→NoPrincipal, identity-failed→Failed). Replace the two RBAC-specific tests with:
+
+```csharp
+[Fact]
+public async Task ValidEnforcingIdentity_RetrievesAllAzblob_ForTheVerifierToTighten()
+{
+    var links = Substitute.For<IAzureIdentityLinkReader>();
+    links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+    var directory = Substitute.For<IAzureDirectoryReader>();
+    directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
+    var r = Build(links: links, directory: directory);
+
+    SearchScopes s = await r.ResolveAsync(User);
+
+    s.Outcome.Should().Be(ScopeOutcome.Granted);
+    s.Matches.Should().ContainSingle().Which.Value.Should().Be("azblob://");
+    s.Matches[0].IsExact.Should().BeFalse();
+}
+```
+
+(Delete `Enabled_WithRbacPrefixes_ReturnsGrantedAzblobMatches` and `Enabled_NoRbacPrefixes_IsNoGrants`, and drop the now-unused `rbac`/`IAzureRbacReader` wiring from the test's `Build` helper.)
+
+- [ ] **Step 2: Run to verify the new test fails**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureSearchScopeResolverTests"`
+Expected: FAIL — resolver still emits RBAC prefixes / references removed members.
+
+- [ ] **Step 3: Broaden the resolver**
+
+In `AzureSearchScopeResolver.ResolveUncachedAsync`, after the deprovisioning gate, replace the RBAC resolution + prefix projection with the broad match:
+
+```csharp
+private async Task<SearchScopes> ResolveUncachedAsync(Guid userId, CancellationToken ct)
+{
+    AzureIdentityRef? link = await links.GetLinkAsync(userId, ct);
+    if (link is null)
+        return SearchScopes.NoPrincipal;
+
+    AzureIdentitySet identity = await directory.ResolveAsync(link, ct);
+    if (identity.Outcome is AzureIdentityOutcome.Deprovisioned)
+    {
+        logger.LogInformation("A linked Entra identity is disabled or gone; denying");
+        return SearchScopes.NoPrincipal;
+    }
+    if (identity.Outcome is AzureIdentityOutcome.Failed)
+        return SearchScopes.Failed;
+
+    // Broad retrieve-then-verify (§E amendment): a valid enforcing identity retrieves EVERY Azure
+    // candidate by relevance; the post-retrieval verifier (Phase 4e) tightens per hit via RBAC
+    // coverage, tag conditions, and Gen2 file-ACL + ancestor traverse. Narrowing here (e.g. to RBAC
+    // prefixes) would drop ACL-only "Case C" files, which can live in any container.
+    return SearchScopes.Of([new GrantMatch("azblob://", IsExact: false)]);
+}
+```
+
+Remove the `IAzureRbacReader rbac` constructor parameter and its `using`/field if now unused. (Leave `IAzureDirectoryReader` — the deprovisioning gate still needs it.)
+
+- [ ] **Step 4: Run to verify tests pass**
+
+Run: `dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --filter "FullyQualifiedName~AzureSearchScopeResolverTests"`
+Expected: PASS. Also run the composite tests to confirm no break: `--filter "FullyQualifiedName~CompositeSearchScopeResolverTests"`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs
+git commit -m "feat(azure): broaden Azure retrieval to azblob:// (verify tightens) (#490)"
+```
+
+---
+
+### Task 8: Wire the verifier into the pipeline + DI + integration test
+
+**Files:**
+- Modify: `src/Connapse.Search/Hybrid/HybridSearchService.cs`
+- Modify: `src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs`
+- Test: `tests/Connapse.Integration.Tests/AzureVerifyEnforcementTests.cs`
+
+**Interfaces:**
+- Consumes: `ISearchResultVerifier` (Task 6). The service resolves it in the per-search DI scope (like `vectorSearch`/`keywordSearch`).
+
+- [ ] **Step 1: Over-fetch, verify, backfill in `HybridSearchService`**
+
+The retrieval leaves use `options.TopK`. To give the verifier backfill headroom, retrieve with an inflated `TopK` (`options.TopK * verifier.CandidateMultiplier`), then verify down to `options.TopK`. Resolve the verifier in the existing `scope` (line 104 area) alongside the other scoped services, and compute the inflated options BEFORE dispatch:
+
+```csharp
+var verifier = scope.ServiceProvider.GetRequiredService<ISearchResultVerifier>();
+int overFetch = Math.Max(1, verifier.CandidateMultiplier);
+SearchOptions retrieveOptions = options with { TopK = options.TopK * overFetch };
+```
+
+Use `retrieveOptions` for the `vectorSearch.SearchAsync` / `keywordSearch.SearchAsync` / `PerformHybridSearchAsync` calls and for rerank. Then insert the verify AFTER the `filtered` ordering (line 171) and BEFORE `AutoCut`/substitution:
+
+```csharp
+var ordered = hits
+    .Where(h => h.Score >= options.MinScore)
+    .OrderByDescending(h => h.Score)
+    .ToList();
+
+IReadOnlyList<SearchHit> verified = await verifier.VerifyAsync(ordered, options.UserId, options.TopK, ct);
+
+var filtered = verified.ToList();
+if (searchSettings.AutoCut)
+    filtered = ApplyAutoCut(filtered);
+
+IReadOnlyList<SearchHit> substituted = SentenceWindowSubstitution
+    .SubstituteIfEnabled(filtered, searchSettings.SentenceWindowSubstituteOnSearch);
+
+var finalHits = substituted.Take(options.TopK).ToList();
+```
+
+(`SearchOptions` is a record — confirm `with` works; if it is not a record, construct a copy explicitly. Verify against `src/Connapse.Core/Models/SearchModels.cs`.)
+
+- [ ] **Step 2: Register the verifier + seams in DI**
+
+In `ServiceCollectionExtensions.cs`, alongside the CloudScope registrations, register the seams (Task 3/4 concretes) and choose the verifier based on whether Azure is in play. Simplest and safe: always register the Azure verifier (it self-no-ops when Azure isn't enforcing):
+
+```csharp
+services.AddSingleton<IGen2FileAclReader>(sp => (DataLakeGen2DirectoryReader)sp.GetRequiredService<IGen2DirectoryReader>());
+services.AddSingleton<IBlobTagReader, BlobTagReader>();
+services.AddScoped<ISearchResultVerifier, AzureSearchResultVerifier>();
+services.Configure<AzureVerifierSettings>(configuration.GetSection(AzureVerifierSettings.SectionName));
+```
+
+(If `IGen2DirectoryReader` is registered as the concrete `DataLakeGen2DirectoryReader`, resolve the same singleton for `IGen2FileAclReader` as shown so both interfaces share one instance. `AzureSearchResultVerifier` depends on `IDocumentStore`, the Azure readers, `AncestorTraverseResolver`, and the options — all already registered. Confirm `configuration`/`IConfiguration` is in scope in this extension method; if not, bind settings the way the file binds other sections.)
+
+- [ ] **Step 3: Write the integration test**
+
+`tests/Connapse.Integration.Tests/AzureVerifyEnforcementTests.cs` — mirror `AzureFlatEnforcementTests`' fixture usage. Seed documents with `azblob://` and `s3://` and NULL `resource_uri`, drive `IKnowledgeSearch.SearchAsync` (or the verifier directly with a seeded `IDocumentStore`) and assert: an azblob hit with no grant is dropped; an azblob hit under an RBAC prefix passes; an s3 and a non-cloud hit pass untouched; Azure-not-enforcing passes everything. Because live Azure calls can't run in CI, inject fake `IGen2FileAclReader`/`IBlobTagReader`/`IAzureRbacReader`/`IAzureDirectoryReader`/`IAzureIdentityLinkReader` into the verifier and exercise the real `IDocumentStore.GetResourceUrisAsync` against the seeded database (this is the piece that needs the container). Assert the resource_uri lookup + routing end to end.
+
+```csharp
+// Shape (adapt fixture/DI to the SharedWebAppFixture pattern):
+// 1. Seed 4 docs: azblob in-RBAC, azblob no-grant, s3, non-cloud.
+// 2. Build AzureSearchResultVerifier with the real IDocumentStore (from the fixture) + fake Azure readers.
+// 3. VerifyAsync(rankedHits, user, topK) → assert the expected survivors.
+```
+
+- [ ] **Step 4: Build + run the full unit suites and the new integration test**
+
+Run:
+```bash
+dotnet build -clp:ErrorsOnly
+dotnet test tests/Connapse.Core.Tests/Connapse.Core.Tests.csproj --no-build --filter "Category=Unit"
+dotnet test tests/Connapse.Storage.Tests/Connapse.Storage.Tests.csproj --no-build --filter "Category=Unit"
+dotnet test tests/Connapse.Search.Tests/Connapse.Search.Tests.csproj --no-build --filter "Category=Unit"   # if present
+dotnet test tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj --no-build --filter "FullyQualifiedName~AzureVerifyEnforcementTests"
+```
+Expected: build clean; unit suites green; the new integration test green (the 23 pre-existing Ollama integration failures are unrelated and environmental).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(azure): wire per-hit verifier into HybridSearchService + DI (#490)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (§E + amendment):**
+- `ISearchResultVerifier` + no-op default → Tasks 6.
+- Over-fetch + backfill + bounded parallelism → Task 6 (parallelism, backfill) + Task 8 (over-fetch via `CandidateMultiplier`).
+- Retrieve by relevance over a broad over-approximation, folder structure never narrows retrieval → Task 7 (`azblob://`).
+- Routing: exact/prefix RBAC → pass; HNS → file ACL + ancestor traverse; flat tag → tag verify; AWS/non-cloud → untouched → Task 6 `AdmitAzureHitAsync`.
+- Reading a Gen2 file requires the file's own Read AND traverse-X on every ancestor (folder access never trusted) → Task 6 (both checks) using 4d.
+- Soundness (locked file dropped) + Completeness (Case C returned) → Task 6 tests `LockedFileBeneathReadableFolder_IsDropped`, `CaseC_PerFileGrantBeneathUnreadableFolder_IsReturned`.
+- Fail-closed matrix (no link / deprovisioned / failed / uncertain read) → Task 6 (`ResolveContextAsync` + null-drops).
+- AWS path unchanged → verifier passes s3/non-cloud; resolver change is Azure-only; SQL stores untouched.
+
+**2. Placeholder scan:** Every code step has full code except Task 5 (store impl adapts to the existing DbContext idiom) and Task 8 Step 3 (integration test shape) — both name the exact types and assertions required and defer only to existing local patterns, which the implementer must read. No TBD/TODO.
+
+**3. Type consistency:** `Gen2Path`, `Gen2Acl`, `Gen2Permission`, `PosixAclEvaluator.Grants(acl, userOid, groupOids, perm)`, `AncestorTraverseResolver.HoldsTraverseOnAllAncestorsAsync(path, userOid, groupOids, ct)`, `AzureRbacScopes.ReadablePrefixes`/`TagConditioned`, `AzureTagCondition(Scope, TagKey, TagValue, KeyCaseSensitive, ValueCaseSensitive)`, `AzureIdentitySet.PrincipalOids`/`Outcome`, `AzureIdentityRef.ObjectId`, `SearchHit(ChunkId, DocumentId, Content, Score, Metadata)`, `ISearchResultVerifier.VerifyAsync/CandidateMultiplier` — names match across producing and consuming tasks and the Explore map. The implementer MUST confirm three things against the real code before relying on them: (a) `SearchOptions` supports `with` (record) — Task 8; (b) the `IDocumentStore` implementation's DbContext/entity names — Task 5; (c) the DI extension method's access to `IConfiguration` for binding `AzureVerifierSettings` — Task 8. Each is flagged in its task.

--- a/docs/superpowers/specs/2026-09-05-azure-phase2-app-identity-connector-design.md
+++ b/docs/superpowers/specs/2026-09-05-azure-phase2-app-identity-connector-design.md
@@ -1,0 +1,91 @@
+# Azure Phase 2 — ConnapseAzureCredentials + Azure Blob connector
+
+**Status:** Design — approved in brainstorming, pending spec review
+**Date:** 2026-09-05
+**Milestone:** v0.4.0 · Issue #477 · Epic #475
+**Parent design:** `docs/superpowers/specs/2026-09-05-azure-blob-provider-design.md` (§A credentials, §E data plane). This phase spec refines that section with the phase-specific decisions; where they differ, this document governs Phase 2.
+
+## Goal
+
+Deliver Azure Blob ingestion end-to-end: Connapse's own Azure identity plus a rebuilt read-only Azure Blob data-plane connector, creatable through the existing Connections/Sources UI. **No per-user permission filtering** (that is Phase 4). Independently shippable — a green increment that ingests Azure blobs.
+
+## Scope decisions (from brainstorming)
+
+1. **One credential story, two runtime contexts** — not a chooser among kinds. Ambient **managed identity** in Azure; a configured service-principal **certificate** off-Azure. No client-secret, no workload-identity-federation, no UI toggle among kinds.
+2. **Credential config comes from the settings hierarchy**, not `ProviderCredentialEntity`. DataProtection-encrypted DB storage of the cert (written by a guided Providers page) is a **deferred** follow-up. Reading a cert by path/config keeps this phase decoupled from that UI.
+3. **UI is connection/source forms only.** The guided Azure Providers setup page (credential status cards) is deferred.
+
+## Components
+
+### A. `ConnapseAzureCredentials` (Connapse.Storage/CloudScope)
+
+Mirror of [`ConnapseAwsCredentials`](../../../src/Connapse.Storage/CloudScope/ConnapseAwsCredentials.cs); `ProviderKey = "azure"`. Exposes an `Azure.Core.TokenCredential` consumed by every Azure SDK client. Built as an explicit `ChainedTokenCredential` (never `DefaultAzureCredential` — deterministic, no silent fall-through):
+
+1. **Configured certificate** — when `AzureProviderSettings` supplies `TenantId` + `ClientId` + a certificate: `new ClientCertificateCredential(tenantId, clientId, cert, new ClientCertificateCredentialOptions { SendCertificateChain = true })`.
+2. **Ambient managed identity** — `new ManagedIdentityCredential(ManagedIdentityId.FromUserAssignedClientId(id))` when `UserAssignedManagedIdentityClientId` is set, else `new ManagedIdentityCredential()`.
+3. **Fail closed** — if neither branch can produce a credential object, the chain has no usable entry; a `GetToken` failure propagates and callers deny. No developer-tool credentials in the chain.
+
+Registered **singleton**. Reads `IOptionsMonitor<AzureProviderSettings>` at token time so config reload (settings table) takes effect without restart. The Azure SDK honors `AccessToken.RefreshOn` for SDK-client calls, so **no manual refresh timer** (unlike the AWS design). Uses `Task.Run` where a synchronous credential path could deadlock the Blazor sync context, matching the AWS credential's precaution.
+
+**`AzureProviderSettings`** (`Connapse.Core/Models`), bound from configuration only:
+- `TenantId : string?`
+- `ClientId : string?`
+- `ClientCertificatePath : string?` (PEM or PFX path; the private key stays on disk under file permissions — the `AZURE_CLIENT_CERTIFICATE_PATH` pattern)
+- `ClientCertificatePassword : string?` (for PFX; optional)
+- `UserAssignedManagedIdentityClientId : string?`
+- `SectionName = "Providers:Azure"`; a `DatabaseSettingsProvider.CategoryPrefixMap` entry maps DB category `azure` → `Providers:Azure`.
+
+Cert loading is a small helper: PEM (`X509Certificate2.CreateFromPemFile`) or PFX (`new X509Certificate2(path, password)`), selected by extension/content. A missing/invalid cert file when `ClientId` is set is a **configuration error surfaced at credential build**, not a silent fall-through to ambient (that would mask a misconfiguration).
+
+### B. Data-plane connector (Connapse.Storage/Connectors)
+
+- **`AzureBlobConnectorConfig`** record: `{ AccountName, ContainerName, Prefix?, BlobEndpoint? }`. `BlobEndpoint` overrides the default `https://{account}.blob.core.windows.net` (Azurite/local).
+- **`AzureBlobConnector : IConnector, IDisposable`** — ctor `(AzureBlobConnectorConfig config, TokenCredential credential)`. Builds one `BlobServiceClient` (per instance) from `BlobEndpoint ?? https://{account}.blob.core.windows.net` + credential; `GetBlobContainerClient(ContainerName)`. `Type => ConnectorType.AzureBlob`; `SupportsLiveWatch => false`.
+  - `ListFilesAsync(prefix)` → `container.GetBlobsAsync(prefix: Combine(Prefix, prefix))`, paged, mapping each to `ConnectorFile` with `ResourceUri.ForAzureBlob(AccountName, ContainerName, blobName)`.
+  - `ReadFileAsync(path)` → `GetBlobClient(path).DownloadStreamingAsync()`.
+  - `ExistsAsync(path)` → `GetBlobClient(path).ExistsAsync()`.
+  - `ResolveJobPath(relative)` → prefix-joined blob key.
+  - `WatchAsync` → not supported (mirrors S3).
+- **`ResourceUri.ForAzureBlob(account, container, path)`** → `azblob://{account}/{container}/{path}` (re-added; mirror `ForS3`).
+- **`AzureBlobConnectionTester : IConnectionTester`** — `TestConnectionAsync` lists up to ~5 blobs via the credential; rich per-status error messages (auth failure, container missing, account not found), mirroring `S3ConnectionTester`.
+
+### C. Enum re-add + factory recombination
+
+- `ConnectorType.AzureBlob = 4`, `ConnectionProvider.AzureBlob = 4`, `CloudProvider.Azure = 1` (values match, per the enum comment's cast-backfill convention).
+- `ConnectorFactory` gains the `ConnectionProvider.AzureBlob` arm: read `accountName`/`blobEndpoint` from the **connection** config, `containerName`/`prefix` from the **source** scope, run `RequirePermittedLocation` (same as S3), pass the singleton `ConnapseAzureCredentials`' `TokenCredential`. Throws if `source.ConnectionId != connection.Id` (existing invariant).
+
+**JSON shapes:**
+- Connection config: `{ "accountName": "...", "blobEndpoint"?: "..." }`
+- Source scope: `{ "containerName": "...", "prefix"?: "..." }`
+
+### D. UI (forms only)
+
+- `ConnectionForm` — add `StorageAccountName` (and optional `BlobEndpoint`) fields; add `AzureBlob` to the `IsCloudProvider` arm, the build case (`ToConfigJson` → `{accountName, blobEndpoint?}`), and validation (account name required, DNS-name shape).
+- `SourceForm` — add the `AzureBlob` case to `ToScopeJson` (`{containerName, prefix?}`) and validation (container required).
+- `Connections.razor` — provider `<option>`, the Azure form branch, the `AzureBlobConnectionTester` test call, and the summary/`DescribeScope` arm.
+- `Sources.razor` — the `ConnectionProvider.AzureBlob` branch for the container/prefix fields.
+
+### E. DI, packages, settings
+
+- Re-add NuGet to `Connapse.Storage.csproj`: `Azure.Storage.Blobs`, `Azure.Identity`.
+- `Connapse.Storage/Extensions/ServiceCollectionExtensions.cs`: register `ConnapseAzureCredentials` (singleton), `AzureBlobConnectionTester` (scoped), and `Configure<AzureProviderSettings>` from the `"Providers:Azure"` section; `ConnectorFactory` picks up the new arm.
+- `DatabaseSettingsProvider.CategoryPrefixMap`: add `["azure"] = "Providers:Azure"`.
+
+## Testing
+
+- **Unit — `ConnapseAzureCredentialsTests`** (no Docker): cert-configured → a `ClientCertificateCredential` is composed; no cert but MI configured → `ManagedIdentityCredential` (system vs user-assigned by settings); neither → fail-closed (a token request throws / yields no token); an invalid cert path with `ClientId` set → surfaces a configuration error rather than silently using ambient. Assert on the composed chain / a seam that exposes which branch was chosen (extract a small pure `AzureCredentialChainFactory` so the composition is unit-testable without real Azure).
+- **Unit** — `ResourceUri.ForAzureBlob` round-trips (clone the S3 cases); `ConnectorFactory` builds the Azure arm from split config/scope; `ConnectionForm`/`SourceForm` Azure build+validation cases.
+- **Integration — `AzureBlobConnectorIntegrationTests`** (Testcontainers **Azurite**): re-add `Testcontainers.Azurite` + an `AzuriteFixture`. **Azurite cannot authenticate an AAD `TokenCredential`**, so the test drives the connector's list/read/`ResourceUri` logic through a blob client built with Azurite's **shared-key/connection-string** (a test-only construction path — the `TestableAzureBlobConnector` pattern that Phase 1 deleted). This proves blob enumeration, prefix scoping, streaming reads, and URI minting; the `TokenCredential` wiring is covered by the unit tests above, not against Azurite.
+- Add the `AzureBlobConnectorTestCollection` back to `CloudConnectorTestCollection.cs`.
+
+## Testable seams (design-for-isolation)
+
+- `AzureCredentialChainFactory` (pure): `(AzureProviderSettings, certLoader) → TokenCredential` — the branch logic, unit-testable without Azure. `ConnapseAzureCredentials` wraps it + `IOptionsMonitor`.
+- `AzureBlobConnector` takes an already-built `BlobServiceClient` via an internal ctor (or a client-factory delegate) so the integration test can inject the Azurite shared-key client while production uses the account+credential path.
+
+## Non-goals (deferred)
+
+- Guided Azure Providers setup page + DataProtection-encrypted `ProviderCredentialEntity` storage of the cert.
+- Workload-identity-federation and client-secret credential kinds.
+- Per-user permission resolution / search filtering (Phase 4, #479).
+- Live-watch for Azure Blob.

--- a/docs/superpowers/specs/2026-09-06-azure-phase3-entra-user-link-design.md
+++ b/docs/superpowers/specs/2026-09-06-azure-phase3-entra-user-link-design.md
@@ -1,0 +1,76 @@
+# Azure Phase 3 — Entra user identity link
+
+**Status:** Design — approved in brainstorming, pending spec review
+**Date:** 2026-09-06
+**Milestone:** v0.4.0 · Issue #478 · Epic #475
+**Branch:** `feature/478-entra-user-link` (off `epic/azure-blob-provider`; Phase 2 merged)
+**Parent design:** `docs/superpowers/specs/2026-09-05-azure-blob-provider-design.md` §B. This phase spec refines §B with the phase-specific decisions; where they differ, this document governs Phase 3.
+
+## Goal
+
+Let a signed-in Connapse user link their Microsoft Entra identity on the integrations page: a one-time OIDC proof that captures **`oid` + `tid`**, stores only those, and is user-revocable. **Permanent** (two GUIDs, nothing that expires). This mirrors the AWS SAML → `UserAwsIdentityLinkEntity` link. Nothing consumes the link yet — the per-user permission engine (Phase 4, #479) reads it.
+
+## Scope decisions (from brainstorming)
+
+1. **Link only.** Phase 3 establishes/stores/revokes the link. The query-time Graph checks it enables — the `accountEnabled` deprovisioning gate and transitive security-group resolution — are **deferred to Phase 4**, which consumes them. (Mirrors how AWS linking existed before `AwsSearchScopeResolver`.)
+2. **New table.** A dedicated `UserAzureIdentityLinkEntity` mirroring `UserAwsIdentityLinkEntity`, with a fresh EF migration. The `user_cloud_identities` table dropped in Phase 1 stays gone.
+3. **Explicit endpoints + auth-code + PKCE + certificate.** A secondary account-*link* flow (the user is already authenticated in Connapse), NOT app login — so **no** `Microsoft.Identity.Web`, **no** second ASP.NET auth scheme. Two plain endpoints mirror the AWS SAML `/aws/connect`→`/aws/acs`. Config lives in a dedicated `Identity:AzureAd` settings record, separate from Phase 2's `Providers:Azure` (the app's data-plane credential).
+4. **Certificate, not client secret.** The `/azure/callback` code redemption is a confidential-client call, so Entra requires a client credential; PKCE is layered on top (not a replacement — verified against Microsoft docs). Use a **certificate** (Microsoft-recommended over a secret), stored DataProtection-encrypted, mirroring the AWS/Phase-2 stored-private-material pattern.
+
+## Components
+
+### A. Link storage (Connapse.Identity)
+
+- **`UserAzureIdentityLinkEntity`** (`Data/Entities/`): `Id (Guid)`, `UserId (Guid)`, `ObjectId (string, the Entra oid)`, `TenantId (string, tid)`, `DisplayName (string?, from id_token name/preferred_username — display only, mutable)`, `ConnectedAt (DateTime)`. Unique index on `UserId` (one Azure link per user). Mirror `UserAwsIdentityLinkEntity`'s shape/conventions.
+- **`AzureIdentityLinkStore`** + **`IAzureIdentityLinkReader`** (persistence; the reader interface is what Phase 4 will consume) and **`AzureIdentityLinkService`** + **`IAzureIdentityLinkService`** (`GetAsync(userId) → AzureIdentityLinkDto?`, `StoreAsync(userId, oid, tid, displayName)`, `DisconnectAsync(userId)`), mirroring `AwsIdentityLinkService`/`AwsIdentityLinkStore`. `AzureIdentityLinkDto` (oid, tid, displayName, ConnectedAt) in Core.
+- **Migration:** `dotnet ef migrations add AddUserAzureIdentityLinks --project src/Connapse.Identity` (ConnapseIdentityDbContext). Add the `DbSet` + mapping + `ConnapseUser` navigation.
+
+### B. Sign-in settings (Connapse.Core)
+
+- **`AzureAdSignInSettings`** (`Models/`), `SectionName = "Identity:AzureAd"`: `TenantId` (a specific tenant id, or `organizations`/`common`), `ClientId`, `RedirectUri` (the `/azure/callback` absolute URL Connapse advertises), and the certificate for code redemption — `ClientCertificatePath` (+ optional password) OR a DataProtection-encrypted stored cert (Phase 3 reads from config/path, consistent with Phase 2's `AzureProviderSettings` cert loading; a Providers-page-managed encrypted cert is a later concern). An `IsConfigured` helper. Bound from configuration; `DatabaseSettingsProvider.CategoryPrefixMap` gets `["azuread"] = "Identity:AzureAd"`.
+- Reuse the Phase-2 cert-loading helper (PEM/PFX) rather than duplicating it.
+
+### C. OIDC link endpoints (Connapse.Web)
+
+Add to the existing `CloudIdentityEndpoints` group (which already holds the AWS `/aws/*` routes), mirroring their structure — **including the AWS `/acs` → `/confirm` two-step**, not just the outer connect/callback shape. This is a correction to this spec's original draft, which described a single callback that validated the id_token and stored the link directly; a security review during implementation (#478) found that shape lets one Connapse account get linked to a *different* Entra identity than the one it started sign-in with, and the fix is the same confirm hop AWS already uses for the identical reason:
+
+- **`GET /api/v1/auth/cloud/azure/connect`** (authenticated): builds the Entra authorization URL for the configured tenant — `authorize` endpoint, `client_id`, `redirect_uri`, `response_type=code`, `scope=openid profile`, `response_mode=query`, a random `state`, a `nonce`, and a **PKCE** `code_challenge` (S256). Stash `{state → (code_verifier, nonce, connapse userId)}` in a short-lived server-side pending store (mirror `SamlSignInRequests` → `AzureSignInRequests`, in-memory with expiry). Redirect the browser to the authorization URL.
+- **`GET /api/v1/auth/cloud/azure/callback?code=&state=`** (anonymous — mirrors why `/aws/acs` is anonymous, see rationale below): look up + remove the pending entry by `state` (reject unknown/expired → error redirect); POST the `code` to Entra's **token** endpoint with `client_id`, `redirect_uri`, `code`, `grant_type=authorization_code`, the **PKCE `code_verifier`**, and the **client certificate assertion** (`client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer` + a signed JWT client assertion from the cert) to obtain the `id_token`; **validate** the id_token (Entra JWKS signature, issuer for the tenant, audience == client_id, `nonce` match, expiry) using `Microsoft.IdentityModel.Tokens` (already present via ITfoxtec — no new package); extract `oid` + `tid` (+ display name). **Does not call `StoreAsync` here.** Instead, park the validated `(startedByUserId, oid, tid, displayName)` under a one-time code (`AzureLinkConfirmations`, an `IMemoryCache`-backed park mirroring `SamlLinkConfirmations`), set that code as an `HttpOnly` cookie (`__connapse_azure_link`, path-scoped to `/api/v1/auth/cloud/azure`, `SameSite=Lax`, lifetime matching the park's 5 minutes), and redirect to `/azure/confirm`. All failures (including the exchange/validation ones above) → integrations page with a generic error message, and **discard the exception detail server-side only** (log it; never put it in the redirect a browser can carry in history). **Fail closed:** any failure — or any unhandled exception anywhere in this handler — stores and parks nothing.
+- **`GET /api/v1/auth/cloud/azure/confirm`** (authenticated — this is where `StoreAsync` actually happens): reached by the same-site top-level redirect from `/callback`, so the session cookie is present alongside the confirm cookie. Read + delete the confirm cookie; require a session (401 if none); consume the parked entry by code (single-use; unknown/already-consumed → error redirect); **if the parked entry's `startedByUserId` does not equal the signed-in user's id, refuse and store nothing** (this is the check that closes the CSRF below); otherwise `StoreAsync(userId, oid, tid, displayName)` and redirect to the integrations page (success).
+- **Disconnect:** the existing `DELETE /{provider}` route already dispatches by provider — add the `Azure` branch calling `AzureIdentityLinkService.DisconnectAsync` (Phase 1 removed the old Azure arm; re-add it pointing at the new service).
+
+**Why the confirm hop is required even though `/callback` is a same-site redirect (unlike AWS's cross-site POST).** `state` only proves the callback belongs to a sign-in this deployment started — it does not prove the browser completing it is the browser that started it. Anybody with a Connapse account (the attacker) can call `/azure/connect` and capture the resulting Entra authorization URL **without following it**, then send that URL to a colleague (the victim). The colleague authenticates at Entra with their own credentials; PKCE binds the authorization code to the *verifier*, not to a person, so the code redemption at `/callback` succeeds regardless of who completes it; the id_token's `nonce` matches because it genuinely was in the request the colleague completed. Every check on the token passes, because the token is real — the forgery is in the pairing between "who started this sign-in" and "whose Entra identity it resolved to." Storing at `/callback` directly would link the attacker's Connapse account to the colleague's Entra identity, which is a privilege-escalation vector once Phase 4 resolves search scope from these links. Parking the outcome and requiring the *session* at a follow-up same-site GET to match `startedByUserId` closes it: the attacker never receives the `HttpOnly` confirm cookie (it lands in the colleague's browser), and the colleague, who does hold it, is not the user the sign-in was started by — so neither can complete the link.
+
+Use `HttpClient` (a named client) for the token-endpoint call. The client-assertion JWT is signed with the configured certificate (`Microsoft.IdentityModel.Tokens` `SigningCredentials`).
+
+### D. UI (Connapse.Web)
+
+Add an **Azure card** to `ProfileIntegrations.razor` mirroring the AWS card: shows connected state (`oid`/tenant/display name/`ConnectedAt`) via `IAzureIdentityLinkService.GetAsync`, a **Connect** button (navigates to `/azure/connect`), and a **Disconnect** button (with confirm, calling the delete route). Reuse the AWS card's structure/styling.
+
+### E. DI + settings wiring (Connapse.Identity / Connapse.Web)
+
+- Register `IAzureIdentityLinkService`/`AzureIdentityLinkService`, `IAzureIdentityLinkReader`/`AzureIdentityLinkStore`, `AzureSignInRequests` (singleton pending store), `Configure<AzureAdSignInSettings>("Identity:AzureAd")`, and the named `HttpClient` for the token endpoint.
+- `DatabaseSettingsProvider.CategoryPrefixMap` += `["azuread"] = "Identity:AzureAd"`.
+- Documented empty `Identity:AzureAd` block in `appsettings.json`.
+
+## Testing
+
+- **Unit:** `AzureIdentityLinkService`/store round-trip (store → get → disconnect); `AzureAdSignInSettings.IsConfigured`; the authorization-URL builder (correct params, PKCE S256 challenge derived from verifier, state/nonce present); the id_token validator (a test-signed token with the right issuer/aud/nonce validates and yields oid/tid; wrong nonce/aud/expired → rejected, nothing stored); the PKCE verifier/challenge helper.
+- **Integration (`WebApplicationFactory` + shared Postgres fixture):** `GET /azure/connect` (configured) redirects to the tenant authorize endpoint with the expected query params and creates a pending entry; `/azure/callback` with an unknown/expired `state` → error redirect, no row; the happy path (same user starts and confirms) routed through `/callback` → `/confirm` stores the row and redirects to the integrations page; disconnect deletes the row and the migration applies cleanly. The **live token exchange** against Entra can't run in tests — factor the token-endpoint call behind a small `IOidcTokenExchanger` seam so the callback's validate-and-park logic is integration-tested with a faked exchange returning a test-signed id_token (mirrors how the connector's Azurite seam isolates the un-testable dependency).
+- **CSRF regression (added post-implementation, #478):** a pending entry started by user A, a valid id_token (via the faked exchanger) for a *different* Entra identity reached over a *different* Connapse user B's session at `/confirm`, must store nothing for either user and must burn the one-time confirm code (a second attempt with the same code, from any session, also fails). This is the test that would have caught the original single-callback design.
+- Fail-closed matrix: bad state, bad nonce, bad signature, wrong audience, expired, and now also **`startedByUserId` ≠ confirming session's user id** → each stores nothing and surfaces a generic error.
+
+## Testable seams (design-for-isolation)
+
+- `IOidcTokenExchanger.ExchangeAsync(code, codeVerifier) → rawIdToken` — the confidential-client token-endpoint POST + client-assertion signing; real impl uses `HttpClient` + the cert, tests inject a fake returning a signed test token. Keeps the callback's state/PKCE/validation/park logic unit- and integration-testable without Entra.
+- `AzureSignInRequests` (pending PKCE/nonce/state store) — a small, testable in-memory store with expiry (mirror `SamlSignInRequests`).
+- `AzureLinkConfirmations` (parked validated-outcome store, keyed by one-time code) — mirrors `SamlLinkConfirmations`; this is the seam that lets the callback's park step and the confirm step's `startedByUserId` check be exercised independently in tests, including the cross-user CSRF case.
+- Reuse Phase 2's PEM/PFX cert loader.
+
+## Non-goals (deferred)
+
+- The Graph `accountEnabled` deprovisioning gate and transitive group resolution (Phase 4, #479 — they're query-time enforcement).
+- Any per-user search filtering / scope resolution (Phase 4).
+- A guided Providers setup page for the Entra app registration + admin-consent generation (a later polish; Phase 3 documents the required registration in the spec/PR, config via settings).
+- Multi-tenant guest-user edge handling beyond storing the resource-tenant `oid`/`tid` (the correct key per the Phase-1 research); no cross-tenant correlation.
+- `Microsoft.Identity.Web`, a second auth scheme, and the OIDC implicit flow.

--- a/docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md
+++ b/docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md
@@ -1,0 +1,295 @@
+# Azure Phase 4 — Per-object query-time permission engine (Azure search filtering)
+
+**Status:** Design — pending spec review
+**Date:** 2026-09-06
+**Milestone:** v0.4.0 · Issue #479 · Epic #475
+**Parent design:** `docs/superpowers/specs/2026-09-05-azure-blob-provider-design.md` (§C engine, §D
+enforcement seam). This phase spec refines those sections into implementable components,
+interfaces, and a PR-sized decomposition; where they differ, this document governs Phase 4.
+
+## Goal
+
+Filter Azure Blob search results so a searcher sees only the blobs they may **currently** read,
+evaluated **live at query time** at parity with Azure's own authorization, failing closed. No
+ingestion-time permission capture, no new stored permission surface. The AWS/S3 path is untouched
+except to wrap it in a composite that both clouds share.
+
+This is the epic's last and hardest phase. It consumes the Entra identity link from Phase 3
+(`IAzureIdentityLinkReader` → `AzureIdentityRef(oid, tid)`) and the app identity from Phase 2
+(`ConnapseAzureCredentials`). When it lands, `epic/azure-blob-provider` merges to `main`.
+
+## Governing principle
+
+Every connector evaluates **per object**, at **parity** with the technology it fronts, and **fails
+closed** — never coarser than the object, never an over-grant. See the project invariant
+(`per-object-permission-principle`). Enforcement must be both **sound** and **complete**, and the
+distinction (settled with the user 2026-09-06) is the spine of this design:
+
+1. **Sound — never shows a file the user can't read.** Absolute. Every returned hit is either
+   admitted by an *exact* scope (RBAC container / flat) or passes **live forward-verification** of
+   the object's own ACL/tags. Anything uncertain fails closed.
+2. **Complete — the permission layer never drops a file the user *can* read.** The only thing that
+   decides whether a readable file *surfaces* is relevance ranking, which is out of scope for
+   permissions. The mechanism: **an exclusion filter may only ever *over*-approximate the user's
+   readable set (exact for RBAC/flat; container-level or none for Gen2 ACL), never *under*.** So no
+   approximation ever excludes a readable file — precision comes from live verify, not from
+   narrowing retrieval. This dissolves the old "Case C" gap: a read granted on a *file* inside a
+   folder the user can traverse but not read as a whole is retrieved by relevance and verified like
+   any other hit — it is never excluded by the folder-level approximation.
+
+Corollaries: under-grant (hiding a readable file) is a defect, not an acceptable shortcut — an ABAC
+tag grant we can't reduce to a prefix is verified live per hit, never dropped. We **read ACLs/tags
+live and never store them** (no ingest-time capture: it can't be kept fresh and would add a
+forbidden permission surface — Microsoft's own product takes that route and carries the staleness;
+see `azure-permission-trimming-precedent`). The **folder walk is an accelerator, not a gate** — it
+lets a hit already known readable skip verification; it never excludes.
+
+## Global constraints
+
+- **Live only.** No ingestion-time permission capture; no new persistence surface. Freshness =
+  cache TTL.
+- **Fail closed everywhere.** Any missing link, disabled account, fetch error, unparseable
+  condition, or deny assignment → deny (for the affected cloud), never `Unrestricted`.
+- **Reuse the provider-agnostic enforcement half.** `ISearchScopeResolver` → `SearchScopes` →
+  `GrantMatch` → the SQL prefix filter in `HybridSearchService`/`PgVectorStore`/
+  `KeywordSearchService` are already generic. Azure contributes a new resolver and a new
+  post-retrieval verifier; it does not reinvent enforcement.
+- **AWS behavior unchanged.** `AwsSearchScopeResolver` and its S3 path keep their exact current
+  behavior; they are wrapped, not modified.
+- **App identity is `Storage Blob Data Reader`** — read-only. RBAC supersedes ACLs for Connapse's
+  own identity, so it can read any path's ACL data to evaluate the *user's* access. Never elevate
+  to Data Owner (rules out the `suoid` probe as baseline).
+- **Never trust the token `groups` claim** (Entra drops it past ~200 groups) — resolve groups via
+  Graph.
+- **Connapse reads only** — never writes a grant, role, or ACL (`connapse-writes-grants`).
+- Cert-based Graph/ARM auth via `ConnapseAzureCredentials`; no client secrets.
+
+## Decomposition (each sub-issue is its own plan → SDD cycle, stacked on `epic/azure-blob-provider`)
+
+| # | Sub-issue | Delivers | End state |
+|---|---|---|---|
+| **4a** | Searcher identity resolution (Graph) | `IAzureDirectoryReader`: one Graph `$batch` → deprovisioning gate + transitive `getMemberGroups` → identity set **P**; cached ~5 min; fail-closed. | Library + tests |
+| **4b** | RBAC scope resolver (ARM) + ABAC | `IAzureRbacReader`: `roleAssignments?assignedTo` ∥ `denyAssignments`, `effective = grants − denies`, 3 hard-coded role GUIDs, ABAC path→prefix parse (tag conditions flagged as residue). Cached ~5 min. | Library + tests |
+| **4c** | Flat resolver + composite + per-cloud enforcement | `AzureSearchScopeResolver : ISearchScopeResolver` (composes 4a+4b, `azblob://` normalizer); `CompositeSearchScopeResolver` (AWS ∪ Azure, per-cloud fail-closed, per-scheme unrestricted); generalize the enforcement latch beyond SAML. **Flat (non-HNS) accounts filter end-to-end.** | Flat correct e2e |
+| **4d** | Gen2 ancestor-traverse resolver + POSIX ACL engine | Pure, unit-testable POSIX first-match evaluator (owner/named/group/other + mask) and a lazily-cached ancestor-traverse resolver (mode bits via `GetPaths`/properties; `GetAccessControl` only for named-entry tie-breaks). No skip-verify from folders, no exclusion. | Library + tests |
+| **4e** | Gen2 live per-hit verify seam | New post-retrieval `ISearchResultVerifier`; retrieve Gen2 by relevance over a safe over-approximation, then live-verify **every** non-RBAC hit with 4d — Gen2 file ACL (HNS) and blob-tag (flat ABAC). Over-fetch/backfill until page full; bounded parallelism. Completes soundness **and** completeness. | **epic → main** |
+
+4a/4b are pure fail-closed libraries. 4c makes flat storage correct end-to-end (the common case).
+4d is the pure Gen2 evaluation engine; 4e wires it into the pipeline as the live per-hit verifier.
+Only an exact RBAC role skips verification — folder access never does — so the epic gates on 4e's
+verify being in place before Azure filtering reaches `main`.
+
+## Component design
+
+### A. Searcher identity resolution — Graph (4a)
+
+**`IAzureDirectoryReader`** (Core):
+```
+Task<AzureIdentitySet> ResolveAsync(AzureIdentityRef link, CancellationToken ct);
+```
+`AzureIdentitySet` (Core record): `{ bool Enabled, IReadOnlyList<string> PrincipalOids, IdentityOutcome Outcome }`.
+`PrincipalOids` = {user oid} ∪ {transitive security-group oids}. `Outcome` ∈
+{`Resolved`, `Deprovisioned`, `Failed`}. Failure/deprovisioned → `Enabled=false`, empty oids.
+
+**`GraphDirectoryReader`** (Storage) — one Graph `$batch` (≤20 subrequests) on
+`ConnapseAzureCredentials`, scope `https://graph.microsoft.com/.default`:
+- **Deprovisioning gate:** `GET /users/{oid}?$select=id,accountEnabled` — 404 or
+  `accountEnabled==false` → `Deprovisioned`, deny everything.
+- **Groups:** `POST /users/{oid}/getMemberGroups {securityEnabledOnly:true}` — one transitive
+  call, GUIDs only.
+- Cache the resolved set ~5 min keyed by oid (`IMemoryCache`, key `azure-identity:{oid}`); cache
+  only confident answers (`Resolved`/`Deprovisioned`), never `Failed`. Mirror
+  `AwsSearchScopeResolver`'s caching discipline.
+
+### B. RBAC scope resolver — ARM + ABAC (4b)
+
+**`IAzureRbacReader`** (Core):
+```
+Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct);
+```
+`AzureRbacScopes` (Core record): `{ IReadOnlyList<AzureScope> ReadablePrefixes,
+IReadOnlyList<AzureTagCondition> TagConditioned, RbacOutcome Outcome }`.
+
+**`ArmRbacReader`** (Storage) — one ARM call plus a parallel deny call, api-version `2022-04-01`,
+on `ConnapseAzureCredentials` (scope `https://management.azure.com/.default`):
+- `GET .../providers/Microsoft.Authorization/roleAssignments?$filter=atScope() and assignedTo('{oid}')`
+  — `assignedTo` is **transitive over the user's groups**, so this single call returns every
+  role assignment reaching the user (no per-group fan-out).
+- In parallel, `.../denyAssignments` with the same filter. **effective = grants − denies** (deny
+  wins; a missing deny call → `Failed`, not "assume none" — ignoring a deny fails open).
+- Match each assignment's role-definition id against three hard-coded built-in GUIDs: Reader
+  `2a2b9908-6ea1-4ae2-8e65-a410df84e7d1`, Contributor `ba92f5b4-2d11-453d-a403-e96b0029c9fe`,
+  Owner `b7e6dc6d-f1e8-4753-8033-0f276bb0955b` (only these grant blob **data** read).
+- Translate each surviving assignment's scope to an `azblob://{account}/{container}[/{prefix}]`
+  scope, applying its ABAC `condition`:
+  - **path/name condition** → narrow to a prefix predicate (a `ReadablePrefix`).
+  - **blob-index-tag condition** → cannot reduce to a prefix; emit an `AzureTagCondition`
+    (container/path scope + the tag predicate) for **live per-hit verification** (§E), never
+    excluded.
+  - **unparseable condition** → drop that assignment (fail closed).
+- Cache ~5 min keyed by oid (`azure-rbac:{oid}`), confident answers only.
+
+### C. Flat resolver + composite + per-cloud enforcement (4c)
+
+**`AzureSearchScopeResolver : ISearchScopeResolver`** (Storage): given `userId`, resolve the link
+(`IAzureIdentityLinkReader`), the identity set (4a), and the RBAC scopes (4b); for a **flat
+account** the RBAC prefix set *is* the answer ("read one blob in container C ⇒ read all of C").
+Normalize each `azblob://` scope to a `GrantMatch` (exact for a whole-container/blob grant,
+prefix otherwise) and return `SearchScopes.Of(matches)`. Per-user cache (`azure-scopes:{userId}`,
+~60 s, confident answers only), fail-closed throughout — mirror `AwsSearchScopeResolver` exactly.
+Tag-conditioned grants contribute their broad scope as a retrieval over-approximation and are
+verified live per hit (§E), never excluded.
+
+**`CompositeSearchScopeResolver : ISearchScopeResolver`** (Search or Core): registered as *the*
+`ISearchScopeResolver`; `AwsSearchScopeResolver` and `AzureSearchScopeResolver` become its inner
+resolvers. Combine rule (per-cloud fail-closed, per-scheme):
+- Each cloud governs its own URI scheme (`s3://`, `azblob://`); non-cloud docs (`resource_uri
+  IS NULL`) are always visible.
+- A cloud whose identity provider is **configured** (enforcing) contributes its per-user scopes,
+  fail-closed empty on error/no-link — so its scheme's docs are hidden unless a scope admits them.
+- A cloud whose provider is **not configured** (not enforcing) leaves its scheme **unrestricted**
+  (that content is ungoverned in this deployment) — matching how AWS already behaves when SAML is
+  unconfigured.
+- Global `Unrestricted` only when **no** cloud is enforcing (single-user/dev mode).
+- One cloud's `Failed`/error never denies the other cloud's legitimately-granted docs, and one
+  cloud's `Unrestricted` never leaks to the other cloud's scheme.
+
+This requires making the scope→SQL plumbing **per-scheme aware**: the composite yields, per
+scheme, either "unconstrained" or "matches one of this scheme's prefixes." `PgVectorStore` and
+`KeywordSearchService` filter builders gain a per-scheme predicate; the existing AWS-only shape is
+the single-scheme case of it. `PermissionEnforcementSettings`/`EnforcementMigration` (today gated
+on `SamlSignInSettings.IsConfigured`) generalize to "enforcing if *any* cloud provider
+configured," with an Azure enforcement latch mirroring `SamlEnforcementLatch`. **This is the
+trickiest integration point; its exact predicate table and combine matrix are finalized in the 4c
+plan with tests.**
+
+### D. Gen2 ancestor-traverse resolver (verify support) (4d)
+
+Reading a Gen2 file requires traverse-`X` on **every** ancestor directory **and** read-`R` on the
+**file's own** ACL. ADLS ACLs are **copy-at-create, not live-inherited**, so a file's own ACL can be
+tighter (or looser) than its directory chain — which means **folder access never proves file
+access**, in either direction. Two consequences fix the model:
+- **No skip-verify from folders.** Only an *exact RBAC role* (which supersedes ACLs entirely) lets a
+  hit skip per-object verification. A readable folder does **not** — a locked-down file beneath it
+  must still be dropped, so every Gen2 hit not covered by RBAC is verified in §E.
+- **No exclude from folders.** An approximation never excludes (governing principle #2), so the
+  folder structure is not a retrieval filter either.
+
+4d therefore provides only the **ancestor-traverse decisions** that §E's per-file verify needs:
+given a candidate file, resolve whether P holds `X` on each ancestor directory. Resolve **lazily
+per candidate** and cache by directory (mode bits from a targeted `GetPaths`/properties read;
+`GetAccessControl` on a directory only when a named entry could be decisive), so candidates sharing
+ancestors share the work. An optional bulk pre-warm — one recursive directories-only
+`GetPaths(recursive:true)` (owner/group/mode octal bits, 5 000/page) — can populate the ancestor
+cache up front for accounts where it pays off, but it is a performance option, never required for
+correctness. Cache traverse decisions ~30–120 s.
+
+### E. Gen2 live per-hit verify seam (4e)
+
+For HNS accounts, Gen2 content is admitted by **relevance over a safe over-approximation** and
+decided by **live forward-verification** — never excluded by the folder-walk approximation
+(governing principle #2). This is what makes enforcement *complete*: the only thing that limits
+which readable files appear is relevance, never the permission layer.
+
+**Retrieval.** Gen2 candidates are retrieved by relevance, filtered only by an over-approximation
+that can never drop a readable file: exact RBAC/flat scopes where they apply, otherwise the
+container(s) the user has any foothold in (or unfiltered across HNS containers). The folder
+structure is never used to narrow retrieval.
+
+**Verify seam.** Add **`ISearchResultVerifier`** (Core): given the retrieved hits plus the resolved
+Azure context (exact RBAC scopes, tag conditions, identity set P, and the 4d ancestor-traverse
+resolver), return the subset that passes live per-object verification. Register a **no-op default**
+(AWS-only
+deployments). `HybridSearchService` calls it after retrieval, **over-fetching and backfilling**
+until the page is full or candidates are exhausted (so a batch full of non-readable hits never ends
+the results early), with **bounded parallelism** (`SemaphoreSlim`/`Parallel.ForEachAsync`, degree
+~16–64) and SDK exponential-backoff retries honoring `503`/`Retry-After`.
+
+Routing per `azblob://` hit:
+- Covered by an **exact RBAC scope** → **pass**, no per-hit call (RBAC supersedes ACLs).
+- **HNS**, otherwise → **verify the file's own ACL:** self-compute the documented POSIX first-match
+  on the file's **own** access ACL against P (owner bypasses mask; named user/group capped by mask;
+  any one group granting suffices) **and** confirm P holds traverse-`X` on every ancestor (4d,
+  cached). Mode-bit short-circuit first; `GetAccessControl` only when a named entry could be
+  decisive. Fail → drop. This one check both surfaces a bespoke per-file grant ("Case C") *and* drops
+  a locked-down file beneath a readable folder — folder access is never trusted.
+- **Flat**, under a **tag condition** → **tag verify:** evaluate the blob's index tags against the
+  condition (`GetBlobTags` per hit, or bulk `FindBlobsByTags` for the query's candidates). Fail → drop.
+- AWS/`s3://` and non-cloud hits → pass untouched (never enter the Azure verifier).
+
+Fail → drop and backfill. Cache per-file ACL/tag decisions for the query's lifetime; short
+cross-query TTL optional. A deployment that wants to trade cost for even tighter retrieval can opt a
+Gen2 account into pure retrieve-then-verify (no over-approximation narrowing at all) — completeness
+is identical, only the candidate volume differs.
+
+## Interfaces & seams
+
+| Interface | Layer | New/Reused | Role |
+|---|---|---|---|
+| `ISearchScopeResolver`, `SearchScopes`, `GrantMatch`, `ScopeResolution.Guard` | Core | Reused | Provider-agnostic scope model (retrieval filter) |
+| `IAzureIdentityLinkReader` → `AzureIdentityRef` | Core | Reused (Phase 3) | userId → oid/tid |
+| `IAzureDirectoryReader` → `AzureIdentitySet` | Core | New (4a) | oid → identity set P + deprovision gate |
+| `IAzureRbacReader` → `AzureRbacScopes` | Core | New (4b) | P → readable prefixes + tag residue |
+| `AzureSearchScopeResolver` | Storage | New (4c) | Azure `ISearchScopeResolver` |
+| `CompositeSearchScopeResolver` | Search/Core | New (4c) | AWS ∪ Azure, per-cloud/scheme |
+| `ISearchResultVerifier` (+ no-op default) | Core | New (4e) | Post-retrieval live per-hit verify |
+| Gen2 POSIX ACL engine + ancestor-traverse resolver | Storage | New (4d) | Per-file read/traverse decision |
+| Gen2 file-ACL verifier, tag verifier | Storage | New (4e) | Per-hit parity (ACL + tags) |
+| `PermissionEnforcementSettings` / `EnforcementMigration` | Core | Reused, generalized (4c) | Per-cloud enforcement latch |
+
+## Caching & throttling
+
+User→identity-set (~5 min), effective RBAC scopes (~5 min), directory-ACL/traverse (~30–120 s),
+per-user composite scopes (~60 s, = revocation delay). Warm-cache per-query control-plane cost ≈ 0;
+cold ≈ 2–4 calls. Only confident answers cached; failures/denials never cached. Data-plane ACL/tag
+reads on a miss use bounded parallelism well under the 20 000 req/s account ceiling; watch
+hot-partition risk on deeply-nested shared directories.
+
+## Fail-closed matrix (cloned/extended from `AwsSearchScopeResolverTests`)
+
+Deny (Azure scheme, never `Unrestricted`) on: no link; Graph 404 / `accountEnabled==false`;
+Graph/ARM throws or times out; deny assignment covering a scope; unparseable ABAC condition;
+enforcement configured-but-unusable. Distinguish **no-grants** (empty, valid) from **failure**
+(fail closed) — both hide Azure docs but only one is cacheable. Never trust the token `groups`
+claim. Per-cloud isolation: an Azure failure must not hide AWS-granted or non-cloud docs.
+
+## Testing strategy
+
+- **4a/4b/4c** — unit fail-closed matrices with faked Graph/ARM readers (mirror
+  `AwsSearchScopeResolverTests`); composite combine matrix (per-cloud, per-scheme) as unit tests;
+  flat end-to-end SQL filtering as an integration test mirroring `SearchScopeEnforcementTests`.
+- **4d** — POSIX first-match matrix (owner bypasses mask; named user/group capped by mask; any one
+  group suffices; "other"); ancestor-traverse resolution (lose `X` on the chain → unreadable),
+  named-entry tie-break fallback, cache.
+- **4e** — verifier drop/backfill; **completeness** (a bespoke per-file "Case C" grant beneath an
+  unreadable folder is retrieved and returned) and **soundness** (a locked-down file beneath a
+  readable folder is dropped); tag-verify; and that exact-RBAC and AWS/flat hits skip verification.
+- Azurite integration where it can exercise the data plane; control-plane (Graph/ARM) covered by
+  faked readers, as Azurite cannot authenticate AAD tokens.
+
+## Resolved open questions (from the parent spec)
+
+- **Deny assignments** — resolve `denyAssignments` in parallel always; `effective = grants − denies`.
+  A missing deny call fails closed (ignoring a deny fails open). Not "assume none."
+- **ABAC blob-index-tag grants** — evaluated **live per hit** (`GetBlobTags`/`FindBlobsByTags`),
+  never excluded (under-grant), never captured at ingest.
+- **Case C recall (Gen2)** — **dissolved.** Because the folder-walk approximation is only an
+  accelerator and never an exclusion filter (§D/§E, governing principle #2), a bespoke per-file
+  grant is retrieved by relevance and live-verified like any other hit — the permission layer never
+  drops it. Not solved by any stored/ingest-time capture (no reverse Azure API exists; a stored
+  booster can't be kept fresh and would add a forbidden permission surface). See
+  `azure-permission-trimming-precedent`.
+- **`suoid` probe** — non-goal (needs Data Owner; group behavior undocumented).
+- **Composite semantics** — per-cloud fail-closed, per-scheme unrestricted (§C).
+- **Cache TTLs** — group-set/RBAC ~5 min, directory-ACL ~30–120 s, composite ~60 s; tunable.
+- **`checkAccess`** — not relied upon.
+- **`user_cloud_identities` table** — resolved in Phase 3 (new `UserAzureIdentityLinkEntity`).
+
+## Non-goals
+
+- ABAC arbitrary-expression parsing beyond the canonical path/tag templates (unparseable → fail
+  closed).
+- The `suoid` server-side probe as baseline.
+- Ingestion-time permission capture / any new stored permission surface.
+- Any write to customer Azure authorization (grants/roles/ACLs).
+- Touching the AWS provider's mechanism (it already satisfies the invariant; it is only wrapped).

--- a/docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md
+++ b/docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md
@@ -111,22 +111,38 @@ Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct);
 IReadOnlyList<AzureTagCondition> TagConditioned, RbacOutcome Outcome }`.
 
 **`ArmRbacReader`** (Storage) — one ARM call plus a parallel deny call, api-version `2022-04-01`,
-on `ConnapseAzureCredentials` (scope `https://management.azure.com/.default`):
-- `GET .../providers/Microsoft.Authorization/roleAssignments?$filter=atScope() and assignedTo('{oid}')`
-  — `assignedTo` is **transitive over the user's groups**, so this single call returns every
-  role assignment reaching the user (no per-group fan-out).
-- In parallel, `.../denyAssignments` with the same filter. **effective = grants − denies** (deny
-  wins; a missing deny call → `Failed`, not "assume none" — ignoring a deny fails open).
-- Match each assignment's role-definition id against three hard-coded built-in GUIDs: Reader
-  `2a2b9908-6ea1-4ae2-8e65-a410df84e7d1`, Contributor `ba92f5b4-2d11-453d-a403-e96b0029c9fe`,
-  Owner `b7e6dc6d-f1e8-4753-8033-0f276bb0955b` (only these grant blob **data** read).
-- Translate each surviving assignment's scope to an `azblob://{account}/{container}[/{prefix}]`
-  scope, applying its ABAC `condition`:
-  - **path/name condition** → narrow to a prefix predicate (a `ReadablePrefix`).
-  - **blob-index-tag condition** → cannot reduce to a prefix; emit an `AzureTagCondition`
-    (container/path scope + the tag predicate) for **live per-hit verification** (§E), never
-    excluded.
-  - **unparseable condition** → drop that assignment (fail closed).
+on `ConnapseAzureCredentials` (scope `https://management.azure.com/.default`), at the
+**subscription scope** (`AzureProviderSettings.SubscriptionId`, added this phase; absent → `Failed`):
+- `GET /subscriptions/{sub}/providers/Microsoft.Authorization/roleAssignments?api-version=2022-04-01&$filter=assignedTo('{oid}')`
+  — **without** `atScope()`. Corrects the parent design: the docs state `atScope()` lists "only the
+  specified scope, **not including the role assignments at subscopes**", so it would miss
+  account- and container-scoped grants (the common case). A plain subscription-scope list includes
+  assignments at the scope, its ancestors (inherited), **and** its descendants (RG / account /
+  container). `assignedTo` is **transitive over the user's groups**, so this single call returns
+  every role assignment reaching the user (no per-group fan-out).
+- In parallel, `.../denyAssignments?...&$filter=assignedTo('{oid}')`. **effective = grants − denies**
+  (deny wins; a missing/failed deny call → `Failed`, not "assume none" — ignoring a deny fails open).
+  Conservative & sound: any deny assignment whose scope covers (is equal to or an ancestor of) a
+  grant's scope and whose (data)actions include the blob read action removes/trims that grant; when
+  a deny's applicability is uncertain, drop the overlapping grant (under-grant, never over-grant).
+- Match each assignment's `roleDefinitionId` (last GUID segment) against three hard-coded built-in
+  GUIDs: Reader `2a2b9908-6ea1-4ae2-8e65-a410df84e7d1`, Contributor
+  `ba92f5b4-2d11-453d-a403-e96b0029c9fe`, Owner `b7e6dc6d-f1e8-4753-8033-0f276bb0955b` (only these
+  grant blob **data** read).
+- Translate each surviving assignment's `scope` to an `azblob://` prefix:
+  `.../storageAccounts/{acct}/blobServices/default/containers/{c}` → `azblob://{acct}/{c}/`;
+  `.../storageAccounts/{acct}` → `azblob://{acct}/`; a broader scope (RG / subscription /
+  management group) covers every account under it → `azblob://` (matches all accounts). Then apply
+  its ABAC `condition`:
+  - **path condition** (`@Resource[...blobs:path] StringLike/StringStartsWith '<p>'`) → narrow to a
+    prefix (`azblob://{acct}/{c}/<p>`), stripping a trailing `*`.
+  - **container-name condition** (`@Resource[...containers:name] StringEquals '<c>'`) → narrow the
+    account/broader scope to that container.
+  - **blob-index-tag condition** (`@Resource[...blobs/tags:<key>...] ...`) → cannot reduce to a
+    prefix; emit an `AzureTagCondition` (scope + the tag predicate) for **live per-hit
+    verification** (§E), never excluded.
+  - **unparseable condition** → drop that one assignment (fail closed for that grant; the rest still
+    count).
 - Cache ~5 min keyed by oid (`azure-rbac:{oid}`), confident answers only.
 
 ### C. Flat resolver + composite + per-cloud enforcement (4c)

--- a/docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md
+++ b/docs/superpowers/specs/2026-09-06-azure-phase4-permission-engine-design.md
@@ -309,3 +309,26 @@ claim. Per-cloud isolation: an Azure failure must not hide AWS-granted or non-cl
 - Ingestion-time permission capture / any new stored permission surface.
 - Any write to customer Azure authorization (grants/roles/ACLs).
 - Touching the AWS provider's mechanism (it already satisfies the invariant; it is only wrapped).
+
+## §E amendment — retrieval breadth decision (2026-09-07, settled with the user)
+
+§E left the Gen2 retrieval over-approximation open ("container(s) the user has a foothold in, or unfiltered across HNS containers"). **Decision: unfiltered — broad retrieve-then-verify, no HNS detection.**
+
+For an enforcing Azure user with a valid, non-deprovisioned identity, `AzureSearchScopeResolver` emits the **broad scheme wildcard `azblob://`** (retrieve every Azure candidate by relevance); all Azure tightening moves to the post-retrieval verifier. This is the only over-approximation that can retrieve a "Case C" file (ACL-granted, RBAC-less) wherever it lives, so completeness holds. It needs **no new Azure permission** (no ARM `isHnsEnabled`; the app stays `Storage Blob Data Reader` + the existing RBAC-read used by 4b).
+
+Consequence: 4c's flat filtering moves from the SQL prefix filter to the verifier's RBAC-coverage check. That check is **in-memory** against the user's already-resolved-and-cached (~5 min, per 4b) RBAC prefixes — no per-hit call, no new persistence (still live-only). Per-hit live reads happen only for hits **not** covered by RBAC: tag-conditioned (blob-tag read) or Gen2 ACL (file-ACL + ancestor traverse). On a flat account a Gen2 ACL read fails → null → drop (fail closed). Rejected alternative: foothold-scoped retrieval + ARM HNS detection — lower verify volume but a new control-plane permission and a Case-C recall gap.
+
+### §E amendment 2 — blob-tag read permission prerequisite (2026-09-07)
+
+Live tag verification (`GetBlobTags`, for ABAC tag-conditioned grants) needs the data action
+`Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read`, which the built-in
+**Storage Blob Data Reader** role does not include. Connapse cannot grant it to itself — it never
+writes roles or grants (`connapse-writes-grants`) and its identity has no role-assignment right — so
+this is a **deployment prerequisite**: the app registration's role assignment must include
+`blobs/tags/read` (add it via a small custom role bundling `blobs/read` + `blobs/tags/read`, or an
+additional assignment). It is a data-plane **read** action, still read-only (never Data Owner).
+
+Fail-closed either way: without it, `GetBlobTags` returns 403 → the reader returns null → the
+verifier falls through to the Gen2 ACL check (§E amendment 1 routing). So a tag-conditioned file that
+is **also** ACL- or RBAC-readable still surfaces; only a file readable **solely** via a matching tag
+condition (ACL denies it) is dropped until the permission is granted. Never an over-grant.

--- a/src/Connapse.Core/CloudScope/AzureTagConditionEvaluator.cs
+++ b/src/Connapse.Core/CloudScope/AzureTagConditionEvaluator.cs
@@ -1,0 +1,35 @@
+namespace Connapse.Core;
+
+/// <summary>
+/// Evaluates a blob's index tags against an <see cref="AzureTagCondition"/> (an RBAC ABAC grant that
+/// could not reduce to a prefix, carried as residue by 4b). Pure; used by the Phase 4e verifier per
+/// hit. A missing key fails closed.
+/// </summary>
+public static class AzureTagConditionEvaluator
+{
+    public static bool Matches(AzureTagCondition condition, IReadOnlyDictionary<string, string> blobTags)
+    {
+        ArgumentNullException.ThrowIfNull(condition);
+        ArgumentNullException.ThrowIfNull(blobTags);
+
+        string? value = FindValue(condition.TagKey, condition.KeyCaseSensitive, blobTags);
+        if (value is null)
+            return false;
+
+        StringComparison valueCmp = condition.ValueCaseSensitive
+            ? StringComparison.Ordinal
+            : StringComparison.OrdinalIgnoreCase;
+        return string.Equals(value, condition.TagValue, valueCmp);
+    }
+
+    private static string? FindValue(string key, bool keyCaseSensitive, IReadOnlyDictionary<string, string> tags)
+    {
+        if (keyCaseSensitive)
+            return tags.TryGetValue(key, out string? v) ? v : null;
+
+        foreach (KeyValuePair<string, string> t in tags)
+            if (string.Equals(t.Key, key, StringComparison.OrdinalIgnoreCase))
+                return t.Value;
+        return null;
+    }
+}

--- a/src/Connapse.Core/CloudScope/PosixAclEvaluator.cs
+++ b/src/Connapse.Core/CloudScope/PosixAclEvaluator.cs
@@ -1,0 +1,68 @@
+// src/Connapse.Core/CloudScope/PosixAclEvaluator.cs
+namespace Connapse.Core;
+
+/// <summary>
+/// The documented POSIX ACL first-match check, as ADLS Gen2 applies it: class precedence
+/// owner &gt; named-user &gt; group-union &gt; other. The mask caps named users, the owning group,
+/// and named groups — never the owner or "other". A matched owner or named-user class is terminal
+/// (even when it denies); in the group class, any one matching entry that (masked) grants suffices.
+/// Pure and side-effect-free so it is exhaustively unit-testable.
+/// <para>
+/// The requester's own object id and their group object ids are <b>separate</b> parameters, matched
+/// against separate ACL classes: the owner and named-<i>user</i> classes only ever match the
+/// requester's own <paramref name="userOid"/>, and the owning-group and named-<i>group</i> classes
+/// only ever match <paramref name="groupOids"/>. Conflating them into one set would let group
+/// membership satisfy a user-typed ACE (e.g. an anomalous <c>user:&lt;group-oid&gt;</c> entry) —
+/// an over-grant relative to ADLS, which evaluates user entries by identity and group entries by
+/// membership.
+/// </para>
+/// </summary>
+public static class PosixAclEvaluator
+{
+    public static bool Grants(Gen2Acl acl, string userOid, IReadOnlySet<string> groupOids, Gen2Permission requested)
+    {
+        ArgumentNullException.ThrowIfNull(acl);
+        ArgumentNullException.ThrowIfNull(userOid);
+        ArgumentNullException.ThrowIfNull(groupOids);
+
+        // 1. Owner class — matched ONLY by the requester's own user oid; terminal, mask does not apply.
+        if (acl.OwnerOid is not null && acl.OwnerOid == userOid)
+            return Has(acl.OwnerPermissions, requested);
+
+        // 2. Named-user class — matched ONLY by the requester's own user oid; terminal, capped by mask.
+        foreach (Gen2NamedAce entry in acl.NamedUsers)
+        {
+            if (entry.Oid == userOid)
+                return Has(Capped(entry.Permissions, acl.Mask), requested);
+        }
+
+        // 3. Group class — owning group ∪ named groups, matched ONLY by group membership. Any one
+        //    that (masked) grants suffices; a match that grants nothing denies rather than falling
+        //    through to "other".
+        bool anyGroupMatch = false;
+        if (acl.OwningGroupOid is not null && groupOids.Contains(acl.OwningGroupOid))
+        {
+            anyGroupMatch = true;
+            if (Has(Capped(acl.OwningGroupPermissions, acl.Mask), requested))
+                return true;
+        }
+        foreach (Gen2NamedAce entry in acl.NamedGroups)
+        {
+            if (!groupOids.Contains(entry.Oid)) continue;
+            anyGroupMatch = true;
+            if (Has(Capped(entry.Permissions, acl.Mask), requested))
+                return true;
+        }
+        if (anyGroupMatch)
+            return false;
+
+        // 4. Other class.
+        return Has(acl.OtherPermissions, requested);
+    }
+
+    private static Gen2Permission Capped(Gen2Permission perms, Gen2Permission? mask) =>
+        mask is null ? perms : perms & mask.Value;
+
+    private static bool Has(Gen2Permission perms, Gen2Permission requested) =>
+        (perms & requested) == requested;
+}

--- a/src/Connapse.Core/Interfaces/IAzureBlobDiscovery.cs
+++ b/src/Connapse.Core/Interfaces/IAzureBlobDiscovery.cs
@@ -34,6 +34,9 @@ public record AzureProbe<T>(T? Value, AzureProbeOutcome Outcome, string? Detail 
 
     public static AzureProbe<T> Failed(string? detail = null) =>
         new(default, AzureProbeOutcome.Failed, detail);
+
+    public static AzureProbe<T> Unusable(string? detail = null) =>
+        new(default, AzureProbeOutcome.Unusable, detail);
 }
 
 public enum AzureProbeOutcome
@@ -47,7 +50,12 @@ public enum AzureProbeOutcome
     Denied = 2,
 
     /// <summary>Something else — a timeout, a network fault, an unexpected error.</summary>
-    Failed = 3
+    Failed = 3,
+
+    /// <summary>The identity is configured but cannot be used from this host: its certificate file
+    /// is missing or unreadable, or the configuration is only partly filled in. Nothing was asked of
+    /// Azure; fixing the file or the settings is the whole remedy.</summary>
+    Unusable = 4
 }
 
 /// <summary>
@@ -56,6 +64,27 @@ public enum AzureProbeOutcome
 /// </summary>
 public interface IAzureBlobDiscovery
 {
+    /// <summary>
+    /// Asks Entra for a token as Connapse's own identity, proving the credential is accepted:
+    /// the certificate is registered on the app and not expired, or the managed identity exists.
+    /// </summary>
+    /// <remarks>
+    /// Authentication only — a token is issued whether or not any role is assigned, so a pass
+    /// says "Entra accepts this identity", not "it can read a container". The value is a sentence
+    /// saying what was verified. <see cref="AzureProbeOutcome.Denied"/> means Entra refused the
+    /// credential itself (an <c>AADSTS</c> error), which only setting access up again can fix;
+    /// <see cref="AzureProbeOutcome.Failed"/> means the check could not complete.
+    /// </remarks>
+    Task<AzureProbe<string>> CheckAccessAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// The same check for settings that are not stored yet — a form about to be saved, or a
+    /// replacement certificate about to be promoted — so nothing that works is replaced by
+    /// something Entra rejects. Also used for the sign-in application, whose identity has the
+    /// same shape. Never answers from a cached token.
+    /// </summary>
+    Task<AzureProbe<string>> CheckAccessAsync(AzureProviderSettings candidate, CancellationToken ct = default);
+
     /// <summary>
     /// Every storage account in the configured subscription the identity may read metadata for.
     /// </summary>

--- a/src/Connapse.Core/Interfaces/IAzureBlobDiscovery.cs
+++ b/src/Connapse.Core/Interfaces/IAzureBlobDiscovery.cs
@@ -1,0 +1,70 @@
+namespace Connapse.Core.Interfaces;
+
+/// <summary>A storage account Connapse's identity can see, with what the connection form needs.</summary>
+/// <param name="Name">The account name.</param>
+/// <param name="BlobEndpoint">The primary blob endpoint, e.g. <c>https://name.blob.core.windows.net</c>.</param>
+/// <param name="ResourceGroup">The resource group it lives in, for telling same-named accounts apart.</param>
+/// <param name="ResourceId">The ARM resource id — the scope a role assignment is written against.</param>
+/// <param name="IsHnsEnabled">Whether the account is Data Lake Gen2 (hierarchical namespace), whose
+/// per-user permissions are POSIX ACLs rather than RBAC alone.</param>
+public record AzureStorageAccountInfo(
+    string Name,
+    string BlobEndpoint,
+    string ResourceGroup,
+    string ResourceId,
+    bool IsHnsEnabled);
+
+/// <summary>
+/// The outcome of asking Azure something, separating the cases that need different advice: it
+/// worked, Connapse has no Azure identity configured, or it has one and Azure refused.
+/// </summary>
+/// <remarks>Mirrors <see cref="AwsProbe{T}"/>; the same three-way split matters for the same reason —
+/// "set up the identity" and "grant the identity a role" send the operator to different places.</remarks>
+public record AzureProbe<T>(T? Value, AzureProbeOutcome Outcome, string? Detail = null)
+{
+    public bool Succeeded => Outcome == AzureProbeOutcome.Succeeded;
+
+    public static AzureProbe<T> Ok(T value) => new(value, AzureProbeOutcome.Succeeded);
+
+    public static AzureProbe<T> NotConfigured(string? detail = null) =>
+        new(default, AzureProbeOutcome.NotConfigured, detail);
+
+    public static AzureProbe<T> Denied(string? detail = null) =>
+        new(default, AzureProbeOutcome.Denied, detail);
+
+    public static AzureProbe<T> Failed(string? detail = null) =>
+        new(default, AzureProbeOutcome.Failed, detail);
+}
+
+public enum AzureProbeOutcome
+{
+    Succeeded = 0,
+
+    /// <summary>No Azure identity is set up — nothing to ask with.</summary>
+    NotConfigured = 1,
+
+    /// <summary>The identity works, and Azure refused the call: a missing role assignment.</summary>
+    Denied = 2,
+
+    /// <summary>Something else — a timeout, a network fault, an unexpected error.</summary>
+    Failed = 3
+}
+
+/// <summary>
+/// Reads what Connapse's own Azure identity can see, so the connection form can be filled in
+/// rather than typed. Every call is read-only.
+/// </summary>
+public interface IAzureBlobDiscovery
+{
+    /// <summary>
+    /// Every storage account in the configured subscription the identity may read metadata for.
+    /// </summary>
+    /// <remarks>Needs <c>Microsoft.Storage/storageAccounts/read</c> at subscription scope. A denial
+    /// must leave the operator typing an account name, never blocked.</remarks>
+    Task<AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>> ListStorageAccountsAsync(CancellationToken ct = default);
+
+    /// <summary>The containers in an account, by its blob endpoint.</summary>
+    /// <remarks>Needs <c>Microsoft.Storage/storageAccounts/blobServices/containers/read</c> on the
+    /// account — a control-plane action even though the call itself is data-plane.</remarks>
+    Task<AzureProbe<IReadOnlyList<string>>> ListContainersAsync(string blobEndpoint, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/IAzureDirectoryReader.cs
+++ b/src/Connapse.Core/Interfaces/IAzureDirectoryReader.cs
@@ -1,0 +1,16 @@
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Resolves a linked Entra searcher into their identity set, reading the directory with Connapse's
+/// own Azure identity. Mirrors <c>IDirectoryUserLookup</c> for AWS: rather than acting as the user,
+/// Connapse asks the directory about them.
+/// </summary>
+public interface IAzureDirectoryReader
+{
+    /// <summary>
+    /// The searcher's identity set (object id ∪ transitive security-group object ids), or a
+    /// fail-closed denial. Applies the deprovisioning gate first — a gone/disabled account resolves
+    /// to <see cref="AzureIdentityOutcome.Deprovisioned"/>.
+    /// </summary>
+    Task<AzureIdentitySet> ResolveAsync(AzureIdentityRef link, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/IAzureHostIdentity.cs
+++ b/src/Connapse.Core/Interfaces/IAzureHostIdentity.cs
@@ -1,0 +1,34 @@
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// The managed identity the host Connapse runs on can sign in as, described from a token Azure
+/// issued to it.
+/// </summary>
+/// <param name="TenantId">The tenant the identity lives in (the token's <c>tid</c>).</param>
+/// <param name="PrincipalId">The identity's service principal object id (<c>oid</c>) — what roles
+/// and Graph app roles are assigned to.</param>
+/// <param name="ClientId">The identity's application (client) id (<c>appid</c>).</param>
+/// <param name="ResourceId">The Azure resource the identity belongs to (<c>xms_mirid</c>): for a
+/// user-assigned identity the identity resource itself, for a system-assigned one the host.</param>
+/// <param name="SubscriptionId">The subscription parsed out of <paramref name="ResourceId"/>, when present.</param>
+/// <param name="IsUserAssigned">Whether the resource is a user-assigned identity rather than the host.</param>
+public sealed record AzureHostIdentityInfo(
+    string TenantId,
+    string PrincipalId,
+    string ClientId,
+    string? ResourceId,
+    string? SubscriptionId,
+    bool IsUserAssigned);
+
+/// <summary>
+/// Finds out whether the host has a managed identity, so the guided Azure setup can grant it
+/// access instead of creating a certificate app. Off Azure the answer is simply "no".
+/// </summary>
+public interface IAzureHostIdentity
+{
+    /// <summary>The host's managed identity, or null when the host has none (or the metadata
+    /// service did not answer in time). Never throws; a found identity is remembered for the
+    /// process, since a host's identity rarely changes while it runs — <paramref name="refresh"/>
+    /// asks again regardless, for the cases where it has (an identity disabled and re-enabled).</summary>
+    Task<AzureHostIdentityInfo?> DetectAsync(bool refresh = false, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/IAzureIdentityLinkReader.cs
+++ b/src/Connapse.Core/Interfaces/IAzureIdentityLinkReader.cs
@@ -1,0 +1,19 @@
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Which Microsoft Entra identity a Connapse user proved they were.
+/// </summary>
+/// <remarks>
+/// A Core interface so the scope resolver need not reference the identity layer to ask the one
+/// question it has of it — mirrors <c>IAwsIdentityLinkReader</c>. The answer is the oid+tid pair
+/// rather than a credential, because there is no credential to hold: Entra attests the identity
+/// once at link time, and permissions are read later with Connapse's own identity.
+/// </remarks>
+public interface IAzureIdentityLinkReader
+{
+    /// <summary>
+    /// The Entra identity linked to <paramref name="userId"/>, or null when they have connected
+    /// none.
+    /// </summary>
+    Task<AzureIdentityRef?> GetLinkAsync(Guid userId, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/IAzureRbacReader.cs
+++ b/src/Connapse.Core/Interfaces/IAzureRbacReader.cs
@@ -1,0 +1,14 @@
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Resolves a searcher's effective RBAC-readable <c>azblob://</c> scope set from Azure Resource
+/// Manager, reading with Connapse's own Azure identity. Fails closed.
+/// </summary>
+public interface IAzureRbacReader
+{
+    /// <summary>
+    /// The <c>azblob://</c> prefixes <paramref name="primaryOid"/> may read via Storage Blob Data
+    /// roles (transitive over groups, minus deny assignments), plus any tag-conditioned residue.
+    /// </summary>
+    Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/IBlobTagReader.cs
+++ b/src/Connapse.Core/Interfaces/IBlobTagReader.cs
@@ -1,0 +1,10 @@
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>Reads a blob's index tags (with Connapse's Data-Reader identity) for live ABAC tag
+/// verification. <c>null</c> on any read failure (fail closed); an empty map is a valid "no tags".</summary>
+public interface IBlobTagReader
+{
+    Task<IReadOnlyDictionary<string, string>?> ReadTagsAsync(Gen2Path blob, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/IDocumentStore.cs
+++ b/src/Connapse.Core/Interfaces/IDocumentStore.cs
@@ -48,4 +48,12 @@ public interface IDocumentStore
     /// to catch any containers missed by event-driven rollup triggering.
     /// </summary>
     Task<IReadOnlyList<Guid>> FindContainersWithStaleSummariesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// The <c>resource_uri</c> of each requested document (null when it has none — uploads and non-cloud
+    /// connectors — or the id is unknown). One batched lookup, for the search verifier which must map
+    /// ranked hits back to their governing URIs.
+    /// </summary>
+    Task<IReadOnlyDictionary<string, string?>> GetResourceUrisAsync(
+        IReadOnlyCollection<string> documentIds, CancellationToken ct = default);
 }

--- a/src/Connapse.Core/Interfaces/IGen2DirectoryReader.cs
+++ b/src/Connapse.Core/Interfaces/IGen2DirectoryReader.cs
@@ -1,0 +1,16 @@
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Reads a single ADLS Gen2 directory's <b>access</b> ACL, with Connapse's own (Data Reader)
+/// identity, to evaluate a searcher's traverse rights. Two calls so the resolver can short-circuit:
+/// the cheap mode-bits read decides on its own whenever the requester owns the directory or the ACL
+/// is not extended; only otherwise is the full ACL fetched. Both return <c>null</c> when the
+/// directory cannot be read — an uncertain answer the caller treats as fail-closed.
+/// </summary>
+public interface IGen2DirectoryReader
+{
+    Task<Gen2ModeBits?> ReadModeBitsAsync(Gen2Path directory, CancellationToken ct = default);
+    Task<Gen2Acl?> ReadAccessAclAsync(Gen2Path directory, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/IGen2FileAclReader.cs
+++ b/src/Connapse.Core/Interfaces/IGen2FileAclReader.cs
@@ -1,0 +1,16 @@
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Reads a single ADLS Gen2 <b>file's own</b> access ACL, with Connapse's Data-Reader identity, to
+/// evaluate a searcher's Read on the leaf (the ancestor-traverse resolver checks only directories).
+/// Returns <c>null</c> when the file cannot be read or the ACL is structurally incomplete — an
+/// uncertain answer the caller treats as fail-closed. On a non-HNS (flat) account the underlying
+/// call fails and this returns <c>null</c>, which is the correct drop for a flat blob reached only
+/// by the broad retrieval over-approximation.
+/// </summary>
+public interface IGen2FileAclReader
+{
+    Task<Gen2Acl?> ReadFileAclAsync(Gen2Path file, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/ISearchResultVerifier.cs
+++ b/src/Connapse.Core/Interfaces/ISearchResultVerifier.cs
@@ -1,0 +1,18 @@
+using Connapse.Core;
+
+namespace Connapse.Core.Interfaces;
+
+/// <summary>
+/// Post-retrieval per-hit permission verify. Returns the readable hits in rank order. An enforcing
+/// verifier drops unreadable hits and caps the result at <paramref name="topK"/>, backfilling from
+/// lower-ranked candidates; a pass-through/no-op verifier returns all candidates unchanged and lets
+/// the caller apply the final <paramref name="topK"/> cap. <see cref="CandidateMultiplier"/> tells
+/// the pipeline how much to over-fetch so backfill has material.
+/// </summary>
+public interface ISearchResultVerifier
+{
+    int CandidateMultiplier { get; }
+
+    Task<IReadOnlyList<SearchHit>> VerifyAsync(
+        IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default);
+}

--- a/src/Connapse.Core/Interfaces/ISettingsStore.cs
+++ b/src/Connapse.Core/Interfaces/ISettingsStore.cs
@@ -25,6 +25,17 @@ public interface ISettingsStore
     Task SaveAsync<T>(string category, T settings, CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>
+    /// Changes the stored settings for a category in one atomic step: the current value is read
+    /// under a lock, <paramref name="update"/> derives the new one from it, and that is written
+    /// before the lock is released. Two callers updating the same category can therefore never
+    /// overwrite each other's change, which <see cref="SaveAsync{T}"/> — a replace from whatever
+    /// the caller read earlier — cannot promise.
+    /// </summary>
+    /// <param name="update">Receives what is stored now (null when nothing is) and returns what to store.</param>
+    /// <returns>The value stored.</returns>
+    Task<T> UpdateAsync<T>(string category, Func<T?, T> update, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
     /// Resets settings for a specific category to defaults (removes from store).
     /// </summary>
     /// <param name="category">The settings category identifier.</param>

--- a/src/Connapse.Core/Models/AuthModels.cs
+++ b/src/Connapse.Core/Models/AuthModels.cs
@@ -106,3 +106,14 @@ public record AwsIdentityLinkDto(
 /// </remarks>
 public record AwsIdentityLinkDisconnectResult(
     bool Deleted, bool LinkChangedDuringDisconnect = false);
+
+/// <summary>
+/// A user's connected Microsoft Entra identity, as the integrations page needs to show it.
+/// </summary>
+public record AzureIdentityLinkDto(string ObjectId, string TenantId, string DisplayName, DateTime ConnectedAt);
+
+/// <summary>
+/// The oid + tid pair that fully qualifies an Entra identity — the join key permissions are read
+/// with, independent of the mutable display name.
+/// </summary>
+public record AzureIdentityRef(string ObjectId, string TenantId);

--- a/src/Connapse.Core/Models/AzblobUri.cs
+++ b/src/Connapse.Core/Models/AzblobUri.cs
@@ -1,0 +1,35 @@
+namespace Connapse.Core;
+
+/// <summary>Parses <c>azblob://account/container/blobpath</c> resource URIs into a
+/// <see cref="Gen2Path"/> (container = filesystem). The blob path is required and kept verbatim.</summary>
+public static class AzblobUri
+{
+    private const string Scheme = "azblob://";
+
+    public static bool IsAzblob(string? resourceUri) =>
+        resourceUri is not null && resourceUri.StartsWith(Scheme, StringComparison.Ordinal);
+
+    public static bool TryParse(string? resourceUri, out Gen2Path path)
+    {
+        path = new Gen2Path("", "", "");
+        if (!IsAzblob(resourceUri))
+            return false;
+
+        string rest = resourceUri![Scheme.Length..];
+        int firstSlash = rest.IndexOf('/');
+        if (firstSlash <= 0)
+            return false; // no container
+        int secondSlash = rest.IndexOf('/', firstSlash + 1);
+        if (secondSlash < 0 || secondSlash == rest.Length - 1)
+            return false; // no container/path boundary, or empty blob path
+
+        string account = rest[..firstSlash];
+        string container = rest[(firstSlash + 1)..secondSlash];
+        string blobPath = rest[(secondSlash + 1)..];
+        if (account.Length == 0 || container.Length == 0 || blobPath.Length == 0)
+            return false;
+
+        path = new Gen2Path(account, container, blobPath);
+        return true;
+    }
+}

--- a/src/Connapse.Core/Models/AzureAdSignInSettings.cs
+++ b/src/Connapse.Core/Models/AzureAdSignInSettings.cs
@@ -1,0 +1,44 @@
+namespace Connapse.Core;
+
+/// <summary>
+/// The Entra ID (Azure AD) application a person signs in through to prove which directory
+/// user they are.
+/// </summary>
+/// <remarks>
+/// Connapse authenticates to Entra with a client certificate rather than a client secret, so
+/// there is nothing here for an attacker to steal out of configuration — <see
+/// cref="ClientCertificatePath"/> points at a file on disk, and <see
+/// cref="ClientCertificatePassword"/> only applies to password-protected PFX bundles. A PEM
+/// certificate needs no password, which is why it is optional rather than required.
+/// </remarks>
+public record AzureAdSignInSettings
+{
+    public const string SectionName = "Identity:AzureAd";
+
+    /// <summary>The Entra tenant (directory) id the application is registered under.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>The application (client) id registered in Entra ID.</summary>
+    public string? ClientId { get; init; }
+
+    /// <summary>Where Entra redirects back to after sign-in, registered on the application.</summary>
+    public string? RedirectUri { get; init; }
+
+    /// <summary>
+    /// Path to the client certificate (PEM or PFX) Connapse authenticates to Entra with.
+    /// </summary>
+    public string? ClientCertificatePath { get; init; }
+
+    /// <summary>
+    /// Password for the certificate at <see cref="ClientCertificatePath"/>, if it is a
+    /// password-protected PFX. A PEM certificate needs none, so this is optional.
+    /// </summary>
+    public string? ClientCertificatePassword { get; init; }
+
+    /// <summary>True once every field sign-in needs — other than the certificate password — is set.</summary>
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(TenantId)
+        && !string.IsNullOrWhiteSpace(ClientId)
+        && !string.IsNullOrWhiteSpace(RedirectUri)
+        && !string.IsNullOrWhiteSpace(ClientCertificatePath);
+}

--- a/src/Connapse.Core/Models/AzureAdSignInSettings.cs
+++ b/src/Connapse.Core/Models/AzureAdSignInSettings.cs
@@ -35,6 +35,13 @@ public record AzureAdSignInSettings
     /// </summary>
     public string? ClientCertificatePassword { get; init; }
 
+    /// <summary>
+    /// True while the access app's Microsoft Graph permissions still await an administrator's
+    /// consent. Recorded by the setup flow so the state survives a reload; until it clears, the
+    /// directory lookups per-user filtering depends on will fail, and filtering fails closed.
+    /// </summary>
+    public bool AdminConsentPending { get; init; }
+
     /// <summary>True once every field sign-in needs — other than the certificate password — is set.</summary>
     public bool IsConfigured =>
         !string.IsNullOrWhiteSpace(TenantId)

--- a/src/Connapse.Core/Models/AzureIdentitySet.cs
+++ b/src/Connapse.Core/Models/AzureIdentitySet.cs
@@ -1,0 +1,37 @@
+namespace Connapse.Core;
+
+/// <summary>What the directory said about a searcher when their identity set was resolved.</summary>
+public enum AzureIdentityOutcome
+{
+    /// <summary>A confident answer: the account is enabled and its group set is known.</summary>
+    Resolved,
+
+    /// <summary>The directory says the account is gone (404) or disabled — deny, and cacheable.</summary>
+    Deprovisioned,
+
+    /// <summary>The directory could not be asked (error/timeout/partial). Deny, and never cached.</summary>
+    Failed,
+}
+
+/// <summary>
+/// A searcher's Entra identity set: the object id plus the transitive security-group object ids
+/// permissions may be held against. Fails closed — unless <see cref="Enabled"/> is true,
+/// <see cref="PrincipalOids"/> is empty and nothing may be authorized from it.
+/// </summary>
+public record AzureIdentitySet(bool Enabled, IReadOnlyList<string> PrincipalOids, AzureIdentityOutcome Outcome)
+{
+    /// <summary>P = {oid} ∪ {group oids}, from a confident directory answer.</summary>
+    /// <remarks>
+    /// The principals are copied into a genuinely immutable collection: this set is handed to
+    /// callers and also held in the resolver's cache, so a caller casting the list back to a
+    /// mutable type must not be able to inject a principal and poison the shared cache entry.
+    /// </remarks>
+    public static AzureIdentitySet Resolved(IReadOnlyList<string> principalOids) =>
+        new(true, Array.AsReadOnly(principalOids.ToArray()), AzureIdentityOutcome.Resolved);
+
+    /// <summary>The account is gone or disabled. Deny; cacheable.</summary>
+    public static AzureIdentitySet Deprovisioned() => new(false, [], AzureIdentityOutcome.Deprovisioned);
+
+    /// <summary>The directory could not be asked. Deny; never cache.</summary>
+    public static AzureIdentitySet Failed() => new(false, [], AzureIdentityOutcome.Failed);
+}

--- a/src/Connapse.Core/Models/AzureProviderSettings.cs
+++ b/src/Connapse.Core/Models/AzureProviderSettings.cs
@@ -14,4 +14,8 @@ public record AzureProviderSettings
     public string? ClientCertificatePath { get; init; }
     public string? ClientCertificatePassword { get; init; }
     public string? UserAssignedManagedIdentityClientId { get; init; }
+
+    /// <summary>The subscription whose role/deny assignments the RBAC resolver queries. Required
+    /// for per-user Azure permission filtering; absent → the resolver fails closed.</summary>
+    public string? SubscriptionId { get; init; }
 }

--- a/src/Connapse.Core/Models/AzureProviderSettings.cs
+++ b/src/Connapse.Core/Models/AzureProviderSettings.cs
@@ -1,0 +1,17 @@
+namespace Connapse.Core;
+
+/// <summary>
+/// Connapse's own Azure app-credential configuration, bound from the settings hierarchy.
+/// When ClientId + a certificate are present, Connapse authenticates as that service principal;
+/// otherwise it uses the ambient managed identity. Never a client secret.
+/// </summary>
+public record AzureProviderSettings
+{
+    public const string SectionName = "Providers:Azure";
+
+    public string? TenantId { get; init; }
+    public string? ClientId { get; init; }
+    public string? ClientCertificatePath { get; init; }
+    public string? ClientCertificatePassword { get; init; }
+    public string? UserAssignedManagedIdentityClientId { get; init; }
+}

--- a/src/Connapse.Core/Models/AzureProviderSettings.cs
+++ b/src/Connapse.Core/Models/AzureProviderSettings.cs
@@ -15,6 +15,18 @@ public record AzureProviderSettings
     public string? ClientCertificatePassword { get; init; }
     public string? UserAssignedManagedIdentityClientId { get; init; }
 
+    /// <summary>
+    /// Sign in as the system-assigned managed identity of the host Connapse runs on. Explicit,
+    /// because "nothing configured" and "use the host's identity" must never look alike: the
+    /// fail-closed rules treat the first as not set up, and only the second as a credential.
+    /// </summary>
+    public bool UseHostManagedIdentity { get; init; }
+
+    /// <summary>The managed identity's service principal object id, recorded by the guided setup
+    /// so the page can name it and the permissions script can grant to it. Informational: the
+    /// credential itself comes from the host.</summary>
+    public string? ManagedIdentityPrincipalId { get; init; }
+
     /// <summary>The subscription whose role/deny assignments the RBAC resolver queries. Required
     /// for per-user Azure permission filtering; absent → the resolver fails closed.</summary>
     public string? SubscriptionId { get; init; }

--- a/src/Connapse.Core/Models/AzureRbacScopes.cs
+++ b/src/Connapse.Core/Models/AzureRbacScopes.cs
@@ -1,0 +1,32 @@
+namespace Connapse.Core;
+
+/// <summary>Whether the RBAC scope set was resolved confidently or must fail closed.</summary>
+public enum RbacOutcome { Resolved, Failed }
+
+/// <summary>An <c>azblob://</c> prefix the searcher may read via an RBAC grant. A whole-account
+/// grant is <c>azblob://{account}/</c>; a grant broader than an account (RG/subscription/management
+/// group) is <c>azblob://</c> (matches every account).</summary>
+public record AzureScope(string Prefix);
+
+/// <summary>An RBAC grant gated on a blob index-tag condition that cannot reduce to a prefix. The
+/// <see cref="Scope"/> is the broad candidate prefix; the tag predicate is verified live per hit
+/// (Phase 4e). Never excluded here. <see cref="KeyCaseSensitive"/> reflects the condition's
+/// <c>&lt;$key_case_sensitive$&gt;</c> marker; <see cref="ValueCaseSensitive"/> is true for
+/// <c>StringEquals</c> and false for <c>StringEqualsIgnoreCase</c> — Phase 4e compares tag values
+/// accordingly.</summary>
+public record AzureTagCondition(
+    string Scope, string TagKey, string TagValue, bool KeyCaseSensitive, bool ValueCaseSensitive = false);
+
+/// <summary>The searcher's effective RBAC-readable scope set. Fails closed: unless
+/// <see cref="Outcome"/> is <see cref="RbacOutcome.Resolved"/>, both lists are empty.</summary>
+public record AzureRbacScopes(
+    IReadOnlyList<AzureScope> ReadablePrefixes,
+    IReadOnlyList<AzureTagCondition> TagConditioned,
+    RbacOutcome Outcome)
+{
+    public static AzureRbacScopes Resolved(
+        IReadOnlyList<AzureScope> readablePrefixes, IReadOnlyList<AzureTagCondition> tagConditioned) =>
+        new(readablePrefixes, tagConditioned, RbacOutcome.Resolved);
+
+    public static AzureRbacScopes Failed() => new([], [], RbacOutcome.Failed);
+}

--- a/src/Connapse.Core/Models/AzureRbacScopes.cs
+++ b/src/Connapse.Core/Models/AzureRbacScopes.cs
@@ -22,11 +22,14 @@ public record AzureTagCondition(
 public record AzureRbacScopes(
     IReadOnlyList<AzureScope> ReadablePrefixes,
     IReadOnlyList<AzureTagCondition> TagConditioned,
-    RbacOutcome Outcome)
+    RbacOutcome Outcome,
+    IReadOnlyList<string> DeniedPrefixes)
 {
     public static AzureRbacScopes Resolved(
-        IReadOnlyList<AzureScope> readablePrefixes, IReadOnlyList<AzureTagCondition> tagConditioned) =>
-        new(readablePrefixes, tagConditioned, RbacOutcome.Resolved);
+        IReadOnlyList<AzureScope> readablePrefixes,
+        IReadOnlyList<AzureTagCondition> tagConditioned,
+        IReadOnlyList<string>? deniedPrefixes = null) =>
+        new(readablePrefixes, tagConditioned, RbacOutcome.Resolved, deniedPrefixes ?? []);
 
-    public static AzureRbacScopes Failed() => new([], [], RbacOutcome.Failed);
+    public static AzureRbacScopes Failed() => new([], [], RbacOutcome.Failed, []);
 }

--- a/src/Connapse.Core/Models/AzureVerifierSettings.cs
+++ b/src/Connapse.Core/Models/AzureVerifierSettings.cs
@@ -1,0 +1,11 @@
+namespace Connapse.Core;
+
+/// <summary>Tuning for the Phase 4e verifier.</summary>
+public sealed class AzureVerifierSettings
+{
+    public const string SectionName = "Azure:Verifier";
+    /// <summary>Bounded per-hit verify concurrency.</summary>
+    public int MaxParallelism { get; set; } = 16;
+    /// <summary>How many candidates to over-fetch per requested result, so backfill has material.</summary>
+    public int CandidateMultiplier { get; set; } = 5;
+}

--- a/src/Connapse.Core/Models/CloudProvider.cs
+++ b/src/Connapse.Core/Models/CloudProvider.cs
@@ -2,5 +2,6 @@ namespace Connapse.Core;
 
 public enum CloudProvider
 {
-    AWS = 0
+    AWS = 0,
+    Azure = 1
 }

--- a/src/Connapse.Core/Models/ConnectionModels.cs
+++ b/src/Connapse.Core/Models/ConnectionModels.cs
@@ -6,7 +6,7 @@ namespace Connapse.Core;
 /// ManagedStorage is deliberately absent: it is Connapse's own backend, not an
 /// external system requiring credentials.
 /// </summary>
-public enum ConnectionProvider { Filesystem = 1, S3 = 3, Sftp = 5 }
+public enum ConnectionProvider { Filesystem = 1, S3 = 3, AzureBlob = 4, Sftp = 5 }
 
 public record Connection(
     Guid Id,

--- a/src/Connapse.Core/Models/Gen2Acl.cs
+++ b/src/Connapse.Core/Models/Gen2Acl.cs
@@ -1,0 +1,88 @@
+namespace Connapse.Core;
+
+/// <summary>POSIX permission bits, as flags so a permission set is one value.</summary>
+[Flags]
+public enum Gen2Permission
+{
+    None = 0,
+    Execute = 1,
+    Write = 2,
+    Read = 4,
+}
+
+/// <summary>A named ADLS ACL entry: a user or group principal object id and its permissions.</summary>
+public record Gen2NamedAce(string Oid, Gen2Permission Permissions);
+
+/// <summary>
+/// One directory's <b>access</b> ACL (never the default/inheritance ACL), as the POSIX evaluator
+/// needs it: the owner and owning-group principals and their permissions, the mask (present only
+/// when the ACL is extended), the named user/group entries, and the "other" permissions.
+/// </summary>
+public record Gen2Acl(
+    string? OwnerOid,
+    string? OwningGroupOid,
+    Gen2Permission OwnerPermissions,
+    Gen2Permission OwningGroupPermissions,
+    Gen2Permission OtherPermissions,
+    Gen2Permission? Mask,
+    IReadOnlyList<Gen2NamedAce> NamedUsers,
+    IReadOnlyList<Gen2NamedAce> NamedGroups);
+
+/// <summary>
+/// The cheap "mode bits" view of a directory — owner/group principals plus the owner/group/other
+/// rwx triples — from a listing (<c>GetPaths</c>) or properties read. <see cref="HasExtendedAcl"/>
+/// is the POSIX '+' marker: when false there are no named entries and no mask, so these bits alone
+/// decide access; when true a named entry could be decisive and the full ACL must be read.
+/// </summary>
+public record Gen2ModeBits(
+    string? OwnerOid,
+    string? OwningGroupOid,
+    Gen2Permission Owner,
+    Gen2Permission OwningGroup,
+    Gen2Permission Other,
+    bool HasExtendedAcl)
+{
+    /// <summary>The equivalent <see cref="Gen2Acl"/> with no named entries and no mask. Correct to
+    /// evaluate against only when the requester owns the directory or when there is no extended ACL;
+    /// the resolver enforces that precondition.</summary>
+    public Gen2Acl ToAcl() =>
+        new(OwnerOid, OwningGroupOid, Owner, OwningGroup, Other, Mask: null, NamedUsers: [], NamedGroups: []);
+}
+
+/// <summary>An ADLS path: the storage account, filesystem (container), and the path within it
+/// (no leading slash; the filesystem root is the empty string).</summary>
+public record Gen2Path(string Account, string FileSystem, string Path);
+
+/// <summary>Parses ADLS symbolic permission strings into <see cref="Gen2Permission"/> triples.</summary>
+public static class Gen2Permissions
+{
+    /// <summary>Maps one rwx triple (e.g. 'r','-','x') to a permission set.</summary>
+    public static Gen2Permission FromRwx(char r, char w, char x)
+    {
+        Gen2Permission p = Gen2Permission.None;
+        if (r == 'r') p |= Gen2Permission.Read;
+        if (w == 'w') p |= Gen2Permission.Write;
+        if (x is 'x' or 's' or 't') p |= Gen2Permission.Execute; // setuid/sticky imply the x slot
+        return p;
+    }
+
+    /// <summary>
+    /// Parses a symbolic permission string into owner/group/other triples plus the extended-ACL
+    /// flag. Accepts a 9-char body ("rwxr-x---"), an optional trailing '+' (extended ACL), and an
+    /// optional leading file-type char ("drwx...").
+    /// </summary>
+    public static (Gen2Permission Owner, Gen2Permission Group, Gen2Permission Other, bool Extended) ParseSymbolic(string symbolic)
+    {
+        ArgumentNullException.ThrowIfNull(symbolic);
+        bool extended = symbolic.EndsWith('+');
+        string s = extended ? symbolic[..^1] : symbolic;
+        if (s.Length == 10) s = s[1..];           // drop a leading file-type char
+        if (s.Length != 9)
+            throw new FormatException($"Unexpected ADLS permission string '{symbolic}'.");
+        return (
+            FromRwx(s[0], s[1], s[2]),
+            FromRwx(s[3], s[4], s[5]),
+            FromRwx(s[6], s[7], s[8]),
+            extended);
+    }
+}

--- a/src/Connapse.Core/Models/PermissionEnforcementSettings.cs
+++ b/src/Connapse.Core/Models/PermissionEnforcementSettings.cs
@@ -49,37 +49,63 @@ public class PermissionEnforcementSettings
     public const string Category = "permissionenforcement";
 
     /// <summary>
-    /// True once this deployment has had per-user permissions working.
+    /// True once this deployment has had SAML per-user permissions working.
     /// </summary>
     /// <remarks>
-    /// Latches. It is set when a complete sign-in configuration is first saved, or by the startup
-    /// migration for a deployment that was already filtering before this flag existed, and is
+    /// Latches. It is set when a complete SAML sign-in configuration is first saved, or by the
+    /// startup migration for a deployment that was already filtering before this flag existed, and is
     /// cleared only by an administrator deciding to stop enforcing. Once set, an incomplete
     /// configuration denies rather than opens.
+    /// <para>
+    /// This marker is <b>per identity provider</b>: it governs SAML/AWS only, and Azure has its own
+    /// <see cref="AzureEnforcing"/>. They must stay independent — a single shared bit would make
+    /// configuring one provider silently switch the OTHER's corpus from unfiltered to denied (once
+    /// latched, an unconfigured provider's resolver returns
+    /// <see cref="EnforcementState.EnforcingButUnusable"/>), which both changes that provider's
+    /// behaviour and hides documents that were meant to be visible.
+    /// </para>
     /// </remarks>
     public bool IsEnforcing { get; set; }
 
-    /// <summary>
-    /// What a resolver should do, given the sign-in settings it has to work with.
-    /// </summary>
-    /// <param name="signIn">The sign-in configuration, from wherever it was configured.</param>
+    /// <summary>True once this deployment has had Azure AD per-user permissions working.</summary>
+    /// <remarks>
+    /// The Azure counterpart to <see cref="IsEnforcing"/>, latched independently so that configuring
+    /// Azure AD never disturbs the SAML/AWS enforcement state, and vice versa. See the remarks on
+    /// <see cref="IsEnforcing"/> for why the two markers must not be shared.
+    /// </remarks>
+    public bool AzureEnforcing { get; set; }
+
+    /// <summary>What a resolver should do, given its own latch and whether its provider is configured.</summary>
+    /// <param name="latched">True once this provider has had per-user permissions working.</param>
+    /// <param name="providerConfigured">True when the provider has a complete sign-in configuration.</param>
     /// <param name="determined">
     /// False when the startup migration could not establish whether this deployment was already
     /// enforcing. An undetermined deployment enforces: not knowing is not permission to open.
     /// </param>
-    public EnforcementState StateFor(SamlSignInSettings signIn, bool determined = true)
+    private static EnforcementState StateFrom(bool latched, bool providerConfigured, bool determined)
     {
-        ArgumentNullException.ThrowIfNull(signIn);
-
         if (!determined)
             return EnforcementState.EnforcingButUnusable;
 
-        if (!IsEnforcing)
+        if (!latched)
             return EnforcementState.NotEnforcing;
 
-        return signIn.IsConfigured
+        return providerConfigured
             ? EnforcementState.Enforcing
             : EnforcementState.EnforcingButUnusable;
+    }
+
+    /// <summary>What the Azure resolver should do, given whether Azure AD sign-in is configured.
+    /// Reads the independent <see cref="AzureEnforcing"/> latch.</summary>
+    public EnforcementState StateForAzure(bool azureConfigured, bool determined = true) =>
+        StateFrom(AzureEnforcing, azureConfigured, determined);
+
+    /// <summary>What the AWS resolver should do, given the SAML sign-in settings it has. Reads the
+    /// SAML latch (<see cref="IsEnforcing"/>) — behaviour is unchanged from before Azure existed.</summary>
+    public EnforcementState StateFor(SamlSignInSettings signIn, bool determined = true)
+    {
+        ArgumentNullException.ThrowIfNull(signIn);
+        return StateFrom(IsEnforcing, signIn.IsConfigured, determined);
     }
 }
 

--- a/src/Connapse.Core/Models/StorageModels.cs
+++ b/src/Connapse.Core/Models/StorageModels.cs
@@ -1,6 +1,6 @@
 ﻿namespace Connapse.Core;
 
-public enum ConnectorType { ManagedStorage = 0, Filesystem = 1, S3 = 3, Sftp = 5 }
+public enum ConnectorType { ManagedStorage = 0, Filesystem = 1, S3 = 3, AzureBlob = 4, Sftp = 5 }
 
 public record ContainerSettingsOverrides
 {

--- a/src/Connapse.Core/Utilities/AzureBlobEndpoint.cs
+++ b/src/Connapse.Core/Utilities/AzureBlobEndpoint.cs
@@ -1,0 +1,104 @@
+using System.Text.RegularExpressions;
+
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Ties the address a connection reads from to the account its documents are labelled as.
+/// </summary>
+/// <remarks>
+/// Every Azure permission decision — role assignments, deny assignments, ACLs, tags — is made
+/// against the account in a document's <c>azblob://account/...</c> URI, and that account is the
+/// name typed on the connection form. The blob endpoint override is a separate string; left
+/// unchecked, a connection could read one account through its endpoint while labelling the
+/// content as another, and every later check would evaluate the wrong account. It would also
+/// hand Connapse's storage token to whatever host the endpoint named. So an override is accepted
+/// only when its host is that same account on a known Azure cloud, or a local emulator (Azurite)
+/// serving that account under a loopback address.
+/// </remarks>
+public static partial class AzureBlobEndpoint
+{
+    /// <summary>Azure's own rule for storage account names: 3–24 lowercase letters and digits.</summary>
+    [GeneratedRegex("^[a-z0-9]{3,24}$")]
+    private static partial Regex AccountName();
+
+    /// <summary>The blob-service host suffixes of the Azure clouds.</summary>
+    private static readonly string[] CloudSuffixes =
+    [
+        ".blob.core.windows.net",
+        ".blob.core.usgovcloudapi.net",
+        ".blob.core.chinacloudapi.cn",
+        ".blob.core.cloudapi.de",
+    ];
+
+    /// <summary>The account name as Azure spells it, or null when it is not a valid one.</summary>
+    public static string? NormaliseAccount(string? accountName)
+    {
+        string? name = accountName?.Trim().ToLowerInvariant();
+        return name is not null && AccountName().IsMatch(name) ? name : null;
+    }
+
+    /// <summary>The public endpoint of an account on the global Azure cloud.</summary>
+    public static Uri DefaultFor(string accountName) =>
+        new($"https://{accountName}.blob.core.windows.net");
+
+    /// <summary>
+    /// The endpoint a connection reads from: the account's public one when no override is set,
+    /// otherwise the override once it is shown to belong to the account. Throws when it does not.
+    /// </summary>
+    public static Uri Resolve(string accountName, string? endpointOverride)
+    {
+        string? problem = Validate(accountName, endpointOverride, out Uri? endpoint);
+        return problem is null ? endpoint! : throw new InvalidOperationException(problem);
+    }
+
+    /// <summary>
+    /// Why an account name and endpoint override cannot be used together, or null when they can,
+    /// with the endpoint to use in <paramref name="endpoint"/>.
+    /// </summary>
+    public static string? Validate(string? accountName, string? endpointOverride, out Uri? endpoint)
+    {
+        endpoint = null;
+        string? account = NormaliseAccount(accountName);
+        if (account is null)
+            return "The storage account name must be 3 to 24 lowercase letters and digits, as Azure names it.";
+
+        if (string.IsNullOrWhiteSpace(endpointOverride))
+        {
+            endpoint = DefaultFor(account);
+            return null;
+        }
+
+        if (!Uri.TryCreate(endpointOverride.Trim(), UriKind.Absolute, out Uri? candidate)
+            || candidate.Scheme is not ("https" or "http"))
+            return "The blob endpoint must be a full https:// address, or be left blank for the account's default.";
+
+        string host = candidate.Host.ToLowerInvariant();
+
+        // The account itself, on any Azure cloud.
+        foreach (string suffix in CloudSuffixes)
+        {
+            if (host == account + suffix)
+            {
+                endpoint = candidate;
+                return null;
+            }
+        }
+
+        // A local emulator serves accounts as the first path segment: http://127.0.0.1:10000/<account>.
+        if (candidate.IsLoopback)
+        {
+            string firstSegment = candidate.AbsolutePath.Trim('/').Split('/')[0].ToLowerInvariant();
+            if (firstSegment == account)
+            {
+                endpoint = candidate;
+                return null;
+            }
+            return $"An emulator endpoint must serve this account: expected {candidate.Scheme}://{candidate.Authority}/{account}.";
+        }
+
+        return $"The blob endpoint '{candidate.Host}' is not storage account '{account}' on an Azure cloud "
+            + $"(expected {account}.blob.core.windows.net or the equivalent on another cloud). A connection "
+            + "reads from the account it is named for; leave the endpoint blank unless you are pointing at "
+            + "a local emulator.";
+    }
+}

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -1,0 +1,356 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>Inputs for the Access step's script: the app name and the PUBLIC certificate it authenticates
+/// with (the private key stays on the host). The subscription is whichever one Cloud Shell is signed
+/// in to — the script reads it and prints it back, so the operator types nothing.</summary>
+/// <param name="ExistingAccessAppClientId">The access app Connapse already recorded, when re-running;
+/// the script reuses exactly that app and never looks one up by display name (names are neither
+/// unique nor authoritative, so a pre-registered look-alike could otherwise be granted the roles).</param>
+public sealed record AzureAccessSetupInput(
+    string AccessAppName,
+    string PublicCertificatePem,
+    string? ExistingAccessAppClientId = null);
+
+/// <summary>The non-secret identifiers the Access script prints back.</summary>
+public sealed record AzureAccessResult(string TenantId, string SubscriptionId, string AccessAppClientId);
+
+/// <summary>Inputs for the Per-user permissions step's script: which access app to grant Graph
+/// permissions on, the sign-in app's redirect URI, the page Entra should bounce back to after admin
+/// consent (registered on the access app — without one, the consent endpoint refuses with
+/// AADSTS500113), and the PUBLIC certificate for the sign-in app.</summary>
+public sealed record AzurePermissionsSetupInput(
+    string AccessAppClientId,
+    string RedirectUri,
+    string ConsentRedirectUri,
+    string SignInAppName,
+    string PublicCertificatePem,
+    string? ExistingSignInAppClientId = null);
+
+/// <summary>What the Per-user permissions script prints back, including whether the operator was able
+/// to grant admin consent (and the URL to hand an administrator when they were not).</summary>
+public sealed record AzurePermissionsResult(string SignInAppClientId, bool ConsentGranted, string? ConsentUrl);
+
+/// <summary>
+/// Generates the Azure Cloud Shell (<c>az</c>) scripts that provision Connapse's Azure setup, one per
+/// step, and parses the block each prints back. A pure string utility mirroring
+/// <see cref="AwsRolesAnywhereSetup"/>: the Access script creates two least-privilege custom roles and
+/// a certificate-authenticated access app; the Permissions script creates the OIDC sign-in app and
+/// adds the access app's Microsoft Graph application permissions, attempting admin consent. Only the
+/// PUBLIC certificate ever appears in a script.
+/// </summary>
+public static class AzureCloudShellSetup
+{
+    public const string AccessBeginMarker = "----- BEGIN CONNAPSE AZURE ACCESS -----";
+    public const string AccessEndMarker = "----- END CONNAPSE AZURE ACCESS -----";
+    public const string PermissionsBeginMarker = "----- BEGIN CONNAPSE AZURE PERMISSIONS -----";
+    public const string PermissionsEndMarker = "----- END CONNAPSE AZURE PERMISSIONS -----";
+
+    /// <summary>The Microsoft Graph resource app id — stable across tenants.</summary>
+    public const string GraphAppId = "00000003-0000-0000-c000-000000000000";
+
+    public const string BlobDataRoleName = "Connapse Blob Data + Tags Reader";
+    public const string RbacReadRoleName = "Connapse RBAC Authorization Reader";
+
+    /// <summary>What the person running the Access script needs (Azure RBAC + Entra), not the runtime identity.</summary>
+    public static readonly IReadOnlyList<string> AccessScriptRequirements =
+    [
+        "Owner or User Access Administrator on the subscription (to create the two custom roles and assign them)",
+        "permission to register applications (the tenant default, or Application Developer / Application Administrator)",
+    ];
+
+    /// <summary>What the person running the Permissions script needs; consent is the one step that may need someone else.</summary>
+    public static readonly IReadOnlyList<string> PermissionsScriptRequirements =
+    [
+        "permission to register applications",
+        "Global Administrator or Privileged Role Administrator to grant admin consent (otherwise the script prints a consent link for one)",
+    ];
+
+    // ---- Access step ----
+
+    public static string GenerateAccessScript(AzureAccessSetupInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        return AccessTemplate
+            .Replace("{{accessAppName}}", Shell(input.AccessAppName))
+            .Replace("{{existingAccessAppId}}", Shell(GuidOrEmpty(input.ExistingAccessAppClientId)))
+            .Replace("{{blobRoleName}}", BlobDataRoleName)
+            .Replace("{{rbacRoleName}}", RbacReadRoleName)
+            .Replace("{{beginMarker}}", AccessBeginMarker)
+            .Replace("{{endMarker}}", AccessEndMarker)
+            .Replace("{{cert}}", input.PublicCertificatePem.Replace("\r\n", "\n").Trim());
+    }
+
+    /// <summary>Parses the Access block. Null unless all three ids are present, well-formed GUIDs.</summary>
+    public static AzureAccessResult? ParseAccessResult(string? pasted)
+    {
+        var values = ExtractBlock(pasted, AccessBeginMarker, AccessEndMarker);
+        if (values is null) return null;
+
+        values.TryGetValue("tenantId", out string? tenant);
+        values.TryGetValue("subscriptionId", out string? subscription);
+        values.TryGetValue("accessAppClientId", out string? accessId);
+
+        if (!Guid.TryParse(tenant, out _) || !Guid.TryParse(subscription, out _) || !Guid.TryParse(accessId, out _))
+            return null;
+
+        return new AzureAccessResult(tenant!, subscription!, accessId!);
+    }
+
+    // ---- Per-user permissions step ----
+
+    public static string GeneratePermissionsScript(AzurePermissionsSetupInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        return PermissionsTemplate
+            .Replace("{{accessAppId}}", Shell(input.AccessAppClientId))
+            .Replace("{{redirectUri}}", Shell(input.RedirectUri))
+            .Replace("{{consentRedirectUri}}", Shell(input.ConsentRedirectUri))
+            .Replace("{{consentRedirectEncoded}}", Uri.EscapeDataString(input.ConsentRedirectUri))
+            .Replace("{{existingSignInAppId}}", Shell(GuidOrEmpty(input.ExistingSignInAppClientId)))
+            .Replace("{{signInAppName}}", Shell(input.SignInAppName))
+            .Replace("{{graphAppId}}", GraphAppId)
+            .Replace("{{beginMarker}}", PermissionsBeginMarker)
+            .Replace("{{endMarker}}", PermissionsEndMarker)
+            .Replace("{{cert}}", input.PublicCertificatePem.Replace("\r\n", "\n").Trim());
+    }
+
+    /// <summary>Parses the Permissions block. Null unless the sign-in app id is a well-formed GUID.</summary>
+    public static AzurePermissionsResult? ParsePermissionsResult(string? pasted)
+    {
+        var values = ExtractBlock(pasted, PermissionsBeginMarker, PermissionsEndMarker);
+        if (values is null) return null;
+
+        values.TryGetValue("signInAppClientId", out string? signInId);
+        if (!Guid.TryParse(signInId, out _)) return null;
+
+        values.TryGetValue("consentGranted", out string? consent);
+        values.TryGetValue("consentUrl", out string? url);
+
+        return new AzurePermissionsResult(
+            signInId!,
+            ConsentGranted: string.Equals(consent, "true", StringComparison.OrdinalIgnoreCase),
+            ConsentUrl: string.IsNullOrWhiteSpace(url) ? null : url);
+    }
+
+    // ---- shared ----
+
+    /// <summary>
+    /// Reads the key=value lines between the LAST marker pair, so pasting the whole terminal (which
+    /// echoes the script) still reads the printed output rather than the source.
+    /// </summary>
+    private static Dictionary<string, string>? ExtractBlock(string? pasted, string begin, string end)
+    {
+        if (string.IsNullOrEmpty(pasted)) return null;
+
+        int endIdx = pasted.LastIndexOf(end, StringComparison.Ordinal);
+        if (endIdx < 0) return null;
+        int startIdx = pasted.LastIndexOf(begin, endIdx, StringComparison.Ordinal);
+        if (startIdx < 0) return null;
+
+        string inner = pasted.Substring(startIdx + begin.Length, endIdx - startIdx - begin.Length);
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string line in inner.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            int eq = line.IndexOf('=');
+            if (eq <= 0) continue;
+            values[line[..eq]] = line[(eq + 1)..].Trim();
+        }
+        return values;
+    }
+
+    /// <summary>Escapes a value for safe inclusion inside single quotes in the generated bash.</summary>
+    private static string Shell(string value) => value.Replace("'", "'\\''");
+
+    /// <summary>An app id is only ever a GUID; anything else is treated as "none recorded".</summary>
+    private static string GuidOrEmpty(string? value) =>
+        Guid.TryParse(value?.Trim(), out Guid id) ? id.ToString() : string.Empty;
+
+    private const string AccessTemplate = """
+        #!/usr/bin/env bash
+        # Connapse Azure setup — step 1 of 2 (Access). Run in Azure Cloud Shell (Bash). Creates two
+        # least-privilege custom roles and Connapse's certificate-authenticated access app, then prints
+        # a block to paste back into Connapse. Safe to re-run. Only the PUBLIC certificate is here.
+        #
+        # It uses the subscription Cloud Shell is signed in to. To use a different one, run
+        #   az account set --subscription <id>
+        # first. To limit the blob role to one storage account instead of the whole subscription,
+        # set STORAGE_SCOPE below to that storage account's resource id.
+        #
+        # Runs in a subshell so that pasting it into the interactive shell cannot close your
+        # session on an error: the failing command is printed and you stay signed in.
+        (
+        set -euo pipefail
+        trap 'echo; echo "Connapse setup failed at: $BASH_COMMAND" >&2' ERR
+
+        ACCESS_APP_NAME='{{accessAppName}}'
+        STORAGE_SCOPE=""
+
+        SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+        TENANT_ID=$(az account show --query tenantId -o tsv)
+        [ -n "$STORAGE_SCOPE" ] || STORAGE_SCOPE="/subscriptions/$SUBSCRIPTION_ID"
+        echo "Using subscription $SUBSCRIPTION_ID ($(az account show --query name -o tsv))"
+
+        CERT_FILE=$(mktemp)
+        cat > "$CERT_FILE" <<'CONNAPSE_CERT_EOF'
+        {{cert}}
+        CONNAPSE_CERT_EOF
+
+        # --- Least-privilege custom roles: created, or updated in place so re-runs upgrade them ---
+        upsert_role() {  # $1 role name, $2 definition JSON in the shape `az role definition create` takes
+          local existing
+          existing=$(az role definition list --name "$1" --custom-role-only true -o json 2>/dev/null | jq -c '.[0] // empty')
+          if [ -z "$existing" ]; then
+            az role definition create --role-definition "$2" >/dev/null
+          else
+            # `update` wants the shape `list` returns (roleName, permissions[], id), so patch the
+            # existing definition rather than resending the create-shaped one.
+            az role definition update --role-definition "$(jq -n --argjson e "$existing" --argjson d "$2" '
+              $e | .description = $d.Description
+                 | .permissions = [{actions: $d.Actions, notActions: $d.NotActions,
+                                    dataActions: $d.DataActions, notDataActions: $d.NotDataActions}]
+                 | .assignableScopes = $d.AssignableScopes')" >/dev/null
+          fi
+        }
+        # Data-plane blob reads, plus listing containers (a control-plane action even over the
+        # data plane) so the connection form can offer a container list.
+        upsert_role '{{blobRoleName}}' "{
+          \"Name\": \"{{blobRoleName}}\", \"IsCustom\": true,
+          \"Description\": \"Read blob content, blob index tags, and container names for Connapse.\",
+          \"Actions\": [\"Microsoft.Storage/storageAccounts/blobServices/containers/read\"],
+          \"NotActions\": [], \"NotDataActions\": [],
+          \"DataActions\": [
+            \"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\",
+            \"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read\"
+          ],
+          \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
+        }"
+        # Subscription-wide reads: role and deny assignments for per-user filtering, and storage
+        # account metadata (names, endpoints — never keys) so the form can offer an account list.
+        upsert_role '{{rbacRoleName}}' "{
+          \"Name\": \"{{rbacRoleName}}\", \"IsCustom\": true,
+          \"Description\": \"Read role and deny assignments and storage account metadata at subscription scope for Connapse.\",
+          \"Actions\": [
+            \"Microsoft.Authorization/roleAssignments/read\",
+            \"Microsoft.Authorization/denyAssignments/read\",
+            \"Microsoft.Storage/storageAccounts/read\"
+          ],
+          \"NotActions\": [], \"DataActions\": [], \"NotDataActions\": [],
+          \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
+        }"
+
+        # --- Access app registration (certificate-authenticated) ---
+        # Re-runs reuse exactly the app Connapse recorded, by id. Never by display name: names are
+        # not unique, and a look-alike registered by someone else must not be handed these roles.
+        ACCESS_APP_ID='{{existingAccessAppId}}'
+        if [ -n "$ACCESS_APP_ID" ]; then
+          az ad app show --id "$ACCESS_APP_ID" --query appId -o tsv >/dev/null \
+            || { echo "The access app Connapse recorded ($ACCESS_APP_ID) no longer exists. Reset the Access step in Connapse and run again." >&2; exit 1; }
+        else
+          ACCESS_APP_ID=$(az ad app create --display-name "$ACCESS_APP_NAME" --query appId -o tsv)
+        fi
+        # Registers the certificate; a re-run with the same certificate is fine, anything else is fatal.
+        register_cert() {
+          local out
+          if out=$(az ad app credential reset --id "$1" --cert "@$CERT_FILE" --append 2>&1 >/dev/null); then return 0; fi
+          if echo "$out" | grep -qi "exist"; then echo "Certificate already registered on $1."; return 0; fi
+          echo "$out" >&2; return 1
+        }
+        register_cert "$ACCESS_APP_ID"
+        az ad sp create --id "$ACCESS_APP_ID" >/dev/null 2>&1 || true
+        rm -f "$CERT_FILE"
+
+        # Role assignments wait for the role definitions + service principal to propagate; retry
+        # briefly, and fail the script if they never land — a paste block without these grants
+        # would record a setup that cannot read anything.
+        assign_role() {  # $1 role name, $2 scope
+          local i
+          for i in 1 2 3 4 5; do
+            if az role assignment create --assignee "$ACCESS_APP_ID" --role "$1" --scope "$2" >/dev/null 2>&1; then return 0; fi
+            sleep 10
+          done
+          echo "Could not assign '$1' at $2 after 5 attempts." >&2
+          return 1
+        }
+        assign_role '{{blobRoleName}}' "$STORAGE_SCOPE"
+        assign_role '{{rbacRoleName}}' "/subscriptions/$SUBSCRIPTION_ID"
+
+        echo
+        printf '%s\ntenantId=%s\nsubscriptionId=%s\naccessAppClientId=%s\n%s\n' \
+          "{{beginMarker}}" "$TENANT_ID" "$SUBSCRIPTION_ID" "$ACCESS_APP_ID" "{{endMarker}}"
+        ) || echo "----- CONNAPSE SETUP FAILED: read the error above. Nothing to paste back yet. -----"
+        """;
+
+    private const string PermissionsTemplate = """
+        #!/usr/bin/env bash
+        # Connapse Azure setup — step 2 of 2 (Per-user permissions). Run in Azure Cloud Shell (Bash).
+        # Creates the sign-in app people authenticate through and grants the access app the Microsoft
+        # Graph permissions it reads the directory with. Admin consent needs a Global Administrator or
+        # Privileged Role Administrator; if you are not one, the script prints a link to send them.
+        #
+        # Runs in a subshell so that pasting it into the interactive shell cannot close your
+        # session on an error: the failing command is printed and you stay signed in.
+        (
+        set -euo pipefail
+        trap 'echo; echo "Connapse setup failed at: $BASH_COMMAND" >&2' ERR
+
+        ACCESS_APP_ID='{{accessAppId}}'
+        REDIRECT_URI='{{redirectUri}}'
+        CONSENT_REDIRECT_URI='{{consentRedirectUri}}'
+        SIGNIN_APP_NAME='{{signInAppName}}'
+        GRAPH_API='{{graphAppId}}'
+
+        TENANT_ID=$(az account show --query tenantId -o tsv)
+
+        CERT_FILE=$(mktemp)
+        cat > "$CERT_FILE" <<'CONNAPSE_CERT_EOF'
+        {{cert}}
+        CONNAPSE_CERT_EOF
+
+        # --- Sign-in app registration (OIDC, certificate client-assertion) ---
+        # Reused only by the id Connapse recorded, never by display name (see the Access script).
+        SIGNIN_APP_ID='{{existingSignInAppId}}'
+        if [ -n "$SIGNIN_APP_ID" ]; then
+          az ad app show --id "$SIGNIN_APP_ID" --query appId -o tsv >/dev/null \
+            || { echo "The sign-in app Connapse recorded ($SIGNIN_APP_ID) no longer exists. Reset the sign-in application in Connapse and run again." >&2; exit 1; }
+        else
+          SIGNIN_APP_ID=$(az ad app create --display-name "$SIGNIN_APP_NAME" --query appId -o tsv)
+        fi
+        az ad app update --id "$SIGNIN_APP_ID" --web-redirect-uris "$REDIRECT_URI"
+        # Registers the certificate; a re-run with the same certificate is fine, anything else is fatal.
+        register_cert() {
+          local out
+          if out=$(az ad app credential reset --id "$1" --cert "@$CERT_FILE" --append 2>&1 >/dev/null); then return 0; fi
+          if echo "$out" | grep -qi "exist"; then echo "Certificate already registered on $1."; return 0; fi
+          echo "$out" >&2; return 1
+        }
+        register_cert "$SIGNIN_APP_ID"
+        az ad sp create --id "$SIGNIN_APP_ID" >/dev/null 2>&1 || true
+        rm -f "$CERT_FILE"
+
+        # The admin-consent page bounces back to a reply URL registered on the ACCESS app; without one
+        # Entra refuses with AADSTS500113. Connapse's Providers page is that landing spot.
+        az ad app update --id "$ACCESS_APP_ID" --web-redirect-uris "$CONSENT_REDIRECT_URI"
+
+        # --- Microsoft Graph application permissions on the ACCESS app (ids resolved live) ---
+        USER_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='User.Read.All'].id | [0]" -o tsv)
+        GROUP_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='GroupMember.Read.All'].id | [0]" -o tsv)
+        az ad app permission add --id "$ACCESS_APP_ID" --api "$GRAPH_API" --api-permissions "$USER_READ_ALL=Role" >/dev/null
+        az ad app permission add --id "$ACCESS_APP_ID" --api "$GRAPH_API" --api-permissions "$GROUP_READ_ALL=Role" >/dev/null
+
+        # --- Admin consent (Global Administrator / Privileged Role Administrator only) ---
+        CONSENT_GRANTED=false
+        if az ad app permission admin-consent --id "$ACCESS_APP_ID" >/dev/null 2>&1; then
+          CONSENT_GRANTED=true
+          # Same administrator can pre-consent the sign-in app's delegated sign-in scopes for everyone,
+          # so people never see a consent prompt. offline_access is implied by the code flow;
+          # Connapse stores no tokens, only the user's object id and tenant.
+          az ad app permission grant --id "$SIGNIN_APP_ID" --api "$GRAPH_API" --scope "openid profile offline_access" >/dev/null 2>&1 || true
+        fi
+        CONSENT_URL="https://login.microsoftonline.com/$TENANT_ID/adminconsent?client_id=$ACCESS_APP_ID&redirect_uri={{consentRedirectEncoded}}"
+
+        echo
+        printf '%s\nsignInAppClientId=%s\nconsentGranted=%s\nconsentUrl=%s\n%s\n' \
+          "{{beginMarker}}" "$SIGNIN_APP_ID" "$CONSENT_GRANTED" "$CONSENT_URL" "{{endMarker}}"
+        ) || echo "----- CONNAPSE SETUP FAILED: read the error above. Nothing to paste back yet. -----"
+        """;
+}

--- a/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
+++ b/src/Connapse.Core/Utilities/AzureCloudShellSetup.cs
@@ -12,23 +12,44 @@ public sealed record AzureAccessSetupInput(
     string? ExistingAccessAppClientId = null);
 
 /// <summary>The non-secret identifiers the Access script prints back.</summary>
-public sealed record AzureAccessResult(string TenantId, string SubscriptionId, string AccessAppClientId);
+/// <param name="CertificateThumbprint">SHA-1 thumbprint (upper-case hex, no separators) of the certificate
+/// the script registered, so the page can refuse to promote a different one; null when the paste
+/// predates the script printing it.</param>
+public sealed record AzureAccessResult(
+    string TenantId, string SubscriptionId, string AccessAppClientId, string? CertificateThumbprint = null);
 
-/// <summary>Inputs for the Per-user permissions step's script: which access app to grant Graph
-/// permissions on, the sign-in app's redirect URI, the page Entra should bounce back to after admin
-/// consent (registered on the access app — without one, the consent endpoint refuses with
-/// AADSTS500113), and the PUBLIC certificate for the sign-in app.</summary>
+/// <summary>Inputs for the Access step's script when Connapse runs on an Azure host with a managed
+/// identity: the identity to grant the roles to. No app registration and no certificate.</summary>
+/// <param name="PrincipalId">The identity's service principal object id — what the roles are assigned to.</param>
+/// <param name="ClientId">The identity's application (client) id, printed back for the record.</param>
+/// <param name="IsUserAssigned">Whether it is a user-assigned identity rather than the host's own.</param>
+public sealed record AzureManagedIdentityAccessSetupInput(string PrincipalId, string ClientId, bool IsUserAssigned);
+
+/// <summary>What the managed-identity Access script prints back.</summary>
+public sealed record AzureManagedIdentityAccessResult(
+    string TenantId, string SubscriptionId, string PrincipalId, string ClientId, bool IsUserAssigned);
+
+/// <summary>Inputs for the Per-user permissions step's script: which access identity to grant Graph
+/// permissions on (an app registration by client id, or a managed identity by principal id), the
+/// sign-in app's redirect URI, the page Entra should bounce back to after admin consent (registered
+/// on the access app — without one, the consent endpoint refuses with AADSTS500113), and the PUBLIC
+/// certificate for the sign-in app.</summary>
+/// <param name="AccessManagedIdentityPrincipalId">Set when the access identity is a managed identity:
+/// the Graph permissions are then granted to it as app roles by REST, since there is no app
+/// registration to consent to, and <paramref name="AccessAppClientId"/> is unused.</param>
 public sealed record AzurePermissionsSetupInput(
     string AccessAppClientId,
     string RedirectUri,
     string ConsentRedirectUri,
     string SignInAppName,
     string PublicCertificatePem,
-    string? ExistingSignInAppClientId = null);
+    string? ExistingSignInAppClientId = null,
+    string? AccessManagedIdentityPrincipalId = null);
 
 /// <summary>What the Per-user permissions script prints back, including whether the operator was able
 /// to grant admin consent (and the URL to hand an administrator when they were not).</summary>
-public sealed record AzurePermissionsResult(string SignInAppClientId, bool ConsentGranted, string? ConsentUrl);
+public sealed record AzurePermissionsResult(
+    string SignInAppClientId, bool ConsentGranted, string? ConsentUrl, string? CertificateThumbprint = null);
 
 /// <summary>
 /// Generates the Azure Cloud Shell (<c>az</c>) scripts that provision Connapse's Azure setup, one per
@@ -44,6 +65,24 @@ public static class AzureCloudShellSetup
     public const string AccessEndMarker = "----- END CONNAPSE AZURE ACCESS -----";
     public const string PermissionsBeginMarker = "----- BEGIN CONNAPSE AZURE PERMISSIONS -----";
     public const string PermissionsEndMarker = "----- END CONNAPSE AZURE PERMISSIONS -----";
+    public const string ManagedIdentityBeginMarker = "----- BEGIN CONNAPSE AZURE MANAGED IDENTITY -----";
+    public const string ManagedIdentityEndMarker = "----- END CONNAPSE AZURE MANAGED IDENTITY -----";
+
+    /// <summary>What whoever runs the managed-identity Access script needs. No application
+    /// registration is involved, so only the subscription-level rights apply.</summary>
+    public static readonly IReadOnlyList<string> ManagedIdentityAccessScriptRequirements =
+    [
+        "Owner or User Access Administrator on the subscription (to create the two custom roles and assign them to the managed identity)",
+    ];
+
+    /// <summary>What whoever runs the Per-user permissions script needs when the access identity is a
+    /// managed identity: the Graph permissions are app-role assignments, which only a directory
+    /// administrator can write.</summary>
+    public static readonly IReadOnlyList<string> ManagedIdentityPermissionsScriptRequirements =
+    [
+        "permission to register applications (for the sign-in app)",
+        "Global Administrator or Privileged Role Administrator to grant the managed identity its two Microsoft Graph permissions (otherwise the script prints the two commands for one to run)",
+    ];
 
     /// <summary>The Microsoft Graph resource app id — stable across tenants.</summary>
     public const string GraphAppId = "00000003-0000-0000-c000-000000000000";
@@ -93,7 +132,71 @@ public static class AzureCloudShellSetup
         if (!Guid.TryParse(tenant, out _) || !Guid.TryParse(subscription, out _) || !Guid.TryParse(accessId, out _))
             return null;
 
-        return new AzureAccessResult(tenant!, subscription!, accessId!);
+        values.TryGetValue("certificateThumbprint", out string? thumbprint);
+        return new AzureAccessResult(tenant!, subscription!, accessId!, Thumbprint(thumbprint));
+    }
+
+    /// <summary>A thumbprint as the scripts print it: 40 hex digits, upper-cased here; anything else
+    /// (an older script that did not print one, or openssl missing) reads as none.</summary>
+    private static string? Thumbprint(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        string cleaned = value.Replace(":", "").Trim().ToUpperInvariant();
+        return cleaned.Length == 40 && cleaned.All(Uri.IsHexDigit) ? cleaned : null;
+    }
+
+    // ---- Access step, for a Connapse running on Azure with a managed identity ----
+
+    /// <summary>The Access script for a host with a managed identity: the same two custom roles,
+    /// assigned to the identity by object id. Nothing is registered and nothing is uploaded.</summary>
+    public static string GenerateManagedIdentityAccessScript(AzureManagedIdentityAccessSetupInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        return ManagedIdentityAccessTemplate
+            .Replace("{{principalId}}", Shell(GuidOrEmpty(input.PrincipalId)))
+            .Replace("{{clientId}}", Shell(GuidOrEmpty(input.ClientId)))
+            .Replace("{{kind}}", input.IsUserAssigned ? "user-assigned" : "system-assigned")
+            .Replace("{{blobRoleName}}", BlobDataRoleName)
+            .Replace("{{rbacRoleName}}", RbacReadRoleName)
+            .Replace("{{beginMarker}}", ManagedIdentityBeginMarker)
+            .Replace("{{endMarker}}", ManagedIdentityEndMarker);
+    }
+
+    /// <summary>Parses the managed-identity Access block. Null unless every id is a well-formed GUID.</summary>
+    public static AzureManagedIdentityAccessResult? ParseManagedIdentityAccessResult(string? pasted)
+    {
+        var values = ExtractBlock(pasted, ManagedIdentityBeginMarker, ManagedIdentityEndMarker);
+        if (values is null) return null;
+
+        values.TryGetValue("tenantId", out string? tenant);
+        values.TryGetValue("subscriptionId", out string? subscription);
+        values.TryGetValue("managedIdentityPrincipalId", out string? principal);
+        values.TryGetValue("managedIdentityClientId", out string? client);
+        values.TryGetValue("managedIdentityKind", out string? kind);
+
+        if (!Guid.TryParse(tenant, out _) || !Guid.TryParse(subscription, out _)
+            || !Guid.TryParse(principal, out _) || !Guid.TryParse(client, out _))
+            return null;
+
+        return new AzureManagedIdentityAccessResult(
+            tenant!, subscription!, principal!, client!,
+            IsUserAssigned: string.Equals(kind, "user-assigned", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// The two commands that grant a managed identity its Microsoft Graph permissions, for a
+    /// directory administrator to run when whoever ran the permissions script could not. The Graph
+    /// service principal's object id and the two app-role ids are looked up live, so nothing here
+    /// is tenant-specific except the identity.
+    /// </summary>
+    public static string GraphAppRoleGrantCommands(string managedIdentityPrincipalId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(managedIdentityPrincipalId);
+        // A GUID or nothing: the id lands inside a JSON body in the script, where anything else
+        // would break the request rather than merely fail it.
+        return ManagedIdentityGraphGrantCommands
+            .Replace("{{accessMiPrincipalId}}", GuidOrEmpty(managedIdentityPrincipalId))
+            .Replace("{{graphAppId}}", GraphAppId);
     }
 
     // ---- Per-user permissions step ----
@@ -102,6 +205,10 @@ public static class AzureCloudShellSetup
     {
         ArgumentNullException.ThrowIfNull(input);
         return PermissionsTemplate
+            .Replace("{{graphGrant}}", input.AccessManagedIdentityPrincipalId is { Length: > 0 }
+                ? ManagedIdentityGraphGrant
+                : AppGraphGrant)
+            .Replace("{{accessMiPrincipalId}}", Shell(GuidOrEmpty(input.AccessManagedIdentityPrincipalId)))
             .Replace("{{accessAppId}}", Shell(input.AccessAppClientId))
             .Replace("{{redirectUri}}", Shell(input.RedirectUri))
             .Replace("{{consentRedirectUri}}", Shell(input.ConsentRedirectUri))
@@ -125,11 +232,13 @@ public static class AzureCloudShellSetup
 
         values.TryGetValue("consentGranted", out string? consent);
         values.TryGetValue("consentUrl", out string? url);
+        values.TryGetValue("certificateThumbprint", out string? thumbprint);
 
         return new AzurePermissionsResult(
             signInId!,
             ConsentGranted: string.Equals(consent, "true", StringComparison.OrdinalIgnoreCase),
-            ConsentUrl: string.IsNullOrWhiteSpace(url) ? null : url);
+            ConsentUrl: string.IsNullOrWhiteSpace(url) ? null : url,
+            CertificateThumbprint: Thumbprint(thumbprint));
     }
 
     // ---- shared ----
@@ -257,6 +366,8 @@ public static class AzureCloudShellSetup
         }
         register_cert "$ACCESS_APP_ID"
         az ad sp create --id "$ACCESS_APP_ID" >/dev/null 2>&1 || true
+        # Printed back so Connapse can refuse to keep a different certificate than the one registered.
+        CERT_THUMBPRINT=$(openssl x509 -in "$CERT_FILE" -noout -fingerprint -sha1 2>/dev/null | sed 's/.*=//; s/://g') || true
         rm -f "$CERT_FILE"
 
         # Role assignments wait for the role definitions + service principal to propagate; retry
@@ -275,8 +386,8 @@ public static class AzureCloudShellSetup
         assign_role '{{rbacRoleName}}' "/subscriptions/$SUBSCRIPTION_ID"
 
         echo
-        printf '%s\ntenantId=%s\nsubscriptionId=%s\naccessAppClientId=%s\n%s\n' \
-          "{{beginMarker}}" "$TENANT_ID" "$SUBSCRIPTION_ID" "$ACCESS_APP_ID" "{{endMarker}}"
+        printf '%s\ntenantId=%s\nsubscriptionId=%s\naccessAppClientId=%s\ncertificateThumbprint=%s\n%s\n' \
+          "{{beginMarker}}" "$TENANT_ID" "$SUBSCRIPTION_ID" "$ACCESS_APP_ID" "$CERT_THUMBPRINT" "{{endMarker}}"
         ) || echo "----- CONNAPSE SETUP FAILED: read the error above. Nothing to paste back yet. -----"
         """;
 
@@ -325,15 +436,28 @@ public static class AzureCloudShellSetup
         }
         register_cert "$SIGNIN_APP_ID"
         az ad sp create --id "$SIGNIN_APP_ID" >/dev/null 2>&1 || true
+        # Printed back so Connapse can refuse to keep a different certificate than the one registered.
+        CERT_THUMBPRINT=$(openssl x509 -in "$CERT_FILE" -noout -fingerprint -sha1 2>/dev/null | sed 's/.*=//; s/://g') || true
         rm -f "$CERT_FILE"
 
+        USER_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='User.Read.All'].id | [0]" -o tsv)
+        GROUP_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='GroupMember.Read.All'].id | [0]" -o tsv)
+        {{graphGrant}}
+
+        echo
+        printf '%s\nsignInAppClientId=%s\nconsentGranted=%s\nconsentUrl=%s\ncertificateThumbprint=%s\n%s\n' \
+          "{{beginMarker}}" "$SIGNIN_APP_ID" "$CONSENT_GRANTED" "$CONSENT_URL" "$CERT_THUMBPRINT" "{{endMarker}}"
+        ) || echo "----- CONNAPSE SETUP FAILED: read the error above. Nothing to paste back yet. -----"
+        """;
+
+    /// <summary>The Graph section of the permissions script when the access identity is an app
+    /// registration: application permissions added to the app, then admin consent.</summary>
+    private const string AppGraphGrant = """
         # The admin-consent page bounces back to a reply URL registered on the ACCESS app; without one
         # Entra refuses with AADSTS500113. Connapse's Providers page is that landing spot.
         az ad app update --id "$ACCESS_APP_ID" --web-redirect-uris "$CONSENT_REDIRECT_URI"
 
-        # --- Microsoft Graph application permissions on the ACCESS app (ids resolved live) ---
-        USER_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='User.Read.All'].id | [0]" -o tsv)
-        GROUP_READ_ALL=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='GroupMember.Read.All'].id | [0]" -o tsv)
+        # --- Microsoft Graph application permissions on the ACCESS app ---
         az ad app permission add --id "$ACCESS_APP_ID" --api "$GRAPH_API" --api-permissions "$USER_READ_ALL=Role" >/dev/null
         az ad app permission add --id "$ACCESS_APP_ID" --api "$GRAPH_API" --api-permissions "$GROUP_READ_ALL=Role" >/dev/null
 
@@ -347,10 +471,134 @@ public static class AzureCloudShellSetup
           az ad app permission grant --id "$SIGNIN_APP_ID" --api "$GRAPH_API" --scope "openid profile offline_access" >/dev/null 2>&1 || true
         fi
         CONSENT_URL="https://login.microsoftonline.com/$TENANT_ID/adminconsent?client_id=$ACCESS_APP_ID&redirect_uri={{consentRedirectEncoded}}"
+        """;
+
+    /// <summary>The Graph section when the access identity is a managed identity: there is no app
+    /// registration to consent to, so the two permissions are app-role assignments on the identity's
+    /// service principal, written by REST. Only a directory administrator can write them; when the
+    /// runner cannot, the script says so and prints false, and the page shows the commands.</summary>
+    private const string ManagedIdentityGraphGrant = """
+        # --- Microsoft Graph application permissions on the ACCESS managed identity (app roles, by REST) ---
+        ACCESS_MI_PRINCIPAL_ID='{{accessMiPrincipalId}}'
+        GRAPH_SP_ID=$(az ad sp show --id "$GRAPH_API" --query id -o tsv)
+        grant_app_role() {  # $1 app role id
+          local out
+          if out=$(az rest -m POST -u "https://graph.microsoft.com/v1.0/servicePrincipals/$ACCESS_MI_PRINCIPAL_ID/appRoleAssignments" \
+                     -b "{\"principalId\":\"$ACCESS_MI_PRINCIPAL_ID\",\"resourceId\":\"$GRAPH_SP_ID\",\"appRoleId\":\"$1\"}" 2>&1 >/dev/null); then return 0; fi
+          if echo "$out" | grep -qi "already exists"; then return 0; fi
+          echo "$out" >&2; return 1
+        }
+        CONSENT_GRANTED=true
+        grant_app_role "$USER_READ_ALL" || CONSENT_GRANTED=false
+        grant_app_role "$GROUP_READ_ALL" || CONSENT_GRANTED=false
+        if [ "$CONSENT_GRANTED" = true ]; then
+          az ad app permission grant --id "$SIGNIN_APP_ID" --api "$GRAPH_API" --scope "openid profile offline_access" >/dev/null 2>&1 || true
+        else
+          echo "Could not grant the managed identity its Graph permissions (a Global Administrator or Privileged Role Administrator must). Connapse shows the two commands to hand them." >&2
+        fi
+        CONSENT_URL=""
+        """;
+
+    /// <summary>The two grants on their own, for an administrator to run when the script's runner could not.</summary>
+    private const string ManagedIdentityGraphGrantCommands = """
+        GRAPH_API='{{graphAppId}}'
+        MI='{{accessMiPrincipalId}}'
+        GRAPH_SP_ID=$(az ad sp show --id "$GRAPH_API" --query id -o tsv)
+        for ROLE in User.Read.All GroupMember.Read.All; do
+          ROLE_ID=$(az ad sp show --id "$GRAPH_API" --query "appRoles[?value=='$ROLE'].id | [0]" -o tsv)
+          az rest -m POST -u "https://graph.microsoft.com/v1.0/servicePrincipals/$MI/appRoleAssignments" \
+            -b "{\"principalId\":\"$MI\",\"resourceId\":\"$GRAPH_SP_ID\",\"appRoleId\":\"$ROLE_ID\"}"
+        done
+        """;
+
+    private const string ManagedIdentityAccessTemplate = """
+        #!/usr/bin/env bash
+        # Connapse Azure setup — step 1 of 2 (Access), for a Connapse running on Azure as a managed
+        # identity. Run in Azure Cloud Shell (Bash). Creates two least-privilege custom roles and assigns
+        # them to the managed identity Connapse runs as ({{kind}}, principal {{principalId}}), then prints
+        # a block to paste back into Connapse. Safe to re-run. No app is registered and nothing is uploaded.
+        #
+        # It uses the subscription Cloud Shell is signed in to. To use a different one, run
+        #   az account set --subscription <id>
+        # first. To limit the blob role to one storage account instead of the whole subscription,
+        # set STORAGE_SCOPE below to that storage account's resource id.
+        #
+        # Runs in a subshell so that pasting it into the interactive shell cannot close your
+        # session on an error: the failing command is printed and you stay signed in.
+        (
+        set -euo pipefail
+        trap 'echo; echo "Connapse setup failed at: $BASH_COMMAND" >&2' ERR
+
+        MI_PRINCIPAL_ID='{{principalId}}'
+        MI_CLIENT_ID='{{clientId}}'
+        MI_KIND='{{kind}}'
+        STORAGE_SCOPE=""
+
+        SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+        TENANT_ID=$(az account show --query tenantId -o tsv)
+        [ -n "$STORAGE_SCOPE" ] || STORAGE_SCOPE="/subscriptions/$SUBSCRIPTION_ID"
+        echo "Using subscription $SUBSCRIPTION_ID ($(az account show --query name -o tsv))"
+
+        # --- Custom roles (created once, updated in place on re-run) ---
+        upsert_role() {  # $1 role name, $2 definition JSON in the shape `az role definition create` takes
+          local existing
+          existing=$(az role definition list --name "$1" --custom-role-only true -o json 2>/dev/null | jq -c '.[0] // empty')
+          if [ -z "$existing" ]; then
+            az role definition create --role-definition "$2" >/dev/null
+          else
+            # `update` wants the shape `list` returns (roleName, permissions[], id), so patch the
+            # existing definition rather than resending the create-shaped one.
+            az role definition update --role-definition "$(jq -n --argjson e "$existing" --argjson d "$2" '
+              $e | .description = $d.Description
+                 | .permissions = [{actions: $d.Actions, notActions: $d.NotActions,
+                                    dataActions: $d.DataActions, notDataActions: $d.NotDataActions}]
+                 | .assignableScopes = $d.AssignableScopes')" >/dev/null
+          fi
+        }
+
+        upsert_role '{{blobRoleName}}' "{
+          \"Name\": \"{{blobRoleName}}\", \"IsCustom\": true,
+          \"Description\": \"Read blob content, blob index tags, and container names for Connapse.\",
+          \"Actions\": [\"Microsoft.Storage/storageAccounts/blobServices/containers/read\"],
+          \"NotActions\": [], \"NotDataActions\": [],
+          \"DataActions\": [
+            \"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\",
+            \"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read\"
+          ],
+          \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
+        }"
+
+        upsert_role '{{rbacRoleName}}' "{
+          \"Name\": \"{{rbacRoleName}}\", \"IsCustom\": true,
+          \"Description\": \"Read role and deny assignments and storage account metadata at subscription scope for Connapse.\",
+          \"Actions\": [
+            \"Microsoft.Authorization/roleAssignments/read\",
+            \"Microsoft.Authorization/denyAssignments/read\",
+            \"Microsoft.Storage/storageAccounts/read\"
+          ],
+          \"NotActions\": [], \"DataActions\": [], \"NotDataActions\": [],
+          \"AssignableScopes\": [\"/subscriptions/$SUBSCRIPTION_ID\"]
+        }"
+
+        # --- Role assignments to the managed identity, by object id (no directory lookup needed) ---
+        # Role definitions take a moment to propagate; retry briefly, and fail the script if they never
+        # land — a paste block without these grants would record a setup that cannot read anything.
+        assign_role() {  # $1 role name, $2 scope
+          local i
+          for i in 1 2 3 4 5; do
+            if az role assignment create --assignee-object-id "$MI_PRINCIPAL_ID" --assignee-principal-type ServicePrincipal \
+                 --role "$1" --scope "$2" >/dev/null 2>&1; then return 0; fi
+            sleep 10
+          done
+          echo "Could not assign '$1' at $2 after 5 attempts." >&2
+          return 1
+        }
+        assign_role '{{blobRoleName}}' "$STORAGE_SCOPE"
+        assign_role '{{rbacRoleName}}' "/subscriptions/$SUBSCRIPTION_ID"
 
         echo
-        printf '%s\nsignInAppClientId=%s\nconsentGranted=%s\nconsentUrl=%s\n%s\n' \
-          "{{beginMarker}}" "$SIGNIN_APP_ID" "$CONSENT_GRANTED" "$CONSENT_URL" "{{endMarker}}"
+        printf '%s\ntenantId=%s\nsubscriptionId=%s\nmanagedIdentityPrincipalId=%s\nmanagedIdentityClientId=%s\nmanagedIdentityKind=%s\n%s\n' \
+          "{{beginMarker}}" "$TENANT_ID" "$SUBSCRIPTION_ID" "$MI_PRINCIPAL_ID" "$MI_CLIENT_ID" "$MI_KIND" "{{endMarker}}"
         ) || echo "----- CONNAPSE SETUP FAILED: read the error above. Nothing to paste back yet. -----"
         """;
 }

--- a/src/Connapse.Core/Utilities/AzureSetupRole.cs
+++ b/src/Connapse.Core/Utilities/AzureSetupRole.cs
@@ -1,0 +1,46 @@
+namespace Connapse.Core.Utilities;
+
+/// <summary>
+/// Builds the <c>az role assignment</c> commands that grant Connapse's blob role on exactly the
+/// containers a connection allows — the Azure counterpart of <see cref="S3SetupPolicy.ForBuckets"/>.
+/// </summary>
+/// <remarks>
+/// Text an operator runs in Cloud Shell; Connapse never assigns a role itself. Aimed at operators
+/// whose access identity was granted subscription-wide by the easy setup and who want this
+/// connection's grant narrowed to what it reads. A prefix inside a container cannot be expressed
+/// as an RBAC scope, so the narrowest grant is the container; the connection's allowed-locations
+/// list still bounds reads below that.
+/// </remarks>
+public static class AzureSetupRole
+{
+    /// <summary>One command per distinct container, or one on the whole account when nothing is allowed yet.</summary>
+    /// <param name="accessClientId">The app (client) id of Connapse's access identity — the assignee.</param>
+    /// <param name="accountResourceId">The storage account's ARM resource id.</param>
+    /// <param name="locations">Allowed locations, each <c>container</c> or <c>container/prefix</c>.</param>
+    public static string AssignmentsFor(string accessClientId, string accountResourceId, IEnumerable<string> locations)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessClientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(accountResourceId);
+
+        var containers = locations
+            .Select(l => (l ?? string.Empty).Trim())
+            .Where(l => l.Length > 0)
+            .Select(l => l.IndexOf('/') is var slash && slash >= 0 ? l[..slash] : l)
+            .Select(c => c.Trim())
+            .Where(c => c.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(c => c, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        string account = accountResourceId.Trim().TrimEnd('/');
+        IEnumerable<string> scopes = containers.Count == 0
+            ? [account]
+            : containers.Select(c => $"{account}/blobServices/default/containers/{c}");
+
+        return string.Join("\n", scopes.Select(scope =>
+            $"az role assignment create --assignee '{Shell(accessClientId.Trim())}' "
+            + $"--role '{AzureCloudShellSetup.BlobDataRoleName}' --scope '{Shell(scope)}'"));
+    }
+
+    private static string Shell(string value) => value.Replace("'", "'\\''");
+}

--- a/src/Connapse.Core/Utilities/ResourceUri.cs
+++ b/src/Connapse.Core/Utilities/ResourceUri.cs
@@ -28,4 +28,12 @@ public static class ResourceUri
         ArgumentException.ThrowIfNullOrWhiteSpace(bucket);
         return $"s3://{bucket}/{key}";
     }
+
+    /// <summary>An Azure Blob Storage object, as <c>azblob://account/container/path</c>.</summary>
+    public static string ForAzureBlob(string account, string container, string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(account);
+        ArgumentException.ThrowIfNullOrWhiteSpace(container);
+        return $"azblob://{account}/{container}/{path}";
+    }
 }

--- a/src/Connapse.Core/Utilities/ResourceUri.cs
+++ b/src/Connapse.Core/Utilities/ResourceUri.cs
@@ -30,10 +30,16 @@ public static class ResourceUri
     }
 
     /// <summary>An Azure Blob Storage object, as <c>azblob://account/container/path</c>.</summary>
+    /// <remarks>
+    /// The account and container are lower-cased: Azure only allows lowercase names for both, and
+    /// the role and deny assignments the permission checks compare against use that spelling. A
+    /// URI carrying a differently cased account would slip past a deny written for the real one.
+    /// The blob path is kept verbatim, as blob names are case-sensitive.
+    /// </remarks>
     public static string ForAzureBlob(string account, string container, string path)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(account);
         ArgumentException.ThrowIfNullOrWhiteSpace(container);
-        return $"azblob://{account}/{container}/{path}";
+        return $"azblob://{account.ToLowerInvariant()}/{container.ToLowerInvariant()}/{path}";
     }
 }

--- a/src/Connapse.Identity/Data/ConnapseIdentityDbContext.cs
+++ b/src/Connapse.Identity/Data/ConnapseIdentityDbContext.cs
@@ -20,6 +20,7 @@ public class ConnapseIdentityDbContext(DbContextOptions<ConnapseIdentityDbContex
     public DbSet<OAuthClientEntity> OAuthClients => Set<OAuthClientEntity>();
     public DbSet<OAuthAuthCodeEntity> OAuthAuthCodes => Set<OAuthAuthCodeEntity>();
     public DbSet<UserAwsIdentityLinkEntity> UserAwsIdentityLinks => Set<UserAwsIdentityLinkEntity>();
+    public DbSet<UserAzureIdentityLinkEntity> UserAzureIdentityLinks => Set<UserAzureIdentityLinkEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -35,6 +36,7 @@ public class ConnapseIdentityDbContext(DbContextOptions<ConnapseIdentityDbContex
         ConfigureOAuthClients(modelBuilder);
         ConfigureOAuthAuthCodes(modelBuilder);
         ConfigureUserAwsIdentityLinks(modelBuilder);
+        ConfigureUserAzureIdentityLinks(modelBuilder);
     }
 
     private static void ConfigureIdentityTables(ModelBuilder modelBuilder)
@@ -638,6 +640,55 @@ public class ConnapseIdentityDbContext(DbContextOptions<ConnapseIdentityDbContex
 
             entity.HasOne(e => e.User)
                 .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+
+    private static void ConfigureUserAzureIdentityLinks(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<UserAzureIdentityLinkEntity>(entity =>
+        {
+            entity.ToTable("user_azure_identity_links");
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.Id)
+                .HasColumnName("id")
+                .HasDefaultValueSql("gen_random_uuid()");
+
+            entity.Property(e => e.UserId)
+                .HasColumnName("user_id")
+                .IsRequired();
+
+            // Entra object id (oid) — immutable per-tenant user identifier.
+            entity.Property(e => e.ObjectId)
+                .HasColumnName("object_id")
+                .HasMaxLength(64)
+                .IsRequired();
+
+            // Entra tenant id (tid), stored with ObjectId as the fully-qualified key.
+            entity.Property(e => e.TenantId)
+                .HasColumnName("tenant_id")
+                .HasMaxLength(64)
+                .IsRequired();
+
+            entity.Property(e => e.DisplayName)
+                .HasColumnName("display_name")
+                .HasMaxLength(256)
+                .IsRequired();
+
+            entity.Property(e => e.ConnectedAt)
+                .HasColumnName("connected_at")
+                .HasDefaultValueSql("now()");
+
+            // One link per user: connecting again replaces it, so nothing has to decide which of
+            // two stored identities is the current one.
+            entity.HasIndex(e => e.UserId)
+                .HasDatabaseName("ix_user_azure_identity_links_user_id")
+                .IsUnique();
+
+            entity.HasOne(e => e.User)
+                .WithMany(u => u.AzureIdentityLinks)
                 .HasForeignKey(e => e.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
         });

--- a/src/Connapse.Identity/Data/Entities/ConnapseUser.cs
+++ b/src/Connapse.Identity/Data/Entities/ConnapseUser.cs
@@ -13,4 +13,5 @@ public class ConnapseUser : IdentityUser<Guid>
     public List<PersonalAccessTokenEntity> PersonalAccessTokens { get; set; } = [];
     public List<RefreshTokenEntity> RefreshTokens { get; set; } = [];
     public List<AuditLogEntity> AuditLogs { get; set; } = [];
+    public List<UserAzureIdentityLinkEntity> AzureIdentityLinks { get; set; } = [];
 }

--- a/src/Connapse.Identity/Data/Entities/UserAzureIdentityLinkEntity.cs
+++ b/src/Connapse.Identity/Data/Entities/UserAzureIdentityLinkEntity.cs
@@ -1,0 +1,18 @@
+namespace Connapse.Identity.Data.Entities;
+
+/// <summary>A Connapse user's linked Microsoft Entra identity (oid + tid). Holds no token —
+/// Entra attests the identity once at link time; permissions are later read with Connapse's own
+/// identity. One row per user (unique index); connecting again replaces the row.</summary>
+public class UserAzureIdentityLinkEntity
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    /// <summary>Entra object id (oid) — immutable per-tenant user identifier; the permanent key.</summary>
+    public string ObjectId { get; set; } = string.Empty;
+    /// <summary>Entra tenant id (tid). Stored with ObjectId as the fully-qualified key.</summary>
+    public string TenantId { get; set; } = string.Empty;
+    /// <summary>Display name/UPN from the id_token — display only, mutable, never a key.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+    public DateTime ConnectedAt { get; set; }
+    public ConnapseUser User { get; set; } = null!;
+}

--- a/src/Connapse.Identity/IdentityServiceExtensions.cs
+++ b/src/Connapse.Identity/IdentityServiceExtensions.cs
@@ -72,6 +72,12 @@ public static class IdentityServiceExtensions
         services.AddScoped<AwsIdentityLinkStore>();
         services.AddScoped<IAwsIdentityLinkReader>(sp => sp.GetRequiredService<AwsIdentityLinkStore>());
         services.AddScoped<IAwsIdentityLinkService, AwsIdentityLinkService>();
+        services.AddScoped<AzureIdentityLinkStore>();
+        services.AddScoped<IAzureIdentityLinkReader>(sp => sp.GetRequiredService<AzureIdentityLinkStore>());
+        services.AddScoped<IAzureIdentityLinkService, AzureIdentityLinkService>();
+        services.AddScoped<AzureIdTokenValidator>();
+        services.AddHttpClient<IAzureSigningKeySource, AzureAdSigningKeySource>();
+        services.AddHttpClient<IOidcTokenExchanger, AzureOidcTokenExchanger>();
 
         // All three are single-process by design and documented as such: one remembers assertion
         // ids so a signed assertion cannot be posted twice, one remembers who started a sign-in so
@@ -81,6 +87,8 @@ public static class IdentityServiceExtensions
         services.AddSingleton<ISamlReplayGuard, MemorySamlReplayGuard>();
         services.AddSingleton<SamlSignInRequests>();
         services.AddSingleton<SamlLinkConfirmations>();
+        services.AddSingleton<AzureSignInRequests>();
+        services.AddSingleton<AzureLinkConfirmations>();
 
         services.AddHttpContextAccessor();
 
@@ -88,6 +96,8 @@ public static class IdentityServiceExtensions
         services.Configure<JwtSettings>(configuration.GetSection(JwtSettings.SectionName));
         services.Configure<SamlSignInSettings>(
             configuration.GetSection(SamlSignInSettings.SectionName));
+        services.Configure<AzureAdSignInSettings>(
+            configuration.GetSection(AzureAdSignInSettings.SectionName));
         services.Configure<IdentityCenterSettings>(
             configuration.GetSection(IdentityCenterSettings.SectionName));
         services.Configure<PermissionEnforcementSettings>(

--- a/src/Connapse.Identity/InternalsVisibleTo.cs
+++ b/src/Connapse.Identity/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Connapse.Identity.Tests")]

--- a/src/Connapse.Identity/Migrations/20260906041509_AddUserAzureIdentityLinks.Designer.cs
+++ b/src/Connapse.Identity/Migrations/20260906041509_AddUserAzureIdentityLinks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Connapse.Identity.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Connapse.Identity.Migrations
 {
     [DbContext(typeof(ConnapseIdentityDbContext))]
-    partial class ConnapseIdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260906041509_AddUserAzureIdentityLinks")]
+    partial class AddUserAzureIdentityLinks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Connapse.Identity/Migrations/20260906041509_AddUserAzureIdentityLinks.cs
+++ b/src/Connapse.Identity/Migrations/20260906041509_AddUserAzureIdentityLinks.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Connapse.Identity.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserAzureIdentityLinks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "user_azure_identity_links",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    object_id = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    tenant_id = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    display_name = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    connected_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_azure_identity_links", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_user_azure_identity_links_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_azure_identity_links_user_id",
+                table: "user_azure_identity_links",
+                column: "user_id",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "user_azure_identity_links");
+        }
+    }
+}

--- a/src/Connapse.Identity/Services/AzureAdSigningKeySource.cs
+++ b/src/Connapse.Identity/Services/AzureAdSigningKeySource.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>
+/// Fetches Entra ID's published JWKS signing keys per tenant from its OIDC discovery document,
+/// via <see cref="ConfigurationManager{T}"/> — which already caches the document (default
+/// refresh interval) and dedupes concurrent refreshes, so no separate cache is needed here.
+/// </summary>
+/// <remarks>
+/// <c>Microsoft.IdentityModel.Protocols.OpenIdConnect</c> is already a direct dependency of this
+/// project (pinned alongside the rest of the Microsoft.IdentityModel set — see the .csproj
+/// comment), so this uses <see cref="ConfigurationManager{T}"/> rather than hand-rolling the
+/// discovery + JWKS fetch, per the task brief's fallback allowance.
+/// </remarks>
+public sealed class AzureAdSigningKeySource(HttpClient httpClient) : IAzureSigningKeySource
+{
+    private readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> _managers = new();
+
+    public async Task<IReadOnlyList<SecurityKey>> GetSigningKeysAsync(string tenantId, CancellationToken ct)
+    {
+        ConfigurationManager<OpenIdConnectConfiguration> manager = _managers.GetOrAdd(tenantId, tid =>
+            new ConfigurationManager<OpenIdConnectConfiguration>(
+                $"https://login.microsoftonline.com/{tid}/v2.0/.well-known/openid-configuration",
+                new OpenIdConnectConfigurationRetriever(),
+                new HttpDocumentRetriever(httpClient) { RequireHttps = true }));
+
+        OpenIdConnectConfiguration config = await manager.GetConfigurationAsync(ct);
+        return config.SigningKeys.ToList();
+    }
+}

--- a/src/Connapse.Identity/Services/AzureAuthorizationUrl.cs
+++ b/src/Connapse.Identity/Services/AzureAuthorizationUrl.cs
@@ -1,0 +1,27 @@
+using Connapse.Core;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>Builds the Entra ID v2.0 authorization-code request URL for the sign-in flow.</summary>
+public static class AzureAuthorizationUrl
+{
+    /// <summary>
+    /// Builds the URL to redirect the browser to at Entra, requesting an authorization code with
+    /// PKCE (S256) and an OIDC id token nonce.
+    /// </summary>
+    public static string Build(AzureAdSignInSettings settings, string state, string nonce, string codeChallenge)
+    {
+        string query = string.Join('&',
+            $"client_id={Uri.EscapeDataString(settings.ClientId ?? string.Empty)}",
+            "response_type=code",
+            $"redirect_uri={Uri.EscapeDataString(settings.RedirectUri ?? string.Empty)}",
+            "response_mode=query",
+            $"scope={Uri.EscapeDataString("openid profile")}",
+            $"state={Uri.EscapeDataString(state)}",
+            $"nonce={Uri.EscapeDataString(nonce)}",
+            $"code_challenge={Uri.EscapeDataString(codeChallenge)}",
+            "code_challenge_method=S256");
+
+        return $"https://login.microsoftonline.com/{settings.TenantId}/oauth2/v2.0/authorize?{query}";
+    }
+}

--- a/src/Connapse.Identity/Services/AzureIdTokenValidator.cs
+++ b/src/Connapse.Identity/Services/AzureIdTokenValidator.cs
@@ -1,0 +1,91 @@
+using Connapse.Core;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>Outcome of validating an Entra id_token. Fails closed: unless <see cref="Ok"/> is
+/// true, none of the other fields are populated, even if some claims could technically be read
+/// off an otherwise-invalid token.</summary>
+public sealed record AzureIdTokenResult(bool Ok, string? ObjectId, string? TenantId, string? DisplayName, string? Error)
+{
+    public static AzureIdTokenResult Failure(string error) => new(false, null, null, null, error);
+}
+
+/// <summary>
+/// Validates an Entra ID id_token: signature (against the tenant's published JWKS), issuer,
+/// audience, and expiry via <see cref="JsonWebTokenHandler"/>, then the OIDC <c>nonce</c> claim
+/// against the value recorded when sign-in was started. Every failure mode returns
+/// <see cref="AzureIdTokenResult.Ok"/> = false with nothing extracted — this is the boundary
+/// where an attacker-controlled token first meets Connapse, so it must fail closed.
+/// </summary>
+public sealed class AzureIdTokenValidator(
+    IOptionsMonitor<AzureAdSignInSettings> options,
+    IAzureSigningKeySource signingKeySource)
+{
+    private static readonly JsonWebTokenHandler Handler = new();
+
+    public async Task<AzureIdTokenResult> ValidateAsync(string idToken, string expectedNonce, CancellationToken ct)
+    {
+        AzureAdSignInSettings settings = options.CurrentValue;
+        if (string.IsNullOrWhiteSpace(settings.TenantId) || string.IsNullOrWhiteSpace(settings.ClientId))
+            return AzureIdTokenResult.Failure("Azure AD sign-in is not configured.");
+
+        IReadOnlyList<SecurityKey> signingKeys;
+        try
+        {
+            signingKeys = await signingKeySource.GetSigningKeysAsync(settings.TenantId, ct);
+        }
+        catch (Exception ex)
+        {
+            return AzureIdTokenResult.Failure($"Failed to fetch Entra signing keys: {ex.Message}");
+        }
+
+        if (signingKeys.Count == 0)
+            return AzureIdTokenResult.Failure("No Entra signing keys available.");
+
+        var validationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = $"https://login.microsoftonline.com/{settings.TenantId}/v2.0",
+            ValidateAudience = true,
+            ValidAudience = settings.ClientId,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKeys = signingKeys,
+            ValidateLifetime = true,
+        };
+
+        TokenValidationResult result;
+        try
+        {
+            result = await Handler.ValidateTokenAsync(idToken, validationParameters);
+        }
+        catch (Exception ex)
+        {
+            // ValidateTokenAsync documents that it does not throw for validation failures (they
+            // come back as !result.IsValid below), but malformed input can still throw before
+            // validation runs at all — fail closed the same way either way.
+            return AzureIdTokenResult.Failure(ex.Message);
+        }
+
+        if (!result.IsValid || result.SecurityToken is not JsonWebToken token)
+            return AzureIdTokenResult.Failure(result.Exception?.Message ?? "id_token failed validation.");
+
+        string? nonce = GetClaim(token, "nonce");
+        if (!string.Equals(nonce, expectedNonce, StringComparison.Ordinal))
+            return AzureIdTokenResult.Failure("id_token nonce does not match the sign-in request.");
+
+        string? objectId = GetClaim(token, "oid");
+        string? tenantId = GetClaim(token, "tid");
+        if (string.IsNullOrWhiteSpace(objectId) || string.IsNullOrWhiteSpace(tenantId))
+            return AzureIdTokenResult.Failure("id_token is missing the oid/tid claim.");
+
+        string? displayName = GetClaim(token, "name") ?? GetClaim(token, "preferred_username");
+
+        return new AzureIdTokenResult(true, objectId, tenantId, displayName, null);
+    }
+
+    private static string? GetClaim(JsonWebToken token, string type) =>
+        token.Claims.FirstOrDefault(c => string.Equals(c.Type, type, StringComparison.Ordinal))?.Value;
+}

--- a/src/Connapse.Identity/Services/AzureIdentityLinkService.cs
+++ b/src/Connapse.Identity/Services/AzureIdentityLinkService.cs
@@ -1,0 +1,29 @@
+using Connapse.Core;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>
+/// Reads, stores, and removes a user's connected Microsoft Entra identity.
+/// </summary>
+/// <remarks>
+/// Thin, mirroring <see cref="AwsIdentityLinkService"/>: the link holds an attested identity
+/// rather than a credential, so there is nothing at Entra to tell on disconnect — this simply
+/// delegates to <see cref="AzureIdentityLinkStore"/>.
+/// </remarks>
+public sealed class AzureIdentityLinkService(AzureIdentityLinkStore linkStore) : IAzureIdentityLinkService
+{
+    public async Task<AzureIdentityLinkDto?> GetAsync(Guid userId, CancellationToken ct = default)
+    {
+        var link = await linkStore.GetAsync(userId, ct);
+        return link is null
+            ? null
+            : new AzureIdentityLinkDto(link.ObjectId, link.TenantId, link.DisplayName, link.ConnectedAt);
+    }
+
+    public Task StoreAsync(
+        Guid userId, string oid, string tid, string displayName, CancellationToken ct = default) =>
+        linkStore.SaveAsync(userId, oid, tid, displayName, ct);
+
+    public Task<bool> DisconnectAsync(Guid userId, CancellationToken ct = default) =>
+        linkStore.DeleteAsync(userId, ct);
+}

--- a/src/Connapse.Identity/Services/AzureIdentityLinkService.cs
+++ b/src/Connapse.Identity/Services/AzureIdentityLinkService.cs
@@ -7,10 +7,15 @@ namespace Connapse.Identity.Services;
 /// </summary>
 /// <remarks>
 /// Thin, mirroring <see cref="AwsIdentityLinkService"/>: the link holds an attested identity
-/// rather than a credential, so there is nothing at Entra to tell on disconnect — this simply
-/// delegates to <see cref="AzureIdentityLinkStore"/>.
+/// rather than a credential, so there is nothing at Entra to tell on disconnect — this delegates
+/// to <see cref="AzureIdentityLinkStore"/>. Disconnecting also refuses every sign-in or parked
+/// confirmation the user started before it: a second tab that completes an older flow after the
+/// disconnect must not put the link back.
 /// </remarks>
-public sealed class AzureIdentityLinkService(AzureIdentityLinkStore linkStore) : IAzureIdentityLinkService
+public sealed class AzureIdentityLinkService(
+    AzureIdentityLinkStore linkStore,
+    AzureSignInRequests signIns,
+    AzureLinkConfirmations confirmations) : IAzureIdentityLinkService
 {
     public async Task<AzureIdentityLinkDto?> GetAsync(Guid userId, CancellationToken ct = default)
     {
@@ -24,6 +29,12 @@ public sealed class AzureIdentityLinkService(AzureIdentityLinkStore linkStore) :
         Guid userId, string oid, string tid, string displayName, CancellationToken ct = default) =>
         linkStore.SaveAsync(userId, oid, tid, displayName, ct);
 
-    public Task<bool> DisconnectAsync(Guid userId, CancellationToken ct = default) =>
-        linkStore.DeleteAsync(userId, ct);
+    public Task<bool> DisconnectAsync(Guid userId, CancellationToken ct = default)
+    {
+        // Revoked before the row goes, so a flow racing the delete finds the revocation whichever
+        // order the two land in.
+        signIns.RevokeFor(userId);
+        confirmations.RevokeFor(userId);
+        return linkStore.DeleteAsync(userId, ct);
+    }
 }

--- a/src/Connapse.Identity/Services/AzureIdentityLinkStore.cs
+++ b/src/Connapse.Identity/Services/AzureIdentityLinkStore.cs
@@ -1,0 +1,122 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Identity.Data;
+using Connapse.Identity.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>
+/// Reads and writes which Microsoft Entra identity a Connapse user signed in as.
+/// </summary>
+/// <remarks>
+/// Holds no token, mirroring <see cref="AwsIdentityLinkStore"/>: the row records an identity Entra
+/// attested once at link time, and permissions are read later with Connapse's own identity — so
+/// there is nothing to encrypt, nothing to rotate, and nothing that expires.
+/// </remarks>
+public sealed class AzureIdentityLinkStore(
+    IDbContextFactory<ConnapseIdentityDbContext> factory,
+    TimeProvider timeProvider) : IAzureIdentityLinkReader
+{
+    /// <inheritdoc />
+    public async Task<AzureIdentityRef?> GetLinkAsync(Guid userId, CancellationToken ct = default)
+    {
+        var link = await GetAsync(userId, ct);
+        return link is null ? null : new AzureIdentityRef(link.ObjectId, link.TenantId);
+    }
+
+    /// <summary>Stores a user's link, replacing any existing one.</summary>
+    /// <remarks>
+    /// The read-then-write below is not itself atomic — two concurrent connects for the same user
+    /// can both read "no row" and both try to insert. Without the catch below, the unique index on
+    /// <c>user_id</c> would reject whichever insert loses that race with an unhandled
+    /// <see cref="DbUpdateException"/> instead of one link simply winning. Catching the violation
+    /// and falling back to an update keeps this correct without a raw-SQL <c>ON CONFLICT</c>
+    /// upsert, which the EF Core InMemory provider (used by this store's unit tests) cannot run.
+    /// </remarks>
+    public async Task SaveAsync(
+        Guid userId,
+        string oid,
+        string tid,
+        string displayName,
+        CancellationToken ct = default)
+    {
+        // The object id and tenant id together are the join key, so both are required. The
+        // display name is display data and legitimately absent from some tokens, which is why it
+        // is the only one not guarded.
+        ArgumentException.ThrowIfNullOrWhiteSpace(oid);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tid);
+
+        await using var db = await factory.CreateDbContextAsync(ct);
+
+        var existing = await db.UserAzureIdentityLinks
+            .SingleOrDefaultAsync(x => x.UserId == userId, ct);
+
+        // Replace rather than add: the unique index would reject a second row anyway, and an
+        // upsert keeps ConnectedAt meaning "when this link was established".
+        if (existing is null)
+        {
+            var candidate = new UserAzureIdentityLinkEntity
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                ObjectId = oid,
+                TenantId = tid,
+                DisplayName = displayName ?? string.Empty,
+                ConnectedAt = timeProvider.GetUtcNow().UtcDateTime,
+            };
+            db.UserAzureIdentityLinks.Add(candidate);
+
+            try
+            {
+                await db.SaveChangesAsync(ct);
+                return;
+            }
+            catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+            {
+                // Lost a race with a concurrent connect for the same user: the row now exists
+                // because someone else's insert landed first between our read above and this
+                // write. Detach the insert the unique index rejected — otherwise the next
+                // SaveChangesAsync below would try to re-insert it alongside the update — and
+                // fall through to update the row that won instead of surfacing the violation.
+                db.Entry(candidate).State = EntityState.Detached;
+                existing = await db.UserAzureIdentityLinks.SingleAsync(x => x.UserId == userId, ct);
+            }
+        }
+
+        existing.ObjectId = oid;
+        existing.TenantId = tid;
+        existing.DisplayName = displayName ?? string.Empty;
+        existing.ConnectedAt = timeProvider.GetUtcNow().UtcDateTime;
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    private static bool IsUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation };
+
+    /// <summary>The link, or null when the user has not connected one.</summary>
+    public async Task<UserAzureIdentityLinkEntity?> GetAsync(Guid userId, CancellationToken ct = default)
+    {
+        await using var db = await factory.CreateDbContextAsync(ct);
+        return await db.UserAzureIdentityLinks
+            .AsNoTracking()
+            .SingleOrDefaultAsync(x => x.UserId == userId, ct);
+    }
+
+    /// <summary>Removes a user's link. False when there was nothing to remove.</summary>
+    public async Task<bool> DeleteAsync(Guid userId, CancellationToken ct = default)
+    {
+        await using var db = await factory.CreateDbContextAsync(ct);
+
+        var existing = await db.UserAzureIdentityLinks
+            .SingleOrDefaultAsync(x => x.UserId == userId, ct);
+        if (existing is null)
+            return false;
+
+        db.UserAzureIdentityLinks.Remove(existing);
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+}

--- a/src/Connapse.Identity/Services/AzureLinkConfirmations.cs
+++ b/src/Connapse.Identity/Services/AzureLinkConfirmations.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>A validated Entra id_token outcome, held until a real session can be shown to own it.</summary>
+/// <param name="StartedByUserId">The Connapse user who started the sign-in at /azure/connect.</param>
+/// <param name="ObjectId">The Entra object id (<c>oid</c>) the id_token resolved to.</param>
+/// <param name="TenantId">The Entra tenant id (<c>tid</c>) the id_token resolved to.</param>
+/// <param name="DisplayName">Display data, read from the token's <c>name</c>/<c>preferred_username</c>
+/// claim. Authorizes nothing.</param>
+public sealed record PendingAzureLink(
+    Guid StartedByUserId, string ObjectId, string TenantId, string DisplayName);
+
+/// <summary>
+/// Holds a validated Entra id_token outcome between the callback arriving and a signed-in user
+/// claiming it.
+/// </summary>
+/// <remarks>
+/// <b>Why the link is not saved when the id_token is validated.</b> Mirrors <see
+/// cref="SamlLinkConfirmations"/> and exists for the identical reason, even though the trigger is
+/// different. The AWS assertion arrives on a cross-site POST that carries no session, so the
+/// consumer literally cannot see who is signed in. The Entra callback is different — it is a
+/// same-site top-level GET, so a session cookie may well be present — but trusting that session
+/// would still be wrong: <c>state</c> only proves the callback belongs to a sign-in this
+/// deployment started, not that the browser completing it is the browser that started it.
+/// Anybody with a Connapse account can call /azure/connect, capture the resulting Entra
+/// authorization URL without following it, and send it to a colleague. The colleague's own,
+/// genuine Entra sign-in then returns to /azure/callback carrying the attacker's <c>state</c> —
+/// PKCE binds the authorization code to the verifier, not to a person, and the id_token's
+/// <c>nonce</c> matches because it was in the request the colleague actually completed. Every
+/// check on the token passes, because the token is real; the forgery is in the pairing between
+/// "who started this" and "whose identity it resolved to," exactly as with AWS.
+/// <para>
+/// So the outcome is parked here under a one-time code, the code goes out as an <c>HttpOnly</c>
+/// cookie, and the browser is redirected to a page that requires a session. That redirect is a
+/// same-site top-level GET, so both the code cookie and the session cookie are sent. Saving then
+/// happens only when the session and the started-by user agree — the attacker never receives the
+/// cookie (it is HttpOnly in the colleague's browser), and the colleague, who does hold it, is not
+/// the user the sign-in was started by.
+/// </para>
+/// <para>
+/// Single-process, like <see cref="SamlLinkConfirmations"/> and <see cref="AzureSignInRequests"/>.
+/// </para>
+/// </remarks>
+public sealed class AzureLinkConfirmations(IMemoryCache cache)
+{
+    private const string KeyPrefix = "azure-confirm:";
+
+    /// <summary>How long the confirmation may sit before it has to be started again.</summary>
+    public static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// A parked link plus the flag that makes claiming it single-use. The flag, not the cache
+    /// removal, is the boundary: <see cref="IMemoryCache"/> exposes no atomic take-and-remove, so
+    /// two concurrent <see cref="Consume"/> calls could both read the entry before either removed
+    /// it and both go on to save the link — the second racing an intervening disconnect and
+    /// re-establishing a link after deletion. Flipping <see cref="Claimed"/> with an interlocked
+    /// exchange lets exactly one caller win; the cache removal that follows is only cleanup.
+    /// </summary>
+    private sealed class Slot(PendingAzureLink link)
+    {
+        public readonly PendingAzureLink Link = link;
+
+        /// <summary>0 until a caller claims it; the winner is the one that moves it to 1.</summary>
+        public int Claimed;
+    }
+
+    /// <summary>Parks <paramref name="link"/> and returns the one-time code that claims it.</summary>
+    public string Start(PendingAzureLink link)
+    {
+        ArgumentNullException.ThrowIfNull(link);
+
+        string code = SamlNonce.Create();
+        cache.Set(KeyPrefix + code, new Slot(link), Lifetime);
+        return code;
+    }
+
+    /// <summary>The link <paramref name="code"/> claims, or null. Single use, even under concurrent
+    /// calls: exactly one caller ever receives a given parked link.</summary>
+    public PendingAzureLink? Consume(string? code)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+            return null;
+
+        string key = KeyPrefix + code;
+        if (!cache.TryGetValue(key, out Slot? slot) || slot is null)
+            return null;
+
+        // Exactly one concurrent caller flips 0 -> 1 and owns the link; the rest see a non-zero
+        // prior value and get nothing.
+        if (Interlocked.Exchange(ref slot.Claimed, 1) != 0)
+            return null;
+
+        cache.Remove(key);
+        return slot.Link;
+    }
+}

--- a/src/Connapse.Identity/Services/AzureLinkConfirmations.cs
+++ b/src/Connapse.Identity/Services/AzureLinkConfirmations.cs
@@ -61,6 +61,9 @@ public sealed class AzureLinkConfirmations(IMemoryCache cache)
     {
         public readonly PendingAzureLink Link = link;
 
+        /// <summary>When the link was parked, so a disconnect made after it can refuse it.</summary>
+        public readonly DateTime StartedAtUtc = DateTime.UtcNow;
+
         /// <summary>0 until a caller claims it; the winner is the one that moves it to 1.</summary>
         public int Claimed;
     }
@@ -92,6 +95,12 @@ public sealed class AzureLinkConfirmations(IMemoryCache cache)
             return null;
 
         cache.Remove(key);
-        return slot.Link;
+
+        // Parked before the person disconnected: the disconnect was the later decision, and
+        // claiming this now would put back the link it removed.
+        return AzureLinkRevocations.WasRevokedSince(cache, slot.Link.StartedByUserId, slot.StartedAtUtc) ? null : slot.Link;
     }
+
+    /// <summary>Refuses every confirmation parked for this user before now. Called on disconnect.</summary>
+    public void RevokeFor(Guid userId) => AzureLinkRevocations.Record(cache, userId);
 }

--- a/src/Connapse.Identity/Services/AzureOidcTokenExchanger.cs
+++ b/src/Connapse.Identity/Services/AzureOidcTokenExchanger.cs
@@ -1,0 +1,112 @@
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using Connapse.Core;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>
+/// Redeems an Entra ID authorization code for an id_token, authenticating the token request with
+/// a signed client-assertion JWT (private_key_jwt) rather than a client secret — Connapse never
+/// holds an Entra client secret, only the certificate configured in <see
+/// cref="AzureAdSignInSettings"/>.
+/// </summary>
+public sealed class AzureOidcTokenExchanger(
+    HttpClient httpClient,
+    IOptionsMonitor<AzureAdSignInSettings> options) : IOidcTokenExchanger
+{
+    private const string ClientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+    private static readonly JsonWebTokenHandler Handler = new();
+
+    public async Task<string> ExchangeAsync(string code, string codeVerifier, CancellationToken ct)
+    {
+        AzureAdSignInSettings settings = options.CurrentValue;
+        if (!settings.IsConfigured)
+            throw new InvalidOperationException("Azure AD sign-in is not configured.");
+
+        string tokenEndpoint = $"https://login.microsoftonline.com/{settings.TenantId}/oauth2/v2.0/token";
+        string clientAssertion = BuildClientAssertion(settings, tokenEndpoint);
+
+        var form = new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["code"] = code,
+            ["redirect_uri"] = settings.RedirectUri ?? string.Empty,
+            ["client_id"] = settings.ClientId ?? string.Empty,
+            ["code_verifier"] = codeVerifier,
+            ["client_assertion_type"] = ClientAssertionType,
+            ["client_assertion"] = clientAssertion,
+        };
+
+        using HttpResponseMessage response = await httpClient.PostAsync(
+            tokenEndpoint, new FormUrlEncodedContent(form), ct);
+        string body = await response.Content.ReadAsStringAsync(ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"Entra token exchange failed with status {(int)response.StatusCode}: {body}");
+        }
+
+        using JsonDocument doc = JsonDocument.Parse(body);
+        if (!doc.RootElement.TryGetProperty("id_token", out JsonElement idTokenElement))
+            throw new InvalidOperationException("Entra token response did not contain an id_token.");
+
+        return idTokenElement.GetString()
+            ?? throw new InvalidOperationException("Entra token response id_token was null.");
+    }
+
+    // Builds a private_key_jwt client assertion (RFC 7523 / OIDC core): a short-lived JWT
+    // asserting the client's own identity, signed with the certificate configured for Entra
+    // rather than a shared secret. iss/sub are both the client id per the spec; aud is the
+    // token endpoint being called.
+    private static string BuildClientAssertion(AzureAdSignInSettings settings, string tokenEndpoint)
+    {
+        X509Certificate2 cert = LoadCertificate(settings)
+            ?? throw new InvalidOperationException(
+                $"No usable client certificate loaded from '{settings.ClientCertificatePath}'. "
+                + "Fix the certificate configuration; Connapse will not fall back to a client secret.");
+
+        var signingCredentials = new X509SigningCredentials(cert, SecurityAlgorithms.RsaSha256);
+        DateTime now = DateTime.UtcNow;
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Audience = tokenEndpoint,
+            NotBefore = now.AddMinutes(-2),
+            Expires = now.AddMinutes(5),
+            SigningCredentials = signingCredentials,
+            Claims = new Dictionary<string, object>
+            {
+                ["iss"] = settings.ClientId!,
+                ["sub"] = settings.ClientId!,
+                ["jti"] = Guid.NewGuid().ToString(),
+            },
+            // Entra identifies the signing cert by the base64url SHA-1 thumbprint in the `x5t`
+            // header, not by `kid` — set it explicitly rather than relying on default header
+            // population.
+            AdditionalHeaderClaims = new Dictionary<string, object>
+            {
+                ["x5t"] = Base64UrlEncoder.Encode(cert.GetCertHash()),
+            },
+        };
+
+        return Handler.CreateToken(descriptor);
+    }
+
+    // Mirrors Connapse.Storage.CloudScope.ConnapseAzureCredentials.LoadCertificate. Connapse.Identity
+    // does not (and should not) reference Connapse.Storage, so this is a small local copy rather
+    // than a shared helper — keep the two in sync if the loading rule ever changes.
+    private static X509Certificate2? LoadCertificate(AzureAdSignInSettings settings)
+    {
+        if (string.IsNullOrWhiteSpace(settings.ClientCertificatePath)) return null;
+        if (!File.Exists(settings.ClientCertificatePath)) return null;
+
+        string ext = Path.GetExtension(settings.ClientCertificatePath).ToLowerInvariant();
+        return ext is ".pem" or ".crt"
+            ? X509Certificate2.CreateFromPemFile(settings.ClientCertificatePath)
+            : X509CertificateLoader.LoadPkcs12FromFile(settings.ClientCertificatePath, settings.ClientCertificatePassword);
+    }
+}

--- a/src/Connapse.Identity/Services/AzureOidcTokenExchanger.cs
+++ b/src/Connapse.Identity/Services/AzureOidcTokenExchanger.cs
@@ -18,6 +18,27 @@ public sealed class AzureOidcTokenExchanger(
     IOptionsMonitor<AzureAdSignInSettings> options) : IOidcTokenExchanger
 {
     private const string ClientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+    /// <summary>The <c>error</c> code, the first AADSTS code in the description, and the correlation
+    /// id from an Entra error response — enough to look the failure up, without the response body.</summary>
+    internal static string DescribeError(string body)
+    {
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(body);
+            JsonElement root = document.RootElement;
+            string? error = root.TryGetProperty("error", out JsonElement e) ? e.GetString() : null;
+            string? description = root.TryGetProperty("error_description", out JsonElement d) ? d.GetString() : null;
+            string? correlation = root.TryGetProperty("correlation_id", out JsonElement c) ? c.GetString() : null;
+            string? code = description is null ? null
+                : System.Text.RegularExpressions.Regex.Match(description, "AADSTS[0-9]+").Value is { Length: > 0 } m ? m : null;
+            return $"{error ?? "unknown_error"}{(code is null ? "" : $" ({code})")}{(correlation is null ? "" : $", correlation {correlation}")}";
+        }
+        catch (JsonException)
+        {
+            return "unreadable error response";
+        }
+    }
     private static readonly JsonWebTokenHandler Handler = new();
 
     public async Task<string> ExchangeAsync(string code, string codeVerifier, CancellationToken ct)
@@ -46,8 +67,10 @@ public sealed class AzureOidcTokenExchanger(
 
         if (!response.IsSuccessStatusCode)
         {
+            // The error code and correlation id, not the whole body: callers log this exception,
+            // and a remote response body is not something to copy into logs verbatim.
             throw new InvalidOperationException(
-                $"Entra token exchange failed with status {(int)response.StatusCode}: {body}");
+                $"Entra token exchange failed with status {(int)response.StatusCode}: {DescribeError(body)}");
         }
 
         using JsonDocument doc = JsonDocument.Parse(body);

--- a/src/Connapse.Identity/Services/AzureOidcTokenExchanger.cs
+++ b/src/Connapse.Identity/Services/AzureOidcTokenExchanger.cs
@@ -62,7 +62,7 @@ public sealed class AzureOidcTokenExchanger(
     // asserting the client's own identity, signed with the certificate configured for Entra
     // rather than a shared secret. iss/sub are both the client id per the spec; aud is the
     // token endpoint being called.
-    private static string BuildClientAssertion(AzureAdSignInSettings settings, string tokenEndpoint)
+    internal static string BuildClientAssertion(AzureAdSignInSettings settings, string tokenEndpoint)
     {
         X509Certificate2 cert = LoadCertificate(settings)
             ?? throw new InvalidOperationException(
@@ -85,12 +85,8 @@ public sealed class AzureOidcTokenExchanger(
                 ["jti"] = Guid.NewGuid().ToString(),
             },
             // Entra identifies the signing cert by the base64url SHA-1 thumbprint in the `x5t`
-            // header, not by `kid` — set it explicitly rather than relying on default header
-            // population.
-            AdditionalHeaderClaims = new Dictionary<string, object>
-            {
-                ["x5t"] = Base64UrlEncoder.Encode(cert.GetCertHash()),
-            },
+            // header. JsonWebTokenHandler writes `x5t` (and `kid`) itself from X509SigningCredentials
+            // and rejects them in AdditionalHeaderClaims (IDX14116), so nothing is added here.
         };
 
         return Handler.CreateToken(descriptor);

--- a/src/Connapse.Identity/Services/AzureSignInRequests.cs
+++ b/src/Connapse.Identity/Services/AzureSignInRequests.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>What was recorded when an Entra sign-in was started.</summary>
+/// <remarks>
+/// The PKCE verifier and nonce travel with the state so the callback can redeem the
+/// authorization code and validate the id token's nonce against the request that asked for it.
+/// </remarks>
+public sealed record AzurePendingSignIn(
+    string State,
+    string CodeVerifier,
+    string Nonce,
+    Guid UserId,
+    DateTime ExpiresAtUtc);
+
+/// <summary>
+/// Remembers who started an Entra sign-in, keyed by the OAuth <c>state</c> value, so the
+/// callback can attribute the returned authorization code and validate it belongs to a request
+/// this process actually issued.
+/// </summary>
+/// <remarks>
+/// Backed by <see cref="IMemoryCache"/>, like <see cref="SamlSignInRequests"/> and for the same
+/// two reasons. First, the cache expires each entry at the sign-in's own deadline, so a sign-in
+/// that is started and never completed — the browser closed at the Entra prompt, the redirect
+/// URL captured but never followed — does not linger: abandoned entries are evicted on expiry
+/// rather than accumulating for the life of the process. A raw dictionary that only removed on
+/// redemption would grow without bound under repeated abandoned sign-ins. Second, single-process
+/// by design: it spans one redirect to Entra and back, and several instances behind a load
+/// balancer would need the callback to land on the instance that started the sign-in, or a
+/// shared store.
+/// </remarks>
+public sealed class AzureSignInRequests(IMemoryCache cache)
+{
+    private const string KeyPrefix = "azure-signin:";
+
+    /// <summary>Records that a sign-in was started for <paramref name="pending"/>'s state.</summary>
+    /// <remarks>
+    /// The entry is set to expire at the request's own <see cref="AzurePendingSignIn.ExpiresAtUtc"/>,
+    /// so it is reclaimed automatically whether or not the callback ever arrives.
+    /// </remarks>
+    public void Add(AzurePendingSignIn pending) =>
+        cache.Set(KeyPrefix + pending.State, pending, new DateTimeOffset(pending.ExpiresAtUtc, TimeSpan.Zero));
+
+    /// <summary>
+    /// Removes and returns the pending sign-in for <paramref name="state"/>, or null if it does
+    /// not exist or has expired. Single use.
+    /// </summary>
+    public AzurePendingSignIn? TakeByState(string state)
+    {
+        string key = KeyPrefix + state;
+        if (!cache.TryGetValue(key, out AzurePendingSignIn? pending) || pending is null)
+            return null;
+
+        cache.Remove(key);
+        return pending;
+    }
+}

--- a/src/Connapse.Identity/Services/AzureSignInRequests.cs
+++ b/src/Connapse.Identity/Services/AzureSignInRequests.cs
@@ -42,8 +42,16 @@ public sealed class AzureSignInRequests(IMemoryCache cache)
     /// The entry is set to expire at the request's own <see cref="AzurePendingSignIn.ExpiresAtUtc"/>,
     /// so it is reclaimed automatically whether or not the callback ever arrives.
     /// </remarks>
-    public void Add(AzurePendingSignIn pending) =>
+    public void Add(AzurePendingSignIn pending)
+    {
+        // A request recorded without a start time started now. Left at its default it would read
+        // as older than every revocation, and one disconnect would refuse the user's sign-ins for
+        // as long as the revocation is remembered.
+        if (pending.StartedAtUtc == default)
+            pending = pending with { StartedAtUtc = DateTime.UtcNow };
+
         cache.Set(KeyPrefix + pending.State, pending, new DateTimeOffset(pending.ExpiresAtUtc, TimeSpan.Zero));
+    }
 
     /// <summary>
     /// Removes and returns the pending sign-in for <paramref name="state"/>, or null if it does

--- a/src/Connapse.Identity/Services/AzureSignInRequests.cs
+++ b/src/Connapse.Identity/Services/AzureSignInRequests.cs
@@ -7,12 +7,15 @@ namespace Connapse.Identity.Services;
 /// The PKCE verifier and nonce travel with the state so the callback can redeem the
 /// authorization code and validate the id token's nonce against the request that asked for it.
 /// </remarks>
+/// <param name="StartedAtUtc">When the sign-in was started, so a disconnect made after it can
+/// refuse it: a flow begun before the person revoked their link must not re-create the link.</param>
 public sealed record AzurePendingSignIn(
     string State,
     string CodeVerifier,
     string Nonce,
     Guid UserId,
-    DateTime ExpiresAtUtc);
+    DateTime ExpiresAtUtc,
+    DateTime StartedAtUtc = default);
 
 /// <summary>
 /// Remembers who started an Entra sign-in, keyed by the OAuth <c>state</c> value, so the
@@ -53,6 +56,34 @@ public sealed class AzureSignInRequests(IMemoryCache cache)
             return null;
 
         cache.Remove(key);
-        return pending;
+
+        // A sign-in started before the person disconnected must not finish: the disconnect was
+        // the later decision, and completing the older flow would re-create the link it removed.
+        return AzureLinkRevocations.WasRevokedSince(cache, pending.UserId, pending.StartedAtUtc) ? null : pending;
     }
+
+    /// <summary>Refuses every sign-in this user started before now. Called on disconnect.</summary>
+    public void RevokeFor(Guid userId) => AzureLinkRevocations.Record(cache, userId);
+}
+
+/// <summary>
+/// The moment a user last disconnected their Entra identity, kept for as long as any flow they
+/// started before it could still complete. Shared by the sign-in and confirmation stores, which
+/// both sit on the same cache; a flow whose start predates the revocation is refused by whichever
+/// store it reaches next.
+/// </summary>
+internal static class AzureLinkRevocations
+{
+    private const string KeyPrefix = "azure-link-revoked:";
+
+    /// <summary>Longer than a sign-in (10 min) or a parked confirmation (5 min) can live.</summary>
+    private static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(15);
+
+    public static void Record(IMemoryCache cache, Guid userId) =>
+        cache.Set(KeyPrefix + userId, DateTime.UtcNow, Lifetime);
+
+    /// <summary>Whether the user disconnected at or after <paramref name="startedAtUtc"/>. A flow
+    /// with no recorded start (default) is treated as older than any revocation.</summary>
+    public static bool WasRevokedSince(IMemoryCache cache, Guid userId, DateTime startedAtUtc) =>
+        cache.TryGetValue(KeyPrefix + userId, out DateTime revokedAt) && revokedAt >= startedAtUtc;
 }

--- a/src/Connapse.Identity/Services/IAzureIdentityLinkService.cs
+++ b/src/Connapse.Identity/Services/IAzureIdentityLinkService.cs
@@ -1,0 +1,20 @@
+using Connapse.Core;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>
+/// The read/store/disconnect side of a user's Entra identity link, for the integrations page and
+/// any other caller that needs the link's state without touching <see cref="AzureIdentityLinkStore"/>
+/// directly.
+/// </summary>
+public interface IAzureIdentityLinkService
+{
+    /// <summary>The link's display state, or null when the user has not connected one.</summary>
+    Task<AzureIdentityLinkDto?> GetAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>Stores a user's link, replacing any existing one.</summary>
+    Task StoreAsync(Guid userId, string oid, string tid, string displayName, CancellationToken ct = default);
+
+    /// <summary>Removes a user's link. False when there was nothing to remove.</summary>
+    Task<bool> DisconnectAsync(Guid userId, CancellationToken ct = default);
+}

--- a/src/Connapse.Identity/Services/IAzureSigningKeySource.cs
+++ b/src/Connapse.Identity/Services/IAzureSigningKeySource.cs
@@ -1,0 +1,13 @@
+using Microsoft.IdentityModel.Tokens;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>
+/// Supplies the JSON Web Key Set (JWKS) signing keys Entra ID publishes for a tenant, so <see
+/// cref="AzureIdTokenValidator"/> never has to know whether they came from the network or a test
+/// double — validation itself must never make a network call.
+/// </summary>
+public interface IAzureSigningKeySource
+{
+    Task<IReadOnlyList<SecurityKey>> GetSigningKeysAsync(string tenantId, CancellationToken ct);
+}

--- a/src/Connapse.Identity/Services/IOidcTokenExchanger.cs
+++ b/src/Connapse.Identity/Services/IOidcTokenExchanger.cs
@@ -1,0 +1,12 @@
+namespace Connapse.Identity.Services;
+
+/// <summary>
+/// Redeems an Entra ID authorization code (from the OAuth 2.1 + PKCE sign-in flow) for the raw
+/// id_token JWT. The id_token still needs to be validated by <see cref="AzureIdTokenValidator"/>
+/// before any claim in it is trusted.
+/// </summary>
+public interface IOidcTokenExchanger
+{
+    /// <summary>Exchanges an authorization <paramref name="code"/> for a raw id_token JWT.</summary>
+    Task<string> ExchangeAsync(string code, string codeVerifier, CancellationToken ct);
+}

--- a/src/Connapse.Identity/Services/OidcPkce.cs
+++ b/src/Connapse.Identity/Services/OidcPkce.cs
@@ -1,0 +1,29 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Connapse.Identity.Services;
+
+/// <summary>
+/// Generates a PKCE (RFC 7636) verifier/challenge pair for the Entra authorization-code flow.
+/// </summary>
+/// <remarks>
+/// S256 only — the challenge sent to Entra is never the plaintext verifier, so a value observed
+/// in the authorization request (redirect URL, browser history, proxy logs) cannot be replayed
+/// to redeem a code without also knowing the verifier held back for the token exchange.
+/// </remarks>
+public static class OidcPkce
+{
+    /// <summary>Creates a new (verifier, challenge) pair. <c>challenge = base64url(SHA256(ASCII(verifier)))</c>.</summary>
+    public static (string Verifier, string Challenge) Create()
+    {
+        string verifier = Base64Url(RandomNumberGenerator.GetBytes(32));
+
+        using SHA256 sha = SHA256.Create();
+        string challenge = Base64Url(sha.ComputeHash(Encoding.ASCII.GetBytes(verifier)));
+
+        return (verifier, challenge);
+    }
+
+    private static string Base64Url(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+}

--- a/src/Connapse.Search/Hybrid/HybridSearchService.cs
+++ b/src/Connapse.Search/Hybrid/HybridSearchService.cs
@@ -106,6 +106,15 @@ public class HybridSearchService : IKnowledgeSearch
         var vectorSearch = scope.ServiceProvider.GetRequiredService<VectorSearchService>();
         var keywordSearch = scope.ServiceProvider.GetRequiredService<KeywordSearchService>();
 
+        // Per-hit verify (Phase 4e). Resolved once per search alongside the other scoped services
+        // above. Retrieval over-fetches by CandidateMultiplier so the verifier's drop+backfill has
+        // material to work with; VerifyAsync narrows back down to options.TopK after ranking. For
+        // AWS-only/non-cloud deployments (Azure AD not configured) the multiplier is 1, so this
+        // costs nothing extra and VerifyAsync passes every hit through untouched.
+        var verifier = scope.ServiceProvider.GetRequiredService<ISearchResultVerifier>();
+        int overFetch = Math.Max(1, verifier.CandidateMultiplier);
+        SearchOptions retrieveOptions = options with { TopK = options.TopK * overFetch };
+
         // One resolution per search, taken here because this is where the query fans out. Doing it
         // inside each leaf would mean two answers for one query, and hybrid would be the mode in
         // which they could disagree — half a result set from one set of permissions and half from
@@ -131,16 +140,16 @@ public class HybridSearchService : IKnowledgeSearch
         switch (mode)
         {
             case SearchMode.Semantic:
-                hits = await vectorSearch.SearchAsync(query, options, scopes, ct);
+                hits = await vectorSearch.SearchAsync(query, retrieveOptions, scopes, ct);
                 break;
 
             case SearchMode.Keyword:
-                hits = await keywordSearch.SearchAsync(query, options, scopes, ct);
+                hits = await keywordSearch.SearchAsync(query, retrieveOptions, scopes, ct);
                 break;
 
             case SearchMode.Hybrid:
             default:
-                hits = await PerformHybridSearchAsync(query, options, scopes, ct);
+                hits = await PerformHybridSearchAsync(query, retrieveOptions, scopes, ct);
                 break;
         }
 
@@ -164,12 +173,18 @@ public class HybridSearchService : IKnowledgeSearch
             }
         }
 
-        // Apply final score threshold, auto-cut, and limit
-        var filtered = hits
+        // Apply final score threshold and rank order
+        var ordered = hits
             .Where(h => h.Score >= options.MinScore)
             .OrderByDescending(h => h.Score)
             .ToList();
 
+        // Per-hit verify + backfill: drops hits the searcher may not read and backfills from the
+        // over-fetched, lower-ranked candidates so up to options.TopK survivors come back where
+        // possible. Passes s3/non-cloud hits and everything else untouched when not enforcing.
+        IReadOnlyList<SearchHit> verified = await verifier.VerifyAsync(ordered, options.UserId, options.TopK, ct);
+
+        var filtered = verified.ToList();
         if (searchSettings.AutoCut)
             filtered = ApplyAutoCut(filtered);
 

--- a/src/Connapse.Storage/CloudScope/AncestorTraverseResolver.cs
+++ b/src/Connapse.Storage/CloudScope/AncestorTraverseResolver.cs
@@ -1,0 +1,89 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Decides whether an identity set holds traverse-<c>X</c> on <b>every</b> ancestor directory of a
+/// candidate Gen2 file — the necessary condition (with the file's own read, checked by Phase 4e's
+/// verifier) for the file to be readable. Resolves lazily per directory with the mode-bits
+/// short-circuit and caches confident per-directory decisions, so candidates that share ancestors
+/// share the work. Fails closed: any directory that cannot be read denies the whole traverse and is
+/// never cached.
+/// </summary>
+public sealed class AncestorTraverseResolver(IGen2DirectoryReader reader, IMemoryCache cache)
+{
+    /// <summary>Cache window for a confident per-directory traverse decision; also its revocation
+    /// delay. Kept short (the spec's ~30–120 s) so a changed ACL takes effect quickly.</summary>
+    public static readonly TimeSpan CacheLifetime = TimeSpan.FromSeconds(60);
+
+    private const string KeyPrefix = "gen2-traverse:";
+
+    public async Task<bool> HoldsTraverseOnAllAncestorsAsync(
+        Gen2Path file, string userOid, IReadOnlySet<string> groupOids, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(userOid);
+        ArgumentNullException.ThrowIfNull(groupOids);
+
+        // Snapshot the group set once, up front. The caller passes an IReadOnlySet, which does not
+        // guarantee immutability (a HashSet satisfies it); a set mutated during an awaited read could
+        // otherwise cache a decision computed with post-mutation membership under the pre-mutation
+        // key. The snapshot is used for both the cache key and every evaluation. userOid is a single
+        // immutable value.
+        var groups = groupOids.ToHashSet(StringComparer.Ordinal);
+        string principalKey = userOid + "|" + string.Join(",", groups.OrderBy(g => g, StringComparer.Ordinal));
+
+        foreach (Gen2Path dir in Ancestors(file))
+        {
+            string key = $"{KeyPrefix}{dir.Account}:{dir.FileSystem}:{dir.Path}:{principalKey}";
+            if (cache.TryGetValue(key, out bool cached))
+            {
+                if (!cached) return false; // a cached definitive deny short-circuits the whole walk
+                continue;
+            }
+
+            bool? decision = await ResolveDirectoryExecuteAsync(dir, userOid, groups, ct);
+            if (decision is null)
+                return false; // uncertain → fail closed, uncached (retried next time)
+
+            cache.Set(key, decision.Value, CacheLifetime);
+            if (!decision.Value)
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>Whether the requester (<paramref name="userOid"/> plus <paramref name="groupOids"/>)
+    /// holds traverse-<c>X</c> on one directory. <c>null</c> means the directory could not be read
+    /// (uncertain → the caller denies).</summary>
+    private async Task<bool?> ResolveDirectoryExecuteAsync(
+        Gen2Path dir, string userOid, IReadOnlySet<string> groupOids, CancellationToken ct)
+    {
+        Gen2ModeBits? bits = await reader.ReadModeBitsAsync(dir, ct);
+        if (bits is null)
+            return null;
+
+        // Mode bits alone are authoritative when the requester owns the directory (owner is terminal)
+        // or the ACL is not extended (no named entries, no mask). Otherwise a named entry could be
+        // decisive, so the full access ACL is read.
+        bool ownsDir = bits.OwnerOid is not null && bits.OwnerOid == userOid;
+        if (ownsDir || !bits.HasExtendedAcl)
+            return PosixAclEvaluator.Grants(bits.ToAcl(), userOid, groupOids, Gen2Permission.Execute);
+
+        Gen2Acl? full = await reader.ReadAccessAclAsync(dir, ct);
+        if (full is null)
+            return null;
+        return PosixAclEvaluator.Grants(full, userOid, groupOids, Gen2Permission.Execute);
+    }
+
+    /// <summary>The filesystem root and every directory prefix of the file, file itself excluded.</summary>
+    private static IEnumerable<Gen2Path> Ancestors(Gen2Path file)
+    {
+        yield return file with { Path = "" }; // filesystem root
+
+        string[] segments = file.Path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (int i = 1; i < segments.Length; i++) // exclude the last segment (the file)
+            yield return file with { Path = string.Join('/', segments[..i]) };
+    }
+}

--- a/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
+++ b/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
@@ -1,0 +1,246 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Azure.Core;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Resolves a searcher's effective RBAC-readable azblob scopes from ARM: one roleAssignments call
+/// at the subscription scope (transitive over groups, WITHOUT atScope so account/container
+/// assignments are included) minus a parallel denyAssignments call. Fails closed; caches only
+/// confident answers. Mirrors <see cref="GraphDirectoryReader"/>'s transport/caching discipline.
+/// </summary>
+public sealed class ArmRbacReader(
+    HttpClient httpClient,
+    TokenCredential azureCredential,
+    IMemoryCache cache,
+    IOptionsMonitor<AzureProviderSettings> options) : IAzureRbacReader
+{
+    private const string ArmBase = "https://management.azure.com";
+    private const string ApiVersion = "2022-04-01";
+    private static readonly string[] ArmScopes = ["https://management.azure.com/.default"];
+
+    private static readonly HashSet<string> BlobDataReadRoles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1", // Storage Blob Data Reader
+        "ba92f5b4-2d11-453d-a403-e96b0029c9fe", // Storage Blob Data Contributor
+        "b7e6dc6d-f1e8-4753-8033-0f276bb0955b", // Storage Blob Data Owner
+    };
+
+    public static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(5);
+
+    public async Task<AzureRbacScopes> ResolveAsync(string primaryOid, CancellationToken ct = default)
+    {
+        AzureProviderSettings settings = options.CurrentValue;
+        string? sub = settings.SubscriptionId;
+        if (string.IsNullOrWhiteSpace(sub))
+            return AzureRbacScopes.Failed();
+
+        // Key by tenant + subscription + oid: the subscription and credential come from reloadable
+        // settings, so a cached result must never be reused across a subscription or tenant change
+        // (which would expose accounts not authorized in the new context).
+        string cacheKey = $"azure-rbac:{settings.TenantId}:{sub}:{primaryOid}";
+        if (cache.TryGetValue(cacheKey, out AzureRbacScopes? cached) && cached is not null)
+            return cached;
+
+        AzureRbacScopes result;
+        try
+        {
+            result = await ResolveUncachedAsync(sub, primaryOid, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return AzureRbacScopes.Failed();
+        }
+
+        if (result.Outcome is RbacOutcome.Resolved)
+            cache.Set(cacheKey, result, CacheLifetime);
+        return result;
+    }
+
+    private async Task<AzureRbacScopes> ResolveUncachedAsync(string sub, string oid, CancellationToken ct)
+    {
+        AccessToken token = await azureCredential.GetTokenAsync(new TokenRequestContext(ArmScopes), ct);
+
+        Task<IReadOnlyList<Assignment>> grantsTask = ListAllAsync(
+            $"{ArmBase}/subscriptions/{sub}/providers/Microsoft.Authorization/roleAssignments" +
+            $"?api-version={ApiVersion}&$filter=assignedTo('{oid}')", token, ct);
+        Task<IReadOnlyList<Assignment>> denyTask = ListAllAsync(
+            $"{ArmBase}/subscriptions/{sub}/providers/Microsoft.Authorization/denyAssignments" +
+            $"?api-version={ApiVersion}&$filter=assignedTo('{oid}')", token, ct);
+        await Task.WhenAll(grantsTask, denyTask); // a failure in either throws → caller fails closed
+
+        var prefixes = new List<AzureScope>();
+        var tags = new List<AzureTagCondition>();
+        foreach (Assignment a in grantsTask.Result)
+        {
+            string? roleGuid = LastSegment(a.Properties?.RoleDefinitionId);
+            if (roleGuid is null || !BlobDataReadRoles.Contains(roleGuid) || a.Properties?.Scope is null)
+                continue;
+            ApplyGrant(a.Properties.Scope, a.Properties.Condition, prefixes, tags);
+        }
+
+        IReadOnlyList<string> denyPrefixes = DenyPrefixes(denyTask.Result);
+        if (denyPrefixes.Count > 0)
+        {
+            prefixes = prefixes.Where(p => !CoveredByAnyDeny(p.Prefix, denyPrefixes)).ToList();
+            tags = tags.Where(t => !CoveredByAnyDeny(t.Scope, denyPrefixes)).ToList();
+        }
+
+        return AzureRbacScopes.Resolved(prefixes, tags);
+    }
+
+    /// <summary>Deny scopes (as azblob prefixes) that apply to blob read for this searcher.</summary>
+    private static IReadOnlyList<string> DenyPrefixes(IReadOnlyList<Assignment> denies)
+    {
+        var result = new List<string>();
+        foreach (Assignment d in denies)
+        {
+            if (d.Properties?.Scope is null) continue;
+            if (AppliesToBlobRead(d.Properties.Permissions))
+                result.Add(AzureRbacScopeTranslator.ToAzblobPrefix(d.Properties.Scope));
+        }
+        return result;
+    }
+
+    private const string BlobReadAction = "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read";
+
+    private static bool AppliesToBlobRead(IReadOnlyList<Permission>? permissions)
+    {
+        if (permissions is null) return false;
+        foreach (Permission p in permissions)
+        {
+            // A deny applies to blob read only when a dataAction covers the read action AND no
+            // notDataAction excludes it (dataActions minus notDataActions). Ignoring notDataActions
+            // would over-subtract and hide legitimately-readable content.
+            bool granted = (p.DataActions ?? []).Any(MatchesBlobRead);
+            bool excluded = (p.NotDataActions ?? []).Any(MatchesBlobRead);
+            if (granted && !excluded)
+                return true;
+        }
+        return false;
+    }
+
+    private static bool MatchesBlobRead(string action) =>
+        action == "*"
+        || action.Equals(BlobReadAction, StringComparison.OrdinalIgnoreCase)
+        || (action.EndsWith('*') && BlobReadAction.StartsWith(action[..^1], StringComparison.OrdinalIgnoreCase));
+
+    // A grant is removed if it OVERLAPS any applicable deny in EITHER direction:
+    //  - deny at a broader-or-equal scope (deny is a prefix of the grant) covers the grant; and
+    //  - deny at a narrower scope (a "hole" beneath the grant — the grant is a prefix of the deny)
+    //    cannot be represented as "grant minus a hole" in a prefix set, so the whole grant is
+    //    conservatively dropped (over-subtraction = under-grant, the fail-closed direction).
+    // Deny wins either way. "azblob://" on either side matches everything. All emitted prefixes end
+    // in "/" (or are a path-condition prefix), so container-name boundaries are respected.
+    private static bool CoveredByAnyDeny(string grantPrefix, IReadOnlyList<string> denyPrefixes) =>
+        denyPrefixes.Any(d =>
+            grantPrefix.StartsWith(d, StringComparison.Ordinal) ||
+            d.StartsWith(grantPrefix, StringComparison.Ordinal));
+
+    /// <summary>Maps one matched grant (scope + ABAC condition) into a prefix, a tag residue, or a
+    /// drop. Every ABAC restriction is intersected with the assignment's own scope; when it cannot
+    /// be expressed as an azblob prefix the grant is dropped (fail closed), never broadened.</summary>
+    internal static void ApplyGrant(string armScope, string? condition, List<AzureScope> prefixes, List<AzureTagCondition> tags)
+    {
+        string basePrefix = AzureRbacScopeTranslator.ToAzblobPrefix(armScope);
+        (string? account, string? container) = SplitPrefix(basePrefix);
+        AbacResult abac = AzureAbacConditionParser.Parse(condition);
+        switch (abac.Kind)
+        {
+            case AbacKind.None:
+                prefixes.Add(new AzureScope(basePrefix));
+                break;
+
+            case AbacKind.PathPrefix:
+                // A blob-path condition is a prefix WITHIN a container, so it can only be expressed
+                // as an azblob prefix when the scope already fixes the container. On an account or
+                // broader scope the same path applies inside EVERY container (not a container named
+                // for the path), which cannot be represented — drop (fail closed).
+                if (container is not null)
+                    prefixes.Add(new AzureScope(basePrefix + abac.PathPrefix));
+                break;
+
+            case AbacKind.ContainerName:
+                string? named = abac.ContainerName;
+                if (account is null || named is null)
+                    break; // account unknown → can't apply → drop
+                if (container is null)
+                    prefixes.Add(new AzureScope($"azblob://{account}/{named}/")); // narrow account to the named container
+                else if (string.Equals(container, named, StringComparison.Ordinal))
+                    prefixes.Add(new AzureScope(basePrefix)); // condition names the same container as the scope
+                // else: names a DIFFERENT container than the assignment's scope → grants nothing → drop
+                break;
+
+            case AbacKind.Tag:
+                tags.Add(new AzureTagCondition(basePrefix, abac.TagKey!, abac.TagValue!, abac.TagKeyCaseSensitive, abac.ValueCaseSensitive));
+                break;
+
+            case AbacKind.Unparseable:
+            default:
+                break; // drop this grant only (fail closed)
+        }
+    }
+
+    /// <summary>Splits an azblob prefix into (account?, container?): "azblob://" → (null,null);
+    /// "azblob://acct/" → (acct,null); "azblob://acct/c/" → (acct,c).</summary>
+    private static (string? Account, string? Container) SplitPrefix(string basePrefix)
+    {
+        if (basePrefix == "azblob://")
+            return (null, null);
+        string[] segs = basePrefix["azblob://".Length..].TrimEnd('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segs.Length switch
+        {
+            0 => (null, null),
+            1 => (segs[0], null),
+            _ => (segs[0], segs[1]),
+        };
+    }
+
+    private static string? LastSegment(string? id) =>
+        string.IsNullOrEmpty(id) ? null : id.Split('/', StringSplitOptions.RemoveEmptyEntries)[^1];
+
+    private async Task<IReadOnlyList<Assignment>> ListAllAsync(string url, AccessToken token, CancellationToken ct)
+    {
+        var all = new List<Assignment>();
+        string? next = url;
+        while (next is not null)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, next);
+            request.Headers.Authorization = new("Bearer", token.Token);
+            using HttpResponseMessage response = await httpClient.SendAsync(request, ct);
+            response.EnsureSuccessStatusCode(); // non-2xx → throw → caller fails closed
+            ArmList? page = await response.Content.ReadFromJsonAsync<ArmList>(ct);
+            // A 200 whose body is missing or has a null "value" is a malformed/anomalous page. It
+            // must fail closed rather than be read as "no entries" — silently swallowing a deny page
+            // this way would omit denies and turn into an over-grant.
+            if (page?.Value is null)
+                throw new InvalidOperationException("ARM list response had no 'value' array.");
+            all.AddRange(page.Value);
+            next = page.NextLink;
+        }
+        return all;
+    }
+
+    // ---- ARM DTOs ----
+    internal sealed record ArmList(
+        [property: JsonPropertyName("value")] IReadOnlyList<Assignment>? Value,
+        [property: JsonPropertyName("nextLink")] string? NextLink);
+    internal sealed record Assignment([property: JsonPropertyName("properties")] AssignmentProps? Properties);
+    internal sealed record AssignmentProps(
+        [property: JsonPropertyName("roleDefinitionId")] string? RoleDefinitionId,
+        [property: JsonPropertyName("scope")] string? Scope,
+        [property: JsonPropertyName("condition")] string? Condition,
+        [property: JsonPropertyName("permissions")] IReadOnlyList<Permission>? Permissions);
+    internal sealed record Permission(
+        [property: JsonPropertyName("dataActions")] IReadOnlyList<string>? DataActions,
+        [property: JsonPropertyName("notDataActions")] IReadOnlyList<string>? NotDataActions);
+}

--- a/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
+++ b/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
@@ -95,7 +95,7 @@ public sealed class ArmRbacReader(
             tags = tags.Where(t => !CoveredByAnyDeny(t.Scope, denyPrefixes)).ToList();
         }
 
-        return AzureRbacScopes.Resolved(prefixes, tags);
+        return AzureRbacScopes.Resolved(prefixes, tags, denyPrefixes);
     }
 
     /// <summary>Deny scopes (as azblob prefixes) that apply to blob read for this searcher.</summary>

--- a/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
+++ b/src/Connapse.Storage/CloudScope/ArmRbacReader.cs
@@ -152,6 +152,15 @@ public sealed class ArmRbacReader(
     internal static void ApplyGrant(string armScope, string? condition, List<AzureScope> prefixes, List<AzureTagCondition> tags)
     {
         string basePrefix = AzureRbacScopeTranslator.ToAzblobPrefix(armScope);
+
+        // A resource-group scope translates to the bare "azblob://" wildcard but is bounded to the
+        // accounts in that one resource group, which cannot be enumerated here. Honouring the
+        // wildcard would grant every account across the subscription — a cross-scope disclosure — so
+        // the whole grant is dropped (fail closed, an under-grant), regardless of any ABAC condition.
+        // Only a subscription/management-group/root scope legitimately covers everything.
+        if (basePrefix == "azblob://" && !AzureRbacScopeTranslator.IsSubscriptionWideOrBroader(armScope))
+            return;
+
         (string? account, string? container) = SplitPrefix(basePrefix);
         AbacResult abac = AzureAbacConditionParser.Parse(condition);
         switch (abac.Kind)

--- a/src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs
+++ b/src/Connapse.Storage/CloudScope/AzureAbacConditionParser.cs
@@ -1,0 +1,91 @@
+using System.Text.RegularExpressions;
+
+namespace Connapse.Storage.CloudScope;
+
+public enum AbacKind { None, PathPrefix, ContainerName, Tag, Unparseable }
+
+public record AbacResult(
+    AbacKind Kind,
+    string? PathPrefix = null,
+    string? ContainerName = null,
+    string? TagKey = null,
+    string? TagValue = null,
+    bool TagKeyCaseSensitive = false,
+    bool ValueCaseSensitive = false);
+
+/// <summary>
+/// Classifies the canonical Azure Blob ABAC read conditions into a path prefix, a container name, a
+/// tag predicate, or Unparseable. Soundness over recall: the WHOLE condition must match one of the
+/// documented read templates (an action guard <c>(!(ActionMatches{…blobs/read} [AND NOT
+/// SubOperationMatches{Blob.List}])) OR (&lt;single predicate&gt;)</c>) — a fragment match is never
+/// enough, because a compound/inverted expression would otherwise be read as a positive grant. Any
+/// condition that is not exactly a recognized template is <see cref="AbacKind.Unparseable"/> and the
+/// caller drops that grant (fail closed). A null/blank condition is <see cref="AbacKind.None"/> (an
+/// unconditional grant).
+/// </summary>
+public static partial class AzureAbacConditionParser
+{
+    // Whole-condition templates: ^( (!(ActionMatches{…read} [AND NOT SubOperationMatches{Blob.List}])) OR ( <predicate> ) )$
+    // Anchored so a compound/inverted/extra-clause condition cannot partially match.
+
+    [GeneratedRegex(
+        @"^\s*\(\s*\(\s*!\s*\(\s*ActionMatches\{'Microsoft\.Storage/storageAccounts/blobServices/containers/blobs/read'\}(?:\s+AND\s+NOT\s+SubOperationMatches\{'Blob\.List'\})?\s*\)\s*\)\s+OR\s+\(\s*@Resource\[Microsoft\.Storage/storageAccounts/blobServices/containers/blobs:path\]\s+(StringStartsWith|StringLike)\s+'([^']*)'\s*\)\s*\)\s*$",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex PathTemplate();
+
+    [GeneratedRegex(
+        @"^\s*\(\s*\(\s*!\s*\(\s*ActionMatches\{'Microsoft\.Storage/storageAccounts/blobServices/containers/blobs/read'\}(?:\s+AND\s+NOT\s+SubOperationMatches\{'Blob\.List'\})?\s*\)\s*\)\s+OR\s+\(\s*@Resource\[Microsoft\.Storage/storageAccounts/blobServices/containers:name\]\s+(StringEquals|StringEqualsIgnoreCase)\s+'([^']*)'\s*\)\s*\)\s*$",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex NameTemplate();
+
+    [GeneratedRegex(
+        @"^\s*\(\s*\(\s*!\s*\(\s*ActionMatches\{'Microsoft\.Storage/storageAccounts/blobServices/containers/blobs/read'\}(?:\s+AND\s+NOT\s+SubOperationMatches\{'Blob\.List'\})?\s*\)\s*\)\s+OR\s+\(\s*@Resource\[Microsoft\.Storage/storageAccounts/blobServices/containers/blobs/tags:([^<\]]+)<\$key_(case_sensitive|case_insensitive)\$>\]\s+(StringEquals|StringEqualsIgnoreCase)\s+'([^']*)'\s*\)\s*\)\s*$",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex TagTemplate();
+
+    public static AbacResult Parse(string? condition)
+    {
+        if (string.IsNullOrWhiteSpace(condition))
+            return new AbacResult(AbacKind.None);
+
+        Match tag = TagTemplate().Match(condition);
+        if (tag.Success)
+            return new AbacResult(AbacKind.Tag,
+                TagKey: tag.Groups[1].Value,
+                TagValue: tag.Groups[4].Value,
+                TagKeyCaseSensitive: tag.Groups[2].Value.Equals("case_sensitive", StringComparison.OrdinalIgnoreCase),
+                ValueCaseSensitive: tag.Groups[3].Value.Equals("StringEquals", StringComparison.OrdinalIgnoreCase));
+
+        Match path = PathTemplate().Match(condition);
+        if (path.Success)
+        {
+            string op = path.Groups[1].Value;
+            string value = path.Groups[2].Value;
+            string? prefix = op.Equals("StringStartsWith", StringComparison.OrdinalIgnoreCase)
+                ? value                    // literal prefix
+                : SafeLikePrefix(value);   // StringLike: only "<literal>*" reduces to a prefix
+            return prefix is null
+                ? new AbacResult(AbacKind.Unparseable)
+                : new AbacResult(AbacKind.PathPrefix, PathPrefix: prefix);
+        }
+
+        Match name = NameTemplate().Match(condition);
+        if (name.Success)
+            return new AbacResult(AbacKind.ContainerName, ContainerName: name.Groups[2].Value);
+
+        return new AbacResult(AbacKind.Unparseable);
+    }
+
+    /// <summary>
+    /// A <c>StringLike</c> pattern reduces to a prefix only when it is a literal followed by exactly
+    /// one trailing <c>*</c> and contains no other wildcard (<c>*</c> or <c>?</c>). Anything else
+    /// (an exact match with no wildcard, a mid-string wildcard) cannot be represented as a prefix
+    /// safely — return null so the grant is dropped.
+    /// </summary>
+    private static string? SafeLikePrefix(string like)
+    {
+        if (!like.EndsWith('*')) return null;
+        string body = like[..^1];
+        return body.Contains('*') || body.Contains('?') ? null : body;
+    }
+}

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -85,11 +85,13 @@ public sealed class AzureBlobDiscovery(
             logger.LogWarning(ex, "Connapse's Azure identity cannot be used from this host");
             return AzureProbe<string>.Unusable(ex.Message);
         }
-        catch (CredentialUnavailableException ex) when (AzureCredentialChainFactory.IsManagedIdentity(candidate))
+        catch (AuthenticationFailedException ex)
+            when (AzureCredentialChainFactory.IsManagedIdentity(candidate) && IsNoManagedIdentityHere(ex))
         {
-            // Settings say "sign in as a managed identity" and the host has none to offer: not a
-            // transport fault to retry, the identity is gone from this host (or the settings came
-            // from another one).
+            // Settings say "sign in as a managed identity" and the host has none to offer — no
+            // metadata service at all, or one that answers "Identity not found" (an Azure VM with
+            // no identity assigned). Not a transport fault to retry: the identity is gone from this
+            // host, or the settings came from another one.
             logger.LogWarning(ex, "Connapse is configured to use a managed identity, but this host has none");
             return AzureProbe<string>.Unusable(
                 "No managed identity is available on this host: " + ex.Message);
@@ -112,6 +114,12 @@ public sealed class AzureBlobDiscovery(
             "Entra answered but did not judge the credential (a transient fault or throttling); try again. " + ex.Message,
         _ => ex.Message,
     };
+
+    /// <summary>Whether a managed-identity failure means this host simply has no such identity:
+    /// no metadata service to ask, or one that answers "Identity not found".</summary>
+    internal static bool IsNoManagedIdentityHere(AuthenticationFailedException ex) =>
+        ex is CredentialUnavailableException
+        || ex.Message.Contains("Identity not found", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Whether Entra rejected the credential itself — something only setting access up again fixes —

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -1,4 +1,6 @@
 using Azure;
+using Azure.Core;
+using Azure.Identity;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Storage;
@@ -21,6 +23,116 @@ public sealed class AzureBlobDiscovery(
     ILogger<AzureBlobDiscovery> logger) : IAzureBlobDiscovery
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>The audience a token is requested for. Azure Resource Manager issues one to any
+    /// identity in the tenant, so the check tests the credential and nothing else.</summary>
+    private const string ArmScope = "https://management.azure.com/.default";
+
+    public Task<AzureProbe<string>> CheckAccessAsync(CancellationToken ct = default) =>
+        CheckAccessAsync(options.CurrentValue, ct);
+
+    public async Task<AzureProbe<string>> CheckAccessAsync(AzureProviderSettings candidate, CancellationToken ct = default)
+    {
+        if (!IsConfigured(candidate))
+            return AzureProbe<string>.NotConfigured(
+                "No Azure identity is set up — configure it on the Azure provider page.");
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(Timeout);
+
+        try
+        {
+            // A credential of its own, never the shared cached one: ClientCertificateCredential
+            // hands back a token it already holds without asking Entra, and a certificate removed
+            // from the app after that would keep reading as accepted until the token expired.
+            TokenCredential fresh = ConnapseAzureCredentials.Build(candidate);
+            AccessToken token = await fresh.GetTokenAsync(new TokenRequestContext([ArmScope]), timeout.Token);
+
+            // A managed-identity token is issued whatever tenant the settings name, so the tenant
+            // is checked against the token itself: one that names another tenant would only fail
+            // later, in the sign-in defaults and the role-assignment reads.
+            if (AzureCredentialChainFactory.IsManagedIdentity(candidate) && !string.IsNullOrWhiteSpace(candidate.TenantId))
+            {
+                string? issuedFor = AzureHostIdentity.Describe(token.Token)?.TenantId;
+                if (issuedFor is null)
+                    logger.LogDebug("The managed identity's token did not name its tenant; the stored tenant was not checked against it");
+                else if (!string.Equals(issuedFor, candidate.TenantId.Trim(), StringComparison.OrdinalIgnoreCase))
+                    return AzureProbe<string>.Unusable(
+                        $"The managed identity is in tenant {issuedFor}, but the settings name tenant "
+                        + $"{candidate.TenantId}. Enter tenant {issuedFor}.");
+            }
+
+            string verified = AzureCredentialChainFactory.IsHostManagedIdentity(candidate)
+                ? "Azure issued a token for this host's managed identity"
+                  + (candidate.ManagedIdentityPrincipalId is { Length: > 0 } principal ? $" (principal {principal})." : ".")
+                : AzureCredentialChainFactory.IsUserAssignedManagedIdentity(candidate)
+                    ? $"Azure issued a token for managed identity {candidate.UserAssignedManagedIdentityClientId}."
+                    : $"Entra accepted the certificate for app {candidate.ClientId} in tenant {candidate.TenantId}.";
+            return AzureProbe<string>.Ok(verified);
+        }
+        catch (AuthenticationFailedException ex) when (IsCredentialRefusal(ex))
+        {
+            // Entra answered and said no: the certificate is not registered on the app, has
+            // expired, or the app or tenant no longer exists. Only a new setup fixes it.
+            logger.LogWarning("Entra refused Connapse's Azure credential: {Reason}", ex.Message);
+            return AzureProbe<string>.Denied(ex.Message);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException || AzureCertificateFile.IsUnreadable(ex))
+        {
+            // The credential could not even be built: the certificate file is missing or unreadable,
+            // or the settings are only partly filled in. Azure was never asked; this host is what
+            // needs fixing, and the card should say so plainly rather than "could not confirm".
+            logger.LogWarning(ex, "Connapse's Azure identity cannot be used from this host");
+            return AzureProbe<string>.Unusable(ex.Message);
+        }
+        catch (CredentialUnavailableException ex) when (AzureCredentialChainFactory.IsManagedIdentity(candidate))
+        {
+            // Settings say "sign in as a managed identity" and the host has none to offer: not a
+            // transport fault to retry, the identity is gone from this host (or the settings came
+            // from another one).
+            logger.LogWarning(ex, "Connapse is configured to use a managed identity, but this host has none");
+            return AzureProbe<string>.Unusable(
+                "No managed identity is available on this host: " + ex.Message);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            // Network faults, an inconclusive answer from Entra, or no managed identity on this
+            // host: the check could not be completed either way.
+            logger.LogWarning(ex, "Checking Connapse's Azure identity failed");
+            return AzureProbe<string>.Failed(Describe(ex));
+        }
+    }
+
+    /// <summary>What to tell the operator when the check could not run, by what stopped it.</summary>
+    private static string Describe(Exception ex) => ex switch
+    {
+        CredentialUnavailableException => "No managed identity is available on this host: " + ex.Message,
+        OperationCanceledException => $"Azure did not answer within {Timeout.TotalSeconds:F0} seconds.",
+        AuthenticationFailedException when ex.Message.Contains("AADSTS", StringComparison.Ordinal) =>
+            "Entra answered but did not judge the credential (a transient fault or throttling); try again. " + ex.Message,
+        _ => ex.Message,
+    };
+
+    /// <summary>
+    /// Whether Entra rejected the credential itself — something only setting access up again fixes —
+    /// as opposed to the request not reaching it or Entra being unable to answer. Only the codes that
+    /// mean the certificate, app, or tenant is wrong count; every other <c>AADSTS</c> code (throttling,
+    /// a transient fault, directory unavailability) is inconclusive, not a verdict.
+    /// </summary>
+    internal static bool IsCredentialRefusal(AuthenticationFailedException ex) =>
+        ex is not CredentialUnavailableException
+        && CredentialRefusalCodes.Any(code => ex.Message.Contains(code, StringComparison.Ordinal));
+
+    /// <summary>Entra error codes that mean the credential is invalid: the certificate is not
+    /// registered on the app or its assertion is not signed by a registered key (700027), the app's
+    /// keys have expired (7000222), the client credential is wrong (7000215), the app has no service
+    /// principal (7000229), the app is disabled (7000112), the app does not exist (700016), or the
+    /// tenant does not (90002).</summary>
+    internal static readonly IReadOnlyList<string> CredentialRefusalCodes =
+    [
+        "AADSTS700027", "AADSTS7000222", "AADSTS7000215", "AADSTS7000229", "AADSTS7000112",
+        "AADSTS700016", "AADSTS90002",
+    ];
 
     public async Task<AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>> ListStorageAccountsAsync(
         CancellationToken ct = default)
@@ -108,11 +220,12 @@ public sealed class AzureBlobDiscovery(
         }
     }
 
-    /// <summary>The same rule the Providers page uses for "Access is set up".</summary>
+    /// <summary>The same rule the Providers page uses for "Access is set up": a tenant, and one of
+    /// a certificate app, a user-assigned managed identity, or the host's own managed identity.</summary>
     internal static bool IsConfigured(AzureProviderSettings s) =>
         !string.IsNullOrWhiteSpace(s.TenantId)
         && ((!string.IsNullOrWhiteSpace(s.ClientId) && !string.IsNullOrWhiteSpace(s.ClientCertificatePath))
-            || !string.IsNullOrWhiteSpace(s.UserAssignedManagedIdentityClientId));
+            || AzureCredentialChainFactory.IsManagedIdentity(s));
 
     internal static bool IsDenial(RequestFailedException ex) => ex.Status is 401 or 403;
 }

--- a/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
+++ b/src/Connapse.Storage/CloudScope/AzureBlobDiscovery.cs
@@ -1,0 +1,118 @@
+using Azure;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
+using Azure.ResourceManager.Storage;
+using Azure.Storage.Blobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Asks Azure what Connapse's own identity can see. Mirrors <see cref="S3Discovery"/>: the same
+/// credential every Azure client uses (<see cref="ConnapseAzureCredentials"/>), read-only calls,
+/// and a denial reported as advice rather than a fault.
+/// </summary>
+public sealed class AzureBlobDiscovery(
+    ConnapseAzureCredentials credentials,
+    IOptionsMonitor<AzureProviderSettings> options,
+    ILogger<AzureBlobDiscovery> logger) : IAzureBlobDiscovery
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(15);
+
+    public async Task<AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>> ListStorageAccountsAsync(
+        CancellationToken ct = default)
+    {
+        AzureProviderSettings settings = options.CurrentValue;
+        if (!IsConfigured(settings))
+            return AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>.NotConfigured(
+                "No Azure identity is set up — configure it on the Azure provider page.");
+        if (string.IsNullOrWhiteSpace(settings.SubscriptionId))
+            return AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>.NotConfigured(
+                "The Azure subscription is not set, so there is nowhere to list accounts from.");
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(Timeout);
+
+        try
+        {
+            var arm = new ArmClient(credentials);
+            SubscriptionResource subscription = arm.GetSubscriptionResource(
+                SubscriptionResource.CreateResourceIdentifier(settings.SubscriptionId.Trim()));
+
+            var accounts = new List<AzureStorageAccountInfo>();
+            await foreach (StorageAccountResource account in subscription.GetStorageAccountsAsync(timeout.Token))
+            {
+                StorageAccountData data = account.Data;
+                Uri? blob = data.PrimaryEndpoints?.BlobUri;
+                if (blob is null) continue; // no blob service (e.g. a files-only account)
+
+                accounts.Add(new AzureStorageAccountInfo(
+                    data.Name,
+                    blob.ToString().TrimEnd('/'),
+                    account.Id.ResourceGroupName ?? string.Empty,
+                    account.Id.ToString(),
+                    data.IsHnsEnabled == true));
+            }
+
+            accounts.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+            return AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>.Ok(accounts);
+        }
+        catch (RequestFailedException ex) when (IsDenial(ex))
+        {
+            // Expected when the subscription-wide reader role has not been assigned — the form
+            // falls back to asking for the account name.
+            logger.LogDebug("Listing storage accounts was denied — the identity has no subscription read");
+            return AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>.Denied(ex.Message);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            logger.LogWarning(ex, "Listing storage accounts failed");
+            return AzureProbe<IReadOnlyList<AzureStorageAccountInfo>>.Failed(ex.Message);
+        }
+    }
+
+    public async Task<AzureProbe<IReadOnlyList<string>>> ListContainersAsync(
+        string blobEndpoint, CancellationToken ct = default)
+    {
+        if (!IsConfigured(options.CurrentValue))
+            return AzureProbe<IReadOnlyList<string>>.NotConfigured(
+                "No Azure identity is set up — configure it on the Azure provider page.");
+        if (!Uri.TryCreate(blobEndpoint?.Trim(), UriKind.Absolute, out Uri? endpoint))
+            return AzureProbe<IReadOnlyList<string>>.Failed("No storage account chosen.");
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(Timeout);
+
+        try
+        {
+            var service = new BlobServiceClient(endpoint, credentials);
+            var names = new List<string>();
+            await foreach (var container in service.GetBlobContainersAsync(cancellationToken: timeout.Token))
+                names.Add(container.Name);
+
+            names.Sort(StringComparer.OrdinalIgnoreCase);
+            return AzureProbe<IReadOnlyList<string>>.Ok(names);
+        }
+        catch (RequestFailedException ex) when (IsDenial(ex))
+        {
+            logger.LogDebug("Listing containers on {Endpoint} was denied", endpoint);
+            return AzureProbe<IReadOnlyList<string>>.Denied(ex.Message);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            logger.LogWarning(ex, "Listing containers on {Endpoint} failed", endpoint);
+            return AzureProbe<IReadOnlyList<string>>.Failed(ex.Message);
+        }
+    }
+
+    /// <summary>The same rule the Providers page uses for "Access is set up".</summary>
+    internal static bool IsConfigured(AzureProviderSettings s) =>
+        !string.IsNullOrWhiteSpace(s.TenantId)
+        && ((!string.IsNullOrWhiteSpace(s.ClientId) && !string.IsNullOrWhiteSpace(s.ClientCertificatePath))
+            || !string.IsNullOrWhiteSpace(s.UserAssignedManagedIdentityClientId));
+
+    internal static bool IsDenial(RequestFailedException ex) => ex.Status is 401 or 403;
+}

--- a/src/Connapse.Storage/CloudScope/AzureCertificateFile.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCertificateFile.cs
@@ -1,0 +1,55 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Reads the certificate files Connapse's Azure identities sign with, in the two shapes the settings
+/// accept: a PEM holding certificate plus private key (<c>.pem</c>/<c>.crt</c>), or a PKCS#12 bundle
+/// with an optional password. One loader, so the credential chain, the expiry shown on the provider
+/// page, and the setup check all read the same file the same way.
+/// </summary>
+public static class AzureCertificateFile
+{
+    /// <summary>The certificate at <paramref name="path"/>, or null when no path is set or the file is missing.</summary>
+    /// <exception cref="CryptographicException">The file exists but is not a readable certificate (or the password is wrong).</exception>
+    public static X509Certificate2? Load(string? path, string? password)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return null;
+
+        string extension = Path.GetExtension(path).ToLowerInvariant();
+        return extension is ".pem" or ".crt"
+            ? X509Certificate2.CreateFromPemFile(path)
+            : X509CertificateLoader.LoadPkcs12FromFile(path, password);
+    }
+
+    /// <summary>When the certificate at <paramref name="path"/> stops being accepted, in UTC; null
+    /// when there is no readable certificate there.</summary>
+    public static DateTime? Expiry(string? path, string? password)
+    {
+        try
+        {
+            using X509Certificate2? certificate = Load(path, password);
+            return certificate?.NotAfter.ToUniversalTime();
+        }
+        catch (Exception ex) when (IsUnreadable(ex))
+        {
+            return null;
+        }
+    }
+
+    /// <summary>The ways a certificate file fails to read: not a certificate (or the wrong password),
+    /// an I/O fault, a permission the process lacks, or a path the runtime rejects. None of them is
+    /// a reason for the page showing the file to fail to render.</summary>
+    public static bool IsUnreadable(Exception ex) =>
+        ex is CryptographicException or IOException or UnauthorizedAccessException or ArgumentException;
+
+    /// <summary>The SHA-1 thumbprint of a PEM-encoded certificate, upper-case hex with no separators —
+    /// the form <c>openssl x509 -fingerprint</c> prints once its colons are stripped, and what Entra
+    /// shows under Certificates &amp; secrets.</summary>
+    public static string Thumbprint(string certificatePem)
+    {
+        using X509Certificate2 certificate = X509Certificate2.CreateFromPem(certificatePem);
+        return certificate.Thumbprint.ToUpperInvariant();
+    }
+}

--- a/src/Connapse.Storage/CloudScope/AzureCertificateGenerator.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCertificateGenerator.cs
@@ -1,0 +1,39 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>A generated self-signed certificate: the public certificate (uploaded to Entra) and the
+/// combined PEM (certificate + private key) that Connapse stores on its host and authenticates with.</summary>
+public sealed record AzureCertificateMaterial(string PublicCertificatePem, string CombinedPem);
+
+/// <summary>
+/// Generates a self-signed certificate and RSA key locally for Connapse's Azure app registrations.
+/// Only <see cref="AzureCertificateMaterial.PublicCertificatePem"/> is uploaded to Entra (via the setup
+/// script); the private key never leaves the host — the same property as the AWS Roles Anywhere flow.
+/// Mirrors <see cref="RolesAnywhere.RolesAnywhereKeyGenerator"/>.
+/// </summary>
+public static class AzureCertificateGenerator
+{
+    /// <summary>Generates a 1-year self-signed certificate for <paramref name="commonName"/>.</summary>
+    public static AzureCertificateMaterial Generate(string commonName, TimeProvider? clock = null)
+    {
+        DateTimeOffset now = (clock ?? TimeProvider.System).GetUtcNow();
+
+        using RSA key = RSA.Create(2048);
+        var request = new CertificateRequest(
+            $"CN={commonName}", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        // The certificate signs the client assertion Connapse presents to Entra.
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, critical: false));
+
+        using X509Certificate2 certificate = request.CreateSelfSigned(now.AddDays(-1), now.AddYears(1));
+
+        string publicPem = certificate.ExportCertificatePem();
+        string privateKeyPem = key.ExportPkcs8PrivateKeyPem();
+
+        // One PEM holding both, which X509Certificate2.CreateFromPemFile reads back as cert + key.
+        string combined = publicPem + "\n" + privateKeyPem + "\n";
+        return new AzureCertificateMaterial(publicPem, combined);
+    }
+}

--- a/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
@@ -1,0 +1,58 @@
+using Azure.Core;
+using Azure.Identity;
+using Connapse.Core;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Pure selection of Connapse's Azure credential from settings: a configured
+/// service-principal certificate first, else the ambient managed identity, else fail closed.
+/// Deterministic (an explicit ChainedTokenCredential) — never DefaultAzureCredential.
+/// </summary>
+public static class AzureCredentialChainFactory
+{
+    public static TokenCredential Create(
+        AzureProviderSettings settings,
+        Func<AzureProviderSettings, X509Certificate2?> certLoader)
+    {
+        bool anyServicePrincipalFieldSet =
+            !string.IsNullOrWhiteSpace(settings.TenantId)
+            || !string.IsNullOrWhiteSpace(settings.ClientId)
+            || !string.IsNullOrWhiteSpace(settings.ClientCertificatePath)
+            || !string.IsNullOrWhiteSpace(settings.ClientCertificatePassword);
+
+        if (!anyServicePrincipalFieldSet)
+        {
+            // No service-principal intent at all: managed-identity-only chain.
+            TokenCredential managedIdentity = string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+                ? new ManagedIdentityCredential()
+                : new ManagedIdentityCredential(
+                    ManagedIdentityId.FromUserAssignedClientId(settings.UserAssignedManagedIdentityClientId));
+
+            return new ChainedTokenCredential(managedIdentity);
+        }
+
+        // Any populated service-principal field is intent to use certificate auth.
+        // Require a complete, usable set — never fall through to managed identity
+        // (a broader, ambient identity) on a partial or broken configuration.
+        if (string.IsNullOrWhiteSpace(settings.TenantId) || string.IsNullOrWhiteSpace(settings.ClientId))
+        {
+            throw new InvalidOperationException(
+                "Azure service-principal fields are partially configured (some of TenantId, ClientId, "
+                + "ClientCertificatePath, ClientCertificatePassword are set) but TenantId and ClientId are "
+                + "both required. Fix the certificate configuration; Connapse will not silently fall back "
+                + "to managed identity.");
+        }
+
+        X509Certificate2 cert = certLoader(settings)
+            ?? throw new InvalidOperationException(
+                "Azure ClientId is configured but no usable certificate was loaded "
+                + $"(ClientCertificatePath='{settings.ClientCertificatePath}'). "
+                + "Fix the certificate configuration; Connapse will not silently fall back to managed identity.");
+
+        return new ChainedTokenCredential(new ClientCertificateCredential(
+            settings.TenantId, settings.ClientId, cert,
+            new ClientCertificateCredentialOptions { SendCertificateChain = true }));
+    }
+}

--- a/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
@@ -12,10 +12,62 @@ namespace Connapse.Storage.CloudScope;
 /// </summary>
 public static class AzureCredentialChainFactory
 {
+    /// <summary>
+    /// Whether <paramref name="settings"/> name a user-assigned managed identity and nothing of a
+    /// certificate app. The tenant is allowed alongside it — the provider page records the tenant
+    /// for every identity, and a tenant alone is not certificate intent.
+    /// </summary>
+    public static bool IsUserAssignedManagedIdentity(AzureProviderSettings settings) =>
+        !string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+        && !settings.UseHostManagedIdentity
+        && string.IsNullOrWhiteSpace(settings.ClientId)
+        && string.IsNullOrWhiteSpace(settings.ClientCertificatePath)
+        && string.IsNullOrWhiteSpace(settings.ClientCertificatePassword);
+
+    /// <summary>
+    /// Whether <paramref name="settings"/> name the host's own system-assigned managed identity and
+    /// nothing of a certificate app. As with the user-assigned case, the tenant may sit beside it.
+    /// </summary>
+    public static bool IsHostManagedIdentity(AzureProviderSettings settings) =>
+        settings.UseHostManagedIdentity
+        && string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+        && string.IsNullOrWhiteSpace(settings.ClientId)
+        && string.IsNullOrWhiteSpace(settings.ClientCertificatePath)
+        && string.IsNullOrWhiteSpace(settings.ClientCertificatePassword);
+
+    /// <summary>Either kind of managed identity: the host's own, or a user-assigned one by client id.</summary>
+    public static bool IsManagedIdentity(AzureProviderSettings settings) =>
+        IsHostManagedIdentity(settings) || IsUserAssignedManagedIdentity(settings);
+
     public static TokenCredential Create(
         AzureProviderSettings settings,
         Func<AzureProviderSettings, X509Certificate2?> certLoader)
     {
+        // The host's identity named beside another identity is a mix the form cannot produce;
+        // arriving from configuration it is a mistake, and picking either side silently would be
+        // choosing an identity nobody asked for.
+        if (settings.UseHostManagedIdentity
+            && (!string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
+                || !string.IsNullOrWhiteSpace(settings.ClientId)
+                || !string.IsNullOrWhiteSpace(settings.ClientCertificatePath)
+                || !string.IsNullOrWhiteSpace(settings.ClientCertificatePassword)))
+        {
+            throw new InvalidOperationException(
+                "Azure settings name both the host's managed identity (UseHostManagedIdentity) and another "
+                + "identity (a user-assigned managed identity or a certificate app). Keep one; Connapse will not choose.");
+        }
+
+        if (IsHostManagedIdentity(settings))
+        {
+            return new ChainedTokenCredential(new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned));
+        }
+
+        if (IsUserAssignedManagedIdentity(settings))
+        {
+            return new ChainedTokenCredential(new ManagedIdentityCredential(
+                ManagedIdentityId.FromUserAssignedClientId(settings.UserAssignedManagedIdentityClientId)));
+        }
+
         bool anyServicePrincipalFieldSet =
             !string.IsNullOrWhiteSpace(settings.TenantId)
             || !string.IsNullOrWhiteSpace(settings.ClientId)
@@ -24,13 +76,8 @@ public static class AzureCredentialChainFactory
 
         if (!anyServicePrincipalFieldSet)
         {
-            // No service-principal intent at all: managed-identity-only chain.
-            TokenCredential managedIdentity = string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId)
-                ? new ManagedIdentityCredential()
-                : new ManagedIdentityCredential(
-                    ManagedIdentityId.FromUserAssignedClientId(settings.UserAssignedManagedIdentityClientId));
-
-            return new ChainedTokenCredential(managedIdentity);
+            // No service-principal intent at all: the host's system-assigned identity.
+            return new ChainedTokenCredential(new ManagedIdentityCredential());
         }
 
         // Any populated service-principal field is intent to use certificate auth.

--- a/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
+++ b/src/Connapse.Storage/CloudScope/AzureCredentialChainFactory.cs
@@ -76,8 +76,21 @@ public static class AzureCredentialChainFactory
 
         if (!anyServicePrincipalFieldSet)
         {
-            // No service-principal intent at all: the host's system-assigned identity.
-            return new ChainedTokenCredential(new ManagedIdentityCredential());
+            // Nothing configured is nothing, not the host's identity. Using the host's identity is
+            // an explicit choice (UseHostManagedIdentity); reading it into an empty record would let
+            // a reset, or a lost row, quietly continue as whatever identity the host happens to have.
+            throw new InvalidOperationException(
+                "No Azure identity is configured. Set access up on the Azure provider page: a certificate "
+                + "app registration, a user-assigned managed identity, or the host's own managed identity.");
+        }
+
+        // A certificate app beside a user-assigned identity is the same kind of mix as the host's
+        // identity beside either: nobody asked for a choice, so none is made.
+        if (!string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId))
+        {
+            throw new InvalidOperationException(
+                "Azure settings name both a certificate app registration and a user-assigned managed "
+                + "identity (UserAssignedManagedIdentityClientId). Keep one; Connapse will not choose.");
         }
 
         // Any populated service-principal field is intent to use certificate auth.

--- a/src/Connapse.Storage/CloudScope/AzureHostIdentity.cs
+++ b/src/Connapse.Storage/CloudScope/AzureHostIdentity.cs
@@ -1,0 +1,140 @@
+using System.Text;
+using System.Text.Json;
+using Azure.Core;
+using Azure.Identity;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Detects the host's managed identity by asking Azure's instance metadata service for a token and
+/// reading who the token was issued to. Off Azure the metadata endpoint does not exist and the
+/// credential gives up within about a second; a hard cap covers the slow-network case.
+/// </summary>
+/// <remarks>
+/// The token's claims are read without validating its signature. That is fine here: nothing is
+/// authorised by them. They only describe the identity so the setup script can name it, and every
+/// later call to Azure authenticates for real with a token of its own.
+/// </remarks>
+public sealed class AzureHostIdentity(ILogger<AzureHostIdentity> logger) : IAzureHostIdentity
+{
+    private const string ArmScope = "https://management.azure.com/.default";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    private readonly SemaphoreSlim gate = new(1, 1);
+    private AzureHostIdentityInfo? found;
+
+    /// <summary>How the token is obtained; replaced in tests so no metadata service is needed.</summary>
+    internal Func<CancellationToken, Task<string>> AcquireToken { get; init; } = async ct =>
+    {
+        var credential = new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned);
+        AccessToken token = await credential.GetTokenAsync(new TokenRequestContext([ArmScope]), ct);
+        return token.Token;
+    };
+
+    public async Task<AzureHostIdentityInfo?> DetectAsync(bool refresh = false, CancellationToken ct = default)
+    {
+        if (!refresh && found is not null) return found;
+
+        await gate.WaitAsync(ct);
+        try
+        {
+            if (!refresh && found is not null) return found;
+
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeout.CancelAfter(Timeout);
+            try
+            {
+                string token = await AcquireToken(timeout.Token);
+                found = Describe(token);
+                if (found is null)
+                    logger.LogWarning("The host's managed identity issued a token, but it carried none of the claims that name the identity");
+                return found;
+            }
+            catch (CredentialUnavailableException)
+            {
+                // The ordinary answer off Azure: no metadata service, so no identity. On a refresh
+                // it also means an identity remembered earlier is gone, and must not be handed out.
+                if (refresh) found = null;
+                return null;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+            {
+                logger.LogDebug(ex, "Could not detect a managed identity on this host");
+                return null;
+            }
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>Reads the identity a managed-identity token describes, or null when the required
+    /// claims are missing.</summary>
+    public static AzureHostIdentityInfo? Describe(string jwt)
+    {
+        string[] parts = jwt.Split('.');
+        if (parts.Length < 2) return null;
+
+        JsonDocument payload;
+        try
+        {
+            payload = JsonDocument.Parse(Base64UrlDecode(parts[1]));
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException)
+        {
+            return null;
+        }
+
+        using (payload)
+        {
+            JsonElement root = payload.RootElement;
+            string? tenant = Claim(root, "tid");
+            string? principal = Claim(root, "oid");
+            string? client = Claim(root, "appid");
+            if (tenant is null || principal is null || client is null) return null;
+
+            string? resourceId = Claim(root, "xms_mirid");
+            return new AzureHostIdentityInfo(
+                tenant, principal, client, resourceId,
+                SubscriptionFrom(resourceId),
+                resourceId?.Contains("/providers/Microsoft.ManagedIdentity/userAssignedIdentities/", StringComparison.OrdinalIgnoreCase) == true);
+        }
+    }
+
+    /// <summary>The subscription segment of an ARM resource id, or null.</summary>
+    public static string? SubscriptionFrom(string? resourceId)
+    {
+        if (string.IsNullOrWhiteSpace(resourceId)) return null;
+        string[] segments = resourceId.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (int i = 0; i + 1 < segments.Length; i++)
+        {
+            if (segments[i].Equals("subscriptions", StringComparison.OrdinalIgnoreCase) && Guid.TryParse(segments[i + 1], out Guid id))
+                return id.ToString();
+        }
+        return null;
+    }
+
+    private static string? Claim(JsonElement root, string name) =>
+        root.TryGetProperty(name, out JsonElement value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static byte[] Base64UrlDecode(string value)
+    {
+        string padded = value.Replace('-', '+').Replace('_', '/');
+        padded = padded.PadRight(padded.Length + (4 - padded.Length % 4) % 4, '=');
+        return Convert.FromBase64String(padded);
+    }
+
+    /// <summary>Encodes a payload the way a token carries it; used by tests to build one.</summary>
+    public static string EncodePayload(object payload)
+    {
+        byte[] json = JsonSerializer.SerializeToUtf8Bytes(payload);
+        string body = Convert.ToBase64String(json).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        string header = Convert.ToBase64String(Encoding.UTF8.GetBytes("{\"alg\":\"none\"}")).TrimEnd('=');
+        return $"{header}.{body}.";
+    }
+}

--- a/src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs
+++ b/src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs
@@ -1,0 +1,28 @@
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Translates an ARM role-assignment scope into the <c>azblob://</c> prefix it governs. Resource
+/// provider and type segments are matched case-insensitively (ARM is case-insensitive on them);
+/// the account and container names keep their original case (they are the resource_uri content).
+/// </summary>
+public static class AzureRbacScopeTranslator
+{
+    public static string ToAzblobPrefix(string armScope)
+    {
+        string[] parts = armScope.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        int acctIdx = Array.FindIndex(parts,
+            p => string.Equals(p, "storageAccounts", StringComparison.OrdinalIgnoreCase));
+        if (acctIdx < 0 || acctIdx + 1 >= parts.Length)
+            return "azblob://"; // broader than an account (RG / subscription / management group)
+
+        string account = parts[acctIdx + 1];
+
+        int containersIdx = Array.FindIndex(parts, acctIdx + 1,
+            p => string.Equals(p, "containers", StringComparison.OrdinalIgnoreCase));
+        if (containersIdx >= 0 && containersIdx + 1 < parts.Length)
+            return $"azblob://{account}/{parts[containersIdx + 1]}/";
+
+        return $"azblob://{account}/";
+    }
+}

--- a/src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs
+++ b/src/Connapse.Storage/CloudScope/AzureRbacScopeTranslator.cs
@@ -25,4 +25,25 @@ public static class AzureRbacScopeTranslator
 
         return $"azblob://{account}/";
     }
+
+    /// <summary>
+    /// Whether an ARM scope that translated to the bare <c>azblob://</c> wildcard genuinely covers
+    /// every storage account Connapse's configured subscription can see — i.e. it is the
+    /// subscription itself, a management group above it, or the tenant root.
+    /// </summary>
+    /// <remarks>
+    /// A <b>resource-group</b> scope also lacks a <c>storageAccounts</c> segment and so translates to
+    /// the same wildcard, but it is bounded to the accounts in that one resource group. Treating its
+    /// wildcard as authoritative on the <i>grant</i> side would disclose accounts in other resource
+    /// groups — an over-grant — so the caller drops such grants rather than widening them. (The
+    /// <i>deny</i> side keeps the wildcard: over-denying is the fail-closed direction.) A resource
+    /// group is recognised by its <c>resourceGroups</c> segment; a subscription/management-group/root
+    /// scope has none.
+    /// </remarks>
+    public static bool IsSubscriptionWideOrBroader(string armScope)
+    {
+        string[] parts = armScope.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return !Array.Exists(parts,
+            p => string.Equals(p, "resourceGroups", StringComparison.OrdinalIgnoreCase));
+    }
 }

--- a/src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs
+++ b/src/Connapse.Storage/CloudScope/AzureSearchResultVerifier.cs
@@ -1,0 +1,165 @@
+using System.Collections.Concurrent;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Live per-hit Azure permission verify (Phase 4e). Passes non-Azure hits untouched; for each
+/// azblob hit, admits it only if covered by an RBAC prefix (in-memory), or a matching blob-tag
+/// condition, or the file's own ACL grants Read AND every ancestor directory grants traverse-X
+/// (4d). Fails closed on every uncertain read. Preserves rank order. When actually enforcing,
+/// caps the result at topK (backfilling from lower-ranked survivors); when not enforcing, returns
+/// every candidate unchanged so the pipeline's own final cap sees the untouched pool.
+/// </summary>
+public sealed class AzureSearchResultVerifier(
+    IDocumentStore documents,
+    IAzureIdentityLinkReader links,
+    IAzureDirectoryReader directory,
+    IAzureRbacReader rbac,
+    IGen2FileAclReader fileAcl,
+    IBlobTagReader blobTags,
+    AncestorTraverseResolver traverse,
+    IOptionsMonitor<AzureAdSignInSettings> azureAd,
+    IOptionsMonitor<PermissionEnforcementSettings> enforcement,
+    EnforcementMigration migration,
+    IOptions<AzureVerifierSettings> settings,
+    ILogger<AzureSearchResultVerifier> logger) : ISearchResultVerifier
+{
+    // Over-fetch only pays off when VerifyAsync will actually drop hits, which happens only in the
+    // Enforcing state below. NotEnforcing and EnforcingButUnusable never call into the per-hit
+    // logic that needs backfill material (NotEnforcing passes everything; EnforcingButUnusable
+    // drops every azblob hit outright, and backfill can't rescue a class that's dropped wholesale).
+    // So AWS-only, non-cloud, and configured-but-not-yet-enforcing Azure deployments never pay the
+    // over-fetch cost even though this verifier is always registered.
+    public int CandidateMultiplier =>
+        enforcement.CurrentValue.StateForAzure(azureAd.CurrentValue.IsConfigured, migration.Determined)
+            == EnforcementState.Enforcing
+            ? Math.Max(1, settings.Value.CandidateMultiplier)
+            : 1;
+
+    public async Task<IReadOnlyList<SearchHit>> VerifyAsync(
+        IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default)
+    {
+        // No Azure enforcement → the resolver did not broaden; nothing to tighten. Return every
+        // candidate unchanged (not capped at topK) — the pipeline's own final Take(topK) applies
+        // the cap, so AutoCut still sees the full pool exactly as it would with no verifier at all.
+        // A resolve/verify state flip is benign: off→NotEnforcing returns unfiltered (correct for
+        // not-enforcing); on→Enforcing filters (fail-closed). Neither over-grants.
+        EnforcementState state = enforcement.CurrentValue.StateForAzure(
+            azureAd.CurrentValue.IsConfigured, migration.Determined);
+        if (state == EnforcementState.NotEnforcing)
+            return rankedCandidates;
+
+        // Map hits to their governing URIs (one batched query).
+        IReadOnlyDictionary<string, string?> uris =
+            await documents.GetResourceUrisAsync(rankedCandidates.Select(h => h.DocumentId).ToList(), ct);
+
+        // Enforcing → resolve identity. EnforcingButUnusable ("searches deny") → no context, so every
+        // azblob hit is dropped (and non-cloud still passes), matching the resolver's SearchScopes.Failed.
+        AzureContext? azure = state == EnforcementState.Enforcing
+            ? await ResolveContextAsync(userId, ct)
+            : null;
+
+        // Verify azblob hits concurrently (bounded); non-azblob pass; decision keyed by index so we
+        // can re-assemble in rank order.
+        var verdicts = new ConcurrentDictionary<int, bool>();
+        using var gate = new SemaphoreSlim(Math.Max(1, settings.Value.MaxParallelism));
+
+        await Task.WhenAll(rankedCandidates.Select(async (hit, i) =>
+        {
+            if (!uris.TryGetValue(hit.DocumentId, out string? uri))
+            {
+                verdicts[i] = false; // document row not found (deleted/dangling chunk) → fail closed
+                return;
+            }
+            if (uri is null || !AzblobUri.IsAzblob(uri))
+            {
+                verdicts[i] = true; // non-cloud (null) or non-Azure (s3://) → pass untouched
+                return;
+            }
+            if (!AzblobUri.TryParse(uri, out Gen2Path path))
+            {
+                verdicts[i] = false; // azblob scheme but unparseable → fail closed, never bypass
+                return;
+            }
+            if (azure is null)
+            {
+                verdicts[i] = false; // enforcing but no usable identity → drop azblob
+                return;
+            }
+            await gate.WaitAsync(ct);
+            try { verdicts[i] = await AdmitAzureHitAsync(uri, path, azure, ct); }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+            catch (Exception ex) { logger.LogError(ex, "Azure hit verify failed; dropping"); verdicts[i] = false; }
+            finally { gate.Release(); }
+        }));
+
+        var survivors = new List<SearchHit>(topK);
+        for (int i = 0; i < rankedCandidates.Count && survivors.Count < topK; i++)
+            if (verdicts.GetValueOrDefault(i)) survivors.Add(rankedCandidates[i]);
+        return survivors;
+    }
+
+    private async Task<bool> AdmitAzureHitAsync(string uri, Gen2Path path, AzureContext azure, CancellationToken ct)
+    {
+        // 0. Deny assignments outrank every grant (RBAC and ACL). A hit under any applicable deny scope is
+        //    blocked by Azure regardless of ACLs, so drop it before any permissive check.
+        if (azure.DeniedPrefixes.Any(d => uri.StartsWith(d, StringComparison.Ordinal)))
+            return false;
+
+        // 1. RBAC read supersedes ACLs — covered by any readable prefix → pass, no live call.
+        // Prefix match is safe because resolver-minted prefixes are account/container-terminated with '/'
+        // (or the bare azblob:// wildcard); it never partial-matches a sibling like azblob://acct/docs-secret/.
+        if (azure.ReadablePrefixes.Any(p => uri.StartsWith(p, StringComparison.Ordinal)))
+            return true;
+
+        // 2. Tag-conditioned residue → live tag verify. A MATCH grants (RBAC-ABAC supersedes ACLs). A
+        //    non-match or unreadable tags does NOT drop: this assignment simply doesn't grant, and the file
+        //    may still be readable via its own ACL (Azure evaluates ACLs when ABAC does not grant), so fall
+        //    through to the Gen2 ACL check below (which is itself fail-closed).
+        AzureTagCondition[] covering =
+            azure.TagConditions.Where(t => uri.StartsWith(t.Scope, StringComparison.Ordinal)).ToArray();
+        if (covering.Length > 0)
+        {
+            IReadOnlyDictionary<string, string>? tags = await blobTags.ReadTagsAsync(path, ct);
+            if (tags is not null && covering.Any(c => AzureTagConditionEvaluator.Matches(c, tags)))
+                return true;
+            // else: no tag grant — fall through to the ACL path (never over-grants; ACL is fail-closed).
+        }
+
+        // 3. Gen2 ACL: file's own Read AND traverse-X on every ancestor. Folder access never trusted.
+        Gen2Acl? acl = await fileAcl.ReadFileAclAsync(path, ct);
+        if (acl is null) return false; // unreadable / flat account / incomplete → drop
+        if (!PosixAclEvaluator.Grants(acl, azure.UserOid, azure.GroupOids, Gen2Permission.Read))
+            return false;
+        return await traverse.HoldsTraverseOnAllAncestorsAsync(path, azure.UserOid, azure.GroupOids, ct);
+    }
+
+    private async Task<AzureContext?> ResolveContextAsync(Guid? userId, CancellationToken ct)
+    {
+        if (userId is null) return null;
+        AzureIdentityRef? link = await links.GetLinkAsync(userId.Value, ct);
+        if (link is null) return null;
+
+        AzureIdentitySet identity = await directory.ResolveAsync(link, ct);
+        if (identity.Outcome != AzureIdentityOutcome.Resolved) return null; // deprovisioned/failed → drop azblob
+
+        AzureRbacScopes scopes = await rbac.ResolveAsync(link.ObjectId, ct);
+        if (scopes.Outcome != RbacOutcome.Resolved) return null; // RBAC uncertain → fail closed
+
+        var groups = identity.PrincipalOids.Where(o => o != link.ObjectId).ToHashSet(StringComparer.Ordinal);
+        return new AzureContext(
+            link.ObjectId, groups,
+            scopes.ReadablePrefixes.Select(s => s.Prefix).ToArray(),
+            scopes.TagConditioned.ToArray(),
+            scopes.DeniedPrefixes.ToArray());
+    }
+
+    private sealed record AzureContext(
+        string UserOid, IReadOnlySet<string> GroupOids,
+        IReadOnlyList<string> ReadablePrefixes, IReadOnlyList<AzureTagCondition> TagConditions,
+        IReadOnlyList<string> DeniedPrefixes);
+}

--- a/src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs
+++ b/src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs
@@ -7,15 +7,16 @@ using Microsoft.Extensions.Options;
 namespace Connapse.Storage.CloudScope;
 
 /// <summary>
-/// Answers what a Connapse user may search in Azure Blob, from the Storage-Blob-Data role
-/// assignments held against the Entra identity they linked. Flat accounts only: the RBAC prefix set
-/// is exact and complete. Mirrors <see cref="AwsSearchScopeResolver"/> — enforcement gate first,
-/// then link → deprovisioning gate → RBAC — and fails closed on every uncertain path.
+/// Answers what a Connapse user may search in Azure Blob. Broad retrieve-then-verify: for any valid
+/// enforcing identity (link present, not deprovisioned, directory not failed) this returns the single
+/// broad <c>azblob://</c> match so every Azure candidate is retrieved by relevance; the Phase 4e
+/// per-hit verifier tightens the result via RBAC coverage, tag conditions, and Gen2 ACLs. Mirrors
+/// <see cref="AwsSearchScopeResolver"/> for the enforcement gate and link → deprovisioning gate, and
+/// fails closed on every uncertain path.
 /// </summary>
 public sealed class AzureSearchScopeResolver(
     IAzureIdentityLinkReader links,
     IAzureDirectoryReader directory,
-    IAzureRbacReader rbac,
     IOptionsMonitor<AzureAdSignInSettings> azureAd,
     IOptionsMonitor<PermissionEnforcementSettings> enforcement,
     EnforcementMigration migration,
@@ -81,17 +82,10 @@ public sealed class AzureSearchScopeResolver(
         if (identity.Outcome is AzureIdentityOutcome.Failed)
             return SearchScopes.Failed;
 
-        AzureRbacScopes scopes = await rbac.ResolveAsync(link.ObjectId, ct);
-        if (scopes.Outcome is RbacOutcome.Failed)
-            return SearchScopes.Failed;
-
-        // Flat accounts: RBAC readable prefixes are the answer. Tag-conditioned residue and Gen2
-        // ACLs are NOT admitted here — they require Phase 4e's live per-hit verifier; omitting them
-        // is a temporary under-grant on the epic branch that 4e closes before the epic reaches main.
-        var matches = scopes.ReadablePrefixes
-            .Select(s => new GrantMatch(s.Prefix, IsExact: false))
-            .ToList();
-
-        return SearchScopes.Of(matches);
+        // Broad retrieve-then-verify (§E amendment): a valid enforcing identity retrieves EVERY Azure
+        // candidate by relevance; the post-retrieval verifier (Phase 4e) tightens per hit via RBAC
+        // coverage, tag conditions, and Gen2 file-ACL + ancestor traverse. Narrowing here (e.g. to RBAC
+        // prefixes) would drop ACL-only "Case C" files, which can live in any container.
+        return SearchScopes.Of([new GrantMatch("azblob://", IsExact: false)]);
     }
 }

--- a/src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs
+++ b/src/Connapse.Storage/CloudScope/AzureSearchScopeResolver.cs
@@ -1,0 +1,97 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Answers what a Connapse user may search in Azure Blob, from the Storage-Blob-Data role
+/// assignments held against the Entra identity they linked. Flat accounts only: the RBAC prefix set
+/// is exact and complete. Mirrors <see cref="AwsSearchScopeResolver"/> — enforcement gate first,
+/// then link → deprovisioning gate → RBAC — and fails closed on every uncertain path.
+/// </summary>
+public sealed class AzureSearchScopeResolver(
+    IAzureIdentityLinkReader links,
+    IAzureDirectoryReader directory,
+    IAzureRbacReader rbac,
+    IOptionsMonitor<AzureAdSignInSettings> azureAd,
+    IOptionsMonitor<PermissionEnforcementSettings> enforcement,
+    EnforcementMigration migration,
+    IMemoryCache cache,
+    ILogger<AzureSearchScopeResolver> logger) : ISearchScopeResolver
+{
+    public static readonly TimeSpan CacheLifetime = TimeSpan.FromSeconds(60);
+    private const string KeyPrefix = "azure-scopes:";
+
+    public async Task<SearchScopes> ResolveAsync(Guid? userId, CancellationToken ct = default)
+    {
+        switch (enforcement.CurrentValue.StateForAzure(azureAd.CurrentValue.IsConfigured, migration.Determined))
+        {
+            case EnforcementState.NotEnforcing:
+                return SearchScopes.Unrestricted;
+            case EnforcementState.EnforcingButUnusable:
+                logger.LogError(
+                    "Azure per-user permissions cannot be determined — Azure AD sign-in is incomplete or the startup migration did not complete; denying rather than widening");
+                return SearchScopes.Failed;
+        }
+
+        if (userId is null)
+            return SearchScopes.NoPrincipal;
+
+        string key = KeyPrefix + userId.Value;
+        if (cache.TryGetValue(key, out SearchScopes? cached) && cached is not null)
+            return cached;
+
+        SearchScopes resolved;
+        try
+        {
+            resolved = await ResolveUncachedAsync(userId.Value, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Could not resolve Azure search scopes; denying rather than widening");
+            return SearchScopes.Failed;
+        }
+
+        if (resolved.Outcome is ScopeOutcome.Granted or ScopeOutcome.NoGrants)
+            cache.Set(key, resolved, CacheLifetime);
+        return resolved;
+    }
+
+    private async Task<SearchScopes> ResolveUncachedAsync(Guid userId, CancellationToken ct)
+    {
+        AzureIdentityRef? link = await links.GetLinkAsync(userId, ct);
+        if (link is null)
+            return SearchScopes.NoPrincipal;
+
+        // Deprovisioning gate: a disabled/deleted Entra account is denied even if role assignments
+        // still exist. A Failed identity lookup is an uncertain answer → deny.
+        AzureIdentitySet identity = await directory.ResolveAsync(link, ct);
+        if (identity.Outcome is AzureIdentityOutcome.Deprovisioned)
+        {
+            logger.LogInformation("A linked Entra identity is disabled or gone; denying");
+            return SearchScopes.NoPrincipal;
+        }
+        if (identity.Outcome is AzureIdentityOutcome.Failed)
+            return SearchScopes.Failed;
+
+        AzureRbacScopes scopes = await rbac.ResolveAsync(link.ObjectId, ct);
+        if (scopes.Outcome is RbacOutcome.Failed)
+            return SearchScopes.Failed;
+
+        // Flat accounts: RBAC readable prefixes are the answer. Tag-conditioned residue and Gen2
+        // ACLs are NOT admitted here — they require Phase 4e's live per-hit verifier; omitting them
+        // is a temporary under-grant on the epic branch that 4e closes before the epic reaches main.
+        var matches = scopes.ReadablePrefixes
+            .Select(s => new GrantMatch(s.Prefix, IsExact: false))
+            .ToList();
+
+        return SearchScopes.Of(matches);
+    }
+}

--- a/src/Connapse.Storage/CloudScope/BlobTagReader.cs
+++ b/src/Connapse.Storage/CloudScope/BlobTagReader.cs
@@ -1,0 +1,36 @@
+using Azure;
+using Azure.Core;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>Reads a blob's index tags over <c>Azure.Storage.Blobs</c>. Thin shell; fail-closed
+/// (<c>null</c>) on any error, genuine caller cancellation propagates.</summary>
+public sealed class BlobTagReader(TokenCredential credential) : IBlobTagReader
+{
+    public async Task<IReadOnlyDictionary<string, string>?> ReadTagsAsync(Gen2Path blob, CancellationToken ct = default)
+    {
+        try
+        {
+            var service = new BlobServiceClient(
+                new Uri($"https://{blob.Account}.blob.core.windows.net"), credential);
+            BlobClient client = service.GetBlobContainerClient(blob.FileSystem).GetBlobClient(blob.Path);
+            Response<GetBlobTagResult> tags = await client.GetTagsAsync(cancellationToken: ct);
+            return MapTags(tags.Value?.Tags);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    internal static IReadOnlyDictionary<string, string> MapTags(IDictionary<string, string>? tags) =>
+        tags is null ? new Dictionary<string, string>() : new Dictionary<string, string>(tags);
+}

--- a/src/Connapse.Storage/CloudScope/CompositeSearchScopeResolver.cs
+++ b/src/Connapse.Storage/CloudScope/CompositeSearchScopeResolver.cs
@@ -1,0 +1,74 @@
+using Connapse.Core;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Unions the AWS and Azure scope resolvers into one, per cloud and per URI scheme. Each cloud
+/// governs its own scheme (<c>s3://</c>, <c>azblob://</c>); non-cloud documents (resource_uri NULL)
+/// are always admitted by the store's existing fallback. A cloud that is not enforcing contributes
+/// its scheme wildcard (its docs visible); a cloud that denies or fails contributes nothing (its
+/// docs hidden), and one cloud's failure never denies the other's or non-cloud docs. Only when both
+/// clouds are unrestricted is the result globally unrestricted.
+/// </summary>
+// The inner resolvers are typed as ISearchScopeResolver (not the concrete AWS/Azure types) purely
+// so this can be unit-tested with throwing fakes; DI wires the two concrete resolvers in via an
+// explicit factory, which also avoids a self-referential ISearchScopeResolver resolution.
+public sealed class CompositeSearchScopeResolver(
+    ISearchScopeResolver aws,
+    ISearchScopeResolver azure) : ISearchScopeResolver
+{
+    private static readonly Combiner Rule = new();
+
+    public async Task<SearchScopes> ResolveAsync(Guid? userId, CancellationToken ct = default)
+    {
+        SearchScopes awsScopes = await SafeResolveAsync(aws, userId, ct);
+        SearchScopes azureScopes = await SafeResolveAsync(azure, userId, ct);
+        return Rule.Combine(awsScopes, azureScopes);
+    }
+
+    // A throw from one cloud fails only that cloud closed; cancellation still propagates.
+    private static async Task<SearchScopes> SafeResolveAsync(ISearchScopeResolver inner, Guid? userId, CancellationToken ct)
+    {
+        try
+        {
+            return await inner.ResolveAsync(userId, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return SearchScopes.Failed;
+        }
+    }
+
+    /// <summary>The pure combine rule, separated so it can be unit-tested without resolvers.</summary>
+    public sealed class Combiner
+    {
+        private const string S3Scheme = "s3://";
+        private const string AzureScheme = "azblob://";
+
+        public SearchScopes Combine(SearchScopes awsScopes, SearchScopes azureScopes)
+        {
+            if (awsScopes.IsUnrestricted && azureScopes.IsUnrestricted)
+                return SearchScopes.Unrestricted;
+
+            var matches = new List<GrantMatch>();
+            matches.AddRange(ContributionFor(awsScopes, S3Scheme));
+            matches.AddRange(ContributionFor(azureScopes, AzureScheme));
+            return SearchScopes.Of(matches);
+        }
+
+        // Unrestricted → the scheme wildcard (all of that cloud's docs). Granted → its own matches.
+        // Any denial/failure/no-principal → nothing (that scheme's docs are hidden — fail closed).
+        private static IReadOnlyList<GrantMatch> ContributionFor(SearchScopes scopes, string schemeWildcard)
+        {
+            if (scopes.IsUnrestricted)
+                return [new GrantMatch(schemeWildcard, IsExact: false)];
+            if (scopes.Outcome is ScopeOutcome.Granted)
+                return scopes.Matches;
+            return [];
+        }
+    }
+}

--- a/src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs
+++ b/src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs
@@ -1,0 +1,67 @@
+using Azure.Core;
+using Connapse.Core;
+using Microsoft.Extensions.Options;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Connapse's own Azure identity: an explicit certificate-or-ambient-managed-identity chain,
+/// rebuilt when settings reload. The single TokenCredential every Azure SDK client uses.
+/// </summary>
+public sealed class ConnapseAzureCredentials : TokenCredential, IDisposable
+{
+    public const string ProviderKey = "azure";
+
+    private readonly IOptionsMonitor<AzureProviderSettings> _options;
+    private readonly IDisposable? _reload;
+    private readonly object _gate = new();
+    private TokenCredential? _current;
+
+    public ConnapseAzureCredentials(IOptionsMonitor<AzureProviderSettings> options)
+    {
+        _options = options;
+        // Deliberately do NOT build here: a missing/unreadable cert or incomplete config
+        // must not throw during DI construction and take down unrelated (non-Azure) hosts.
+        // The credential is built lazily on first GetToken/GetTokenAsync call.
+        _reload = options.OnChange(_ =>
+        {
+            // Invalidate only — never build (and never let a build failure throw) from
+            // the reload callback. The next token request rebuilds from fresh settings.
+            lock (_gate) { _current = null; }
+        });
+    }
+
+    private TokenCredential Current
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _current ??= Build(_options.CurrentValue);
+            }
+        }
+    }
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken ct) =>
+        Current.GetToken(requestContext, ct);
+
+    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken ct) =>
+        Current.GetTokenAsync(requestContext, ct);
+
+    private static TokenCredential Build(AzureProviderSettings settings) =>
+        AzureCredentialChainFactory.Create(settings, LoadCertificate);
+
+    private static X509Certificate2? LoadCertificate(AzureProviderSettings s)
+    {
+        if (string.IsNullOrWhiteSpace(s.ClientCertificatePath)) return null;
+        if (!File.Exists(s.ClientCertificatePath)) return null;
+
+        string ext = Path.GetExtension(s.ClientCertificatePath).ToLowerInvariant();
+        return ext is ".pem" or ".crt"
+            ? X509Certificate2.CreateFromPemFile(s.ClientCertificatePath)
+            : X509CertificateLoader.LoadPkcs12FromFile(s.ClientCertificatePath, s.ClientCertificatePassword);
+    }
+
+    public void Dispose() => _reload?.Dispose();
+}

--- a/src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs
+++ b/src/Connapse.Storage/CloudScope/ConnapseAzureCredentials.cs
@@ -49,19 +49,14 @@ public sealed class ConnapseAzureCredentials : TokenCredential, IDisposable
     public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken ct) =>
         Current.GetTokenAsync(requestContext, ct);
 
-    private static TokenCredential Build(AzureProviderSettings settings) =>
+    /// <summary>A credential built from <paramref name="settings"/> alone, sharing nothing with the
+    /// cached one — so a check made with it always goes to Entra rather than answering from a token
+    /// the shared credential still holds.</summary>
+    public static TokenCredential Build(AzureProviderSettings settings) =>
         AzureCredentialChainFactory.Create(settings, LoadCertificate);
 
-    private static X509Certificate2? LoadCertificate(AzureProviderSettings s)
-    {
-        if (string.IsNullOrWhiteSpace(s.ClientCertificatePath)) return null;
-        if (!File.Exists(s.ClientCertificatePath)) return null;
-
-        string ext = Path.GetExtension(s.ClientCertificatePath).ToLowerInvariant();
-        return ext is ".pem" or ".crt"
-            ? X509Certificate2.CreateFromPemFile(s.ClientCertificatePath)
-            : X509CertificateLoader.LoadPkcs12FromFile(s.ClientCertificatePath, s.ClientCertificatePassword);
-    }
+    private static X509Certificate2? LoadCertificate(AzureProviderSettings s) =>
+        AzureCertificateFile.Load(s.ClientCertificatePath, s.ClientCertificatePassword);
 
     public void Dispose() => _reload?.Dispose();
 }

--- a/src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs
+++ b/src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs
@@ -14,7 +14,7 @@ namespace Connapse.Storage.CloudScope;
 /// failure returns <c>null</c> (the resolver treats that as fail-closed); genuine caller
 /// cancellation propagates.
 /// </summary>
-public sealed class DataLakeGen2DirectoryReader(TokenCredential credential) : IGen2DirectoryReader
+public sealed class DataLakeGen2DirectoryReader(TokenCredential credential) : IGen2DirectoryReader, IGen2FileAclReader
 {
     public async Task<Gen2ModeBits?> ReadModeBitsAsync(Gen2Path directory, CancellationToken ct = default)
     {
@@ -50,6 +50,28 @@ public sealed class DataLakeGen2DirectoryReader(TokenCredential credential) : IG
             Response<PathAccessControl> ac = await dir.GetAccessControlAsync(cancellationToken: ct);
             Gen2Acl acl = MapAccessControl(ac.Value.Owner, ac.Value.Group, ac.Value.AccessControlList);
             return IsStructurallyComplete(acl) ? acl : null; // incomplete ACL → deny (fail closed)
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task<Gen2Acl?> ReadFileAclAsync(Gen2Path file, CancellationToken ct = default)
+    {
+        try
+        {
+            var service = new DataLakeServiceClient(
+                new Uri($"https://{file.Account}.dfs.core.windows.net"), credential);
+            DataLakeFileSystemClient fs = service.GetFileSystemClient(file.FileSystem);
+            DataLakeFileClient fileClient = fs.GetFileClient(file.Path);
+            Response<PathAccessControl> ac = await fileClient.GetAccessControlAsync(cancellationToken: ct);
+            Gen2Acl acl = MapAccessControl(ac.Value.Owner, ac.Value.Group, ac.Value.AccessControlList);
+            return IsStructurallyComplete(acl) ? acl : null;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {

--- a/src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs
+++ b/src/Connapse.Storage/CloudScope/DataLakeGen2DirectoryReader.cs
@@ -1,0 +1,130 @@
+using Azure;
+using Azure.Core;
+using Azure.Storage.Files.DataLake;
+using Azure.Storage.Files.DataLake.Models;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Reads a Gen2 directory's access ACL live over the ADLS SDK, with Connapse's own
+/// <see cref="TokenCredential"/> (Storage Blob Data Reader). A thin shell over the SDK: every
+/// translation lives in the <c>internal static</c> mappers, which are unit-tested directly. Any SDK
+/// failure returns <c>null</c> (the resolver treats that as fail-closed); genuine caller
+/// cancellation propagates.
+/// </summary>
+public sealed class DataLakeGen2DirectoryReader(TokenCredential credential) : IGen2DirectoryReader
+{
+    public async Task<Gen2ModeBits?> ReadModeBitsAsync(Gen2Path directory, CancellationToken ct = default)
+    {
+        try
+        {
+            DataLakeDirectoryClient dir = DirectoryClient(directory);
+            Response<PathAccessControl> ac = await dir.GetAccessControlAsync(cancellationToken: ct);
+            // GetAccessControl returns the full ACL; derive the cheap mode-bits view from it. (The
+            // GetPaths-listing optimization is a Phase-4e pre-warm concern; correctness does not
+            // depend on it.) The extended flag is "any named entry or mask present".
+            Gen2Acl acl = MapAccessControl(ac.Value.Owner, ac.Value.Group, ac.Value.AccessControlList);
+            if (!IsStructurallyComplete(acl))
+                return null; // anomalous/incomplete ACL → deny (fail closed), never coerce to valid
+            bool extended = acl.NamedUsers.Count > 0 || acl.NamedGroups.Count > 0 || acl.Mask is not null;
+            return new Gen2ModeBits(acl.OwnerOid, acl.OwningGroupOid,
+                acl.OwnerPermissions, acl.OwningGroupPermissions, acl.OtherPermissions, extended);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task<Gen2Acl?> ReadAccessAclAsync(Gen2Path directory, CancellationToken ct = default)
+    {
+        try
+        {
+            DataLakeDirectoryClient dir = DirectoryClient(directory);
+            Response<PathAccessControl> ac = await dir.GetAccessControlAsync(cancellationToken: ct);
+            Gen2Acl acl = MapAccessControl(ac.Value.Owner, ac.Value.Group, ac.Value.AccessControlList);
+            return IsStructurallyComplete(acl) ? acl : null; // incomplete ACL → deny (fail closed)
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private DataLakeDirectoryClient DirectoryClient(Gen2Path directory)
+    {
+        var service = new DataLakeServiceClient(
+            new Uri($"https://{directory.Account}.dfs.core.windows.net"), credential);
+        DataLakeFileSystemClient fs = service.GetFileSystemClient(directory.FileSystem);
+        return directory.Path.Length == 0
+            ? fs.GetDirectoryClient("/")
+            : fs.GetDirectoryClient(directory.Path);
+    }
+
+    /// <summary>Parses an SDK owner/group/symbolic-permissions triple into mode bits.</summary>
+    internal static Gen2ModeBits MapModeBits(string? owner, string? group, string symbolicPermissions)
+    {
+        var (o, g, other, extended) = Gen2Permissions.ParseSymbolic(symbolicPermissions);
+        return new Gen2ModeBits(owner, group, o, g, other, extended);
+    }
+
+    /// <summary>Builds a <see cref="Gen2Acl"/> from the SDK access-control list, ignoring default
+    /// (inheritance) entries and keeping only the access-scope ones.</summary>
+    internal static Gen2Acl MapAccessControl(string? owner, string? group, IEnumerable<PathAccessControlItem> items)
+    {
+        Gen2Permission ownerPerms = Gen2Permission.None, groupPerms = Gen2Permission.None, other = Gen2Permission.None;
+        Gen2Permission? mask = null;
+        var namedUsers = new List<Gen2NamedAce>();
+        var namedGroups = new List<Gen2NamedAce>();
+
+        foreach (PathAccessControlItem item in items)
+        {
+            if (item.DefaultScope) continue; // inheritance ACL, not evaluated
+            Gen2Permission perms = FromRolePermissions(item.Permissions);
+            bool named = !string.IsNullOrEmpty(item.EntityId);
+            switch (item.AccessControlType)
+            {
+                case AccessControlType.User when named: namedUsers.Add(new Gen2NamedAce(item.EntityId!, perms)); break;
+                case AccessControlType.User: ownerPerms = perms; break;
+                case AccessControlType.Group when named: namedGroups.Add(new Gen2NamedAce(item.EntityId!, perms)); break;
+                case AccessControlType.Group: groupPerms = perms; break;
+                case AccessControlType.Mask: mask = perms; break;
+                case AccessControlType.Other: other = perms; break;
+            }
+        }
+
+        return new Gen2Acl(owner, group, ownerPerms, groupPerms, other, mask, namedUsers, namedGroups);
+    }
+
+    /// <summary>
+    /// Whether a mapped ACL is structurally complete enough to evaluate soundly. An ADLS access ACL
+    /// always names an owner and an owning group, and an <i>extended</i> ACL (one with named entries)
+    /// always carries a mask. A response missing any of these is anomalous — evaluating it would let
+    /// the real owner/owning-group fall through to a more permissive class (an over-grant) or leave a
+    /// named entry uncapped. The reader denies such directories (returns <c>null</c>) rather than
+    /// coerce them into an apparently valid ACL.
+    /// </summary>
+    internal static bool IsStructurallyComplete(Gen2Acl acl) =>
+        !string.IsNullOrEmpty(acl.OwnerOid)
+        && !string.IsNullOrEmpty(acl.OwningGroupOid)
+        && (acl.Mask is not null || (acl.NamedUsers.Count == 0 && acl.NamedGroups.Count == 0));
+
+    private static Gen2Permission FromRolePermissions(RolePermissions p)
+    {
+        Gen2Permission result = Gen2Permission.None;
+        if (p.HasFlag(RolePermissions.Read)) result |= Gen2Permission.Read;
+        if (p.HasFlag(RolePermissions.Write)) result |= Gen2Permission.Write;
+        if (p.HasFlag(RolePermissions.Execute)) result |= Gen2Permission.Execute;
+        return result;
+    }
+}

--- a/src/Connapse.Storage/CloudScope/GraphDirectoryReader.cs
+++ b/src/Connapse.Storage/CloudScope/GraphDirectoryReader.cs
@@ -1,0 +1,155 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Azure.Core;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>
+/// Resolves a searcher's Entra identity set in one Microsoft Graph <c>$batch</c>: the deprovisioning
+/// gate (<c>GET /users/{oid}?$select=id,accountEnabled</c>) and transitive security groups
+/// (<c>POST /users/{oid}/getMemberGroups {securityEnabledOnly:true}</c>). Authenticates with
+/// Connapse's own <see cref="TokenCredential"/>. Fails closed; caches only confident answers.
+/// </summary>
+public sealed class GraphDirectoryReader(
+    HttpClient httpClient,
+    TokenCredential azureCredential,
+    IMemoryCache cache) : IAzureDirectoryReader
+{
+    private const string GraphBatchUrl = "https://graph.microsoft.com/v1.0/$batch";
+    private static readonly string[] GraphScopes = ["https://graph.microsoft.com/.default"];
+
+    /// <summary>Cache window for a confident answer; also the revocation-propagation delay.</summary>
+    public static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(5);
+
+    public async Task<AzureIdentitySet> ResolveAsync(AzureIdentityRef link, CancellationToken ct = default)
+    {
+        string oid = link.ObjectId;
+        // Keyed by (tenant, oid) so a resolved set can never be reused across a tenant boundary,
+        // even though the single-tenant deployment and globally-unique Entra object ids make a
+        // collision practically impossible.
+        string cacheKey = "azure-identity:" + link.TenantId + ":" + oid;
+        if (cache.TryGetValue(cacheKey, out AzureIdentitySet? cached) && cached is not null)
+            return cached;
+
+        AzureIdentitySet result;
+        try
+        {
+            result = await ResolveUncachedAsync(oid, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Genuine caller cancellation propagates cooperatively.
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            // An HttpClient internal timeout surfaces as TaskCanceledException with ct NOT
+            // cancelled — that is a transport failure, so fail closed rather than propagate.
+            return AzureIdentitySet.Failed();
+        }
+        catch
+        {
+            // Any other transport/parse failure fails closed and is never cached.
+            return AzureIdentitySet.Failed();
+        }
+
+        // Only confident answers are cached; a failure must be retried on the next search.
+        if (result.Outcome is not AzureIdentityOutcome.Failed)
+            cache.Set(cacheKey, result, CacheLifetime);
+        return result;
+    }
+
+    private async Task<AzureIdentitySet> ResolveUncachedAsync(string oid, CancellationToken ct)
+    {
+        AccessToken token = await azureCredential.GetTokenAsync(new TokenRequestContext(GraphScopes), ct);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, GraphBatchUrl);
+        request.Headers.Authorization = new("Bearer", token.Token);
+        request.Content = JsonContent.Create(new BatchRequest(
+        [
+            new("user", "GET", $"/users/{oid}?$select=id,accountEnabled", null, null),
+            new("groups", "POST", $"/users/{oid}/getMemberGroups",
+                new GetMemberGroupsBody(true),
+                new Dictionary<string, string> { ["Content-Type"] = "application/json" }),
+        ]));
+
+        using HttpResponseMessage response = await httpClient.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+            return AzureIdentitySet.Failed();   // whole-batch failure (e.g. 401 bad token)
+
+        BatchResponse? batch = await response.Content.ReadFromJsonAsync<BatchResponse>(ct);
+        return Interpret(oid, batch);
+    }
+
+    /// <summary>
+    /// The fail-closed decision, isolated from transport so it is exhaustively unit-testable:
+    /// deprovisioning gate first, then the group set. Missing/partial responses fail closed.
+    /// </summary>
+    internal static AzureIdentitySet Interpret(string oid, BatchResponse? batch)
+    {
+        SubResponse? user = batch?.Responses?.FirstOrDefault(r => r.Id == "user");
+        SubResponse? groups = batch?.Responses?.FirstOrDefault(r => r.Id == "groups");
+        if (user is null || groups is null)
+            return AzureIdentitySet.Failed();
+
+        // Deprovisioning gate. A 404 is a confirmed denial (cacheable).
+        if (user.Status == 404)
+            return AzureIdentitySet.Deprovisioned();
+        if (user.Status != 200)
+            return AzureIdentitySet.Failed();
+
+        // The 200 body must actually be the requested user BEFORE we trust anything in it — a
+        // $batch scopes each sub-response by request id and URL, but a stale/misassociated body
+        // must never drive either the enabled OR the disabled decision for this searcher. A
+        // missing/mismatched id is uncertain, so it fails closed (Failed, uncached) rather than
+        // caching a Deprovisioned denial off another user's body.
+        if (!string.Equals(user.Body?.Id, oid, StringComparison.OrdinalIgnoreCase))
+            return AzureIdentitySet.Failed();
+
+        // A 200 that omits accountEnabled is anomalous/uncertain → Failed (uncached); an explicit
+        // accountEnabled==false is a confirmed disable → Deprovisioned (cacheable).
+        bool? accountEnabled = user.Body?.AccountEnabled;
+        if (accountEnabled is null)
+            return AzureIdentitySet.Failed();
+        if (accountEnabled == false)
+            return AzureIdentitySet.Deprovisioned();
+
+        // Groups must resolve, or the identity set is unknown — fail closed.
+        if (groups.Status != 200 || groups.Body?.Value is null)
+            return AzureIdentitySet.Failed();
+
+        // Every group value must be a real Entra object GUID. A null, empty, or non-GUID element
+        // is an anomalous response, so fail closed rather than admit a bogus principal into P.
+        var principals = new List<string>(1 + groups.Body.Value.Count) { oid };
+        foreach (string? group in groups.Body.Value)
+        {
+            if (!Guid.TryParse(group, out _))
+                return AzureIdentitySet.Failed();
+            principals.Add(group!);
+        }
+        return AzureIdentitySet.Resolved(principals);
+    }
+
+    // ---- Graph $batch DTOs ----
+    private sealed record BatchRequest([property: JsonPropertyName("requests")] IReadOnlyList<SubRequest> Requests);
+    private sealed record SubRequest(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("method")] string Method,
+        [property: JsonPropertyName("url")] string Url,
+        [property: JsonPropertyName("body")] object? Body,
+        [property: JsonPropertyName("headers")] IReadOnlyDictionary<string, string>? Headers);
+    private sealed record GetMemberGroupsBody([property: JsonPropertyName("securityEnabledOnly")] bool SecurityEnabledOnly);
+
+    internal sealed record BatchResponse([property: JsonPropertyName("responses")] IReadOnlyList<SubResponse>? Responses);
+    internal sealed record SubResponse(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("status")] int Status,
+        [property: JsonPropertyName("body")] SubBody? Body);
+    internal sealed record SubBody(
+        [property: JsonPropertyName("id")] string? Id,
+        [property: JsonPropertyName("accountEnabled")] bool? AccountEnabled,
+        [property: JsonPropertyName("value")] IReadOnlyList<string>? Value);
+}

--- a/src/Connapse.Storage/CloudScope/NoOpSearchResultVerifier.cs
+++ b/src/Connapse.Storage/CloudScope/NoOpSearchResultVerifier.cs
@@ -1,0 +1,16 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+
+namespace Connapse.Storage.CloudScope;
+
+/// <summary>The default: no verification. Returns every candidate unchanged — the caller (the search
+/// pipeline's own final <c>Take(topK)</c>) applies the cap, so AutoCut still sees the full pool
+/// exactly as it would with no verifier in the pipeline at all.</summary>
+public sealed class NoOpSearchResultVerifier : ISearchResultVerifier
+{
+    public int CandidateMultiplier => 1;
+
+    public Task<IReadOnlyList<SearchHit>> VerifyAsync(
+        IReadOnlyList<SearchHit> rankedCandidates, Guid? userId, int topK, CancellationToken ct = default) =>
+        Task.FromResult(rankedCandidates);
+}

--- a/src/Connapse.Storage/Connapse.Storage.csproj
+++ b/src/Connapse.Storage/Connapse.Storage.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="AWSSDK.SSO" Version="4.0.2.14" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.15" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.Identity" Version="1.16.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -38,6 +40,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Connapse.Core.Tests" />
     <InternalsVisibleTo Include="Connapse.Storage.Tests" />
+    <InternalsVisibleTo Include="Connapse.Integration.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Connapse.Storage/Connapse.Storage.csproj
+++ b/src/Connapse.Storage/Connapse.Storage.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
     <PackageReference Include="Azure.Identity" Version="1.16.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
+    <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.22.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Connapse.Storage/Connapse.Storage.csproj
+++ b/src/Connapse.Storage/Connapse.Storage.csproj
@@ -13,7 +13,8 @@
     <PackageReference Include="AWSSDK.SSO" Version="4.0.2.14" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.15" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Azure.Identity" Version="1.16.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.ResourceManager.Storage" Version="1.7.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.22.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">

--- a/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
@@ -1,0 +1,57 @@
+using Azure;
+using Azure.Storage.Blobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using Connapse.Storage.Connectors;
+
+namespace Connapse.Storage.ConnectionTesters;
+
+/// <summary>Validates an Azure Blob connection by listing a few blobs with Connapse's identity.</summary>
+public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentials) : IConnectionTester
+{
+    public async Task<ConnectionTestResult> TestConnectionAsync(
+        object settings, TimeSpan? timeout = null, CancellationToken ct = default)
+    {
+        if (settings is not AzureBlobConnectorConfig cfg)
+            return ConnectionTestResult.CreateFailure(
+                "Invalid settings: expected AzureBlobConnectorConfig.");
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(timeout ?? TimeSpan.FromSeconds(10));
+
+        try
+        {
+            var service = new BlobServiceClient(
+                new Uri(cfg.BlobEndpoint ?? $"https://{cfg.AccountName}.blob.core.windows.net"),
+                credentials);
+            var container = service.GetBlobContainerClient(cfg.ContainerName);
+
+            int seen = 0;
+            await foreach (var _ in container.GetBlobsAsync(prefix: cfg.Prefix, cancellationToken: cts.Token))
+                if (++seen >= 5) break;
+
+            return ConnectionTestResult.CreateSuccess(
+                $"Connected to container '{cfg.ContainerName}' on account '{cfg.AccountName}'.");
+        }
+        catch (RequestFailedException ex) when (ex.Status == 403)
+        {
+            return ConnectionTestResult.CreateFailure(
+                "Authorization failed — Connapse's identity lacks read access to this container "
+                + "(needs Storage Blob Data Reader).");
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return ConnectionTestResult.CreateFailure(
+                $"Container '{cfg.ContainerName}' or account '{cfg.AccountName}' not found.");
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return ConnectionTestResult.CreateFailure("Connection test timed out.");
+        }
+        catch (Exception ex)
+        {
+            return ConnectionTestResult.CreateFailure($"Connection test failed: {ex.Message}");
+        }
+    }
+}

--- a/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using Azure;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
@@ -8,6 +10,11 @@ using Connapse.Storage.Connectors;
 namespace Connapse.Storage.ConnectionTesters;
 
 /// <summary>Validates an Azure Blob connection by listing a few blobs with Connapse's identity.</summary>
+/// <remarks>
+/// Every message says which layer failed — reaching the account, Entra accepting Connapse's
+/// credential, the role assignment allowing the read, or the container existing — and what to
+/// change. The raw reason travels in <c>Details["error"]</c> for the operator who wants it.
+/// </remarks>
 public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentials) : IConnectionTester
 {
     public async Task<ConnectionTestResult> TestConnectionAsync(
@@ -17,41 +24,157 @@ public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentia
             return ConnectionTestResult.CreateFailure(
                 "Invalid settings: expected AzureBlobConnectorConfig.");
 
+        TimeSpan limit = timeout ?? TimeSpan.FromSeconds(10);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        cts.CancelAfter(timeout ?? TimeSpan.FromSeconds(10));
+        cts.CancelAfter(limit);
+
+        string endpoint = cfg.BlobEndpoint ?? $"https://{cfg.AccountName}.blob.core.windows.net";
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? endpointUri) || endpointUri.Scheme is not ("https" or "http"))
+        {
+            return ConnectionTestResult.CreateFailure(
+                $"'{endpoint}' is not a full https:// address. Fix the Blob endpoint field, or clear it to "
+                + "use the account's default endpoint.",
+                new Dictionary<string, object> { ["error"] = "Invalid blob endpoint", ["endpoint"] = endpoint });
+        }
+
+        string where = string.IsNullOrEmpty(cfg.Prefix) ? "" : $" under prefix '{cfg.Prefix}'";
+        var stopwatch = Stopwatch.StartNew();
 
         try
         {
-            var service = new BlobServiceClient(
-                new Uri(cfg.BlobEndpoint ?? $"https://{cfg.AccountName}.blob.core.windows.net"),
-                credentials);
+            var service = new BlobServiceClient(endpointUri, credentials);
             var container = service.GetBlobContainerClient(cfg.ContainerName);
 
             int seen = 0;
+            bool hasMore = false;
             await foreach (var _ in container.GetBlobsAsync(prefix: cfg.Prefix, cancellationToken: cts.Token))
-                if (++seen >= 5) break;
+            {
+                if (++seen >= 5) { hasMore = true; break; }
+            }
+
+            stopwatch.Stop();
+            string what = seen > 0
+                ? $"{seen}{(hasMore ? "+" : "")} blob{(seen != 1 ? "s" : "")} found{where}"
+                : $"it is empty{where}";
 
             return ConnectionTestResult.CreateSuccess(
-                $"Connected to container '{cfg.ContainerName}' on account '{cfg.AccountName}'.");
+                $"Reached account '{cfg.AccountName}', Entra accepted Connapse's identity, and listed "
+                + $"container '{cfg.ContainerName}': {what}.",
+                new Dictionary<string, object>
+                {
+                    ["accountName"] = cfg.AccountName,
+                    ["containerName"] = cfg.ContainerName,
+                    ["prefix"] = cfg.Prefix ?? "(none)",
+                    ["blobsFound"] = seen,
+                    ["hasMore"] = hasMore,
+                },
+                stopwatch.Elapsed);
         }
-        catch (RequestFailedException ex) when (ex.Status == 403)
+        catch (AuthenticationFailedException ex) when (AzureBlobDiscovery.IsCredentialRefusal(ex))
         {
-            return ConnectionTestResult.CreateFailure(
-                "Authorization failed — Connapse's identity lacks read access to this container "
-                + "(needs Storage Blob Data Reader).");
+            // Entra answered and would not issue a token: the certificate is not registered on the
+            // app, has expired, or the app is gone. Nothing on the connection form fixes that.
+            stopwatch.Stop();
+            return Failure(
+                "Entra rejected Connapse's identity, so nothing on this account can be read. Check "
+                + "the Access step on the Azure provider page — Recheck there says why.",
+                ex, stopwatch.Elapsed);
+        }
+        catch (CredentialUnavailableException ex)
+        {
+            stopwatch.Stop();
+            return Failure(
+                "No managed identity is available on this host, so Connapse has nothing to sign in "
+                + "with. Check the Access step on the Azure provider page.",
+                ex, stopwatch.Elapsed);
+        }
+        catch (AuthenticationFailedException ex) when (ex.Message.Contains("AADSTS", StringComparison.Ordinal))
+        {
+            // Entra answered, but with a code that is not a verdict on the credential — a transient
+            // fault, throttling, clock skew. Retrying is the remedy, not re-setup or the network.
+            stopwatch.Stop();
+            return Failure(
+                "Entra answered but did not judge Connapse's credential (a transient fault or throttling), "
+                + "so the test is inconclusive. Try again in a moment; the raw reply is below.",
+                ex, stopwatch.Elapsed);
+        }
+        catch (AuthenticationFailedException ex)
+        {
+            // The sign-in request never got an answer from Entra — a transport fault, not a
+            // verdict on the credential.
+            stopwatch.Stop();
+            return Failure(
+                "Could not reach Entra to sign Connapse in, so the credential was not checked. Confirm "
+                + "this server can reach login.microsoftonline.com, then try again.",
+                ex, stopwatch.Elapsed);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // The credential chain refuses to build: the certificate file is missing or the
+            // identity is only partly configured.
+            stopwatch.Stop();
+            return Failure(
+                "Connapse's Azure identity is not usable: " + ex.Message
+                + " Fix it on the Access step of the Azure provider page.",
+                ex, stopwatch.Elapsed);
+        }
+        catch (RequestFailedException ex) when (ex.Status is 401 or 403)
+        {
+            stopwatch.Stop();
+            return Failure(
+                $"Entra accepted Connapse's identity, but it is not allowed to list container "
+                + $"'{cfg.ContainerName}' on account '{cfg.AccountName}'. Assign it the "
+                + $"'{Core.Utilities.AzureCloudShellSetup.BlobDataRoleName}' role (or Storage Blob Data Reader) on "
+                + "the account or container — the commands under the allowed locations do exactly that. "
+                + "A new assignment can take a few minutes to apply.",
+                ex, stopwatch.Elapsed);
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
         {
-            return ConnectionTestResult.CreateFailure(
-                $"Container '{cfg.ContainerName}' or account '{cfg.AccountName}' not found.");
+            stopwatch.Stop();
+            return Failure(
+                $"Entra accepted Connapse's identity, but no container '{cfg.ContainerName}' exists on "
+                + $"account '{cfg.AccountName}'. Check the name — Azure has no default container, so "
+                + "the test needs one that exists.",
+                ex, stopwatch.Elapsed);
+        }
+        catch (RequestFailedException ex)
+        {
+            stopwatch.Stop();
+            return Failure(
+                $"Azure refused the request ({ex.ErrorCode ?? "unknown code"}): {ex.Message}",
+                ex, stopwatch.Elapsed);
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
-            return ConnectionTestResult.CreateFailure("Connection test timed out.");
+            stopwatch.Stop();
+            return ConnectionTestResult.CreateFailure(
+                $"Azure did not answer within {limit.TotalSeconds:F0} seconds. Check that this server can "
+                + $"reach {endpointUri.Host}, then try again.",
+                new Dictionary<string, object>
+                {
+                    ["error"] = "Timeout",
+                    ["timeoutSeconds"] = limit.TotalSeconds,
+                },
+                stopwatch.Elapsed);
         }
         catch (Exception ex)
         {
-            return ConnectionTestResult.CreateFailure($"Connection test failed: {ex.Message}");
+            stopwatch.Stop();
+            return Failure(
+                $"Could not reach '{endpointUri.Host}': {ex.Message} Check the storage account name "
+                + "and, if one is set, the blob endpoint.",
+                ex, stopwatch.Elapsed);
         }
     }
+
+    private static ConnectionTestResult Failure(string message, Exception ex, TimeSpan elapsed) =>
+        ConnectionTestResult.CreateFailure(
+            message,
+            new Dictionary<string, object>
+            {
+                ["error"] = ex.Message,
+                ["errorType"] = ex.GetType().Name,
+            },
+            elapsed);
 }

--- a/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
+++ b/src/Connapse.Storage/ConnectionTesters/AzureBlobConnectionTester.cs
@@ -28,14 +28,15 @@ public sealed class AzureBlobConnectionTester(ConnapseAzureCredentials credentia
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         cts.CancelAfter(limit);
 
-        string endpoint = cfg.BlobEndpoint ?? $"https://{cfg.AccountName}.blob.core.windows.net";
-        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? endpointUri) || endpointUri.Scheme is not ("https" or "http"))
+        // The same rule the connector applies: the endpoint must be the named account's, or the
+        // test would prove access to one account for a connection labelled as another.
+        if (Core.Utilities.AzureBlobEndpoint.Validate(cfg.AccountName, cfg.BlobEndpoint, out Uri? endpointUri) is { } endpointProblem)
         {
             return ConnectionTestResult.CreateFailure(
-                $"'{endpoint}' is not a full https:// address. Fix the Blob endpoint field, or clear it to "
-                + "use the account's default endpoint.",
-                new Dictionary<string, object> { ["error"] = "Invalid blob endpoint", ["endpoint"] = endpoint });
+                endpointProblem,
+                new Dictionary<string, object> { ["error"] = "Invalid storage account or blob endpoint", ["endpoint"] = cfg.BlobEndpoint ?? "" });
         }
+        endpointUri = endpointUri!;
 
         string where = string.IsNullOrEmpty(cfg.Prefix) ? "" : $" under prefix '{cfg.Prefix}'";
         var stopwatch = Stopwatch.StartNew();

--- a/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
+++ b/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
@@ -1,0 +1,99 @@
+using Azure.Core;
+using Azure.Storage.Blobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
+using System.Runtime.CompilerServices;
+
+namespace Connapse.Storage.Connectors;
+
+/// <summary>
+/// Read-only Azure Blob Storage connector. Builds a BlobServiceClient from the account +
+/// Connapse's TokenCredential; the internal ctor accepts a prebuilt client for tests
+/// (Azurite cannot authenticate an AAD TokenCredential). SupportsLiveWatch = false.
+/// </summary>
+public sealed class AzureBlobConnector : IConnector, IDisposable
+{
+    private readonly AzureBlobConnectorConfig _config;
+    private readonly BlobContainerClient _container;
+
+    public AzureBlobConnector(AzureBlobConnectorConfig config, TokenCredential credential)
+        : this(config, new BlobServiceClient(
+            new Uri(config.BlobEndpoint ?? $"https://{config.AccountName}.blob.core.windows.net"),
+            credential))
+    { }
+
+    internal AzureBlobConnector(AzureBlobConnectorConfig config, BlobServiceClient client)
+    {
+        _config = config;
+        _container = client.GetBlobContainerClient(config.ContainerName);
+    }
+
+    public ConnectorType Type => ConnectorType.AzureBlob;
+    public bool SupportsLiveWatch => false;
+
+    public string ResolveJobPath(string relativePath) => CombinePrefix(relativePath);
+
+    public async Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
+    {
+        string effective = CombinePrefix(prefix ?? "");
+        var files = new List<ConnectorFile>();
+        await foreach (var item in _container.GetBlobsAsync(prefix: effective, cancellationToken: ct))
+        {
+            files.Add(new ConnectorFile(
+                item.Name,
+                item.Properties.ContentLength ?? 0,
+                (item.Properties.LastModified ?? DateTimeOffset.MinValue).UtcDateTime,
+                item.Properties.ContentType,
+                ResourceUri.ForAzureBlob(_config.AccountName, _config.ContainerName, item.Name)));
+        }
+        return files;
+    }
+
+    public async Task<Stream> ReadFileAsync(string path, CancellationToken ct = default)
+    {
+        if (!IsInPrefixScope(path))
+        {
+            throw new UnauthorizedAccessException(
+                $"Blob '{path}' is outside the source's configured prefix scope.");
+        }
+        var download = await _container.GetBlobClient(path).DownloadStreamingAsync(cancellationToken: ct);
+        return download.Value.Content;
+    }
+
+    public async Task<bool> ExistsAsync(string path, CancellationToken ct = default)
+        => IsInPrefixScope(path) && await _container.GetBlobClient(path).ExistsAsync(ct);
+
+    /// <summary>
+    /// Enforces the configured prefix as an exact-subtree boundary: a path is in scope only if
+    /// the prefix is empty (whole container), equals the path exactly, or is followed by '/'.
+    /// Prevents a sibling prefix (e.g. "team-archive/") from matching "team/" via a raw StartsWith.
+    /// </summary>
+    internal bool IsInPrefixScope(string path)
+    {
+        string normalizedPrefix = _config.Prefix?.Trim('/') ?? "";
+        if (string.IsNullOrEmpty(normalizedPrefix))
+        {
+            return true;
+        }
+        return path.Equals(normalizedPrefix, StringComparison.Ordinal)
+            || path.StartsWith(normalizedPrefix + "/", StringComparison.Ordinal);
+    }
+
+    public async IAsyncEnumerable<ConnectorFileEvent> WatchAsync([EnumeratorCancellation] CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Azure Blob connector does not support live watch.");
+#pragma warning disable CS0162
+        yield break;
+#pragma warning restore CS0162
+    }
+
+    private string CombinePrefix(string tail)
+    {
+        string p = _config.Prefix?.Trim('/') ?? "";
+        string t = tail.TrimStart('/');
+        return string.IsNullOrEmpty(p) ? t : string.IsNullOrEmpty(t) ? p + "/" : $"{p}/{t}";
+    }
+
+    public void Dispose() { }
+}

--- a/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
+++ b/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
@@ -1,5 +1,6 @@
 using Azure.Core;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Core.Utilities;
@@ -34,12 +35,32 @@ public sealed class AzureBlobConnector : IConnector, IDisposable
 
     public string ResolveJobPath(string relativePath) => CombinePrefix(relativePath);
 
+    /// <summary>
+    /// Whether a listed blob is a directory rather than a file: a Gen2 directory (marked
+    /// <c>hdi_isfolder</c>) or a flat-namespace folder marker (a name ending in <c>/</c>). Either
+    /// one ingested as a file is an empty document with no extension.
+    /// </summary>
+    internal static bool IsDirectoryPlaceholder(string name, long? contentLength, IDictionary<string, string>? metadata)
+    {
+        // A directory never has content. A blob that does is a file whatever its name or metadata
+        // says — both are application-controlled on a flat-namespace account.
+        if (contentLength is > 0) return false;
+        if (name.EndsWith('/')) return true;
+        return metadata is not null
+            && metadata.TryGetValue("hdi_isfolder", out string? isFolder)
+            && string.Equals(isFolder, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
     public async Task<IReadOnlyList<ConnectorFile>> ListFilesAsync(string? prefix = null, CancellationToken ct = default)
     {
         string effective = CombinePrefix(prefix ?? "");
         var files = new List<ConnectorFile>();
-        await foreach (var item in _container.GetBlobsAsync(prefix: effective, cancellationToken: ct))
+        // Metadata is requested because on a Data Lake Gen2 (hierarchical namespace) account a flat
+        // listing returns each directory as a zero-byte blob whose only tell is hdi_isfolder=true.
+        await foreach (var item in _container.GetBlobsAsync(BlobTraits.Metadata, BlobStates.None, effective, ct))
         {
+            if (IsDirectoryPlaceholder(item.Name, item.Properties.ContentLength, item.Metadata)) continue;
+
             files.Add(new ConnectorFile(
                 item.Name,
                 item.Properties.ContentLength ?? 0,

--- a/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
+++ b/src/Connapse.Storage/Connectors/AzureBlobConnector.cs
@@ -18,9 +18,14 @@ public sealed class AzureBlobConnector : IConnector, IDisposable
     private readonly AzureBlobConnectorConfig _config;
     private readonly BlobContainerClient _container;
 
+    /// <remarks>
+    /// The endpoint is resolved through <see cref="AzureBlobEndpoint"/>, which refuses an override
+    /// that is not the named account: the documents this connector lists are labelled with
+    /// <c>AccountName</c>, and every permission decision is made against that label.
+    /// </remarks>
     public AzureBlobConnector(AzureBlobConnectorConfig config, TokenCredential credential)
         : this(config, new BlobServiceClient(
-            new Uri(config.BlobEndpoint ?? $"https://{config.AccountName}.blob.core.windows.net"),
+            AzureBlobEndpoint.Resolve(config.AccountName, config.BlobEndpoint),
             credential))
     { }
 

--- a/src/Connapse.Storage/Connectors/AzureBlobConnectorConfig.cs
+++ b/src/Connapse.Storage/Connectors/AzureBlobConnectorConfig.cs
@@ -1,0 +1,11 @@
+namespace Connapse.Storage.Connectors;
+
+/// <summary>Recombined connection (account/endpoint) + source (container/prefix) config for the Azure Blob connector.</summary>
+public record AzureBlobConnectorConfig
+{
+    public string AccountName { get; init; } = "";
+    public string ContainerName { get; init; } = "";
+    public string? Prefix { get; init; }
+    /// <summary>Overrides https://{account}.blob.core.windows.net (Azurite/local).</summary>
+    public string? BlobEndpoint { get; init; }
+}

--- a/src/Connapse.Storage/Connectors/ConnectorFactory.cs
+++ b/src/Connapse.Storage/Connectors/ConnectorFactory.cs
@@ -14,6 +14,7 @@ public class ConnectorFactory(
     IOptionsMonitor<SourceSecuritySettings> sourceSecurity,
     ISshHostKeyStore hostKeyStore,
     CloudScope.ConnapseAwsCredentials awsCredentials,
+    CloudScope.ConnapseAzureCredentials azureCredentials,
     ILogger<ConnectorFactory> logger) : IConnectorFactory
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -69,6 +70,22 @@ public class ConnectorFactory(
             // The identity an administrator configured, so a sync runs as whatever the
             // Providers page reports rather than as whatever the container is carrying.
             awsCredentials),
+
+            ConnectionProvider.AzureBlob => new AzureBlobConnector(new AzureBlobConnectorConfig
+            {
+                AccountName = Str(credential, "accountName")
+                    ?? throw new InvalidOperationException(
+                        $"Connection '{connection.Name}' has no accountName."),
+                BlobEndpoint = Str(credential, "blobEndpoint"),
+                ContainerName = RequirePermittedLocation(
+                    StorageLocationPolicy.ReadAllowedLocations(credential.RootElement),
+                    Str(scope, "containerName")
+                        ?? throw new InvalidOperationException(
+                            $"Source '{source.Name}' has no containerName in its scope."),
+                    Str(scope, "prefix"),
+                    connection.Name, source.Name),
+                Prefix = Str(scope, "prefix"),
+            }, azureCredentials),
 
             ConnectionProvider.Filesystem => new FilesystemConnector(new FilesystemConnectorConfig
             {

--- a/src/Connapse.Storage/Connectors/S3Connector.cs
+++ b/src/Connapse.Storage/Connectors/S3Connector.cs
@@ -77,6 +77,9 @@ public class S3Connector : IConnector, IDisposable
             foreach (var obj in response.S3Objects ?? [])
             {
                 if (obj.Key == effectivePrefix) continue;
+                // A "folder" made in the S3 console is a zero-byte key ending in "/". It is not a
+                // file, and ingested as one it is an empty document with no extension.
+                if (obj.Key.EndsWith('/') && (obj.Size ?? 0) == 0) continue;
                 // Return virtual path: strip config prefix, ensure leading /
                 var virtualPath = StripConfigPrefix(obj.Key);
                 files.Add(new ConnectorFile(

--- a/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
+++ b/src/Connapse.Storage/Documents/PostgresDocumentStore.cs
@@ -353,6 +353,26 @@ public class PostgresDocumentStore : IDocumentStore
             stats.LastIndexedAt);
     }
 
+    public async Task<IReadOnlyDictionary<string, string?>> GetResourceUrisAsync(
+        IReadOnlyCollection<string> documentIds, CancellationToken ct = default)
+    {
+        var result = new Dictionary<string, string?>();
+        if (documentIds.Count == 0) return result;
+
+        Guid[] ids = documentIds.Select(Guid.Parse).ToArray();
+        await using var context = await _factory.CreateDbContextAsync(ct);
+
+        var rows = await context.Documents
+            .Where(d => ids.Contains(d.Id))
+            .Select(d => new { d.Id, d.ResourceUri })
+            .ToListAsync(ct);
+
+        foreach (var row in rows)
+            result[row.Id.ToString()] = row.ResourceUri;
+
+        return result;
+    }
+
     private static Document MapToModel(DocumentEntity entity)
     {
         var metadata = new Dictionary<string, string>(entity.Metadata ?? new());

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -235,6 +235,11 @@ public static class ServiceCollectionExtensions
         // transient reader instance per resolve still shares one cache across the process.
         services.AddHttpClient<Connapse.Core.Interfaces.IAzureDirectoryReader, CloudScope.GraphDirectoryReader>();
 
+        // Reads the searcher's effective RBAC-readable azblob scopes from ARM (role assignments
+        // minus deny assignments). Typed HttpClient; the 5-minute decision cache is the shared
+        // IMemoryCache singleton. TokenCredential is already mapped to ConnapseAzureCredentials (4a).
+        services.AddHttpClient<Connapse.Core.Interfaces.IAzureRbacReader, CloudScope.ArmRbacReader>();
+
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();
         services.AddSingleton<IAccessGrantsReader, CloudScope.S3AccessGrantsReader>();

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -224,6 +224,17 @@ public static class ServiceCollectionExtensions
             configuration.GetSection(AzureProviderSettings.SectionName));
         services.AddSingleton<CloudScope.ConnapseAzureCredentials>();
 
+        // Expose Connapse's Azure identity as the ambient TokenCredential for Azure control-plane
+        // readers (Graph, and ARM in 4b). Nothing else resolves a bare TokenCredential today —
+        // connectors take ConnapseAzureCredentials directly — so this mapping is unambiguous.
+        services.TryAddSingleton<Azure.Core.TokenCredential>(
+            sp => sp.GetRequiredService<CloudScope.ConnapseAzureCredentials>());
+
+        // Reads the Entra directory (deprovisioning gate + transitive groups) over Graph $batch.
+        // Typed HttpClient; the 5-minute decision cache is the shared IMemoryCache singleton, so a
+        // transient reader instance per resolve still shares one cache across the process.
+        services.AddHttpClient<Connapse.Core.Interfaces.IAzureDirectoryReader, CloudScope.GraphDirectoryReader>();
+
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();
         services.AddSingleton<IAccessGrantsReader, CloudScope.S3AccessGrantsReader>();

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -189,6 +189,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<OllamaConnectionTester>();
         services.AddScoped<MinioConnectionTester>();
         services.AddScoped<S3ConnectionTester>();
+        services.AddScoped<AzureBlobConnectionTester>();
 
         // Singleton: it holds no per-request state, and the SDK caches and refreshes the resolved
         // credential itself, so a new instance per scope would discard that cache each time.
@@ -214,6 +215,15 @@ public static class ServiceCollectionExtensions
         // credential provider therefore takes IServiceScopeFactory and opens a scope per refresh
         // rather than holding the store.
         services.AddSingleton<CloudScope.ConnapseAwsCredentials>();
+
+        // Connapse's own Azure app identity — bound from Providers:Azure, consumed by
+        // ConnectorFactory and AzureBlobConnectionTester. Singleton for the same reason as
+        // ConnapseAwsCredentials: it caches/rebuilds its own credential chain on settings
+        // reload, so one instance per process is the correct shape, not one per scope.
+        services.Configure<AzureProviderSettings>(
+            configuration.GetSection(AzureProviderSettings.SectionName));
+        services.AddSingleton<CloudScope.ConnapseAzureCredentials>();
+
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();
         services.AddSingleton<IAccessGrantsReader, CloudScope.S3AccessGrantsReader>();

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -249,10 +249,18 @@ public static class ServiceCollectionExtensions
         services.AddMemoryCache();
         // Starts undetermined, so a host that never runs the startup migration refuses to answer
         // rather than assuming nothing was being enforced. Connapse.Web completes it from
-        // SamlEnforcementLatch; nothing else resolves this today.
+        // CloudEnforcementLatch; nothing else resolves this today.
         services.TryAddSingleton(new EnforcementMigration());
 
-        services.AddScoped<ISearchScopeResolver, CloudScope.AwsSearchScopeResolver>();
+        // The composite is THE resolver; it unions the AWS and Azure resolvers per cloud/scheme.
+        // AWS keeps its exact behavior as one inner resolver. Wired via an explicit factory that
+        // passes the two concrete resolvers, so the composite's ISearchScopeResolver parameters do
+        // not resolve back to the composite itself (no self-reference).
+        services.AddScoped<CloudScope.AwsSearchScopeResolver>();
+        services.AddScoped<CloudScope.AzureSearchScopeResolver>();
+        services.AddScoped<ISearchScopeResolver>(sp => new CloudScope.CompositeSearchScopeResolver(
+            sp.GetRequiredService<CloudScope.AwsSearchScopeResolver>(),
+            sp.GetRequiredService<CloudScope.AzureSearchScopeResolver>()));
 
         // Reads the connections, so scoped alongside the store it uses.
         services.AddScoped<IAwsGrantRegions, CloudScope.ConnectionGrantRegions>();

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -240,6 +240,11 @@ public static class ServiceCollectionExtensions
         // IMemoryCache singleton. TokenCredential is already mapped to ConnapseAzureCredentials (4a).
         services.AddHttpClient<Connapse.Core.Interfaces.IAzureRbacReader, CloudScope.ArmRbacReader>();
 
+        // Gen2 permission engine (Phase 4d). A pure library the Phase 4e verifier consumes; nothing here
+        // is wired into the search pipeline yet.
+        services.AddSingleton<IGen2DirectoryReader, DataLakeGen2DirectoryReader>();
+        services.AddSingleton<AncestorTraverseResolver>();
+
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();
         services.AddSingleton<IAccessGrantsReader, CloudScope.S3AccessGrantsReader>();

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -258,6 +258,7 @@ public static class ServiceCollectionExtensions
         services.Configure<AzureVerifierSettings>(configuration.GetSection(AzureVerifierSettings.SectionName));
 
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
+        services.AddSingleton<IAzureBlobDiscovery, CloudScope.AzureBlobDiscovery>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();
         services.AddSingleton<IAccessGrantsReader, CloudScope.S3AccessGrantsReader>();
 

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -259,6 +259,9 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
         services.AddSingleton<IAzureBlobDiscovery, CloudScope.AzureBlobDiscovery>();
+        // Remembers the host's managed identity once found, so the provider page's detection is
+        // one metadata call per process, not one per render.
+        services.AddSingleton<IAzureHostIdentity, CloudScope.AzureHostIdentity>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();
         services.AddSingleton<IAccessGrantsReader, CloudScope.S3AccessGrantsReader>();
 

--- a/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Connapse.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -240,10 +240,22 @@ public static class ServiceCollectionExtensions
         // IMemoryCache singleton. TokenCredential is already mapped to ConnapseAzureCredentials (4a).
         services.AddHttpClient<Connapse.Core.Interfaces.IAzureRbacReader, CloudScope.ArmRbacReader>();
 
-        // Gen2 permission engine (Phase 4d). A pure library the Phase 4e verifier consumes; nothing here
-        // is wired into the search pipeline yet.
-        services.AddSingleton<IGen2DirectoryReader, DataLakeGen2DirectoryReader>();
+        // Gen2 permission engine (Phase 4d), consumed by the Phase 4e per-hit verifier below.
+        // DataLakeGen2DirectoryReader implements both IGen2DirectoryReader (mode bits for ancestor
+        // traverse checks) and IGen2FileAclReader (a file's own ACL) — one singleton serves both
+        // interfaces so directory reads share the client construction and any future caching.
+        services.AddSingleton<DataLakeGen2DirectoryReader>();
+        services.AddSingleton<IGen2DirectoryReader>(sp => sp.GetRequiredService<DataLakeGen2DirectoryReader>());
+        services.AddSingleton<IGen2FileAclReader>(sp => sp.GetRequiredService<DataLakeGen2DirectoryReader>());
         services.AddSingleton<AncestorTraverseResolver>();
+
+        // Live per-hit permission verify (Phase 4e), wired into HybridSearchService's search
+        // pipeline. Always registered — it self-no-ops (CandidateMultiplier=1, VerifyAsync passes
+        // everything through) when Azure AD isn't configured, so AWS-only/non-cloud deployments
+        // pay nothing extra.
+        services.AddSingleton<IBlobTagReader, BlobTagReader>();
+        services.AddScoped<ISearchResultVerifier, AzureSearchResultVerifier>();
+        services.Configure<AzureVerifierSettings>(configuration.GetSection(AzureVerifierSettings.SectionName));
 
         services.AddSingleton<IS3Discovery, CloudScope.S3Discovery>();
         services.AddSingleton<IDirectoryUserLookup, CloudScope.IdentityStoreUserLookup>();

--- a/src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs
+++ b/src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs
@@ -23,6 +23,7 @@ public class DatabaseSettingsProvider : ConfigurationProvider
         ["samlsignin"] = "Identity:SamlSignIn",
         ["identitycenter"] = "Identity:IdentityCenter",
         ["permissionenforcement"] = "Identity:PermissionEnforcement",
+        ["azure"] = "Providers:Azure",
     };
 
     public DatabaseSettingsProvider(Action<DbContextOptionsBuilder> optionsAction)

--- a/src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs
+++ b/src/Connapse.Storage/Settings/DatabaseSettingsProvider.cs
@@ -24,6 +24,7 @@ public class DatabaseSettingsProvider : ConfigurationProvider
         ["identitycenter"] = "Identity:IdentityCenter",
         ["permissionenforcement"] = "Identity:PermissionEnforcement",
         ["azure"] = "Providers:Azure",
+        ["azuread"] = "Identity:AzureAd",
     };
 
     public DatabaseSettingsProvider(Action<DbContextOptionsBuilder> optionsAction)

--- a/src/Connapse.Storage/Settings/PostgresSettingsStore.cs
+++ b/src/Connapse.Storage/Settings/PostgresSettingsStore.cs
@@ -10,6 +10,12 @@ namespace Connapse.Storage.Settings;
 /// PostgreSQL-backed settings store using JSONB for flexible schema.
 /// Settings are stored by category and can be updated at runtime.
 /// </summary>
+/// <remarks>
+/// The context is scoped and shared with everything else in the request, so a write that fails
+/// must not leave its mutation tracked: the next successful save of any category would carry it
+/// along and commit the change that was reported as failed. Every write path clears the tracker
+/// on failure before rethrowing.
+/// </remarks>
 public class PostgresSettingsStore(KnowledgeDbContext context, ISettingsReloader settingsReloader) : ISettingsStore
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -39,47 +45,104 @@ public class PostgresSettingsStore(KnowledgeDbContext context, ISettingsReloader
         var json = JsonSerializer.Serialize(settings, JsonOptions);
         var jsonDocument = JsonDocument.Parse(json);
 
-        var entity = await context.Settings
-            .FirstOrDefaultAsync(s => s.Category == category, cancellationToken);
-
-        if (entity is null)
+        try
         {
-            // Create new entry
-            entity = new SettingEntity
+            var entity = await context.Settings
+                .FirstOrDefaultAsync(s => s.Category == category, cancellationToken);
+
+            if (entity is null)
             {
-                Category = category,
-                Values = jsonDocument,
-                UpdatedAt = DateTime.UtcNow
-            };
-            context.Settings.Add(entity);
-        }
-        else
-        {
-            // Update existing entry
-            entity.Values = jsonDocument;
-            entity.UpdatedAt = DateTime.UtcNow;
-            context.Settings.Update(entity);
-        }
+                // Create new entry
+                entity = new SettingEntity
+                {
+                    Category = category,
+                    Values = jsonDocument,
+                    UpdatedAt = DateTime.UtcNow
+                };
+                context.Settings.Add(entity);
+            }
+            else
+            {
+                // Update existing entry
+                entity.Values = jsonDocument;
+                entity.UpdatedAt = DateTime.UtcNow;
+                context.Settings.Update(entity);
+            }
 
-        await context.SaveChangesAsync(cancellationToken);
+            await context.SaveChangesAsync(cancellationToken);
+        }
+        catch
+        {
+            context.ChangeTracker.Clear();
+            throw;
+        }
 
         // Reload configuration to notify IOptionsMonitor subscribers of the change
         settingsReloader.Reload();
     }
 
+    public async Task<T> UpdateAsync<T>(string category, Func<T?, T> update, CancellationToken cancellationToken = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(update);
+
+        T updated;
+        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            // Make sure there is a row to lock, then lock it: the read and the write below happen
+            // with every other updater of this category waiting, in this process or any other.
+            DateTime now = DateTime.UtcNow;
+            await context.Database.ExecuteSqlAsync(
+                $$"""INSERT INTO settings (category, "values", updated_at) VALUES ({{category}}, '{}'::jsonb, {{now}}) ON CONFLICT (category) DO NOTHING""",
+                cancellationToken);
+
+            var entity = await context.Settings
+                .FromSql($"SELECT * FROM settings WHERE category = {category} FOR UPDATE")
+                .AsNoTracking()
+                .FirstAsync(cancellationToken);
+
+            string currentJson = entity.Values.RootElement.GetRawText();
+            T? current = currentJson == "{}" ? null : JsonSerializer.Deserialize<T>(currentJson, JsonOptions);
+
+            updated = update(current);
+            string json = JsonSerializer.Serialize(updated, JsonOptions);
+            await context.Database.ExecuteSqlAsync(
+                $"""UPDATE settings SET "values" = {json}::jsonb, updated_at = {now} WHERE category = {category}""",
+                cancellationToken);
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            context.ChangeTracker.Clear();
+            throw;
+        }
+
+        settingsReloader.Reload();
+        return updated;
+    }
+
     public async Task ResetAsync(string category, CancellationToken cancellationToken = default)
     {
-        var entity = await context.Settings
-            .FirstOrDefaultAsync(s => s.Category == category, cancellationToken);
-
-        if (entity is not null)
+        try
         {
+            var entity = await context.Settings
+                .FirstOrDefaultAsync(s => s.Category == category, cancellationToken);
+
+            if (entity is null)
+                return;
+
             context.Settings.Remove(entity);
             await context.SaveChangesAsync(cancellationToken);
-
-            // Reload configuration to notify IOptionsMonitor subscribers of the change
-            settingsReloader.Reload();
         }
+        catch
+        {
+            context.ChangeTracker.Clear();
+            throw;
+        }
+
+        // Reload configuration to notify IOptionsMonitor subscribers of the change
+        settingsReloader.Reload();
     }
 
     public async Task<IReadOnlyList<string>> GetCategoriesAsync(CancellationToken cancellationToken = default)

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -15,6 +15,7 @@
 @inject IOptionsMonitor<SourceSecuritySettings> SourceSecurity
 @inject IContainerHostResolver HostResolver
 @inject S3ConnectionTester S3Tester
+@inject AzureBlobConnectionTester AzureBlobTester
 @inject SftpConnectionTester SftpTester
 @inject IS3Discovery S3Discovery
 @inject IProviderSetupReader SetupReader
@@ -475,6 +476,7 @@
             <label class="form-label" for="connection-provider">Provider</label>
             <select id="connection-provider" class="form-select" @bind="form.Provider" disabled="@(!isNew)">
                 <option value="@ConnectionProvider.S3">Amazon S3</option>
+                <option value="@ConnectionProvider.AzureBlob">Azure Blob Storage</option>
                 <option value="@ConnectionProvider.Filesystem">Local filesystem</option>
                 <option value="@ConnectionProvider.Sftp">SFTP</option>
             </select>
@@ -519,6 +521,31 @@
                 </div>
             }
 
+        }
+        else if (form.Provider == ConnectionProvider.AzureBlob)
+        {
+            <div class="col-12" style="max-width:32rem">
+                <label class="form-label" for="azure-account-name">Storage account name</label>
+                <input id="azure-account-name" class="form-control font-monospace" @bind="form.StorageAccountName"
+                       placeholder="mystorageaccount" aria-describedby="azure-account-name-help" />
+                <div id="azure-account-name-help" class="form-text">
+                    Connapse reaches it as its own Azure identity — no key or connection string is
+                    entered here.
+                </div>
+            </div>
+
+            <div class="col-12" style="max-width:32rem">
+                <label class="form-label" for="azure-blob-endpoint">
+                    Blob endpoint <span class="text-muted">(optional)</span>
+                </label>
+                <input id="azure-blob-endpoint" class="form-control font-monospace" @bind="form.BlobEndpoint"
+                       placeholder="@($"https://{(string.IsNullOrWhiteSpace(form.StorageAccountName) ? "account" : form.StorageAccountName)}.blob.core.windows.net")"
+                       aria-describedby="azure-blob-endpoint-help" />
+                <div id="azure-blob-endpoint-help" class="form-text">
+                    Set only to override the default endpoint above — for example, to point at
+                    Azurite or another local emulator.
+                </div>
+            </div>
         }
         else if (form.Provider == ConnectionProvider.Sftp)
         {
@@ -1658,6 +1685,33 @@
                 return;
             }
 
+            if (form.Provider == ConnectionProvider.AzureBlob)
+            {
+                // Unlike a bucket name, "$root" is not a safe default: Azure storage accounts
+                // do not auto-create a root container, so probing it when nobody has chosen a
+                // container yet would report a perfectly valid account as unreachable.
+                var azureProbe = form.ResolveProbeTarget(probeTarget);
+                if (azureProbe is null)
+                {
+                    testSuccess = false;
+                    testMessage = "Enter a container name (or configure an allowed location) to test this Azure connection.";
+                    return;
+                }
+
+                ConnectionTestResult azureResult = await AzureBlobTester.TestConnectionAsync(new AzureBlobConnectorConfig
+                {
+                    AccountName = form.StorageAccountName?.Trim() ?? "",
+                    BlobEndpoint = NullIfBlank(form.BlobEndpoint),
+                    ContainerName = azureProbe.Value.Container,
+                    Prefix = azureProbe.Value.Prefix,
+                }, TimeSpan.FromSeconds(15));
+
+                testSuccess = azureResult.Success;
+                testMessage = azureResult.Message;
+                testDetail = RawError(azureResult);
+                return;
+            }
+
             string? target = NullIfBlank(probeTarget) ?? form.FirstAllowedLocation();
             if (target is null)
             {
@@ -1700,6 +1754,7 @@
         {
             ConnectionProvider.Filesystem => form.AllowedRoot ?? "—",
             ConnectionProvider.S3 => form.Region ?? "—",
+            ConnectionProvider.AzureBlob => form.StorageAccountName ?? "—",
             ConnectionProvider.Sftp => $"{form.Username}@{form.Host}:{form.AllowedRoot}",
             _ => "—"
         };

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -1493,12 +1493,13 @@
             string.Equals(a.Name, form.StorageAccountName?.Trim(), StringComparison.OrdinalIgnoreCase));
 
     /// <summary>The endpoint the connection will use: the override if set, else the public default.</summary>
-    private string? AzureEndpointForForm()
-    {
-        if (!string.IsNullOrWhiteSpace(form.BlobEndpoint)) return form.BlobEndpoint.Trim();
-        string? name = form.StorageAccountName?.Trim();
-        return string.IsNullOrWhiteSpace(name) ? null : $"https://{name}.blob.core.windows.net";
-    }
+    /// <summary>The endpoint the container picker lists from — the account's own, or an override
+    /// shown to be that account. An override for some other host gets nothing listed rather than
+    /// Connapse's token sent there.</summary>
+    private string? AzureEndpointForForm() =>
+        AzureBlobEndpoint.Validate(form.StorageAccountName, form.BlobEndpoint, out Uri? endpoint) is null
+            ? endpoint!.ToString().TrimEnd('/')
+            : null;
 
     /// <summary>A different account means a different set of containers.</summary>
     private void AccountNameChanged()

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -471,6 +471,10 @@
                 {
                     <text>Filled in from the first bucket you choose if left blank.</text>
                 }
+                else if (form.Provider == ConnectionProvider.AzureBlob)
+                {
+                    <text>Filled in from the first container you choose if left blank.</text>
+                }
             </div>
         </div>
 
@@ -734,7 +738,7 @@
                                 @bind-Value="form.PrivateKey" />
                 <div id="sftp-key-help" class="form-text">
                     Encrypted at rest and never shown again. This is an SSH key for a server you run —
-                    the rule that Connapse stores no cloud credentials is about AWS
+                    the rule that Connapse stores no cloud credentials is about AWS and Azure
                     identities, which are not stored and are not asked for.
                     @if (!isNew)
                     {
@@ -1079,7 +1083,8 @@
                 <input id="probe-target" class="form-control font-monospace" @bind="probeTarget"
                        placeholder="@ProbePlaceholder()" aria-describedby="probe-target-help" />
                 <div id="probe-target-help" class="form-text">
-                    Not saved. The connection holds no bucket of its own, so testing needs one to probe.
+                    Not saved. The connection holds no @(form.Provider == ConnectionProvider.S3 ? "bucket" : "container")
+                    of its own, so testing needs one to probe.
                 </div>
             </div>
         }

--- a/src/Connapse.Web/Components/Pages/Connections.razor
+++ b/src/Connapse.Web/Components/Pages/Connections.razor
@@ -18,6 +18,8 @@
 @inject AzureBlobConnectionTester AzureBlobTester
 @inject SftpConnectionTester SftpTester
 @inject IS3Discovery S3Discovery
+@inject IAzureBlobDiscovery AzureDiscovery
+@inject IOptionsMonitor<AzureProviderSettings> AzureProviderOptions
 @inject IProviderSetupReader SetupReader
 
 @*
@@ -524,27 +526,133 @@
         }
         else if (form.Provider == ConnectionProvider.AzureBlob)
         {
-            <div class="col-12" style="max-width:32rem">
+            @* The same notice the S3 form shows, for the same reason: whether Connapse can reach
+               Azure at all is a property of the deployment, set on the provider page. *@
+            @if (azureAccess is RequirementStatus.NotConfigured or RequirementStatus.Failed
+                                or RequirementStatus.Provisioning or RequirementStatus.Warning)
+            {
+                <div class="col-12">
+                    <div class="alert @(azureAccess == RequirementStatus.Warning ? "alert-secondary" : "alert-warning") d-flex flex-wrap align-items-center gap-2 py-2 mb-0 small">
+                        <span class="bi-cloud-fill"></span>
+                        <span class="flex-grow-1">
+                            @(azureAccess switch
+                            {
+                                RequirementStatus.Warning =>
+                                    "Connapse cannot confirm what its Azure identity reaches. Test this connection to be sure.",
+                                _ => "Connapse cannot read Azure Blob Storage yet — its Azure identity is set up on the provider page, not here."
+                            })
+                        </span>
+                        <a class="btn btn-outline-secondary btn-sm" href="/admin/providers/azure">
+                            Azure setup <span class="bi-box-arrow-up-right ms-1 small"></span>
+                        </a>
+                    </div>
+                </div>
+            }
+
+            @* One full-width column with the fields stacked inside it. As sibling capped columns
+               they float up beside Name and Provider on a wide screen. *@
+            <div class="col-12">
+              <div style="max-width:32rem">
                 <label class="form-label" for="azure-account-name">Storage account name</label>
                 <input id="azure-account-name" class="form-control font-monospace" @bind="form.StorageAccountName"
+                       @bind:after="AccountNameChanged"
                        placeholder="mystorageaccount" aria-describedby="azure-account-name-help" />
                 <div id="azure-account-name-help" class="form-text">
                     Connapse reaches it as its own Azure identity — no key or connection string is
                     entered here.
                 </div>
-            </div>
 
-            <div class="col-12" style="max-width:32rem">
+                @* The list, rather than a name typed from memory — the Azure counterpart of the
+                   bucket picker. Listing needs subscription-wide storage-account read, which the
+                   easy setup grants; a denial reads as "type it", not as a fault. *@
+                <div class="mt-2 position-relative">
+                    <button type="button" class="btn btn-sm btn-outline-secondary"
+                            aria-expanded="@(accountPickerOpen ? "true" : "false")"
+                            aria-controls="account-picker"
+                            @onclick="ToggleAccountPicker" disabled="@listingAccounts">
+                        @if (listingAccounts)
+                        {
+                            <span class="spinner-border spinner-border-sm me-1"></span>
+                        }
+                        else
+                        {
+                            <span class="bi-list-ul me-1"></span>
+                        }
+                        <span>Choose from storage accounts Connapse can see</span>
+                        <span class="@(accountPickerOpen ? "bi-chevron-up" : "bi-chevron-down") ms-1 small"></span>
+                    </button>
+
+                    @if (accountPickerOpen)
+                    {
+                        <div id="account-picker" class="card mt-1 shadow-sm">
+                            <div class="card-body p-2">
+                                <label class="form-label small mb-1" for="account-search">Search storage accounts</label>
+                                <input id="account-search" class="form-control form-control-sm mb-2"
+                                       placeholder="Part of an account name"
+                                       @bind="accountFilter" @bind:event="oninput" />
+
+                                @if (!string.IsNullOrEmpty(accountListMessage))
+                                {
+                                    <div class="small text-muted px-1 py-2">@accountListMessage</div>
+                                }
+                                else if (MatchingAccounts() is { Count: 0 })
+                                {
+                                    <div class="small text-muted px-1 py-2">
+                                        No storage account matches “@accountFilter”.
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="list-group list-group-flush overflow-auto" style="max-height:14rem">
+                                        @foreach (var account in MatchingAccounts())
+                                        {
+                                            bool chosen = string.Equals(account.Name, form.StorageAccountName?.Trim(), StringComparison.OrdinalIgnoreCase);
+                                            <button type="button"
+                                                    class="list-group-item list-group-item-action d-flex align-items-center gap-2 py-1 px-2"
+                                                    @onclick="() => ChooseAccount(account)">
+                                                <span class="@(chosen ? "bi-check-lg text-success" : "bi-plus-lg text-primary") small"></span>
+                                                <code class="text-break">@account.Name</code>
+                                                <span class="small text-muted flex-grow-1 text-truncate">@account.ResourceGroup</span>
+                                                @if (account.IsHnsEnabled)
+                                                {
+                                                    <span class="badge text-bg-info">Data Lake Gen2</span>
+                                                }
+                                            </button>
+                                        }
+                                    </div>
+                                    <div class="form-text px-1 mb-0">
+                                        @MatchingAccounts().Count of @(discoveredAccounts?.Count ?? 0)
+                                        storage account@(discoveredAccounts?.Count == 1 ? "" : "s")
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                @if (SelectedAccount() is { IsHnsEnabled: true })
+                {
+                    <div class="form-text">
+                        <span class="badge text-bg-info me-1">Data Lake Gen2</span>
+                        Hierarchical namespace: per-user results follow this account's POSIX ACLs as well
+                        as its role assignments.
+                    </div>
+                }
+              </div>
+
+              <div class="mt-3" style="max-width:32rem">
                 <label class="form-label" for="azure-blob-endpoint">
                     Blob endpoint <span class="text-muted">(optional)</span>
                 </label>
                 <input id="azure-blob-endpoint" class="form-control font-monospace" @bind="form.BlobEndpoint"
+                       @bind:after="AccountNameChanged"
                        placeholder="@($"https://{(string.IsNullOrWhiteSpace(form.StorageAccountName) ? "account" : form.StorageAccountName)}.blob.core.windows.net")"
                        aria-describedby="azure-blob-endpoint-help" />
                 <div id="azure-blob-endpoint-help" class="form-text">
                     Set only to override the default endpoint above — for example, to point at
                     Azurite or another local emulator.
                 </div>
+              </div>
             </div>
         }
         else if (form.Provider == ConnectionProvider.Sftp)
@@ -814,6 +922,76 @@
                         }
                     </div>
                 }
+                else if (form.Provider == ConnectionProvider.AzureBlob)
+                {
+                    @* The container picker, mirroring the bucket picker above. *@
+                    <div class="mt-2 position-relative" style="max-width:32rem">
+                        <button type="button" class="btn btn-sm btn-outline-secondary"
+                                aria-expanded="@(containerPickerOpen ? "true" : "false")"
+                                aria-controls="container-picker"
+                                @onclick="ToggleContainerPicker"
+                                disabled="@(listingContainers || string.IsNullOrWhiteSpace(form.StorageAccountName))">
+                            @if (listingContainers)
+                            {
+                                <span class="spinner-border spinner-border-sm me-1"></span>
+                            }
+                            else
+                            {
+                                <span class="bi-list-ul me-1"></span>
+                            }
+                            <span>Choose from containers Connapse can see</span>
+                            <span class="@(containerPickerOpen ? "bi-chevron-up" : "bi-chevron-down") ms-1 small"></span>
+                        </button>
+
+                        @if (containerPickerOpen)
+                        {
+                            <div id="container-picker" class="card mt-1 shadow-sm">
+                                <div class="card-body p-2">
+                                    <label class="form-label small mb-1" for="container-search">Search containers</label>
+                                    <input id="container-search" class="form-control form-control-sm mb-2"
+                                           placeholder="Part of a container name"
+                                           @bind="containerFilter" @bind:event="oninput"
+                                           @onkeydown="ContainerSearchKey" />
+
+                                    @if (!string.IsNullOrEmpty(containerListMessage))
+                                    {
+                                        <div class="small text-muted px-1 py-2">@containerListMessage</div>
+                                    }
+                                    else if (MatchingContainers() is { Count: 0 })
+                                    {
+                                        <div class="small text-muted px-1 py-2">
+                                            No container matches “@containerFilter”.
+                                        </div>
+                                    }
+                                    else
+                                    {
+                                        <div class="list-group list-group-flush overflow-auto" style="max-height:14rem">
+                                            @foreach (string container in MatchingContainers())
+                                            {
+                                                bool already = IsAllowed(container);
+                                                <button type="button"
+                                                        class="list-group-item list-group-item-action d-flex align-items-center gap-2 py-1 px-2"
+                                                        disabled="@already"
+                                                        @onclick="() => AllowContainer(container)">
+                                                    <span class="@(already ? "bi-check-lg text-success" : "bi-plus-lg text-primary") small"></span>
+                                                    <code class="flex-grow-1 text-start text-break">@container</code>
+                                                    @if (already)
+                                                    {
+                                                        <span class="small text-muted">added</span>
+                                                    }
+                                                </button>
+                                            }
+                                        </div>
+                                        <div class="form-text px-1 mb-0">
+                                            @MatchingContainers().Count of @(discoveredContainers?.Count ?? 0)
+                                            container@(discoveredContainers?.Count == 1 ? "" : "s")
+                                        </div>
+                                    }
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
 
                 @* Offered once something is allowed, because until then there is nothing to scope
                    a policy to. Aimed at operators whose credential currently allows more than this
@@ -831,6 +1009,25 @@
                             writes to a source. Attach this to narrow a credential that currently
                             allows more, at the cost of a return trip to AWS for every bucket added
                             after it.
+                        </div>
+                    </details>
+                }
+
+                @* The Azure counterpart: role assignments on exactly the chosen containers, for an
+                   identity the easy setup granted subscription-wide. *@
+                @if (form.Provider == ConnectionProvider.AzureBlob && AzureRoleForAllowed() is { } roleCommands)
+                {
+                    <details class="mt-2">
+                        <summary class="small text-muted" style="cursor:pointer">
+                            Role assignments granting exactly this access
+                        </summary>
+                        <pre class="bg-body-tertiary border rounded p-2 small mt-2 mb-1" style="max-height:20rem;overflow:auto"><code>@roleCommands</code></pre>
+                        <div class="form-text">
+                            Reads only — Connapse's blob role on each container named above, run in
+                            Azure Cloud Shell. A prefix inside a container cannot be an RBAC scope, so
+                            the container is the narrowest grant; the allowed locations still bound
+                            reads below it. To narrow an identity granted across the subscription,
+                            remove that wider assignment after adding these.
                         </div>
                     </details>
                 }
@@ -925,6 +1122,11 @@
                         <a class="alert-link ms-1" target="_blank" rel="noopener"
                            href="https://github.com/Destrayon/Connapse/blob/main/docs/aws-setup.md#troubleshooting">Troubleshooting</a>
                     }
+                    @if (!testSuccess && form.Provider == ConnectionProvider.AzureBlob)
+                    {
+                        <a class="alert-link ms-1" target="_blank" rel="noopener"
+                           href="https://github.com/Destrayon/Connapse/blob/main/docs/azure-setup.md#troubleshooting">Troubleshooting</a>
+                    }
                     @if (!testSuccess && testDetail is { Length: > 0 })
                     {
                         <details class="mt-1">
@@ -1009,8 +1211,11 @@
 
         try
         {
-            var aws = (await SetupReader.ReadAsync()).FirstOrDefault(p => p.Key == "aws");
+            var setups = await SetupReader.ReadAsync();
+            var aws = setups.FirstOrDefault(p => p.Key == "aws");
             awsAccess = aws?.Requirements.FirstOrDefault(r => r.Name == "Access")?.Status;
+            var azure = setups.FirstOrDefault(p => p.Key == "azure");
+            azureAccess = azure?.Requirements.FirstOrDefault(r => r.Name == "Access")?.Status;
         }
         catch
         {
@@ -1237,6 +1442,204 @@
         catch
         {
             // Left blank on purpose. A region nobody could look up is one somebody can type.
+        }
+    }
+
+    // ── Azure Blob discovery — the same shape as the S3 pieces above ──────────────────────────
+
+    private RequirementStatus? azureAccess;
+
+    private IReadOnlyList<AzureStorageAccountInfo>? discoveredAccounts;
+    private bool listingAccounts;
+    private string? accountListMessage;
+    private bool accountPickerOpen;
+    private string? accountFilter;
+
+    private IReadOnlyList<string>? discoveredContainers;
+
+    /// <summary>The endpoint <see cref="discoveredContainers"/> was listed from. A different endpoint
+    /// — the account name or the override changed — means a different set of containers.</summary>
+    private string? discoveredContainersFor;
+    private bool listingContainers;
+    private string? containerListMessage;
+    private bool containerPickerOpen;
+    private string? containerFilter;
+
+    private IReadOnlyList<AzureStorageAccountInfo> MatchingAccounts()
+    {
+        var all = discoveredAccounts ?? [];
+        if (string.IsNullOrWhiteSpace(accountFilter)) return all;
+
+        return [.. all.Where(a => a.Name.Contains(accountFilter.Trim(), StringComparison.OrdinalIgnoreCase)
+                                || a.ResourceGroup.Contains(accountFilter.Trim(), StringComparison.OrdinalIgnoreCase))];
+    }
+
+    private IReadOnlyList<string> MatchingContainers()
+    {
+        var all = discoveredContainers ?? [];
+        if (string.IsNullOrWhiteSpace(containerFilter)) return all;
+
+        return [.. all.Where(c => c.Contains(containerFilter.Trim(), StringComparison.OrdinalIgnoreCase))];
+    }
+
+    /// <summary>The account the form names, as discovery described it — null when unknown.</summary>
+    private AzureStorageAccountInfo? SelectedAccount() =>
+        discoveredAccounts?.FirstOrDefault(a =>
+            string.Equals(a.Name, form.StorageAccountName?.Trim(), StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>The endpoint the connection will use: the override if set, else the public default.</summary>
+    private string? AzureEndpointForForm()
+    {
+        if (!string.IsNullOrWhiteSpace(form.BlobEndpoint)) return form.BlobEndpoint.Trim();
+        string? name = form.StorageAccountName?.Trim();
+        return string.IsNullOrWhiteSpace(name) ? null : $"https://{name}.blob.core.windows.net";
+    }
+
+    /// <summary>A different account means a different set of containers.</summary>
+    private void AccountNameChanged()
+    {
+        discoveredContainers = null;
+        containerPickerOpen = false;
+    }
+
+    private async Task ToggleAccountPicker()
+    {
+        accountPickerOpen = !accountPickerOpen;
+        if (!accountPickerOpen) return;
+
+        if (discoveredAccounts is null)
+            await ListAccounts();
+    }
+
+    private async Task ListAccounts()
+    {
+        listingAccounts = true;
+        accountListMessage = null;
+        try
+        {
+            var probe = await AzureDiscovery.ListStorageAccountsAsync();
+
+            discoveredAccounts = probe.Value;
+            accountListMessage = probe.Outcome switch
+            {
+                AzureProbeOutcome.Succeeded when probe.Value is { Count: 0 } =>
+                    "No storage accounts in this subscription.",
+                AzureProbeOutcome.Succeeded => null,
+                AzureProbeOutcome.NotConfigured =>
+                    "Connapse has no Azure identity yet — set one up on the Azure provider page.",
+                AzureProbeOutcome.Denied =>
+                    "This identity may not list storage accounts, so type the name instead.",
+                _ => probe.Detail
+            };
+        }
+        finally
+        {
+            listingAccounts = false;
+        }
+    }
+
+    /// <summary>Fills the account from the list; the endpoint only when it is not the public default.</summary>
+    private void ChooseAccount(AzureStorageAccountInfo account)
+    {
+        form.StorageAccountName = account.Name;
+        string publicDefault = $"https://{account.Name}.blob.core.windows.net";
+        form.BlobEndpoint = string.Equals(account.BlobEndpoint, publicDefault, StringComparison.OrdinalIgnoreCase)
+            ? null
+            : account.BlobEndpoint;
+        accountPickerOpen = false;
+        AccountNameChanged();
+    }
+
+    private async Task ToggleContainerPicker()
+    {
+        containerPickerOpen = !containerPickerOpen;
+        if (!containerPickerOpen) return;
+
+        if (discoveredContainers is null || discoveredContainersFor != AzureEndpointForForm())
+            await ListContainers();
+    }
+
+    private async Task ListContainers()
+    {
+        string endpoint = AzureEndpointForForm() ?? "";
+        listingContainers = true;
+        containerListMessage = null;
+        try
+        {
+            var probe = await AzureDiscovery.ListContainersAsync(endpoint);
+
+            // The account may have changed while the request was in flight; a list for the old
+            // endpoint must not be offered as the new one's.
+            if (endpoint != (AzureEndpointForForm() ?? "")) return;
+
+            discoveredContainersFor = endpoint;
+            discoveredContainers = probe.Value;
+            containerListMessage = probe.Outcome switch
+            {
+                AzureProbeOutcome.Succeeded when probe.Value is { Count: 0 } =>
+                    "No containers in this storage account.",
+                AzureProbeOutcome.Succeeded => null,
+                AzureProbeOutcome.NotConfigured =>
+                    "Connapse has no Azure identity yet — set one up on the Azure provider page.",
+                AzureProbeOutcome.Denied =>
+                    "This identity may not list containers here, so type the name instead.",
+                _ => probe.Detail
+            };
+        }
+        finally
+        {
+            listingContainers = false;
+        }
+    }
+
+    private Task ContainerSearchKey(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            containerPickerOpen = false;
+            return Task.CompletedTask;
+        }
+
+        if (e.Key != "Enter") return Task.CompletedTask;
+
+        string? first = MatchingContainers().FirstOrDefault(c => !IsAllowed(c));
+        if (first is not null) AllowContainer(first);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Appends a container to the allowlist, the same way a bucket is added above.</summary>
+    private void AllowContainer(string container)
+    {
+        if (IsAllowed(container)) return;
+
+        var entries = AllowedList().ToList();
+        entries.Add(container);
+        form.AllowedLocations = string.Join("\n", entries);
+
+        if (string.IsNullOrWhiteSpace(probeTarget))
+            probeTarget = container;
+
+        if (string.IsNullOrWhiteSpace(form.Name))
+            form.Name = container;
+    }
+
+    /// <summary>Role assignments for whatever is currently allowed, once the account is known.</summary>
+    private string? AzureRoleForAllowed()
+    {
+        var list = AllowedList();
+        if (list.Count == 0) return null;
+
+        string? clientId = AzureProviderOptions.CurrentValue.ClientId;
+        string? accountId = SelectedAccount()?.ResourceId;
+        if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(accountId)) return null;
+
+        try
+        {
+            return AzureSetupRole.AssignmentsFor(clientId, accountId, list);
+        }
+        catch (ArgumentException)
+        {
+            return null;
         }
     }
 

--- a/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
+++ b/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
@@ -7,7 +7,9 @@
 @using Microsoft.AspNetCore.WebUtilities
 @using Microsoft.Extensions.Options
 @inject IAwsIdentityLinkService AwsIdentityLinkService
+@inject IAzureIdentityLinkService AzureIdentityLinkService
 @inject IOptionsMonitor<SamlSignInSettings> SamlOptions
+@inject IOptionsMonitor<AzureAdSignInSettings> AzureAdOptions
 @inject IOptionsMonitor<PermissionEnforcementSettings> EnforcementOptions
 @inject EnforcementMigration Migration
 @inject AuthenticationStateProvider AuthenticationStateProvider
@@ -201,6 +203,101 @@
                 }
             </div>
         </div>
+
+        <!-- Azure (Entra ID) Identity Card -->
+        <div class="col-md-6">
+            <div class="card h-100 provider-card @(azureIdentity is not null ? "provider-connected" : "")"
+                 style="--provider-color: #0078d4;">
+                <div class="card-body p-4">
+                    <div class="d-flex align-items-center mb-3">
+                        <div class="rounded d-flex align-items-center justify-content-center flex-shrink-0"
+                             style="width: 40px; height: 40px; background: rgba(0, 120, 212, 0.1); border: 1px solid rgba(0, 120, 212, 0.25);">
+                            <span class="bi-shield-lock" style="font-size: 1.1rem; color: #0078d4;"></span>
+                        </div>
+                        <div class="ms-3 flex-grow-1">
+                            <strong>Microsoft Entra ID</strong>
+                        </div>
+                        @if (azureIdentity is not null)
+                        {
+                            <span class="badge rounded-pill" style="background: color-mix(in srgb, var(--color-success) 15%, transparent); color: color-mix(in srgb, var(--color-success) 70%, white); border: 1px solid color-mix(in srgb, var(--color-success) 30%, transparent);">
+                                <span class="bi-check-circle-fill me-1"></span>Connected
+                            </span>
+                        }
+                    </div>
+
+                    @if (!azureSignInConfigured)
+                    {
+                        <div class="rounded-3 p-3" style="background: rgba(0, 120, 212, 0.08); border: 1px solid rgba(0, 120, 212, 0.2);">
+                            <small class="d-flex align-items-start" style="color: #60a5fa;">
+                                <span class="bi-info-circle-fill me-2 mt-1 flex-shrink-0"></span>
+                                <span>Entra ID sign-in is not set up yet. An administrator configures this under Providers &rarr; Microsoft Entra ID before anyone can connect.</span>
+                            </small>
+                        </div>
+                    }
+                    else if (azureIdentity is not null)
+                    {
+                        <div class="d-flex flex-column gap-2 mb-3">
+                            <div>
+                                <small class="text-muted d-block">Connected as</small>
+                                <span class="small">@azureIdentity.DisplayName</span>
+                            </div>
+                            <div class="d-flex gap-4">
+                                <div>
+                                    <small class="text-muted d-block">Tenant</small>
+                                    <small>@azureIdentity.TenantId</small>
+                                </div>
+                                <div>
+                                    <small class="text-muted d-block">Connected</small>
+                                    <small>@azureIdentity.ConnectedAt.ToString("MMM dd, yyyy")</small>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="text-muted small mb-0">
+                            <span class="bi-box-arrow-up-right me-1"></span>
+                            You sign in at <strong>Microsoft Entra ID</strong> with the
+                            credentials and multi-factor you already use — not in Connapse, which
+                            never sees what you type there.
+                        </p>
+                    }
+                </div>
+                @if (azureIdentity is not null)
+                {
+                    <!-- Same reasoning as the AWS footer above: disconnect must not depend on
+                         azureSignInConfigured, or a connected row becomes unremovable once an
+                         administrator clears the Entra settings. -->
+                    <div class="card-footer border-top-0 px-4 pb-4 pt-0">
+                        @if (confirmDisconnectAzure)
+                        {
+                            <div class="d-flex gap-2">
+                                <button class="btn btn-sm btn-danger" @onclick="DisconnectAzureAsync" disabled="@isProcessing">
+                                    Confirm Disconnect
+                                </button>
+                                <button class="btn btn-sm btn-outline-secondary" @onclick="() => confirmDisconnectAzure = false">
+                                    Cancel
+                                </button>
+                            </div>
+                        }
+                        else
+                        {
+                            <button class="btn btn-sm btn-outline-danger" @onclick="() => confirmDisconnectAzure = true" disabled="@isProcessing">
+                                <span class="bi-x-circle me-1"></span>Disconnect
+                            </button>
+                        }
+                    </div>
+                }
+                else if (azureSignInConfigured)
+                {
+                    <div class="card-footer border-top-0 px-4 pb-4 pt-0">
+                        <button class="btn btn-sm btn-primary" @onclick="ConnectAzureAsync" disabled="@isProcessing">
+                            <span class="bi-box-arrow-up-right me-1"></span>Continue to Entra sign-in
+                        </button>
+                    </div>
+                }
+            </div>
+        </div>
     </div>
 </div>
 
@@ -217,6 +314,10 @@
     private EnforcementState awsEnforcement;
     private bool confirmDisconnectAws;
 
+    private AzureIdentityLinkDto? azureIdentity;
+    private bool azureSignInConfigured;
+    private bool confirmDisconnectAzure;
+
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
@@ -229,8 +330,10 @@
         awsSignInConfigured = SamlOptions.CurrentValue.IsConfigured;
         awsEnforcement = EnforcementOptions.CurrentValue.StateFor(
             SamlOptions.CurrentValue, Migration.Determined);
+        azureSignInConfigured = AzureAdOptions.CurrentValue.IsConfigured;
 
         ApplyAwsErrorFromQuery();
+        ApplyAzureErrorFromQuery();
 
         await LoadIdentitiesAsync();
     }
@@ -238,6 +341,7 @@
     private async Task LoadIdentitiesAsync()
     {
         awsIdentity = await AwsIdentityLinkService.GetAsync(currentUserId);
+        azureIdentity = await AzureIdentityLinkService.GetAsync(currentUserId);
     }
 
     // The assertion consumer redirects here with ?error=aws_<reason> when a sign-in failed. A
@@ -285,6 +389,68 @@
     private void ConnectAwsAsync()
     {
         Navigation.NavigateTo("/api/v1/auth/cloud/aws/connect", forceLoad: true);
+    }
+
+    // The Entra callback/confirm hop redirects here with ?error=azure_<reason> when a sign-in
+    // failed. Unlike AWS, every failure path collapses to one of two generic reasons — the
+    // detail (a bad signature, a replayed callback, a validator rejection) is logged
+    // server-side and never put in a URL a browser can carry in history.
+    private void ApplyAzureErrorFromQuery()
+    {
+        var uri = new Uri(Navigation.Uri);
+        var query = QueryHelpers.ParseQuery(uri.Query);
+        if (!query.TryGetValue("error", out var errorValues))
+            return;
+
+        var error = errorValues.ToString();
+        if (!error.StartsWith("azure_", StringComparison.Ordinal))
+            return;
+
+        var reason = error["azure_".Length..];
+        statusMessage = reason switch
+        {
+            "not_configured" => "Could not connect your Entra identity: Entra ID sign-in is not set up yet. An administrator sets it up under Providers.",
+            "link_failed" => "Could not connect your Entra identity. Please try again.",
+            _ => "Could not connect your Entra identity. Please try again.",
+        };
+        statusSuccess = false;
+    }
+
+    private void ConnectAzureAsync()
+    {
+        Navigation.NavigateTo("/api/v1/auth/cloud/azure/connect", forceLoad: true);
+    }
+
+    private async Task DisconnectAzureAsync()
+    {
+        isProcessing = true;
+        statusMessage = null;
+        confirmDisconnectAzure = false;
+        try
+        {
+            bool deleted = await AzureIdentityLinkService.DisconnectAsync(currentUserId);
+            if (deleted)
+            {
+                statusMessage = "Entra identity disconnected.";
+                statusSuccess = true;
+                await LoadIdentitiesAsync();
+            }
+            else
+            {
+                statusMessage = "No Entra identity link found.";
+                statusSuccess = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to disconnect Azure identity link for user {UserId}", currentUserId);
+            statusMessage = "Failed to disconnect. Please try again.";
+            statusSuccess = false;
+        }
+        finally
+        {
+            isProcessing = false;
+        }
     }
 
     private async Task DisconnectAwsAsync()

--- a/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
+++ b/src/Connapse.Web/Components/Pages/ProfileIntegrations.razor
@@ -230,7 +230,7 @@
                         <div class="rounded-3 p-3" style="background: rgba(0, 120, 212, 0.08); border: 1px solid rgba(0, 120, 212, 0.2);">
                             <small class="d-flex align-items-start" style="color: #60a5fa;">
                                 <span class="bi-info-circle-fill me-2 mt-1 flex-shrink-0"></span>
-                                <span>Entra ID sign-in is not set up yet. An administrator configures this under Providers &rarr; Microsoft Entra ID before anyone can connect.</span>
+                                <span>Entra ID sign-in is not set up yet. An administrator configures this under Providers &rarr; Azure &rarr; Per-user permissions before anyone can connect.</span>
                             </small>
                         </div>
                     }

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -9,6 +9,7 @@
 @using Connapse.Web.Components.Settings
 @using Connapse.Web.Services
 @using Connapse.Storage.Settings
+@using Connapse.Storage.CloudScope
 @using Connapse.Storage.CloudScope.RolesAnywhere
 @using Microsoft.Extensions.Options
 @inject ISettingsStore SettingsStore
@@ -16,6 +17,9 @@
 @inject IOptionsMonitor<SamlSignInSettings> SamlOptions
 @inject IOptionsMonitor<PermissionEnforcementSettings> EnforcementOptions
 @inject IOptionsMonitor<IdentityCenterSettings> IdentityCenterOptions
+@inject IOptionsMonitor<AzureProviderSettings> AzureProviderOptions
+@inject IOptionsMonitor<AzureAdSignInSettings> AzureAdOptions
+@inject Microsoft.AspNetCore.Hosting.IWebHostEnvironment WebHostEnvironment
 @inject IProviderSetupReader SetupReader
 @inject IProviderCredentialStore CredentialStore
 @inject IRolesAnywhereSetupValidator RaValidator
@@ -152,8 +156,9 @@
         }
 
         @* AWS renders status and setup together below. Repeating these cards above those sections
-           made the page read like two separate checklists for the same work. *@
-        @if (Key != "aws")
+           made the page read like two separate checklists for the same work. Azure does the same
+           (its setup cards below), so it is excluded here too. *@
+        @if (Key != "aws" && Key != "azure")
         {
         @* Requirements first: someone arriving here is asking what is left to do, and answering
            that before showing forms is the reason this page exists. *@
@@ -1063,6 +1068,294 @@
                 </Actions>
             </ProviderStepCard>
         }
+        else if (Key == "azure")
+        {
+            <p class="text-muted">
+                Two steps: the Azure app identity Connapse reads Blob storage and permissions with, and
+                the Entra application people sign in through. No client secrets — Connapse authenticates
+                with certificates it generates on this host (the private keys never leave it) or a
+                managed identity.
+            </p>
+
+            <ProviderStepCard Id="azure-access" Title="Access"
+                              Description="The Azure app identity Connapse reads Blob storage with, and queries Entra and Azure Resource Manager (role and deny assignments) through."
+                              Status="AccessStatus" StatusLabel="@RequirementLabel(AccessStatus)"
+                              @bind-Expanded="showAzureAccess" EditLabel="Update or replace"
+                              EasyTitle="Easy setup with Azure Cloud Shell" EasyOpen="true">
+                <Summary>
+                    @if (azureProviderSettings.TenantId is { Length: > 0 })
+                    {
+                        <dl class="row small mb-0">
+                            <dt class="col-sm-3">Tenant</dt>
+                            <dd class="col-sm-9 font-monospace">@azureProviderSettings.TenantId</dd>
+                            <dt class="col-sm-3">Subscription</dt>
+                            <dd class="col-sm-9 font-monospace">@(azureProviderSettings.SubscriptionId is { Length: > 0 } sub ? sub : "not set")</dd>
+                            <dt class="col-sm-3">Identity</dt>
+                            <dd class="col-sm-9 font-monospace">
+                                @if (azureProviderSettings.UserAssignedManagedIdentityClientId is { Length: > 0 } mi)
+                                {
+                                    <text>managed identity @mi</text>
+                                }
+                                else
+                                {
+                                    <text>app @azureProviderSettings.ClientId (certificate)</text>
+                                }
+                            </dd>
+                        </dl>
+                    }
+                </Summary>
+                <ManualContent>
+                    <details class="border rounded p-3 mb-3">
+                        <summary class="fw-semibold">Manual values — use an existing app registration or managed identity</summary>
+                        <div class="mt-3">
+                            <AzureProviderSettingsTab Settings="azureProviderSettings" OnSave="SaveAzureProviderFromForm" />
+                        </div>
+                    </details>
+                </ManualContent>
+                <EasyContent>
+                    <p class="small text-muted">
+                        Nothing to fill in. Connapse generates a certificate on this host; you run one script in Azure
+                        Cloud Shell — it uses whichever subscription Cloud Shell is signed in to, creates two
+                        least-privilege custom roles and the access app registration, and uploads only the public
+                        certificate — then paste back what it prints.
+                    </p>
+                    <p class="small mb-3">
+                        <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.AccessScriptRequirements).
+                    </p>
+
+                        @{ EnsureAzureAccessScript(); }
+                        @if (azureAccessScript is { Length: > 0 } accessScript)
+                        {
+                            <div class="alert alert-secondary py-2 small mb-2">
+                                <span class="bi-info-circle me-1" aria-hidden="true"></span>
+                                Keep this page open until you have pasted the result back — the certificate is held
+                                here until you save. Regenerating makes a fresh one.
+                            </div>
+
+                            <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:18rem;overflow:auto"><code>@accessScript</code></pre>
+
+                            <div class="d-flex flex-wrap gap-2 mb-2">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(accessScript)">
+                                    <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy command
+                                </button>
+                                <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener" href="https://shell.azure.com">
+                                    <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
+                                    <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
+                                </a>
+                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="NewAzureAccessCertificate">
+                                    <span class="bi-arrow-repeat me-1" aria-hidden="true"></span> New certificate
+                                </button>
+                                <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
+                            </div>
+
+                            <label class="form-label small mb-1" for="az-access-paste">Paste what it printed</label>
+                            <textarea id="az-access-paste" class="form-control font-monospace" rows="4"
+                                      @bind="azureAccessPasted" @bind:event="oninput"
+                                      placeholder="@AzureCloudShellSetup.AccessBeginMarker&#10;tenantId=…&#10;@AzureCloudShellSetup.AccessEndMarker"></textarea>
+
+                            @if (!string.IsNullOrWhiteSpace(azureAccessPasted))
+                            {
+                                var accessResult = AzureCloudShellSetup.ParseAccessResult(azureAccessPasted);
+                                @if (accessResult is null)
+                                {
+                                    <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                        <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                        No valid block found yet. Copy everything the command printed, including
+                                        both <code>-----</code> marker lines.
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+                                        <span class="small flex-grow-1">
+                                            Access app <code>@accessResult.AccessAppClientId</code> in tenant
+                                            <code>@accessResult.TenantId</code>.
+                                        </span>
+                                        <button type="button" class="btn btn-sm btn-primary"
+                                                @onclick="() => SaveAzureAccessFromScript(accessResult)" disabled="@azureBusy">
+                                            @if (azureBusy)
+                                            {
+                                                <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+                                            }
+                                            else
+                                            {
+                                                <span class="bi-check-lg me-1" aria-hidden="true"></span>
+                                            }
+                                            Save
+                                        </button>
+                                    </div>
+                                }
+                            }
+                        }
+                </EasyContent>
+                <Actions>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
+                    @if (azureProviderSettings.TenantId is { Length: > 0 })
+                    {
+                        <ProviderResetAction Label="Reset access"
+                                             ConfirmLabel="Confirm access reset"
+                                             HelpText="Clears the tenant, subscription, and app identity and discards the stored certificate. Azure connections stop working until access is set up again."
+                                             OnReset="ClearAzureAccess" />
+                    }
+                </Actions>
+            </ProviderStepCard>
+
+            <ProviderStepCard Id="azure-permissions" Title="Per-user permissions"
+                              Description="The Entra application people sign in through, so their Azure results are scoped to what that identity may read. Uses the access app above to look people and groups up."
+                              Status="PermissionsStatus" StatusLabel="@RequirementLabel(PermissionsStatus)"
+                              @bind-Expanded="showAzurePermissions" EditLabel="Update or replace"
+                              EasyTitle="Guided setup" EasyOpen="true">
+                <Summary>
+                    @if (azureAdSettings.ClientId is { Length: > 0 })
+                    {
+                        <dl class="row small mb-0">
+                            <dt class="col-sm-3">Sign-in app</dt>
+                            <dd class="col-sm-9 font-monospace">@azureAdSettings.ClientId</dd>
+                            <dt class="col-sm-3">Redirect URI</dt>
+                            <dd class="col-sm-9 font-monospace">@azureAdSettings.RedirectUri</dd>
+                        </dl>
+                    }
+                    @if (azureAdSettings.AdminConsentPending && AzureConsentUrl is { Length: > 0 } consentUrl)
+                    {
+                        <div class="alert alert-warning mt-2 mb-0" role="alert">
+                            <div class="mb-2">
+                                <span class="bi-shield-exclamation me-1" aria-hidden="true"></span>
+                                <strong>One step left — admin consent.</strong> The apps are created, but the two
+                                Microsoft Graph permissions Connapse looks people up with need a
+                                <strong>Global Administrator</strong> or <strong>Privileged Role Administrator</strong>
+                                to approve. Send them this link; they sign in and click Accept.
+                            </div>
+                            <div class="d-flex flex-wrap gap-2">
+                                <a class="btn btn-sm btn-primary" href="@consentUrl" target="_blank" rel="noopener">
+                                    <span class="bi-box-arrow-up-right me-1" aria-hidden="true"></span> Open consent page
+                                </a>
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(consentUrl)">
+                                    <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy link
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="MarkAzureConsentGranted">
+                                    Consent has been granted
+                                </button>
+                            </div>
+                        </div>
+                    }
+                </Summary>
+                <ManualContent>
+                    <details class="border rounded p-3 mb-3">
+                        <summary class="fw-semibold">Manual values — use an existing sign-in app registration</summary>
+                        <div class="mt-3">
+                            <AzureAdSignInSettingsTab Settings="azureAdSettings" OnSave="SaveAzureAdFromForm" />
+                        </div>
+                    </details>
+                </ManualContent>
+                <EasyContent>
+                    @if (azureProviderSettings.ClientId is not { Length: > 0 })
+                    {
+                        <div class="alert alert-secondary py-2 small mb-0">
+                            <span class="bi-info-circle me-1" aria-hidden="true"></span>
+                            Finish the <strong>Access</strong> step with an app registration first — this script grants
+                            that access app its Microsoft Graph permissions. (A managed-identity access step needs those
+                            permissions granted by hand; use the manual values.)
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="small text-muted">
+                            One more Cloud Shell script: it registers the sign-in app (with its own certificate — only
+                            the public half is uploaded), grants the access app
+                            <code>@azureProviderSettings.ClientId</code> the two Graph permissions, and tries to grant
+                            admin consent.
+                        </p>
+                        <p class="small mb-3">
+                            <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.PermissionsScriptRequirements).
+                        </p>
+
+                        <div class="mb-3" style="max-width:44rem">
+                            <label class="form-label small mb-1" for="az-perm-redirect">Sign-in redirect URI</label>
+                            <input id="az-perm-redirect" class="form-control form-control-sm font-monospace"
+                                   @bind="easyRedirectUri" @bind:after="RefreshAzurePermissionsScript"
+                                   aria-describedby="az-perm-redirect-help" />
+                            <div id="az-perm-redirect-help" class="form-text">
+                                Registered on the sign-in app. Auto-filled from the address you reached Connapse on.
+                            </div>
+                        </div>
+
+                        EnsureAzurePermissionsScript();
+                        @if (azurePermissionsScript is { Length: > 0 } permissionsScript)
+                        {
+                            <div class="alert alert-secondary py-2 small mb-2">
+                                <span class="bi-info-circle me-1" aria-hidden="true"></span>
+                                Keep this page open until you have pasted the result back — the sign-in certificate is
+                                held here until you save.
+                            </div>
+
+                            <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:18rem;overflow:auto"><code>@permissionsScript</code></pre>
+
+                            <div class="d-flex flex-wrap gap-2 mb-2">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(permissionsScript)">
+                                    <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy command
+                                </button>
+                                <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener" href="https://shell.azure.com">
+                                    <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
+                                    <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
+                                </a>
+                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="NewAzureSignInCertificate">
+                                    <span class="bi-arrow-repeat me-1" aria-hidden="true"></span> New certificate
+                                </button>
+                                <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
+                            </div>
+
+                            <label class="form-label small mb-1" for="az-perm-paste">Paste what it printed</label>
+                            <textarea id="az-perm-paste" class="form-control font-monospace" rows="4"
+                                      @bind="azurePermissionsPasted" @bind:event="oninput"
+                                      placeholder="@AzureCloudShellSetup.PermissionsBeginMarker&#10;signInAppClientId=…&#10;@AzureCloudShellSetup.PermissionsEndMarker"></textarea>
+
+                            @if (!string.IsNullOrWhiteSpace(azurePermissionsPasted))
+                            {
+                                var permissionsResult = AzureCloudShellSetup.ParsePermissionsResult(azurePermissionsPasted);
+                                @if (permissionsResult is null)
+                                {
+                                    <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                        <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                        No valid block found yet. Copy everything the command printed, including
+                                        both <code>-----</code> marker lines.
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+                                        <span class="small flex-grow-1">
+                                            Sign-in app <code>@permissionsResult.SignInAppClientId</code>@(permissionsResult.ConsentGranted ? " — admin consent granted." : " — admin consent still pending.")
+                                        </span>
+                                        <button type="button" class="btn btn-sm btn-primary"
+                                                @onclick="() => SaveAzurePermissionsFromScript(permissionsResult)" disabled="@azureBusy">
+                                            @if (azureBusy)
+                                            {
+                                                <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+                                            }
+                                            else
+                                            {
+                                                <span class="bi-check-lg me-1" aria-hidden="true"></span>
+                                            }
+                                            Save
+                                        </button>
+                                    </div>
+                                }
+                            }
+                        }
+                    }
+                </EasyContent>
+                <Actions>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
+                    @if (azureAdSettings.ClientId is { Length: > 0 })
+                    {
+                        <ProviderResetAction Label="Reset sign-in application"
+                                             ConfirmLabel="Confirm sign-in reset"
+                                             HelpText="Per-user filtering stays on, so Azure searches return nothing for anyone until the application is set up again."
+                                             OnReset="ClearAzureSignIn" />
+                    }
+                </Actions>
+            </ProviderStepCard>
+        }
 
     }
 </div>
@@ -1077,6 +1370,27 @@
 
     private SamlSignInSettings samlSettings = new();
     private bool showSamlManual;
+
+    /// <summary>Backs the Azure setup forms — loaded from the effective settings, saved back per section.</summary>
+    private AzureProviderSettings azureProviderSettings = new();
+    private AzureAdSignInSettings azureAdSettings = new();
+
+    // Azure step cards — expanded state, mirroring the AWS cards.
+    private bool showAzureAccess;
+    private bool showAzurePermissions;
+
+    // Azure easy-setup (Cloud Shell) state — one script per step, each with its own certificate.
+    private string easyRedirectUri = "";
+    private string? azureAccessScript;
+    private AzureCertificateMaterial? azureAccessCert;
+    private string? azureAccessPasted;
+    private string? azurePermissionsScript;
+    private AzureCertificateMaterial? azureSignInCert;
+    private string? azurePermissionsPasted;
+    private bool azureBusy;
+
+    /// <summary>Set when Entra bounced back here after the administrator consented; cleared once recorded.</summary>
+    private bool azureConsentBounce;
 
     private string? grantsCopyMessage;
     private bool grantsCopySucceeded;
@@ -1242,6 +1556,29 @@
         // table, which overrides appsettings.json, and reloads without a restart.
         samlSettings = SamlOptions.CurrentValue;
         identityCenterSettings = IdentityCenterOptions.CurrentValue;
+        azureProviderSettings = AzureProviderOptions.CurrentValue;
+        azureAdSettings = AzureAdOptions.CurrentValue;
+
+        // The sign-in app's redirect URI is Connapse's Entra callback at the address this admin reached
+        // it on; pre-fill the subscription from whatever is already stored.
+        easyRedirectUri = Navigation.BaseUri.TrimEnd('/') + "/api/v1/auth/cloud/azure/callback";
+
+        // Returning from Entra's admin-consent page: it bounces back here with ?admin_consent=True
+        // (or ?error=...&error_description=...). Surface which, so "pending" doesn't linger.
+        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(new Uri(Navigation.Uri).Query);
+        if (query.TryGetValue("admin_consent", out var consent)
+            && string.Equals(consent.ToString(), "True", StringComparison.OrdinalIgnoreCase))
+        {
+            saveMessage = "Admin consent granted — Connapse can now look people and groups up in Entra.";
+            saveSuccess = true;
+            azureConsentBounce = true;
+        }
+        else if (query.TryGetValue("error", out var consentError))
+        {
+            string detail = query.TryGetValue("error_description", out var description) ? description.ToString() : consentError.ToString();
+            saveMessage = $"Admin consent was not granted: {LogSanitizer.Sanitize(detail)}";
+            saveSuccess = false;
+        }
     }
 
     /// <summary>
@@ -1258,6 +1595,15 @@
 
         setups = await SetupReader.ReadAsync();
         await LoadAwsCredentialModeAsync();
+
+        // Entra bounced back after the administrator consented: record it, so the pending state
+        // clears for good rather than only for this page view.
+        if (azureConsentBounce && azureAdSettings.AdminConsentPending)
+        {
+            azureConsentBounce = false;
+            await MarkAzureConsentGranted();
+        }
+
         StateHasChanged();
     }
 
@@ -1780,6 +2126,7 @@
     private static string Offer(ProviderSetup provider) => provider.Key switch
     {
         "aws" => "Read files from S3.",
+        "azure" => "Read files from Azure Blob Storage.",
         _ => $"Set up {provider.DisplayName}."
     };
 
@@ -1852,6 +2199,320 @@
         if (saveSuccess) samlSettings = settings;
 
         await RefreshSetups();
+    }
+
+    /// <summary>Stores the Azure access app credential (Providers:Azure) and re-checks status.</summary>
+    private async Task SaveAzureProviderFromForm(AzureProviderSettings settings)
+    {
+        await SaveSettings("azure", settings);
+
+        if (saveSuccess)
+        {
+            // What was posted, not a re-read: the options reload behind SaveSettings may not have
+            // landed yet, so a stale read would hand the form back the previous values.
+            azureProviderSettings = settings;
+            await AuditLogger.LogAsync("provider.azure.saved", "provider", "azure",
+                new
+                {
+                    HasTenant = !string.IsNullOrWhiteSpace(settings.TenantId),
+                    HasSubscription = !string.IsNullOrWhiteSpace(settings.SubscriptionId),
+                });
+        }
+
+        await RefreshSetups();
+    }
+
+    /// <summary>Stores the Entra sign-in application (Identity:AzureAd) and re-checks status.</summary>
+    private async Task SaveAzureAdFromForm(AzureAdSignInSettings settings)
+    {
+        // Latched here, at save time, exactly as SaveSamlSettings does for AWS. The startup latch
+        // alone left a gap: a deployment that configured Azure sign-in and never restarted stayed
+        // NotEnforcing, and every azblob result passed unfiltered until the next process start.
+        bool enforcing = settings.IsConfigured || EnforcementOptions.CurrentValue.AzureEnforcing;
+
+        await SaveSettings("azuread", settings);
+
+        if (saveSuccess)
+        {
+            azureAdSettings = settings;
+            await AuditLogger.LogAsync("provider.azuread.saved", "provider", "azure",
+                new { Configured = settings.IsConfigured });
+        }
+
+        if (saveSuccess && enforcing != EnforcementOptions.CurrentValue.AzureEnforcing)
+        {
+            await SaveSettings(
+                PermissionEnforcementSettings.Category,
+                new PermissionEnforcementSettings
+                {
+                    IsEnforcing = EnforcementOptions.CurrentValue.IsEnforcing,
+                    AzureEnforcing = enforcing,
+                });
+        }
+
+        await RefreshSetups();
+    }
+
+    /// <summary>Generates a fresh certificate on this host and the Access script that uploads only its
+    /// public half. The material is held until the operator saves the pasted-back result.</summary>
+    private void NewAzureAccessCertificate() => GenerateAzureAccessScript(newCertificate: true);
+
+    private void GenerateAzureAccessScript(bool newCertificate)
+    {
+        azureAccessCert = LoadOrMintAzureCertificate(AzureAccessCertFile, "connapse-azure-access", newCertificate);
+        azureAccessScript = AzureCloudShellSetup.GenerateAccessScript(new AzureAccessSetupInput(
+            AccessAppName: "Connapse-Azure-Access",
+            PublicCertificatePem: azureAccessCert.PublicCertificatePem,
+            ExistingAccessAppClientId: azureProviderSettings.ClientId));
+        azureAccessPasted = null;
+        copyMessage = null;
+    }
+
+    /// <summary>The sign-in app gets its own certificate; the script also grants the saved access app
+    /// its Graph permissions, which is why this step waits for the Access step.</summary>
+    private void NewAzureSignInCertificate() => GenerateAzurePermissionsScript(newCertificate: true);
+
+    private void GenerateAzurePermissionsScript(bool newCertificate)
+    {
+        azureSignInCert = LoadOrMintAzureCertificate(AzureSignInCertFile, "connapse-azure-signin", newCertificate);
+        BuildAzurePermissionsScript();
+        azurePermissionsPasted = null;
+        copyMessage = null;
+    }
+
+    /// <summary>Re-renders the Permissions script for the current redirect URI, keeping the certificate.</summary>
+    private void BuildAzurePermissionsScript()
+    {
+        azurePermissionsScript = AzureCloudShellSetup.GeneratePermissionsScript(new AzurePermissionsSetupInput(
+            AccessAppClientId: azureProviderSettings.ClientId ?? string.Empty,
+            RedirectUri: easyRedirectUri.Trim(),
+            ConsentRedirectUri: AzureConsentLandingUri,
+            SignInAppName: "Connapse-Azure-SignIn",
+            PublicCertificatePem: azureSignInCert!.PublicCertificatePem,
+            ExistingSignInAppClientId: azureAdSettings.ClientId));
+    }
+
+    /// <summary>Where Entra sends the administrator after consent — this page, registered as the access
+    /// app's reply URL by the Permissions script.</summary>
+    private string AzureConsentLandingUri => Navigation.BaseUri.TrimEnd('/') + "/admin/providers/azure";
+
+    /// <summary>Clears the access identity and discards its stored certificate, so the next setup mints
+    /// a fresh key instead of re-offering one an old app registration may still hold.</summary>
+    private async Task ClearAzureAccess()
+    {
+        await SaveAzureProviderFromForm(new AzureProviderSettings());
+        if (!saveSuccess) return;
+
+        DeleteAzureCertificate(AzureAccessCertFile);
+        azureAccessScript = null;
+        azureAccessCert = null;
+        azureAccessPasted = null;
+    }
+
+    private async Task ClearAzureSignIn()
+    {
+        // Enforcement is deliberately left on (the Azure latch never releases). With sign-in
+        // incomplete the verifier denies, so Azure searches return nothing for everyone until the
+        // application is set up again, rather than silently widening to the whole corpus.
+        await SaveAzureAdFromForm(new AzureAdSignInSettings());
+        if (!saveSuccess) return;
+
+        DeleteAzureCertificate(AzureSignInCertFile);
+        azurePermissionsScript = null;
+        azureSignInCert = null;
+        azurePermissionsPasted = null;
+    }
+
+    private void DeleteAzureCertificate(string fileName)
+    {
+        string path = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
+        if (File.Exists(path)) File.Delete(path);
+    }
+
+    /// <summary>The admin-consent link for the access app — derived from settings, so it survives a
+    /// reload and needs no stored copy.</summary>
+    private string? AzureConsentUrl =>
+        azureProviderSettings is { TenantId: { Length: > 0 } tenant, ClientId: { Length: > 0 } app }
+            ? $"https://login.microsoftonline.com/{tenant}/adminconsent?client_id={app}&redirect_uri={Uri.EscapeDataString(AzureConsentLandingUri)}"
+            : null;
+
+    private Task MarkAzureConsentGranted() =>
+        SaveAzureAdFromForm(azureAdSettings with { AdminConsentPending = false });
+
+    private void RefreshAzurePermissionsScript()
+    {
+        if (azureSignInCert is not null) BuildAzurePermissionsScript();
+    }
+
+    // The scripts embed a certificate Connapse mints here, so each is produced the moment its guide
+    // renders rather than behind a button. Nothing touches disk until Save.
+    private void EnsureAzureAccessScript()
+    {
+        if (azureAccessScript is null) GenerateAzureAccessScript(newCertificate: false);
+    }
+
+    private void EnsureAzurePermissionsScript()
+    {
+        if (azurePermissionsScript is null) GenerateAzurePermissionsScript(newCertificate: false);
+    }
+
+    private const string AzureAccessCertFile = "connapse-azure-access.pem";
+    private const string AzureSignInCertFile = "connapse-azure-signin.pem";
+
+    /// <summary>
+    /// The certificate a script embeds must be the one Connapse later signs with — across page reloads
+    /// and restarts, which happen between copying a script and pasting its result back. So it lives on
+    /// disk from the moment it is minted, and the guide re-reads that file on later renders instead of
+    /// minting again. Only "New certificate" replaces it. A daemon-app key nothing is registered
+    /// against yet is harmless to keep on disk.
+    /// </summary>
+    private AzureCertificateMaterial LoadOrMintAzureCertificate(string fileName, string commonName, bool newCertificate)
+    {
+        string path = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
+        if (!newCertificate && File.Exists(path))
+        {
+            try
+            {
+                string combined = File.ReadAllText(path);
+                using var existing = System.Security.Cryptography.X509Certificates.X509Certificate2.CreateFromPem(combined);
+                // A file written before owner-only creation existed keeps its old mode; tighten it.
+                if (!OperatingSystem.IsWindows())
+                    File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+                return new AzureCertificateMaterial(existing.ExportCertificatePem(), combined);
+            }
+            catch (Exception ex) when (ex is System.Security.Cryptography.CryptographicException or IOException)
+            {
+                // Unreadable file: fall through and mint a fresh one over it.
+            }
+        }
+
+        AzureCertificateMaterial minted = AzureCertificateGenerator.Generate(commonName);
+        WriteOwnerOnly(path, minted.CombinedPem);
+        return minted;
+    }
+
+    /// <summary>
+    /// Writes a private-key file readable by Connapse's own user only: 0600 in a 0700 directory on
+    /// Unix (a default umask would have made it world-readable); on Windows it inherits the app
+    /// directory's ACL. The mode is set again after writing because a create mode only applies to
+    /// a file that did not exist.
+    /// </summary>
+    private static void WriteOwnerOnly(string path, string content)
+    {
+        string dir = Path.GetDirectoryName(path)!;
+        Directory.CreateDirectory(dir);
+        bool unix = !OperatingSystem.IsWindows();
+        if (unix)
+            File.SetUnixFileMode(dir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var options = new FileStreamOptions { Mode = FileMode.Create, Access = FileAccess.Write, Share = FileShare.None };
+        if (unix) options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        using (var stream = new FileStream(path, options))
+        using (var writer = new StreamWriter(stream))
+        {
+            writer.Write(content);
+        }
+
+        if (unix) File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    private async Task CopyText(string text)
+    {
+        copySucceeded = await JS.InvokeAsync<bool>("connapse.copyToClipboard", text);
+        copyMessage = copySucceeded ? "Copied." : "Could not copy — select it and copy manually.";
+    }
+
+    /// <summary>
+    /// Stores the Access step: writes the generated certificate (with its private key) to the appdata
+    /// volume and records tenant, subscription, and the access app's client id.
+    /// </summary>
+    private async Task SaveAzureAccessFromScript(AzureAccessResult result)
+    {
+        if (azureAccessCert is null)
+        {
+            saveMessage = "Generate the setup command first, so Connapse has the certificate to store.";
+            saveSuccess = false;
+            return;
+        }
+
+        azureBusy = true;
+        try
+        {
+            string certPath = await WriteAzureCertificateAsync("connapse-azure-access.pem", azureAccessCert.CombinedPem);
+            await SaveAzureProviderFromForm(new AzureProviderSettings
+            {
+                TenantId = result.TenantId,
+                ClientId = result.AccessAppClientId,
+                SubscriptionId = result.SubscriptionId,
+                ClientCertificatePath = certPath,
+            });
+
+            azureAccessScript = null;
+            azureAccessCert = null;
+            azureAccessPasted = null;
+            showAzureAccess = false;
+        }
+        catch (Exception ex)
+        {
+            saveMessage = $"Could not save the Azure access setup: {ex.Message}";
+            saveSuccess = false;
+        }
+        finally
+        {
+            azureBusy = false;
+        }
+    }
+
+    /// <summary>The private key stays on this host: the cert + key go to the appdata volume, and only
+    /// the public certificate was uploaded to Azure by the script.</summary>
+    private Task<string> WriteAzureCertificateAsync(string fileName, string combinedPem)
+    {
+        string certPath = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
+        WriteOwnerOnly(certPath, combinedPem);
+        return Task.FromResult(certPath);
+    }
+
+    /// <summary>
+    /// Stores the Per-user permissions step: the sign-in app's own certificate and client id (tenant
+    /// comes from the Access step). Surfaces the admin-consent URL when the operator could not consent.
+    /// </summary>
+    private async Task SaveAzurePermissionsFromScript(AzurePermissionsResult result)
+    {
+        if (azureSignInCert is null)
+        {
+            saveMessage = "Generate the setup command first, so Connapse has the certificate to store.";
+            saveSuccess = false;
+            return;
+        }
+
+        azureBusy = true;
+        try
+        {
+            string certPath = await WriteAzureCertificateAsync("connapse-azure-signin.pem", azureSignInCert.CombinedPem);
+            await SaveAzureAdFromForm(new AzureAdSignInSettings
+            {
+                TenantId = azureProviderSettings.TenantId,
+                ClientId = result.SignInAppClientId,
+                RedirectUri = easyRedirectUri.Trim(),
+                ClientCertificatePath = certPath,
+                // Persisted, so a reload cannot turn "consent still pending" into a green card.
+                AdminConsentPending = !result.ConsentGranted,
+            });
+
+            azurePermissionsScript = null;
+            azureSignInCert = null;
+            azurePermissionsPasted = null;
+            showAzurePermissions = false;
+        }
+        catch (Exception ex)
+        {
+            saveMessage = $"Could not save the Azure sign-in setup: {ex.Message}";
+            saveSuccess = false;
+        }
+        finally
+        {
+            azureBusy = false;
+        }
     }
 
     @* Two labels, because Warning means two different things depending on what carries it, and one
@@ -1933,6 +2594,8 @@
     private static string SettingsName(string category) => category switch
     {
         "samlsignin" => "AWS sign-in",
+        "azure" => "Azure access",
+        "azuread" => "Azure sign-in",
         _ => category
     };
 }

--- a/src/Connapse.Web/Components/Pages/Providers.razor
+++ b/src/Connapse.Web/Components/Pages/Providers.razor
@@ -19,6 +19,8 @@
 @inject IOptionsMonitor<IdentityCenterSettings> IdentityCenterOptions
 @inject IOptionsMonitor<AzureProviderSettings> AzureProviderOptions
 @inject IOptionsMonitor<AzureAdSignInSettings> AzureAdOptions
+@inject IAzureBlobDiscovery AzureDiscovery
+@inject IAzureHostIdentity HostIdentity
 @inject Microsoft.AspNetCore.Hosting.IWebHostEnvironment WebHostEnvironment
 @inject IProviderSetupReader SetupReader
 @inject IProviderCredentialStore CredentialStore
@@ -204,6 +206,13 @@
                 </div>
             }
         </div>
+        }
+
+        @if (checking)
+        {
+            <div class="text-muted small mb-2" role="status">
+                <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span> Checking @Current.DisplayName…
+            </div>
         }
 
         @if (!string.IsNullOrEmpty(saveMessage))
@@ -1074,15 +1083,25 @@
                 Two steps: the Azure app identity Connapse reads Blob storage and permissions with, and
                 the Entra application people sign in through. No client secrets — Connapse authenticates
                 with certificates it generates on this host (the private keys never leave it) or a
-                managed identity.
+                managed identity. Every field, where to find its value, and what each error means are in
+                the
+                <a href="https://github.com/Destrayon/Connapse/blob/main/docs/azure-setup.md"
+                   target="_blank" rel="noopener">Azure setup guide</a>.
             </p>
 
             <ProviderStepCard Id="azure-access" Title="Access"
                               Description="The Azure app identity Connapse reads Blob storage with, and queries Entra and Azure Resource Manager (role and deny assignments) through."
                               Status="AccessStatus" StatusLabel="@RequirementLabel(AccessStatus)"
                               @bind-Expanded="showAzureAccess" EditLabel="Update or replace"
-                              EasyTitle="Easy setup with Azure Cloud Shell" EasyOpen="true">
+                              EasyTitle="@(UseManagedIdentityGuide ? "Easy setup with this host's managed identity" : "Easy setup with Azure Cloud Shell")" EasyOpen="true">
                 <Summary>
+                    @RequirementDetail(AccessRequirement)
+                    @if (azureAccessCertProblem is { Length: > 0 } accessProblem)
+                    {
+                        <div class="alert alert-danger py-2 mb-2 small" role="alert">
+                            <span class="bi-file-earmark-x me-1" aria-hidden="true"></span>@accessProblem
+                        </div>
+                    }
                     @if (azureProviderSettings.TenantId is { Length: > 0 })
                     {
                         <dl class="row small mb-0">
@@ -1092,7 +1111,22 @@
                             <dd class="col-sm-9 font-monospace">@(azureProviderSettings.SubscriptionId is { Length: > 0 } sub ? sub : "not set")</dd>
                             <dt class="col-sm-3">Identity</dt>
                             <dd class="col-sm-9 font-monospace">
-                                @if (azureProviderSettings.UserAssignedManagedIdentityClientId is { Length: > 0 } mi)
+                                @if (AzureCredentialChainFactory.IsHostManagedIdentity(azureProviderSettings))
+                                {
+                                    <text>this host's managed identity@(azureProviderSettings.ManagedIdentityPrincipalId is { Length: > 0 } principal ? $" (principal {principal})" : "")</text>
+                                    @if (azureProviderSettings.ManagedIdentityPrincipalId is { Length: > 0 } recorded
+                                         && hostIdentity is { IsUserAssigned: false } current
+                                         && !string.Equals(recorded, current.PrincipalId, StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        <div class="alert alert-warning py-2 mt-2 mb-0 small font-sans-serif" role="status">
+                                            <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                            The host now reports principal <code>@current.PrincipalId</code>; the roles
+                                            were granted to <code>@recorded</code>. The identity was re-created since
+                                            setup — run the Access script again so the new one has the roles.
+                                        </div>
+                                    }
+                                }
+                                else if (azureProviderSettings.UserAssignedManagedIdentityClientId is { Length: > 0 } mi)
                                 {
                                     <text>managed identity @mi</text>
                                 }
@@ -1101,35 +1135,161 @@
                                     <text>app @azureProviderSettings.ClientId (certificate)</text>
                                 }
                             </dd>
+                            @if (azureAccessCertExpires is { } expires)
+                            {
+                                <dt class="col-sm-3">Certificate expires</dt>
+                                <dd class="col-sm-9">@expires.ToString("u")</dd>
+                            }
                         </dl>
+                        @if (azureAccessCertExpires is { } expired && expired <= DateTime.UtcNow)
+                        {
+                            <div class="alert alert-danger py-2 mt-2 mb-0 small" role="alert">
+                                <span class="bi-x-circle me-1" aria-hidden="true"></span>
+                                The certificate has expired, so Entra refuses this identity and Azure
+                                sources no longer sync. Set access up again below: choose New certificate,
+                                run the script, and paste back what it prints.
+                            </div>
+                        }
+                        else if (azureAccessCertExpires is { } soon && soon <= DateTime.UtcNow.AddDays(30))
+                        {
+                            <div class="alert alert-warning py-2 mt-2 mb-0 small" role="status">
+                                <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                The certificate expires in @((soon - DateTime.UtcNow).Days) days. Choose
+                                New certificate below and run the script before then, or Azure sources
+                                stop syncing.
+                            </div>
+                        }
                     }
                 </Summary>
                 <ManualContent>
                     <details class="border rounded p-3 mb-3">
                         <summary class="fw-semibold">Manual values — use an existing app registration or managed identity</summary>
                         <div class="mt-3">
-                            <AzureProviderSettingsTab Settings="azureProviderSettings" OnSave="SaveAzureProviderFromForm" />
+                            <AzureProviderSettingsTab Settings="azureProviderSettings" OnSave="s => SaveAzureProviderFromForm(s)" />
                         </div>
                     </details>
                 </ManualContent>
                 <EasyContent>
+                    @if (UseManagedIdentityGuide && hostIdentity is { } host)
+                    {
+                        <p class="small text-muted">
+                            This host runs on Azure as a managed identity
+                            (@(host.IsUserAssigned ? "user-assigned" : "system-assigned"), principal
+                            <code>@host.PrincipalId</code>). Nothing to fill in and no certificate to keep: you run one
+                            script in Azure Cloud Shell — it uses whichever subscription Cloud Shell is signed in to,
+                            creates two least-privilege custom roles, and assigns them to that identity — then paste
+                            back what it prints.
+                        </p>
+                        <p class="small mb-1">
+                            <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.ManagedIdentityAccessScriptRequirements).
+                        </p>
+                        <p class="small mb-3">
+                            <button type="button" class="btn btn-link btn-sm p-0 align-baseline" @onclick="() => preferCertificateApp = true">
+                                Use a certificate app registration instead
+                            </button>
+                        </p>
+
+                        EnsureAzureManagedIdentityScript(host);
+                        @if (azureManagedIdentityScript is { Length: > 0 } miScript)
+                        {
+                            <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:18rem;overflow:auto"><code>@miScript</code></pre>
+
+                            <div class="d-flex flex-wrap gap-2 mb-2">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(miScript)">
+                                    <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy command
+                                </button>
+                                <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener" href="https://shell.azure.com">
+                                    <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
+                                    <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
+                                </a>
+                                <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
+                            </div>
+
+                            <label class="form-label small mb-1" for="az-mi-paste">Paste what it printed</label>
+                            <textarea id="az-mi-paste" class="form-control font-monospace" rows="4"
+                                      @bind="azureManagedIdentityPasted" @bind:event="oninput" disabled="@azureBusy"
+                                      placeholder="@AzureCloudShellSetup.ManagedIdentityBeginMarker&#10;tenantId=…&#10;@AzureCloudShellSetup.ManagedIdentityEndMarker"></textarea>
+
+                            @if (!string.IsNullOrWhiteSpace(azureManagedIdentityPasted))
+                            {
+                                var miResult = AzureCloudShellSetup.ParseManagedIdentityAccessResult(azureManagedIdentityPasted);
+                                @if (miResult is null)
+                                {
+                                    <div class="alert alert-warning py-2 mt-2 mb-0 small">
+                                        <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                        No valid block found yet. Copy everything the command printed, including
+                                        both <code>-----</code> marker lines.
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+                                        <span class="small flex-grow-1">
+                                            Managed identity <code>@miResult.PrincipalId</code> in tenant
+                                            <code>@miResult.TenantId</code>, subscription <code>@miResult.SubscriptionId</code>.
+                                        </span>
+                                        <button type="button" class="btn btn-sm btn-primary"
+                                                @onclick="() => SaveAzureAccessFromManagedIdentityScript(miResult)" disabled="@azureBusy">
+                                            @if (azureBusy)
+                                            {
+                                                <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+                                            }
+                                            else
+                                            {
+                                                <span class="bi-check-lg me-1" aria-hidden="true"></span>
+                                            }
+                                            Save
+                                        </button>
+                                    </div>
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
                     <p class="small text-muted">
                         Nothing to fill in. Connapse generates a certificate on this host; you run one script in Azure
                         Cloud Shell — it uses whichever subscription Cloud Shell is signed in to, creates two
                         least-privilege custom roles and the access app registration, and uploads only the public
                         certificate — then paste back what it prints.
                     </p>
-                    <p class="small mb-3">
+                    <p class="small mb-1">
                         <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.AccessScriptRequirements).
                     </p>
+                    @if (detectingHostIdentity)
+                    {
+                        <p class="small text-muted mb-3" role="status">
+                            <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+                            Checking whether this host has a managed identity to use instead — the guide switches
+                            to it if so…
+                        </p>
+                    }
+                    else if (hostIdentity is not null && string.IsNullOrWhiteSpace(azureProviderSettings.ClientId))
+                    {
+                        <p class="small mb-3">
+                            <button type="button" class="btn btn-link btn-sm p-0 align-baseline" @onclick="() => preferCertificateApp = false">
+                                This host has a managed identity — use it instead, with no certificate
+                            </button>
+                        </p>
+                    }
+                    else if (hostIdentity is not null)
+                    {
+                        <p class="small text-muted mb-3">
+                            This host has a managed identity. To switch to it, with no certificate, choose
+                            <strong>Reset access</strong> below first; the guide then offers it.
+                        </p>
+                    }
 
-                        @{ EnsureAzureAccessScript(); }
+                        // Not while the host is still being asked: a certificate minted now would sit
+                        // unused if the answer is a managed identity.
+                        if (!detectingHostIdentity) EnsureAzureAccessScript();
                         @if (azureAccessScript is { Length: > 0 } accessScript)
                         {
                             <div class="alert alert-secondary py-2 small mb-2">
                                 <span class="bi-info-circle me-1" aria-hidden="true"></span>
-                                Keep this page open until you have pasted the result back — the certificate is held
-                                here until you save. Regenerating makes a fresh one.
+                                The script carries the certificate Connapse holds on this host, so it can be
+                                re-run at any time. New certificate makes a replacement that only takes over
+                                once you save; until then the current one keeps working.
                             </div>
 
                             <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:18rem;overflow:auto"><code>@accessScript</code></pre>
@@ -1142,7 +1302,7 @@
                                     <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
                                     <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
                                 </a>
-                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="NewAzureAccessCertificate">
+                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="NewAzureAccessCertificate" disabled="@azureBusy">
                                     <span class="bi-arrow-repeat me-1" aria-hidden="true"></span> New certificate
                                 </button>
                                 <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
@@ -1150,7 +1310,7 @@
 
                             <label class="form-label small mb-1" for="az-access-paste">Paste what it printed</label>
                             <textarea id="az-access-paste" class="form-control font-monospace" rows="4"
-                                      @bind="azureAccessPasted" @bind:event="oninput"
+                                      @bind="azureAccessPasted" @bind:event="oninput" disabled="@azureBusy"
                                       placeholder="@AzureCloudShellSetup.AccessBeginMarker&#10;tenantId=…&#10;@AzureCloudShellSetup.AccessEndMarker"></textarea>
 
                             @if (!string.IsNullOrWhiteSpace(azureAccessPasted))
@@ -1187,25 +1347,41 @@
                                 }
                             }
                         }
+                    }
                 </EasyContent>
                 <Actions>
-                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
+                    @if (AccessStatus == RequirementStatus.Satisfied)
+                    {
+                        <a class="btn btn-sm btn-primary" href="/connections">
+                            <span class="bi-plug me-1" aria-hidden="true"></span> Add a connection
+                        </a>
+                    }
+                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Recheck</button>
                     @if (azureProviderSettings.TenantId is { Length: > 0 })
                     {
                         <ProviderResetAction Label="Reset access"
                                              ConfirmLabel="Confirm access reset"
-                                             HelpText="Clears the tenant, subscription, and app identity and discards the stored certificate. Azure connections stop working until access is set up again."
+                                             HelpText="@(AzureCredentialChainFactory.IsManagedIdentity(azureProviderSettings)
+                                                 ? "Clears the tenant, subscription, and managed identity; the roles assigned in Azure stay until you remove them there. Azure connections stop working until access is set up again."
+                                                 : "Clears the tenant, subscription, and app identity and discards the stored certificate. Azure connections stop working until access is set up again.")"
                                              OnReset="ClearAzureAccess" />
                     }
                 </Actions>
             </ProviderStepCard>
 
             <ProviderStepCard Id="azure-permissions" Title="Per-user permissions"
-                              Description="The Entra application people sign in through, so their Azure results are scoped to what that identity may read. Uses the access app above to look people and groups up."
+                              Description="The Entra application people sign in through, so their Azure results are scoped to what that identity may read. Uses the access identity above to look people and groups up."
                               Status="PermissionsStatus" StatusLabel="@RequirementLabel(PermissionsStatus)"
                               @bind-Expanded="showAzurePermissions" EditLabel="Update or replace"
                               EasyTitle="Guided setup" EasyOpen="true">
                 <Summary>
+                    @RequirementDetail(PermissionsRequirement)
+                    @if (azureSignInCertProblem is { Length: > 0 } signInProblem)
+                    {
+                        <div class="alert alert-danger py-2 mb-2 small" role="alert">
+                            <span class="bi-file-earmark-x me-1" aria-hidden="true"></span>@signInProblem
+                        </div>
+                    }
                     @if (azureAdSettings.ClientId is { Length: > 0 })
                     {
                         <dl class="row small mb-0">
@@ -1213,15 +1389,63 @@
                             <dd class="col-sm-9 font-monospace">@azureAdSettings.ClientId</dd>
                             <dt class="col-sm-3">Redirect URI</dt>
                             <dd class="col-sm-9 font-monospace">@azureAdSettings.RedirectUri</dd>
+                            @if (azureSignInCertExpires is { } expires)
+                            {
+                                <dt class="col-sm-3">Certificate expires</dt>
+                                <dd class="col-sm-9">@expires.ToString("u")</dd>
+                            }
                         </dl>
+                        @if (azureSignInCertExpires is { } expired && expired <= DateTime.UtcNow)
+                        {
+                            <div class="alert alert-danger py-2 mt-2 mb-0 small" role="alert">
+                                <span class="bi-x-circle me-1" aria-hidden="true"></span>
+                                The sign-in certificate has expired, so nobody can connect an Entra
+                                identity. Set the application up again below: choose New certificate,
+                                run the script, and paste back what it prints.
+                            </div>
+                        }
+                        else if (azureSignInCertExpires is { } soon && soon <= DateTime.UtcNow.AddDays(30))
+                        {
+                            <div class="alert alert-warning py-2 mt-2 mb-0 small" role="status">
+                                <span class="bi-exclamation-triangle me-1" aria-hidden="true"></span>
+                                The sign-in certificate expires in @((soon - DateTime.UtcNow).Days) days.
+                                Choose New certificate below and run the script before then, or Entra
+                                sign-in stops working.
+                            </div>
+                        }
                     }
-                    @if (azureAdSettings.AdminConsentPending && AzureConsentUrl is { Length: > 0 } consentUrl)
+                    @if (azureAdSettings.AdminConsentPending && AzureAccessManagedIdentityPrincipal is { } pendingPrincipal)
+                    {
+                        <div class="alert alert-warning mt-2 mb-0" role="alert">
+                            <div class="mb-2">
+                                <span class="bi-shield-exclamation me-1" aria-hidden="true"></span>
+                                <strong>One step left — the managed identity's Graph permissions.</strong> The apps are
+                                created, but the two Microsoft Graph permissions Connapse looks people up with —
+                                <code>User.Read.All</code> and <code>GroupMember.Read.All</code>, read-only lookups of who
+                                a person is and which groups they belong to — are app roles on the managed identity, and
+                                only a <strong>Global Administrator</strong> or <strong>Privileged Role Administrator</strong>
+                                can grant them. Send them these commands to run in Cloud Shell.
+                            </div>
+                            <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:12rem;overflow:auto"><code>@AzureCloudShellSetup.GraphAppRoleGrantCommands(pendingPrincipal)</code></pre>
+                            <div class="d-flex flex-wrap gap-2">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => CopyText(AzureCloudShellSetup.GraphAppRoleGrantCommands(pendingPrincipal))">
+                                    <span class="bi-clipboard me-1" aria-hidden="true"></span> Copy commands
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="MarkAzureConsentGranted">
+                                    The permissions have been granted
+                                </button>
+                            </div>
+                        </div>
+                    }
+                    else if (azureAdSettings.AdminConsentPending && AzureConsentUrl is { Length: > 0 } consentUrl)
                     {
                         <div class="alert alert-warning mt-2 mb-0" role="alert">
                             <div class="mb-2">
                                 <span class="bi-shield-exclamation me-1" aria-hidden="true"></span>
                                 <strong>One step left — admin consent.</strong> The apps are created, but the two
-                                Microsoft Graph permissions Connapse looks people up with need a
+                                Microsoft Graph permissions Connapse looks people up with —
+                                <code>User.Read.All</code> and <code>GroupMember.Read.All</code>, read-only
+                                lookups of who a person is and which groups they belong to — need a
                                 <strong>Global Administrator</strong> or <strong>Privileged Role Administrator</strong>
                                 to approve. Send them this link; they sign in and click Accept.
                             </div>
@@ -1238,36 +1462,98 @@
                             </div>
                         </div>
                     }
+                    else if (azureAdSettings.AdminConsentPending)
+                    {
+                        @* The access identity changed after the sign-in app was set up (re-entered by hand,
+                           say), so neither the consent link nor the grant commands can be built. The
+                           pending state still needs a way out. *@
+                        <div class="alert alert-warning mt-2 mb-0" role="alert">
+                            <div class="mb-2">
+                                <span class="bi-shield-exclamation me-1" aria-hidden="true"></span>
+                                <strong>One step left — the access identity's Graph permissions.</strong> Grant the
+                                access identity <code>User.Read.All</code> and <code>GroupMember.Read.All</code> (a
+                                Global Administrator consents an app registration; for a managed identity, the
+                                commands are under
+                                <a href="https://github.com/Destrayon/Connapse/blob/main/docs/azure-setup.md#graph-permissions-for-a-managed-identity"
+                                   target="_blank" rel="noopener">Graph permissions for a managed identity</a>),
+                                then confirm here.
+                            </div>
+                            <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="MarkAzureConsentGranted">
+                                The permissions have been granted
+                            </button>
+                        </div>
+                    }
                 </Summary>
                 <ManualContent>
                     <details class="border rounded p-3 mb-3">
                         <summary class="fw-semibold">Manual values — use an existing sign-in app registration</summary>
                         <div class="mt-3">
-                            <AzureAdSignInSettingsTab Settings="azureAdSettings" OnSave="SaveAzureAdFromForm" />
+                            <AzureAdSignInSettingsTab Settings="azureAdSettings" OnSave="s => SaveAzureAdFromForm(s)"
+                                                      DefaultTenantId="@azureProviderSettings.TenantId"
+                                                      DefaultRedirectUri="@easyRedirectUri" />
                         </div>
                     </details>
                 </ManualContent>
                 <EasyContent>
-                    @if (azureProviderSettings.ClientId is not { Length: > 0 })
+                    @if (AzureAccessManagedIdentityPrincipal is null && azureProviderSettings.ClientId is not { Length: > 0 })
                     {
                         <div class="alert alert-secondary py-2 small mb-0">
                             <span class="bi-info-circle me-1" aria-hidden="true"></span>
-                            Finish the <strong>Access</strong> step with an app registration first — this script grants
-                            that access app its Microsoft Graph permissions. (A managed-identity access step needs those
-                            permissions granted by hand; use the manual values.)
+                            @if (AzureCredentialChainFactory.IsUserAssignedManagedIdentity(azureProviderSettings))
+                            {
+                                <text>
+                                    The access identity is a user-assigned managed identity entered by hand, so its
+                                    Microsoft Graph permissions are granted by hand too: run the two commands under
+                                    <a href="https://github.com/Destrayon/Connapse/blob/main/docs/azure-setup.md#graph-permissions-for-a-managed-identity"
+                                       target="_blank" rel="noopener">Graph permissions for a managed identity</a>
+                                    as a Global Administrator, then set the sign-in application up under Manual values here.
+                                </text>
+                            }
+                            else if (AzureCredentialChainFactory.IsHostManagedIdentity(azureProviderSettings))
+                            {
+                                <text>
+                                    Access is set to this host's managed identity, but the page could not tell which
+                                    identity that is — the host reported none, or a user-assigned one. Grant the Graph
+                                    permissions by hand with the two commands under
+                                    <a href="https://github.com/Destrayon/Connapse/blob/main/docs/azure-setup.md#graph-permissions-for-a-managed-identity"
+                                       target="_blank" rel="noopener">Graph permissions for a managed identity</a>,
+                                    then set the sign-in application up under Manual values here.
+                                </text>
+                            }
+                            else
+                            {
+                                <text>
+                                    Finish the <strong>Access</strong> step first — this script grants the access identity
+                                    its Microsoft Graph permissions.
+                                </text>
+                            }
                         </div>
                     }
                     else
                     {
-                        <p class="small text-muted">
-                            One more Cloud Shell script: it registers the sign-in app (with its own certificate — only
-                            the public half is uploaded), grants the access app
-                            <code>@azureProviderSettings.ClientId</code> the two Graph permissions, and tries to grant
-                            admin consent.
-                        </p>
-                        <p class="small mb-3">
-                            <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.PermissionsScriptRequirements).
-                        </p>
+                        @if (AzureAccessManagedIdentityPrincipal is { } accessPrincipal)
+                        {
+                            <p class="small text-muted">
+                                One more Cloud Shell script: it registers the sign-in app (with its own certificate — only
+                                the public half is uploaded) and grants the managed identity
+                                <code>@accessPrincipal</code> the two Graph permissions as app roles.
+                            </p>
+                            <p class="small mb-3">
+                                <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.ManagedIdentityPermissionsScriptRequirements).
+                            </p>
+                        }
+                        else
+                        {
+                            <p class="small text-muted">
+                                One more Cloud Shell script: it registers the sign-in app (with its own certificate — only
+                                the public half is uploaded), grants the access app
+                                <code>@azureProviderSettings.ClientId</code> the two Graph permissions, and tries to grant
+                                admin consent.
+                            </p>
+                            <p class="small mb-3">
+                                <strong>Whoever runs it needs:</strong> @string.Join("; ", AzureCloudShellSetup.PermissionsScriptRequirements).
+                            </p>
+                        }
 
                         <div class="mb-3" style="max-width:44rem">
                             <label class="form-label small mb-1" for="az-perm-redirect">Sign-in redirect URI</label>
@@ -1284,8 +1570,9 @@
                         {
                             <div class="alert alert-secondary py-2 small mb-2">
                                 <span class="bi-info-circle me-1" aria-hidden="true"></span>
-                                Keep this page open until you have pasted the result back — the sign-in certificate is
-                                held here until you save.
+                                The script carries the sign-in certificate Connapse holds on this host, so it
+                                can be re-run at any time. New certificate makes a replacement that only takes
+                                over once you save.
                             </div>
 
                             <pre class="bg-body-tertiary border rounded p-2 small mb-2" style="max-height:18rem;overflow:auto"><code>@permissionsScript</code></pre>
@@ -1298,7 +1585,7 @@
                                     <span class="bi-terminal me-1" aria-hidden="true"></span> Open Cloud Shell
                                     <span class="bi-box-arrow-up-right ms-1 small" aria-hidden="true"></span>
                                 </a>
-                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="NewAzureSignInCertificate">
+                                <button type="button" class="btn btn-sm btn-link text-secondary" @onclick="NewAzureSignInCertificate" disabled="@azureBusy">
                                     <span class="bi-arrow-repeat me-1" aria-hidden="true"></span> New certificate
                                 </button>
                                 <span class="align-self-center small @(copySucceeded ? "text-success" : "text-danger")" role="status">@copyMessage</span>
@@ -1306,7 +1593,7 @@
 
                             <label class="form-label small mb-1" for="az-perm-paste">Paste what it printed</label>
                             <textarea id="az-perm-paste" class="form-control font-monospace" rows="4"
-                                      @bind="azurePermissionsPasted" @bind:event="oninput"
+                                      @bind="azurePermissionsPasted" @bind:event="oninput" disabled="@azureBusy"
                                       placeholder="@AzureCloudShellSetup.PermissionsBeginMarker&#10;signInAppClientId=…&#10;@AzureCloudShellSetup.PermissionsEndMarker"></textarea>
 
                             @if (!string.IsNullOrWhiteSpace(azurePermissionsPasted))
@@ -1345,7 +1632,7 @@
                     }
                 </EasyContent>
                 <Actions>
-                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Re-check</button>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="RefreshSetups">Recheck</button>
                     @if (azureAdSettings.ClientId is { Length: > 0 })
                     {
                         <ProviderResetAction Label="Reset sign-in application"
@@ -1558,10 +1845,11 @@
         identityCenterSettings = IdentityCenterOptions.CurrentValue;
         azureProviderSettings = AzureProviderOptions.CurrentValue;
         azureAdSettings = AzureAdOptions.CurrentValue;
+        LoadAzureCertificateExpiry();
 
         // The sign-in app's redirect URI is Connapse's Entra callback at the address this admin reached
-        // it on; pre-fill the subscription from whatever is already stored.
-        easyRedirectUri = Navigation.BaseUri.TrimEnd('/') + "/api/v1/auth/cloud/azure/callback";
+        // it on.
+        easyRedirectUri = Navigation.BaseUri.TrimEnd('/') + AzureCallbackPath;
 
         // Returning from Entra's admin-consent page: it bounces back here with ?admin_consent=True
         // (or ?error=...&error_description=...). Surface which, so "pending" doesn't linger.
@@ -1694,6 +1982,34 @@
     /// <summary>Looks up one of the current provider's requirements by name.</summary>
     private ProviderRequirement? Requirement(string name) =>
         Current?.Requirements.FirstOrDefault(requirement => requirement.Name == name);
+
+    /// <summary>
+    /// What the reader found out about a requirement, in the words it chose: the reason Entra gave
+    /// and what to do about it when it failed, why it could not be confirmed, or what was verified
+    /// when it is ready. A failure is announced; the rest is read in place.
+    /// </summary>
+    private static RenderFragment RequirementDetail(ProviderRequirement? requirement) => builder =>
+    {
+        if (requirement?.Detail is not { Length: > 0 } detail) return;
+
+        (string css, string? role, string icon) = requirement.Status switch
+        {
+            RequirementStatus.Failed => ("alert alert-danger py-2 mb-2 small", "alert", "bi-x-circle"),
+            RequirementStatus.Warning => ("alert alert-warning py-2 mb-2 small", "status", "bi-exclamation-triangle"),
+            RequirementStatus.Provisioning => ("alert alert-info py-2 mb-2 small", "status", "bi-hourglass-split"),
+            _ => ("small text-body-secondary mb-2", null, "bi-check-circle"),
+        };
+
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "class", css);
+        if (role is not null) builder.AddAttribute(2, "role", role);
+        builder.OpenElement(3, "span");
+        builder.AddAttribute(4, "class", icon + " me-1");
+        builder.AddAttribute(5, "aria-hidden", "true");
+        builder.CloseElement();
+        builder.AddContent(6, detail);
+        builder.CloseElement();
+    };
 
     private ProviderRequirement? AccessRequirement => Requirement("Access");
     private ProviderRequirement? IdentityCenterRequirement => Requirement("IAM Identity Center");
@@ -2109,12 +2425,34 @@
         await JS.InvokeVoidAsync("connapse.scrollToId", elementId);
     }
 
+    /// <summary>Whether a status re-read is in flight, shown beside the page title.</summary>
+    private bool checking;
+
+    /// <summary>
+    /// Re-reads every provider's status. The cards stay mounted while it runs: clearing the list
+    /// first would replace them with a spinner and dispose the forms inside them, and with them
+    /// whatever an operator had typed into a manual form whose save had just been refused.
+    /// </summary>
     private async Task RefreshSetups()
     {
-        setups = null;
+        checking = true;
         StateHasChanged();
-        setups = await SetupReader.ReadAsync();
-        await LoadAwsCredentialModeAsync();
+        try
+        {
+            // The host is asked again as well: a probe that timed out, or an identity re-created
+            // since the process cached it, is what Recheck exists to notice.
+            Task detection = Key == "azure" && hostIdentityRequested
+                ? DetectHostIdentityAsync(refresh: true)
+                : Task.CompletedTask;
+            setups = await SetupReader.ReadAsync();
+            await detection;
+            await LoadAwsCredentialModeAsync();
+            LoadAzureCertificateExpiry();
+        }
+        finally
+        {
+            checking = false;
+        }
     }
 
     /// <summary>What a provider would let you do, for one you have not taken up.</summary>
@@ -2177,19 +2515,28 @@
         // the environment, so copying those values into a row here would shadow them permanently.
         bool enforcing = settings.IsConfigured || EnforcementOptions.CurrentValue.IsEnforcing;
 
-        await SaveSettings("samlsignin", settings);
+        // The latch first, and the Azure latch carried along unchanged: the record holds one flag
+        // per provider, and writing it with only this one would switch Azure filtering off. Written
+        // before the sign-in settings for the same reason as the Azure save — a latch that cannot be
+        // written must not leave sign-in configured with filtering off.
+        if (enforcing && !EnforcementOptions.CurrentValue.IsEnforcing)
+        {
+            bool latched = await LatchEnforcementAsync(saml: true);
+            if (!latched || !EnforcementOptions.CurrentValue.IsEnforcing)
+            {
+                saveMessage = "Per-user enforcement for AWS could not be switched on in this process, so "
+                    + $"the sign-in application was not saved: {saveMessage} Restart Connapse and save again.";
+                saveSuccess = false;
+                return;
+            }
+        }
 
-        if (saveSuccess)
+        bool? committed = await SaveSettings("samlsignin", settings);
+
+        if (committed == true)
         {
             await AuditLogger.LogAsync("provider.saml.saved", "provider", "aws",
                 new { settings.EntityId, settings.IdpEntityId, Configured = settings.IsConfigured });
-        }
-
-        if (saveSuccess && enforcing != EnforcementOptions.CurrentValue.IsEnforcing)
-        {
-            await SaveSettings(
-                PermissionEnforcementSettings.Category,
-                new PermissionEnforcementSettings { IsEnforcing = enforcing });
         }
 
         // What was posted, not a re-read of CurrentValue. The options reload behind SaveSettings is
@@ -2201,56 +2548,323 @@
         await RefreshSetups();
     }
 
-    /// <summary>Stores the Azure access app credential (Providers:Azure) and re-checks status.</summary>
-    private async Task SaveAzureProviderFromForm(AzureProviderSettings settings)
+    /// <summary>
+    /// Stores the Azure access app credential (Providers:Azure) and re-checks status. Unless the
+    /// caller has already verified <paramref name="settings"/>, Entra is asked first, and a credential
+    /// it refuses is not stored — the one that works stays in place.
+    /// </summary>
+    private async Task<bool?> SaveAzureProviderFromForm(AzureProviderSettings settings, bool verified = false)
     {
-        await SaveSettings("azure", settings);
+        // A reset (blank tenant) has nothing to verify.
+        if (!verified && !string.IsNullOrWhiteSpace(settings.TenantId))
+        {
+            // The host's own identity is in one tenant, and a managed-identity token check cannot
+            // tell whether the tenant typed matches it; the host already said which it is.
+            if (AzureCredentialChainFactory.IsHostManagedIdentity(settings)
+                && hostIdentity is { } host
+                && !string.Equals(host.TenantId, settings.TenantId.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                saveMessage = $"This host's managed identity is in tenant {host.TenantId}, not {settings.TenantId}. "
+                    + "Nothing was changed; enter that tenant.";
+                saveSuccess = false;
+                return false;
+            }
 
-        if (saveSuccess)
+            var check = await AzureDiscovery.CheckAccessAsync(settings);
+            if (!check.Succeeded)
+            {
+                saveMessage = AzureCheckRefused("access", check);
+                saveSuccess = false;
+                return false;
+            }
+        }
+
+        bool? committed = await SaveSettings("azure", settings);
+
+        if (committed == true)
         {
             // What was posted, not a re-read: the options reload behind SaveSettings may not have
             // landed yet, so a stale read would hand the form back the previous values.
             azureProviderSettings = settings;
-            await AuditLogger.LogAsync("provider.azure.saved", "provider", "azure",
+            LoadAzureCertificateExpiry();
+            // The permissions script names the access identity and takes a different shape for a
+            // managed identity than for an app; one already generated for the old identity must
+            // not stay on screen under an intro describing the new one.
+            RefreshAzurePermissionsScript();
+            await AfterAzureCommitAsync(() => AuditLogger.LogAsync("provider.azure.saved", "provider", "azure",
                 new
                 {
                     HasTenant = !string.IsNullOrWhiteSpace(settings.TenantId),
                     HasSubscription = !string.IsNullOrWhiteSpace(settings.SubscriptionId),
-                });
+                }));
+            // Only after a commit: nothing changed otherwise, so there is nothing to re-read.
+            await AfterAzureCommitAsync(RefreshSetups);
         }
 
-        await RefreshSetups();
+        return committed;
     }
 
-    /// <summary>Stores the Entra sign-in application (Identity:AzureAd) and re-checks status.</summary>
-    private async Task SaveAzureAdFromForm(AzureAdSignInSettings settings)
+    /// <summary>
+    /// Runs a step that follows a commit — the audit line, the status refresh, a cleanup — so that
+    /// its failure is reported beside the save rather than as the save failing. The settings are
+    /// stored by then; telling the operator otherwise would send them to retry a replacement that
+    /// already happened.
+    /// </summary>
+    private async Task AfterAzureCommitAsync(Func<Task> step)
     {
+        try
+        {
+            await step();
+        }
+        catch (Exception ex)
+        {
+            saveMessage = saveSuccess
+                ? $"{saveMessage} A follow-up step failed afterwards ({ex.Message}); the settings themselves are stored."
+                : $"{saveMessage} A follow-up step also failed ({ex.Message}).";
+        }
+    }
+
+    /// <summary>
+    /// Switches a per-provider enforcement latch on. Written as a merge under the store's lock, never
+    /// as a replace: two administrators saving the two providers at once would otherwise each write
+    /// the whole record from their own stale copy, and one of them would switch the other's filtering
+    /// off. A latch only ever goes on, so the merge is an OR of what is stored, what this process
+    /// sees, and what is being asked for. Returns whether the record was written.
+    /// </summary>
+    private async Task<bool> LatchEnforcementAsync(bool saml = false, bool azure = false)
+    {
+        try
+        {
+            await SettingsStore.UpdateAsync<PermissionEnforcementSettings>(
+                PermissionEnforcementSettings.Category,
+                stored => new PermissionEnforcementSettings
+                {
+                    IsEnforcing = (stored?.IsEnforcing ?? false) || EnforcementOptions.CurrentValue.IsEnforcing || saml,
+                    AzureEnforcing = (stored?.AzureEnforcing ?? false) || EnforcementOptions.CurrentValue.AzureEnforcing || azure,
+                });
+        }
+        catch (Exception ex)
+        {
+            saveMessage = $"Failed to record per-user enforcement: {ex.Message}";
+            saveSuccess = false;
+            return false;
+        }
+
+        try
+        {
+            ReloadService.Reload();
+        }
+        catch (Exception)
+        {
+            // The live check that follows every latch is what decides; a failed reload shows there.
+        }
+        return true;
+    }
+
+    /// <summary>Stores the Entra sign-in application (Identity:AzureAd) and re-checks status. As with
+    /// the access app, a credential Entra refuses is not stored unless the caller already verified it.
+    /// Returns whether the sign-in settings themselves were committed; the enforcement latch saved
+    /// after them is reported separately and never turns a committed save into a failed one.</summary>
+    private async Task<bool?> SaveAzureAdFromForm(AzureAdSignInSettings settings, bool verified = false)
+    {
+        if (!verified && settings.IsConfigured)
+        {
+            var check = await AzureDiscovery.CheckAccessAsync(ProviderSetupReader.SignInIdentity(settings));
+            if (!check.Succeeded)
+            {
+                saveMessage = AzureCheckRefused("sign-in", check);
+                saveSuccess = false;
+                return false;
+            }
+        }
+
         // Latched here, at save time, exactly as SaveSamlSettings does for AWS. The startup latch
         // alone left a gap: a deployment that configured Azure sign-in and never restarted stayed
         // NotEnforcing, and every azblob result passed unfiltered until the next process start.
-        bool enforcing = settings.IsConfigured || EnforcementOptions.CurrentValue.AzureEnforcing;
+        //
+        // Latched BEFORE the sign-in settings, never after. With enforcement on and sign-in not yet
+        // stored, Azure searches deny — closed. The other order, sign-in stored and then the latch
+        // failing, would leave sign-in configured with filtering off: every Azure result to everyone.
+        // So a latch that cannot be written stops the save, and the sign-in settings stay as they were.
+        if (settings.IsConfigured && !EnforcementOptions.CurrentValue.AzureEnforcing)
+        {
+            bool latched = await LatchEnforcementAsync(azure: true);
+            // Stored is not enough: the resolver reads the live options, so a latch that was written
+            // but not applied (the reload failed) would let sign-in be saved into an unfiltered
+            // process. Only a latch this process can see counts.
+            if (!latched || !EnforcementOptions.CurrentValue.AzureEnforcing)
+            {
+                saveMessage = "Per-user enforcement for Azure could not be switched on in this process, so "
+                    + $"the sign-in application was not saved: {saveMessage} Restart Connapse and save again.";
+                saveSuccess = false;
+                return false;
+            }
+        }
 
-        await SaveSettings("azuread", settings);
+        bool? committed = await SaveSettings("azuread", settings);
 
-        if (saveSuccess)
+        if (committed == true)
         {
             azureAdSettings = settings;
-            await AuditLogger.LogAsync("provider.azuread.saved", "provider", "azure",
-                new { Configured = settings.IsConfigured });
+            LoadAzureCertificateExpiry();
+            await AfterAzureCommitAsync(() => AuditLogger.LogAsync("provider.azuread.saved", "provider", "azure",
+                new { Configured = settings.IsConfigured }));
+            await AfterAzureCommitAsync(RefreshSetups);
         }
 
-        if (saveSuccess && enforcing != EnforcementOptions.CurrentValue.AzureEnforcing)
+        return committed;
+    }
+
+    // ── The Azure host's managed identity: the guided Access setup without a certificate ──────────
+
+    /// <summary>The managed identity this host runs as, if it has one; null off Azure.</summary>
+    private AzureHostIdentityInfo? hostIdentity;
+
+    /// <summary>Whether the host has been asked, and whether the answer is still on its way.</summary>
+    private bool hostIdentityRequested, detectingHostIdentity;
+
+    /// <summary>Set when the operator asks for a certificate app although the host has a managed identity.</summary>
+    private bool preferCertificateApp;
+
+    /// <summary>
+    /// Asks the host whether it has a managed identity, once, the first time the Azure page is
+    /// shown. From here rather than the first render: the list and the provider page are one
+    /// component, and arriving from the list changes only the route parameter — no first render
+    /// happens again. The answer is awaited off the render path, since off Azure the metadata
+    /// probe is a second or so of waiting for nothing; the guide updates when it lands.
+    /// </summary>
+    protected override void OnParametersSet()
+    {
+        if (Key != "azure" || hostIdentityRequested) return;
+        hostIdentityRequested = true;
+        detectingHostIdentity = true;
+        _ = DetectHostIdentityAsync(refresh: false);
+    }
+
+    private async Task DetectHostIdentityAsync(bool refresh)
+    {
+        try
         {
-            await SaveSettings(
-                PermissionEnforcementSettings.Category,
-                new PermissionEnforcementSettings
+            hostIdentity = await HostIdentity.DetectAsync(refresh);
+        }
+        catch (Exception)
+        {
+            hostIdentity = null;
+        }
+        finally
+        {
+            detectingHostIdentity = false;
+            try
+            {
+                // Scripts generated before the answer landed name whatever principal was known then;
+                // the host's own answer outranks it, so they are rebuilt to match. The Access script
+                // is dropped only when the principal it was built for is no longer the host's — a
+                // paste for that script would be refused, and the refusal says to run the one shown.
+                if (azureManagedIdentityScript is not null
+                    && !string.Equals(azureManagedIdentityScriptFor, hostIdentity?.PrincipalId, StringComparison.OrdinalIgnoreCase))
                 {
-                    IsEnforcing = EnforcementOptions.CurrentValue.IsEnforcing,
-                    AzureEnforcing = enforcing,
-                });
+                    azureManagedIdentityScript = null;
+                    azureManagedIdentityPasted = null;
+                }
+                RefreshAzurePermissionsScript();
+            }
+            catch (Exception)
+            {
+                // A rebuild that fails is regenerated on the next render; the page must still update.
+            }
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private string? azureManagedIdentityScript;
+    private string? azureManagedIdentityPasted;
+
+    /// <summary>The principal the managed-identity Access script on screen was built for.</summary>
+    private string? azureManagedIdentityScriptFor;
+
+    /// <summary>
+    /// Whether the Access guide offers the host's managed identity rather than a certificate app:
+    /// the host has one, the operator has not asked for a certificate app instead, and Access is
+    /// not already a certificate app being replaced.
+    /// </summary>
+    private bool UseManagedIdentityGuide =>
+        hostIdentity is not null
+        && !preferCertificateApp
+        && string.IsNullOrWhiteSpace(azureProviderSettings.ClientId);
+
+    private void EnsureAzureManagedIdentityScript(AzureHostIdentityInfo host)
+    {
+        if (azureManagedIdentityScript is not null) return;
+        azureManagedIdentityScript = AzureCloudShellSetup.GenerateManagedIdentityAccessScript(
+            new AzureManagedIdentityAccessSetupInput(host.PrincipalId, host.ClientId, host.IsUserAssigned));
+        azureManagedIdentityScriptFor = host.PrincipalId;
+    }
+
+    /// <summary>
+    /// Stores the Access step for a managed identity: the tenant, subscription, and the identity the
+    /// script granted the roles to. No certificate is written; the host itself is the credential,
+    /// and it is asked for a token before anything is stored.
+    /// </summary>
+    private async Task SaveAzureAccessFromManagedIdentityScript(AzureManagedIdentityAccessResult result)
+    {
+        if (hostIdentity is { } host && !string.Equals(host.PrincipalId, result.PrincipalId, StringComparison.OrdinalIgnoreCase))
+        {
+            saveMessage = "The script you ran granted access to a different managed identity than the one this host "
+                + "runs as. Nothing was changed. Copy the command shown now, run it again, and paste that result.";
+            saveSuccess = false;
+            return;
         }
 
-        await RefreshSetups();
+        // The tenant comes from whatever Cloud Shell was signed in to, and a managed-identity token
+        // does not care what tenant is stored, so the credential check cannot catch a wrong one.
+        // The host already said which tenant it is in.
+        if (hostIdentity is { } hostTenant && !string.Equals(hostTenant.TenantId, result.TenantId, StringComparison.OrdinalIgnoreCase))
+        {
+            saveMessage = $"The script ran in tenant {result.TenantId}, but this host's managed identity is in tenant "
+                + $"{hostTenant.TenantId}. Nothing was changed. In Cloud Shell, switch to that tenant (az login --tenant …), "
+                + "run the command again, and paste that result.";
+            saveSuccess = false;
+            return;
+        }
+
+        azureBusy = true;
+        try
+        {
+            // What the host knows about itself outranks what was pasted: the kind and client id come
+            // from the token the host was issued, and the paste is only allowed to agree.
+            bool userAssigned = hostIdentity?.IsUserAssigned ?? result.IsUserAssigned;
+            string clientId = hostIdentity?.ClientId ?? result.ClientId;
+            var candidate = new AzureProviderSettings
+            {
+                TenantId = result.TenantId,
+                SubscriptionId = result.SubscriptionId,
+                UseHostManagedIdentity = !userAssigned,
+                UserAssignedManagedIdentityClientId = userAssigned ? clientId : null,
+                ManagedIdentityPrincipalId = result.PrincipalId,
+            };
+            var check = await AzureDiscovery.CheckAccessAsync(candidate);
+            if (!check.Succeeded)
+            {
+                saveMessage = AzureCheckRefused("access", check);
+                saveSuccess = false;
+                return;
+            }
+
+            if (await SaveAzureProviderFromForm(candidate, verified: true) != true) return;
+
+            azureManagedIdentityScript = null;
+            azureManagedIdentityPasted = null;
+            showAzureAccess = false;
+        }
+        catch (Exception ex)
+        {
+            saveMessage = $"Could not save the Azure access setup: {ex.Message}";
+            saveSuccess = false;
+        }
+        finally
+        {
+            azureBusy = false;
+        }
     }
 
     /// <summary>Generates a fresh certificate on this host and the Access script that uploads only its
@@ -2259,7 +2873,8 @@
 
     private void GenerateAzureAccessScript(bool newCertificate)
     {
-        azureAccessCert = LoadOrMintAzureCertificate(AzureAccessCertFile, "connapse-azure-access", newCertificate);
+        azureAccessCert = LoadOrMintAzureCertificate(
+            AzureAccessCertFile, "connapse-azure-access", newCertificate, azureProviderSettings.ClientCertificatePath);
         azureAccessScript = AzureCloudShellSetup.GenerateAccessScript(new AzureAccessSetupInput(
             AccessAppName: "Connapse-Azure-Access",
             PublicCertificatePem: azureAccessCert.PublicCertificatePem,
@@ -2274,7 +2889,8 @@
 
     private void GenerateAzurePermissionsScript(bool newCertificate)
     {
-        azureSignInCert = LoadOrMintAzureCertificate(AzureSignInCertFile, "connapse-azure-signin", newCertificate);
+        azureSignInCert = LoadOrMintAzureCertificate(
+            AzureSignInCertFile, "connapse-azure-signin", newCertificate, azureAdSettings.ClientCertificatePath);
         BuildAzurePermissionsScript();
         azurePermissionsPasted = null;
         copyMessage = null;
@@ -2289,24 +2905,62 @@
             ConsentRedirectUri: AzureConsentLandingUri,
             SignInAppName: "Connapse-Azure-SignIn",
             PublicCertificatePem: azureSignInCert!.PublicCertificatePem,
-            ExistingSignInAppClientId: azureAdSettings.ClientId));
+            ExistingSignInAppClientId: azureAdSettings.ClientId,
+            AccessManagedIdentityPrincipalId: AzureAccessManagedIdentityPrincipal));
+    }
+
+    /// <summary>The access identity's service principal when it is a managed identity the guided
+    /// setup recorded — what the permissions script grants Graph app roles to. Null for a certificate
+    /// app, and for a user-assigned identity entered by hand (no principal id was recorded).</summary>
+    private string? AzureAccessManagedIdentityPrincipal
+    {
+        get
+        {
+            if (!AzureCredentialChainFactory.IsManagedIdentity(azureProviderSettings)) return null;
+
+            // For the host's own identity, what the host says now outranks what was recorded: a
+            // system-assigned identity that was removed and re-enabled has a new principal, and
+            // Graph grants must go to the one that exists. A hand-entered host identity records no
+            // principal at all, and this is where it comes from.
+            if (AzureCredentialChainFactory.IsHostManagedIdentity(azureProviderSettings)
+                && hostIdentity is { IsUserAssigned: false } host)
+                return host.PrincipalId;
+
+            return azureProviderSettings.ManagedIdentityPrincipalId is { Length: > 0 } recorded ? recorded : null;
+        }
     }
 
     /// <summary>Where Entra sends the administrator after consent — this page, registered as the access
     /// app's reply URL by the Permissions script.</summary>
     private string AzureConsentLandingUri => Navigation.BaseUri.TrimEnd('/') + "/admin/providers/azure";
 
+    /// <summary>The path Entra redirects a person back to after sign-in; the sign-in app must register it.</summary>
+    private const string AzureCallbackPath = "/api/v1/auth/cloud/azure/callback";
+
     /// <summary>Clears the access identity and discards its stored certificate, so the next setup mints
     /// a fresh key instead of re-offering one an old app registration may still hold.</summary>
     private async Task ClearAzureAccess()
     {
-        await SaveAzureProviderFromForm(new AzureProviderSettings());
-        if (!saveSuccess) return;
+        // Under the same gate as promotion, so a reset cannot interleave with a save in progress
+        // and remove the key it is about to commit.
+        await AzureCertificateGate.WaitAsync();
+        try
+        {
+            if (await SaveAzureProviderFromForm(new AzureProviderSettings()) != true) return;
 
-        DeleteAzureCertificate(AzureAccessCertFile);
-        azureAccessScript = null;
-        azureAccessCert = null;
-        azureAccessPasted = null;
+            await DeleteAzureCertificatesAsync(AzureAccessCertFile);
+            azureAccessScript = null;
+            azureAccessCert = null;
+            azureAccessPasted = null;
+            // A fresh start offers the host's identity again, as the "Reset access first" note promises.
+            preferCertificateApp = false;
+            azureManagedIdentityScript = null;
+            azureManagedIdentityPasted = null;
+        }
+        finally
+        {
+            AzureCertificateGate.Release();
+        }
     }
 
     private async Task ClearAzureSignIn()
@@ -2314,19 +2968,45 @@
         // Enforcement is deliberately left on (the Azure latch never releases). With sign-in
         // incomplete the verifier denies, so Azure searches return nothing for everyone until the
         // application is set up again, rather than silently widening to the whole corpus.
-        await SaveAzureAdFromForm(new AzureAdSignInSettings());
-        if (!saveSuccess) return;
+        await AzureCertificateGate.WaitAsync();
+        try
+        {
+            if (await SaveAzureAdFromForm(new AzureAdSignInSettings()) != true) return;
 
-        DeleteAzureCertificate(AzureSignInCertFile);
-        azurePermissionsScript = null;
-        azureSignInCert = null;
-        azurePermissionsPasted = null;
+            await DeleteAzureCertificatesAsync(AzureSignInCertFile);
+            azurePermissionsScript = null;
+            azureSignInCert = null;
+            azurePermissionsPasted = null;
+        }
+        finally
+        {
+            AzureCertificateGate.Release();
+        }
     }
 
-    private void DeleteAzureCertificate(string fileName)
+    /// <summary>
+    /// After a reset: the pending copy goes, and so does every file of this kind that nothing committed
+    /// names — read back from the store, since another session may have saved a replacement in the
+    /// meantime — once it is past the grace period. A younger unreferenced file is left for a later
+    /// sweep rather than risk removing a key another process committed a moment ago.
+    /// </summary>
+    private async Task DeleteAzureCertificatesAsync(string fileName)
     {
-        string path = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
-        if (File.Exists(path)) File.Delete(path);
+        string directory = Path.GetDirectoryName(AzureCertificatePath(fileName))!;
+        if (!Directory.Exists(directory)) return;
+
+        string pendingPath = AzurePendingCertificatePath(fileName);
+        if (File.Exists(pendingPath)) File.Delete(pendingPath);
+
+        var referenced = await PersistedAzureCertificatePathsAsync();
+        if (referenced is null) return;
+        DateTime cutoff = DateTime.UtcNow - AzureCertificateGrace;
+        foreach (string path in Directory.EnumerateFiles(directory, Path.GetFileNameWithoutExtension(fileName) + "*.pem"))
+        {
+            if (referenced.Contains(Path.GetFullPath(path))) continue;
+            if (File.GetLastWriteTimeUtc(path) > cutoff) continue;
+            File.Delete(path);
+        }
     }
 
     /// <summary>The admin-consent link for the access app — derived from settings, so it survives a
@@ -2345,7 +3025,7 @@
     }
 
     // The scripts embed a certificate Connapse mints here, so each is produced the moment its guide
-    // renders rather than behind a button. Nothing touches disk until Save.
+    // renders rather than behind a button.
     private void EnsureAzureAccessScript()
     {
         if (azureAccessScript is null) GenerateAzureAccessScript(newCertificate: false);
@@ -2359,43 +3039,111 @@
     private const string AzureAccessCertFile = "connapse-azure-access.pem";
     private const string AzureSignInCertFile = "connapse-azure-signin.pem";
 
+    private string AzureCertificatePath(string fileName) =>
+        Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
+
+    /// <summary>The file a certificate waits in between being minted and being saved.</summary>
+    private string AzurePendingCertificatePath(string fileName) =>
+        AzureCertificatePath(Path.GetFileNameWithoutExtension(fileName) + ".pending.pem");
+
     /// <summary>
     /// The certificate a script embeds must be the one Connapse later signs with — across page reloads
-    /// and restarts, which happen between copying a script and pasting its result back. So it lives on
-    /// disk from the moment it is minted, and the guide re-reads that file on later renders instead of
-    /// minting again. Only "New certificate" replaces it. A daemon-app key nothing is registered
-    /// against yet is harmless to keep on disk.
+    /// and restarts, which happen between copying a script and pasting its result back. So a minted
+    /// certificate lives in a pending file from the moment it is made, and the guide re-reads that file
+    /// on later renders instead of minting again. The file the stored settings point at — the key
+    /// Connapse signs with today — is never written here; Save writes the new key to a file of its own
+    /// and commits settings naming it. Until then "New certificate" only replaces the pending one, so
+    /// an Access step that already works keeps working while a replacement is being set up.
     /// </summary>
-    private AzureCertificateMaterial LoadOrMintAzureCertificate(string fileName, string commonName, bool newCertificate)
+    /// <param name="currentPath">The certificate the stored settings name, if any: re-running a script
+    /// with no replacement pending re-registers the key Connapse already holds.</param>
+    private AzureCertificateMaterial LoadOrMintAzureCertificate(
+        string fileName, string commonName, bool newCertificate, string? currentPath)
     {
-        string path = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
-        if (!newCertificate && File.Exists(path))
+        string pendingPath = AzurePendingCertificatePath(fileName);
+        if (!newCertificate)
         {
-            try
-            {
-                string combined = File.ReadAllText(path);
-                using var existing = System.Security.Cryptography.X509Certificates.X509Certificate2.CreateFromPem(combined);
-                // A file written before owner-only creation existed keeps its old mode; tighten it.
-                if (!OperatingSystem.IsWindows())
-                    File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
-                return new AzureCertificateMaterial(existing.ExportCertificatePem(), combined);
-            }
-            catch (Exception ex) when (ex is System.Security.Cryptography.CryptographicException or IOException)
-            {
-                // Unreadable file: fall through and mint a fresh one over it.
-            }
+            // Pending first: a replacement in progress is what the script must embed.
+            if (ReadAzureCertificate(pendingPath) is { } pending) return pending;
+            if (currentPath is { Length: > 0 } && ReadAzureCertificate(currentPath) is { } current) return current;
         }
 
         AzureCertificateMaterial minted = AzureCertificateGenerator.Generate(commonName);
-        WriteOwnerOnly(path, minted.CombinedPem);
+        WriteOwnerOnly(pendingPath, minted.CombinedPem);
         return minted;
+    }
+
+    /// <summary>Whether a path is one of the certificate files Connapse itself writes under appdata/azure.</summary>
+    private bool IsConnapseAzureFile(string path)
+    {
+        string? directory = Path.GetDirectoryName(Path.GetFullPath(path));
+        string own = Path.GetFullPath(Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure"));
+        return directory is not null && string.Equals(directory, own, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Reads a combined PEM back as material, or null when the file is missing or unreadable.</summary>
+    private AzureCertificateMaterial? ReadAzureCertificate(string path)
+    {
+        if (!File.Exists(path)) return null;
+        try
+        {
+            string combined = File.ReadAllText(path);
+            using var existing = System.Security.Cryptography.X509Certificates.X509Certificate2.CreateFromPem(combined);
+            // A file Connapse wrote before owner-only creation existed keeps its old mode; tighten
+            // it. Only Connapse's own files: a certificate an operator supplied may be shared with
+            // another service or mounted read-only, and its permissions are theirs to set.
+            if (!OperatingSystem.IsWindows() && IsConnapseAzureFile(path))
+                File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            return new AzureCertificateMaterial(existing.ExportCertificatePem(), combined);
+        }
+        catch (Exception ex) when (AzureCertificateFile.IsUnreadable(ex))
+        {
+            return null;
+        }
+    }
+
+    private DateTime? azureAccessCertExpires;
+    private DateTime? azureSignInCertExpires;
+
+    /// <summary>Why the certificate a card's settings name could not be read, if it could not; shown on
+    /// that card so the administrator can fix the file or set access up again.</summary>
+    private string? azureAccessCertProblem;
+    private string? azureSignInCertProblem;
+
+    /// <summary>Read through the same loader the credentials use, so a PFX with a password shows its
+    /// expiry exactly as a PEM does. Never throws: a file this process cannot read is a fact to show
+    /// on the card, not a reason for the page — every provider's page — to fail to render.</summary>
+    private void LoadAzureCertificateExpiry()
+    {
+        (azureAccessCertExpires, azureAccessCertProblem) = InspectAzureCertificate(
+            azureProviderSettings.ClientCertificatePath, azureProviderSettings.ClientCertificatePassword);
+        (azureSignInCertExpires, azureSignInCertProblem) = InspectAzureCertificate(
+            azureAdSettings.ClientCertificatePath, azureAdSettings.ClientCertificatePassword);
+    }
+
+    private static (DateTime? Expires, string? Problem) InspectAzureCertificate(string? path, string? password)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return (null, null);
+        try
+        {
+            using var certificate = AzureCertificateFile.Load(path, password);
+            return certificate is null
+                ? (null, $"The certificate file {path} does not exist on this host, so Connapse cannot sign in. Set access up again, or restore the file.")
+                : (certificate.NotAfter.ToUniversalTime(), null);
+        }
+        catch (Exception ex) when (AzureCertificateFile.IsUnreadable(ex))
+        {
+            return (null, $"Connapse cannot read its certificate file {path}: {ex.Message} Check the file's "
+                + "permissions for the user Connapse runs as, or set access up again.");
+        }
     }
 
     /// <summary>
     /// Writes a private-key file readable by Connapse's own user only: 0600 in a 0700 directory on
     /// Unix (a default umask would have made it world-readable); on Windows it inherits the app
-    /// directory's ACL. The mode is set again after writing because a create mode only applies to
-    /// a file that did not exist.
+    /// directory's ACL. Written to a sibling temporary file and moved into place, so an interrupted
+    /// write leaves the previous file intact rather than truncated. The mode is set again after the
+    /// move because a create mode only applies to a file that did not exist.
     /// </summary>
     private static void WriteOwnerOnly(string path, string content)
     {
@@ -2405,14 +3153,18 @@
         if (unix)
             File.SetUnixFileMode(dir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
 
+        string temp = path + ".tmp";
         var options = new FileStreamOptions { Mode = FileMode.Create, Access = FileAccess.Write, Share = FileShare.None };
         if (unix) options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
-        using (var stream = new FileStream(path, options))
+        using (var stream = new FileStream(temp, options))
         using (var writer = new StreamWriter(stream))
         {
             writer.Write(content);
+            writer.Flush();
+            stream.Flush(flushToDisk: true);
         }
 
+        File.Move(temp, path, overwrite: true);
         if (unix) File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
     }
 
@@ -2428,7 +3180,10 @@
     /// </summary>
     private async Task SaveAzureAccessFromScript(AzureAccessResult result)
     {
-        if (azureAccessCert is null)
+        // A snapshot: the field can be replaced by "New certificate" in another render while the
+        // Entra check below is awaited, and the material verified must be the material stored.
+        AzureCertificateMaterial? material = azureAccessCert;
+        if (material is null)
         {
             saveMessage = "Generate the setup command first, so Connapse has the certificate to store.";
             saveSuccess = false;
@@ -2436,17 +3191,47 @@
         }
 
         azureBusy = true;
+        await AzureCertificateGate.WaitAsync();
         try
         {
-            string certPath = await WriteAzureCertificateAsync("connapse-azure-access.pem", azureAccessCert.CombinedPem);
-            await SaveAzureProviderFromForm(new AzureProviderSettings
+            if (!ThumbprintMatches(result.CertificateThumbprint, material))
+            {
+                saveMessage = AzureThumbprintMismatch;
+                saveSuccess = false;
+                return;
+            }
+
+            // The candidate gets a file of its own, named by its thumbprint, and is verified from
+            // there. The key Connapse signs with today is never moved or overwritten: the stored
+            // settings keep pointing at it until the ones naming the new file are committed.
+            string newPath = AzureVersionedCertificatePath(AzureAccessCertFile, material);
+            WriteOwnerOnly(newPath, material.CombinedPem);
+            var candidate = new AzureProviderSettings
             {
                 TenantId = result.TenantId,
                 ClientId = result.AccessAppClientId,
                 SubscriptionId = result.SubscriptionId,
-                ClientCertificatePath = certPath,
-            });
+                ClientCertificatePath = newPath,
+            };
+            var check = await AzureDiscovery.CheckAccessAsync(candidate);
+            if (!check.Succeeded)
+            {
+                await DeleteAzureCandidateAsync(newPath);
+                saveMessage = AzureCheckRefused("access", check);
+                saveSuccess = false;
+                return;
+            }
 
+            bool? committed = await SaveAzureProviderFromForm(candidate, verified: true);
+            if (committed != true)
+            {
+                // False: not stored, the candidate is surplus. Null: unknown — the file may be the
+                // one the store names by now, so it stays, and so does the paste for a retry.
+                if (committed == false) await DeleteAzureCandidateAsync(newPath);
+                return;
+            }
+
+            await AfterAzureCommitAsync(() => SweepAzureCertificatesAsync(AzureAccessCertFile, promotedPem: material.CombinedPem));
             azureAccessScript = null;
             azureAccessCert = null;
             azureAccessPasted = null;
@@ -2459,18 +3244,131 @@
         }
         finally
         {
+            AzureCertificateGate.Release();
             azureBusy = false;
         }
     }
 
-    /// <summary>The private key stays on this host: the cert + key go to the appdata volume, and only
-    /// the public certificate was uploaded to Azure by the script.</summary>
-    private Task<string> WriteAzureCertificateAsync(string fileName, string combinedPem)
+    /// <summary>
+    /// One promotion at a time in this process. Two administrators saving together would otherwise
+    /// interleave the write / verify / commit / sweep steps and sweep each other's files.
+    /// </summary>
+    private static readonly SemaphoreSlim AzureCertificateGate = new(1, 1);
+
+    /// <summary>Where a candidate certificate lives: its own file, named by the thumbprint and a
+    /// per-attempt suffix, so no two attempts — in this session, another, or another process that
+    /// picked up the same pending material — ever share a path with each other or with the key in
+    /// use. One attempt's cleanup can therefore never touch another's file.</summary>
+    private string AzureVersionedCertificatePath(string fileName, AzureCertificateMaterial material)
     {
-        string certPath = Path.Combine(WebHostEnvironment.ContentRootPath, "appdata", "azure", fileName);
-        WriteOwnerOnly(certPath, combinedPem);
-        return Task.FromResult(certPath);
+        string thumbprint = AzureCertificateFile.Thumbprint(material.PublicCertificatePem);
+        string attempt = Guid.NewGuid().ToString("N")[..8];
+        return AzureCertificatePath($"{Path.GetFileNameWithoutExtension(fileName)}-{thumbprint[..12].ToLowerInvariant()}-{attempt}.pem");
     }
+
+    /// <summary>
+    /// The certificate files anything committed names right now: both Azure settings categories, read
+    /// back from the store rather than from this page's copy — another session or process may have
+    /// committed since this page loaded — plus the live options as a floor when the store has no row
+    /// (settings coming from appsettings or the environment).
+    /// </summary>
+    private async Task<HashSet<string>?> PersistedAzureCertificatePathsAsync()
+    {
+        var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        void Add(string? path) { if (!string.IsNullOrWhiteSpace(path)) paths.Add(Path.GetFullPath(path)); }
+
+        Add(AzureProviderOptions.CurrentValue.ClientCertificatePath);
+        Add(AzureAdOptions.CurrentValue.ClientCertificatePath);
+        try
+        {
+            Add((await SettingsStore.GetAsync<AzureProviderSettings>("azure"))?.ClientCertificatePath);
+            Add((await SettingsStore.GetAsync<AzureAdSignInSettings>("azuread"))?.ClientCertificatePath);
+        }
+        catch (Exception)
+        {
+            // Not knowing what is referenced is not the same as nothing being referenced: with the
+            // store unreadable, nothing is deleted at all.
+            return null;
+        }
+        return paths;
+    }
+
+    /// <summary>
+    /// How long a certificate file is left alone after it was written, whatever else is known. Two
+    /// processes sharing the volume have no lock in common; a candidate one of them wrote seconds ago
+    /// may be committed a moment after the other reads the store. Nothing in flight lives this long.
+    /// </summary>
+    private static readonly TimeSpan AzureCertificateGrace = TimeSpan.FromHours(1);
+
+    /// <summary>Removes a candidate that will not be used — unless something committed names it,
+    /// which happens when two sessions carried the same material and the other one saved it.</summary>
+    private async Task DeleteAzureCandidateAsync(string path)
+    {
+        if (!File.Exists(path)) return;
+        var referenced = await PersistedAzureCertificatePathsAsync();
+        if (referenced is null || referenced.Contains(Path.GetFullPath(path))) return;
+        File.Delete(path);
+    }
+
+    /// <summary>
+    /// After a commit: certificate files of this kind under appdata/azure that nothing committed names
+    /// and that are past the grace period are superseded and removed — earlier versioned files, the
+    /// single fixed-name file older saves wrote. The pending copy goes only if it is the material just
+    /// promoted, so another session's replacement in progress is left alone. Anything not removed now
+    /// is removed by a later sweep.
+    /// </summary>
+    private async Task SweepAzureCertificatesAsync(string fileName, string promotedPem)
+    {
+        string directory = Path.GetDirectoryName(AzureCertificatePath(fileName))!;
+        if (!Directory.Exists(directory)) return;
+
+        var referenced = await PersistedAzureCertificatePathsAsync();
+        if (referenced is null) return;
+        string stem = Path.GetFileNameWithoutExtension(fileName);
+        string pendingPath = Path.GetFullPath(AzurePendingCertificatePath(fileName));
+        DateTime cutoff = DateTime.UtcNow - AzureCertificateGrace;
+
+        // "*.pem*" also catches the ".pem.tmp" a write leaves behind if it is interrupted before
+        // the move: a private key nothing will ever read, and the sweep is the only thing that
+        // knows to remove it.
+        foreach (string path in Directory.EnumerateFiles(directory, stem + "*.pem*"))
+        {
+            string full = Path.GetFullPath(path);
+            if (referenced.Contains(full)) continue;
+            if (string.Equals(full, pendingPath, StringComparison.OrdinalIgnoreCase))
+            {
+                if (File.ReadAllText(path) == promotedPem) File.Delete(path);
+                continue;
+            }
+            if (File.GetLastWriteTimeUtc(path) > cutoff) continue;
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>Whether the certificate the script registered is the one this page holds. A paste from
+    /// a script that predates the thumbprint cannot be checked and is accepted; the Entra check that
+    /// follows is the backstop.</summary>
+    private static bool ThumbprintMatches(string? printed, AzureCertificateMaterial material) =>
+        printed is null
+        || string.Equals(printed, AzureCertificateFile.Thumbprint(material.PublicCertificatePem), StringComparison.OrdinalIgnoreCase);
+
+    private const string AzureThumbprintMismatch =
+        "The script you ran registered a different certificate from the one this page holds — another "
+        + "tab or session may have made a new one since. Nothing was changed. Copy the command shown "
+        + "now, run it again, and paste that result.";
+
+    /// <summary>What to say when Entra would not accept a credential about to be stored.</summary>
+    private static string AzureCheckRefused(string which, AzureProbe<string> check) => check.Outcome switch
+    {
+        AzureProbeOutcome.Denied =>
+            $"Entra refused the {which} credential, so nothing was changed. {check.Detail} If you just "
+            + "ran the script, Entra may still be registering the certificate — wait a minute and save again.",
+        AzureProbeOutcome.Unusable =>
+            $"The {which} credential cannot be used from this host, so nothing was changed: {check.Detail} "
+            + "For a certificate, check the path and that Connapse can read the file; for a managed identity, "
+            + "that this host has one.",
+        _ => $"Could not confirm the {which} credential with Azure, so nothing was changed. {check.Detail}",
+    };
 
     /// <summary>
     /// Stores the Per-user permissions step: the sign-in app's own certificate and client id (tenant
@@ -2478,7 +3376,8 @@
     /// </summary>
     private async Task SaveAzurePermissionsFromScript(AzurePermissionsResult result)
     {
-        if (azureSignInCert is null)
+        AzureCertificateMaterial? material = azureSignInCert;
+        if (material is null)
         {
             saveMessage = "Generate the setup command first, so Connapse has the certificate to store.";
             saveSuccess = false;
@@ -2486,19 +3385,48 @@
         }
 
         azureBusy = true;
+        await AzureCertificateGate.WaitAsync();
         try
         {
-            string certPath = await WriteAzureCertificateAsync("connapse-azure-signin.pem", azureSignInCert.CombinedPem);
-            await SaveAzureAdFromForm(new AzureAdSignInSettings
+            if (!ThumbprintMatches(result.CertificateThumbprint, material))
+            {
+                saveMessage = AzureThumbprintMismatch;
+                saveSuccess = false;
+                return;
+            }
+
+            string newPath = AzureVersionedCertificatePath(AzureSignInCertFile, material);
+            WriteOwnerOnly(newPath, material.CombinedPem);
+            var check = await AzureDiscovery.CheckAccessAsync(new AzureProviderSettings
+            {
+                TenantId = azureProviderSettings.TenantId,
+                ClientId = result.SignInAppClientId,
+                ClientCertificatePath = newPath,
+            });
+            if (!check.Succeeded)
+            {
+                await DeleteAzureCandidateAsync(newPath);
+                saveMessage = AzureCheckRefused("sign-in", check);
+                saveSuccess = false;
+                return;
+            }
+
+            bool? committed = await SaveAzureAdFromForm(new AzureAdSignInSettings
             {
                 TenantId = azureProviderSettings.TenantId,
                 ClientId = result.SignInAppClientId,
                 RedirectUri = easyRedirectUri.Trim(),
-                ClientCertificatePath = certPath,
+                ClientCertificatePath = newPath,
                 // Persisted, so a reload cannot turn "consent still pending" into a green card.
                 AdminConsentPending = !result.ConsentGranted,
-            });
+            }, verified: true);
+            if (committed != true)
+            {
+                if (committed == false) await DeleteAzureCandidateAsync(newPath);
+                return;
+            }
 
+            await AfterAzureCommitAsync(() => SweepAzureCertificatesAsync(AzureSignInCertFile, promotedPem: material.CombinedPem));
             azurePermissionsScript = null;
             azureSignInCert = null;
             azurePermissionsPasted = null;
@@ -2511,6 +3439,7 @@
         }
         finally
         {
+            AzureCertificateGate.Release();
             azureBusy = false;
         }
     }
@@ -2569,19 +3498,68 @@
         _ => "bi-question-circle text-secondary"
     };
 
-    private async Task SaveSettings<T>(string category, T settings) where T : class
+    /// <summary>
+    /// Stores a settings category. Returns whether it was committed. The store reloads the options
+    /// after its own commit, so an exception out of it does not say which half failed; the store is
+    /// read back and compared, and a commit whose reload failed is reported as stored-but-not-applied
+    /// rather than as a failure — callers rolling back on false must never undo a commit.
+    /// </summary>
+    /// <returns>True when committed, false when not, null when the store threw and could not be read
+    /// back either — the outcome is unknown, and callers must neither roll back nor report success.</returns>
+    private async Task<bool?> SaveSettings<T>(string category, T settings) where T : class
     {
+        string? reloadProblem = null;
         try
         {
             await SettingsStore.SaveAsync(category, settings);
-            ReloadService.Reload();
-            saveMessage = $"{SettingsName(category)} settings saved successfully!";
-            saveSuccess = true;
         }
         catch (Exception ex)
         {
-            saveMessage = $"Failed to save {SettingsName(category)} settings: {ex.Message}";
-            saveSuccess = false;
+            switch (await IsStoredAsync(category, settings))
+            {
+                case false:
+                    saveMessage = $"Failed to save {SettingsName(category)} settings: {ex.Message}";
+                    saveSuccess = false;
+                    return false;
+                case null:
+                    saveMessage = $"Could not confirm whether {SettingsName(category)} settings were saved: "
+                        + $"{ex.Message} Check this card again after a restart before retrying.";
+                    saveSuccess = false;
+                    return null;
+            }
+            reloadProblem = ex.Message;
+        }
+
+        try
+        {
+            if (!ReloadService.Reload()) reloadProblem ??= "the settings reload reported failure";
+        }
+        catch (Exception ex)
+        {
+            reloadProblem ??= ex.Message;
+        }
+
+        saveMessage = reloadProblem is null
+            ? $"{SettingsName(category)} settings saved successfully!"
+            : $"{SettingsName(category)} settings were saved, but applying them without a restart "
+              + $"failed: {reloadProblem}. Restart Connapse to apply them.";
+        saveSuccess = true;
+        return true;
+    }
+
+    /// <summary>Whether the store now holds exactly <paramref name="settings"/> under
+    /// <paramref name="category"/>; null when the store cannot be read, which is not a no.</summary>
+    private async Task<bool?> IsStoredAsync<T>(string category, T settings) where T : class
+    {
+        try
+        {
+            T? stored = await SettingsStore.GetAsync<T>(category);
+            return stored is not null
+                && System.Text.Json.JsonSerializer.Serialize(stored) == System.Text.Json.JsonSerializer.Serialize(settings);
+        }
+        catch (Exception)
+        {
+            return null;
         }
     }
 

--- a/src/Connapse.Web/Components/Pages/Sources.razor
+++ b/src/Connapse.Web/Components/Pages/Sources.razor
@@ -294,15 +294,21 @@
                     @* Which scope fields exist is decided by the connection's provider, because
                        the keys ConnectorFactory reads differ per provider and writing the wrong
                        one produces a source that silently syncs nothing. *@
-                    @if (selectedProvider is ConnectionProvider.S3)
+                    @if (selectedProvider is ConnectionProvider.S3 or ConnectionProvider.AzureBlob)
                     {
-                        @* The connection already names which buckets it permits, so asking for
-                           one in free text made the reader supply a fact Connapse was holding —
-                           and a name typed from memory saves cleanly, then fails at the first
-                           sync or is refused by the scope preflight afterwards. *@
+                        @* AzureBlob shares this branch with S3 rather than getting its own: both
+                           are bounded by the same allowedLocations allowlist on the connection,
+                           read through the same StorageLocationPolicy, and differ only in what
+                           the container-like scope is called. *@
+                        string containerNoun = selectedProvider is ConnectionProvider.S3 ? "bucket" : "container";
+
+                        @* The connection already names which buckets/containers it permits, so
+                           asking for one in free text made the reader supply a fact Connapse was
+                           holding — and a name typed from memory saves cleanly, then fails at the
+                           first sync or is refused by the scope preflight afterwards. *@
                         <div class="mb-3">
                             <label class="form-label" for="source-container">
-                                Bucket
+                                @(selectedProvider is ConnectionProvider.S3 ? "Bucket" : "Container")
                             </label>
 
                             @{ var choices = AllowedScopes(); }
@@ -317,7 +323,7 @@
                                     <span class="bi-exclamation-triangle me-1"></span>
                                     This connection's allowed locations cannot be read, so Connapse
                                     cannot say which
-                                    buckets
+                                    @(containerNoun)s
                                     it permits. Fix them on the Connections page before adding a
                                     source — a source saved now would be refused at sync time.
                                 </div>
@@ -345,7 +351,7 @@
                                    count to accommodate two help links would cost more than the
                                    links are worth. *@
                                 <div id="source-container-help" class="form-text">
-                                    Buckets
+                                    @(containerNoun)s
                                     this connection is allowed to read. To use another, add it to
                                     that connection's allowed locations on the Connections page.
                                 </div>
@@ -357,7 +363,7 @@
                                        placeholder="company-knowledge" />
                                 <div id="source-container-help" class="form-text">
                                     Which
-                                    bucket
+                                    @(containerNoun)
                                     inside this connection the source reads. This connection lists
                                     no allowed locations, so it permits any its credential can
                                     reach — naming them on the Connections page bounds that.

--- a/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
@@ -11,46 +11,80 @@
     <div class="col-12">
         <label class="form-label" for="azad-tenant">Directory (tenant) ID</label>
         <input id="azad-tenant" class="form-control font-monospace" @bind="tenantId"
-               placeholder="00000000-0000-0000-0000-000000000000" />
+               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="azad-tenant-help"
+               aria-invalid="@(problemField == "azad-tenant" ? "true" : null)" />
+        <div id="azad-tenant-help" class="form-text">
+            @if (DefaultTenantId is { Length: > 0 })
+            {
+                <text>Filled in from the Access step; change it only if the sign-in app lives in another tenant.</text>
+            }
+            else
+            {
+                <text>
+                    The Entra tenant the sign-in app is registered in. Shown on the
+                    <a href="https://entra.microsoft.com/#view/Microsoft_AAD_IAM/TenantOverview.ReactView" target="_blank" rel="noopener">tenant overview</a>
+                    in the Microsoft Entra admin center.
+                </text>
+            }
+        </div>
     </div>
 
     <div class="col-12">
         <label class="form-label" for="azad-client">Application (client) ID</label>
         <input id="azad-client" class="form-control font-monospace" @bind="clientId"
-               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="azad-client-help" />
+               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="azad-client-help"
+               aria-invalid="@(problemField == "azad-client" ? "true" : null)" />
         <div id="azad-client-help" class="form-text">
-            The Entra app registration people sign in through — separate from the access app above.
+            The app registration people sign in through — separate from the access app above. On its
+            Overview page under
+            <a href="https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade" target="_blank" rel="noopener">App registrations</a>.
         </div>
     </div>
 
     <div class="col-12">
         <label class="form-label" for="azad-redirect">Redirect URI</label>
         <input id="azad-redirect" class="form-control font-monospace" @bind="redirectUri"
-               placeholder="https://connapse.example.com/api/v1/auth/cloud/azure/cb"
-               aria-describedby="azad-redirect-help" />
+               placeholder="@(DefaultRedirectUri ?? "https://connapse.example.com/api/v1/auth/cloud/azure/callback")"
+               aria-describedby="azad-redirect-help"
+               aria-invalid="@(problemField == "azad-redirect" ? "true" : null)" />
         <div id="azad-redirect-help" class="form-text">
-            Registered on the app registration as a redirect URI. Change Connapse's address and this
-            must be updated in Entra too, or sign-in stops with a redirect mismatch.
+            Where Entra sends people back after they sign in: Connapse's address plus
+            <code>/api/v1/auth/cloud/azure/callback</code>. Add the same value under the app's
+            <strong>Authentication</strong> page as a Web redirect URI; if Connapse's address changes,
+            update it in both places or sign-in stops with a redirect mismatch.
         </div>
     </div>
 
     <div class="col-12">
         <label class="form-label" for="azad-cert">Client certificate path</label>
         <input id="azad-cert" class="form-control font-monospace" @bind="certPath"
-               placeholder="/certs/azure-signin.pem" aria-describedby="azad-cert-help" />
+               placeholder="/certs/azure-signin.pem" aria-describedby="azad-cert-help"
+               aria-invalid="@(problemField == "azad-cert" ? "true" : null)" />
         <div id="azad-cert-help" class="form-text">
-            Path on the Connapse host to the PEM or PFX registered on the sign-in app registration.
+            Path on the Connapse host to the PEM (certificate plus private key) or PFX whose public
+            certificate is uploaded under the sign-in app's <strong>Certificates &amp; secrets</strong>.
         </div>
     </div>
 
     <div class="col-12">
         <label class="form-label" for="azad-cert-pw">
-            Certificate password <span class="text-muted">(PFX only)</span>
+            Certificate password <span class="text-muted">(optional — PFX only)</span>
         </label>
         <SecretTextArea Id="azad-cert-pw" Multiline="false" @bind-Value="certPassword"
-                        Placeholder="@(Settings.ClientCertificatePassword is { Length: > 0 } ? "Leave blank to keep the stored password" : "Leave blank for a PEM certificate")" />
+                        Placeholder="@(Settings.ClientCertificatePassword is { Length: > 0 } ? "Leave blank to keep the stored password" : "Leave blank for a PEM certificate")"
+                        DescribedBy="azad-cert-pw-help" />
+        <div id="azad-cert-pw-help" class="form-text">
+            Only for a password-protected PFX. The stored value is never shown here; leave it blank to keep it.
+        </div>
     </div>
 </div>
+
+@if (problem is not null)
+{
+    <div class="alert alert-danger py-2 mt-3 mb-0 small" role="alert">
+        <span class="bi-x-circle me-1" aria-hidden="true"></span>@problem
+    </div>
+}
 
 <div class="d-flex gap-2 mt-3">
     <button type="button" class="btn btn-primary" @onclick="HandleSubmit">Save</button>
@@ -61,21 +95,86 @@
     [Parameter] public AzureAdSignInSettings Settings { get; set; } = new();
     [Parameter] public EventCallback<AzureAdSignInSettings> OnSave { get; set; }
 
+    /// <summary>The tenant the Access step recorded, used when nothing is stored here yet.</summary>
+    [Parameter] public string? DefaultTenantId { get; set; }
+
+    /// <summary>Connapse's own callback at the address this page was reached on, used when nothing is stored here yet.</summary>
+    [Parameter] public string? DefaultRedirectUri { get; set; }
+
     // Local strings: AzureAdSignInSettings is an init-only record, rebuilt on save.
     private string? tenantId, clientId, redirectUri, certPath, certPassword;
 
+    /// <summary>The first thing stopping a save, and the id of the field it is about; null until Save is tried.</summary>
+    private string? problem, problemField;
+
+    /// <summary>Which stored settings this form was last loaded from. Parameters arrive again on every
+    /// parent render; only a different record means the values on screen should be replaced.</summary>
+    private AzureAdSignInSettings? loadedFrom;
+
+    /// <summary>The defaults last applied, so a changed default (the Access step saved after this form
+    /// first rendered) can replace a field that still holds the old one or nothing — never something typed.</summary>
+    private string? appliedDefaultTenant, appliedDefaultRedirect;
+
     protected override void OnParametersSet()
     {
-        tenantId = Settings.TenantId;
+        if (!ReferenceEquals(Settings, loadedFrom))
+        {
+            Load();
+            return;
+        }
+
+        // Same stored record, but the defaults may have moved: this card is visible before Access is
+        // saved, so the tenant arrives after the form exists.
+        if (Settings.TenantId is null && DefaultTenantId != appliedDefaultTenant
+            && (string.IsNullOrWhiteSpace(tenantId) || tenantId == appliedDefaultTenant))
+        {
+            tenantId = DefaultTenantId;
+            appliedDefaultTenant = DefaultTenantId;
+        }
+        if (Settings.RedirectUri is null && DefaultRedirectUri != appliedDefaultRedirect
+            && (string.IsNullOrWhiteSpace(redirectUri) || redirectUri == appliedDefaultRedirect))
+        {
+            redirectUri = DefaultRedirectUri;
+            appliedDefaultRedirect = DefaultRedirectUri;
+        }
+    }
+
+    private void Load()
+    {
+        loadedFrom = Settings;
+        tenantId = Settings.TenantId ?? DefaultTenantId;
+        appliedDefaultTenant = DefaultTenantId;
         clientId = Settings.ClientId;
-        redirectUri = Settings.RedirectUri;
+        redirectUri = Settings.RedirectUri ?? DefaultRedirectUri;
+        appliedDefaultRedirect = DefaultRedirectUri;
         certPath = Settings.ClientCertificatePath;
         // The stored password is never rehydrated into the browser; blank on save keeps it.
         certPassword = null;
     }
 
-    private Task HandleSubmit() =>
-        OnSave.InvokeAsync(new AzureAdSignInSettings
+    private (string Message, string Field)? Validate()
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            return ("Enter the Directory (tenant) ID.", "azad-tenant");
+        if (string.IsNullOrWhiteSpace(clientId))
+            return ("Enter the Application (client) ID.", "azad-client");
+        if (!Uri.TryCreate(redirectUri?.Trim(), UriKind.Absolute, out Uri? uri) || uri.Scheme is not ("https" or "http"))
+            return ("Enter the redirect URI as a full address, starting with https://.", "azad-redirect");
+        if (string.IsNullOrWhiteSpace(certPath))
+            return ("Enter the path to the client certificate on the Connapse host.", "azad-cert");
+        return null;
+    }
+
+    private Task HandleSubmit()
+    {
+        if (Validate() is { } failed)
+        {
+            (problem, problemField) = failed;
+            return Task.CompletedTask;
+        }
+
+        problem = problemField = null;
+        return OnSave.InvokeAsync(new AzureAdSignInSettings
         {
             TenantId = Trim(tenantId),
             ClientId = Trim(clientId),
@@ -84,8 +183,13 @@
             ClientCertificatePassword = string.IsNullOrWhiteSpace(certPassword) ? Settings.ClientCertificatePassword : certPassword,
             AdminConsentPending = Settings.AdminConsentPending,
         });
+    }
 
     private static string? Trim(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
-    private void Reset() => OnParametersSet();
+    private void Reset()
+    {
+        Load();
+        problem = problemField = null;
+    }
 }

--- a/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureAdSignInSettingsTab.razor
@@ -1,0 +1,91 @@
+@using Connapse.Core
+@using Connapse.Web.Components.Shared
+
+@*
+    The Entra (Azure AD) application people sign in through to prove which directory user they are,
+    so their Azure results are scoped to what that identity may read. Connapse authenticates to
+    Entra with a certificate, never a client secret. Stored under the Identity:AzureAd settings.
+*@
+
+<div class="row g-3" style="max-width:44rem">
+    <div class="col-12">
+        <label class="form-label" for="azad-tenant">Directory (tenant) ID</label>
+        <input id="azad-tenant" class="form-control font-monospace" @bind="tenantId"
+               placeholder="00000000-0000-0000-0000-000000000000" />
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="azad-client">Application (client) ID</label>
+        <input id="azad-client" class="form-control font-monospace" @bind="clientId"
+               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="azad-client-help" />
+        <div id="azad-client-help" class="form-text">
+            The Entra app registration people sign in through — separate from the access app above.
+        </div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="azad-redirect">Redirect URI</label>
+        <input id="azad-redirect" class="form-control font-monospace" @bind="redirectUri"
+               placeholder="https://connapse.example.com/api/v1/auth/cloud/azure/cb"
+               aria-describedby="azad-redirect-help" />
+        <div id="azad-redirect-help" class="form-text">
+            Registered on the app registration as a redirect URI. Change Connapse's address and this
+            must be updated in Entra too, or sign-in stops with a redirect mismatch.
+        </div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="azad-cert">Client certificate path</label>
+        <input id="azad-cert" class="form-control font-monospace" @bind="certPath"
+               placeholder="/certs/azure-signin.pem" aria-describedby="azad-cert-help" />
+        <div id="azad-cert-help" class="form-text">
+            Path on the Connapse host to the PEM or PFX registered on the sign-in app registration.
+        </div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="azad-cert-pw">
+            Certificate password <span class="text-muted">(PFX only)</span>
+        </label>
+        <SecretTextArea Id="azad-cert-pw" Multiline="false" @bind-Value="certPassword"
+                        Placeholder="@(Settings.ClientCertificatePassword is { Length: > 0 } ? "Leave blank to keep the stored password" : "Leave blank for a PEM certificate")" />
+    </div>
+</div>
+
+<div class="d-flex gap-2 mt-3">
+    <button type="button" class="btn btn-primary" @onclick="HandleSubmit">Save</button>
+    <button type="button" class="btn btn-outline-secondary" @onclick="Reset">Reset</button>
+</div>
+
+@code {
+    [Parameter] public AzureAdSignInSettings Settings { get; set; } = new();
+    [Parameter] public EventCallback<AzureAdSignInSettings> OnSave { get; set; }
+
+    // Local strings: AzureAdSignInSettings is an init-only record, rebuilt on save.
+    private string? tenantId, clientId, redirectUri, certPath, certPassword;
+
+    protected override void OnParametersSet()
+    {
+        tenantId = Settings.TenantId;
+        clientId = Settings.ClientId;
+        redirectUri = Settings.RedirectUri;
+        certPath = Settings.ClientCertificatePath;
+        // The stored password is never rehydrated into the browser; blank on save keeps it.
+        certPassword = null;
+    }
+
+    private Task HandleSubmit() =>
+        OnSave.InvokeAsync(new AzureAdSignInSettings
+        {
+            TenantId = Trim(tenantId),
+            ClientId = Trim(clientId),
+            RedirectUri = Trim(redirectUri),
+            ClientCertificatePath = Trim(certPath),
+            ClientCertificatePassword = string.IsNullOrWhiteSpace(certPassword) ? Settings.ClientCertificatePassword : certPassword,
+            AdminConsentPending = Settings.AdminConsentPending,
+        });
+
+    private static string? Trim(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private void Reset() => OnParametersSet();
+}

--- a/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
@@ -1,0 +1,119 @@
+@using Connapse.Core
+@using Connapse.Web.Components.Shared
+
+@*
+    Connapse's own Azure app identity — what it reads Blob storage with, and queries Entra and Azure
+    Resource Manager (role/deny assignments) through. A certificate-based app registration or a
+    managed identity; never a client secret. Stored under the Providers:Azure settings.
+*@
+
+<div class="row g-3" style="max-width:44rem">
+    <div class="col-12">
+        <label class="form-label" for="az-tenant">Directory (tenant) ID</label>
+        <input id="az-tenant" class="form-control font-monospace" @bind="tenantId"
+               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="az-tenant-help" />
+        <div id="az-tenant-help" class="form-text">The Entra tenant the app registration lives in.</div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="az-sub">Subscription ID</label>
+        <input id="az-sub" class="form-control font-monospace" @bind="subscriptionId"
+               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="az-sub-help" />
+        <div id="az-sub-help" class="form-text">
+            The subscription whose role and deny assignments per-user filtering reads. Required for
+            Azure permission filtering — without it, Azure searches fail closed.
+        </div>
+    </div>
+
+    <div class="col-12">
+        <hr class="my-1" />
+        <div class="small text-uppercase text-muted">App registration (certificate)</div>
+        <div class="form-text mt-0">Leave these blank to use the host's ambient managed identity instead.</div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="az-client">Application (client) ID</label>
+        <input id="az-client" class="form-control font-monospace" @bind="clientId"
+               placeholder="00000000-0000-0000-0000-000000000000" />
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="az-cert">Client certificate path</label>
+        <input id="az-cert" class="form-control font-monospace" @bind="certPath"
+               placeholder="/certs/azure.pem" aria-describedby="az-cert-help" />
+        <div id="az-cert-help" class="form-text">
+            Path on the Connapse host to the PEM or PFX the app registration trusts. Connapse reads
+            it; it is never uploaded here.
+        </div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="az-cert-pw">
+            Certificate password <span class="text-muted">(PFX only)</span>
+        </label>
+        <SecretTextArea Id="az-cert-pw" Multiline="false" @bind-Value="certPassword"
+                        Placeholder="@(Settings.ClientCertificatePassword is { Length: > 0 } ? "Leave blank to keep the stored password" : "Leave blank for a PEM certificate")"
+                        DescribedBy="az-cert-pw-help" />
+        <div id="az-cert-pw-help" class="form-text">
+            Only for a password-protected PFX. The stored value is never shown here; leave it blank to keep it.
+        </div>
+    </div>
+
+    <div class="col-12">
+        <hr class="my-1" />
+        <div class="small text-uppercase text-muted">Or a managed identity</div>
+    </div>
+
+    <div class="col-12">
+        <label class="form-label" for="az-mi">
+            User-assigned managed identity client ID <span class="text-muted">(optional)</span>
+        </label>
+        <input id="az-mi" class="form-control font-monospace" @bind="miClientId"
+               placeholder="Leave blank to use the certificate above, or the ambient identity"
+               aria-describedby="az-mi-help" />
+        <div id="az-mi-help" class="form-text">
+            On Azure, leave the certificate blank and Connapse uses the host's managed identity; set
+            this to pick a specific user-assigned one.
+        </div>
+    </div>
+</div>
+
+<div class="d-flex gap-2 mt-3">
+    <button type="button" class="btn btn-primary" @onclick="HandleSubmit">Save</button>
+    <button type="button" class="btn btn-outline-secondary" @onclick="Reset">Reset</button>
+</div>
+
+@code {
+    [Parameter] public AzureProviderSettings Settings { get; set; } = new();
+    [Parameter] public EventCallback<AzureProviderSettings> OnSave { get; set; }
+
+    // Local strings rather than binding the record directly: AzureProviderSettings is init-only, so
+    // it cannot be @bound; the record is rebuilt on save.
+    private string? tenantId, clientId, subscriptionId, certPath, certPassword, miClientId;
+
+    protected override void OnParametersSet()
+    {
+        tenantId = Settings.TenantId;
+        clientId = Settings.ClientId;
+        subscriptionId = Settings.SubscriptionId;
+        certPath = Settings.ClientCertificatePath;
+        // The stored password is never rehydrated into the browser; blank on save keeps it.
+        certPassword = null;
+        miClientId = Settings.UserAssignedManagedIdentityClientId;
+    }
+
+    private Task HandleSubmit() =>
+        OnSave.InvokeAsync(new AzureProviderSettings
+        {
+            TenantId = Trim(tenantId),
+            ClientId = Trim(clientId),
+            SubscriptionId = Trim(subscriptionId),
+            ClientCertificatePath = Trim(certPath),
+            ClientCertificatePassword = string.IsNullOrWhiteSpace(certPassword) ? Settings.ClientCertificatePassword : certPassword,
+            UserAssignedManagedIdentityClientId = Trim(miClientId),
+        });
+
+    private static string? Trim(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private void Reset() => OnParametersSet();
+}

--- a/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
+++ b/src/Connapse.Web/Components/Settings/AzureProviderSettingsTab.razor
@@ -1,82 +1,144 @@
 @using Connapse.Core
+@using Connapse.Storage.CloudScope
 @using Connapse.Web.Components.Shared
 
 @*
     Connapse's own Azure app identity — what it reads Blob storage with, and queries Entra and Azure
-    Resource Manager (role/deny assignments) through. A certificate-based app registration or a
-    managed identity; never a client secret. Stored under the Providers:Azure settings.
+    Resource Manager (role/deny assignments) through. A certificate-based app registration, a
+    user-assigned managed identity, or the managed identity of the host Connapse runs on; never a
+    client secret. Stored under the Providers:Azure settings.
 *@
+
+<p class="small text-muted mb-3">
+    Before you start: the identity needs a role that can read blobs on each storage account
+    (<em>Storage Blob Data Reader</em>, or the <em>@Connapse.Core.Utilities.AzureCloudShellSetup.BlobDataRoleName</em>
+    role the script creates). Per-user permissions also need
+    <em>@Connapse.Core.Utilities.AzureCloudShellSetup.RbacReadRoleName</em> on the subscription and the
+    <code>User.Read.All</code> and <code>GroupMember.Read.All</code> Microsoft Graph permissions with admin consent.
+</p>
 
 <div class="row g-3" style="max-width:44rem">
     <div class="col-12">
         <label class="form-label" for="az-tenant">Directory (tenant) ID</label>
         <input id="az-tenant" class="form-control font-monospace" @bind="tenantId"
-               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="az-tenant-help" />
-        <div id="az-tenant-help" class="form-text">The Entra tenant the app registration lives in.</div>
+               placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="az-tenant-help"
+               aria-invalid="@(problemField == "az-tenant" ? "true" : null)" />
+        <div id="az-tenant-help" class="form-text">
+            The Entra tenant the identity lives in. Shown on the
+            <a href="https://entra.microsoft.com/#view/Microsoft_AAD_IAM/TenantOverview.ReactView" target="_blank" rel="noopener">tenant overview</a>
+            in the Microsoft Entra admin center.
+        </div>
     </div>
 
     <div class="col-12">
-        <label class="form-label" for="az-sub">Subscription ID</label>
+        <fieldset>
+            <legend class="form-label fs-6 mb-2">How Connapse signs in to Azure</legend>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" name="az-auth" id="az-auth-cert"
+                       checked="@(mode == AuthMode.Certificate)" @onchange="() => ChooseAuth(AuthMode.Certificate)" />
+                <label class="form-check-label" for="az-auth-cert">
+                    App registration with a certificate
+                </label>
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" name="az-auth" id="az-auth-host"
+                       checked="@(mode == AuthMode.HostManagedIdentity)" @onchange="() => ChooseAuth(AuthMode.HostManagedIdentity)"
+                       aria-describedby="az-auth-host-help" />
+                <label class="form-check-label" for="az-auth-host">
+                    This host's managed identity — Connapse runs on Azure with a system-assigned identity
+                </label>
+            </div>
+            <div id="az-auth-host-help" class="form-text">
+                Nothing else to enter: Azure gives the host its identity. Assign the roles above to the
+                identity shown on the host's <strong>Identity</strong> page in the Azure portal.
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" name="az-auth" id="az-auth-mi"
+                       checked="@(mode == AuthMode.UserAssignedManagedIdentity)" @onchange="() => ChooseAuth(AuthMode.UserAssignedManagedIdentity)"
+                       aria-describedby="az-auth-mi-help" />
+                <label class="form-check-label" for="az-auth-mi">
+                    A user-assigned managed identity attached to this host
+                </label>
+            </div>
+            <div id="az-auth-mi-help" class="form-text">
+                Also no certificate; the identity is named by its client ID.
+            </div>
+        </fieldset>
+    </div>
+
+    @if (mode == AuthMode.Certificate)
+    {
+        <div class="col-12">
+            <label class="form-label" for="az-client">Application (client) ID</label>
+            <input id="az-client" class="form-control font-monospace" @bind="clientId"
+                   placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="az-client-help"
+                   aria-invalid="@(problemField == "az-client" ? "true" : null)" />
+            <div id="az-client-help" class="form-text">
+                On the app's Overview page under
+                <a href="https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade" target="_blank" rel="noopener">App registrations</a>.
+            </div>
+        </div>
+
+        <div class="col-12">
+            <label class="form-label" for="az-cert">Client certificate path</label>
+            <input id="az-cert" class="form-control font-monospace" @bind="certPath"
+                   placeholder="/certs/azure.pem" aria-describedby="az-cert-help"
+                   aria-invalid="@(problemField == "az-cert" ? "true" : null)" />
+            <div id="az-cert-help" class="form-text">
+                Path on the Connapse host to the PEM (certificate plus private key) or PFX whose public
+                certificate is uploaded under the app's <strong>Certificates &amp; secrets</strong>. Connapse
+                reads the file; it is never uploaded here.
+            </div>
+        </div>
+
+        <div class="col-12">
+            <label class="form-label" for="az-cert-pw">
+                Certificate password <span class="text-muted">(optional — PFX only)</span>
+            </label>
+            <SecretTextArea Id="az-cert-pw" Multiline="false" @bind-Value="certPassword"
+                            Placeholder="@(Settings.ClientCertificatePassword is { Length: > 0 } ? "Leave blank to keep the stored password" : "Leave blank for a PEM certificate")"
+                            DescribedBy="az-cert-pw-help" />
+            <div id="az-cert-pw-help" class="form-text">
+                Only for a password-protected PFX. The stored value is never shown here; leave it blank to keep it.
+            </div>
+        </div>
+    }
+    else if (mode == AuthMode.UserAssignedManagedIdentity)
+    {
+        <div class="col-12">
+            <label class="form-label" for="az-mi">Managed identity client ID</label>
+            <input id="az-mi" class="form-control font-monospace" @bind="miClientId"
+                   placeholder="00000000-0000-0000-0000-000000000000"
+                   aria-describedby="az-mi-help" aria-invalid="@(problemField == "az-mi" ? "true" : null)" />
+            <div id="az-mi-help" class="form-text">
+                The Client ID shown on the identity's Overview page under
+                <a href="https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.ManagedIdentity%2FuserAssignedIdentities" target="_blank" rel="noopener">Managed Identities</a>
+                in the Azure portal.
+            </div>
+        </div>
+    }
+
+    <div class="col-12">
+        <label class="form-label" for="az-sub">
+            Subscription ID <span class="text-muted">(optional — needed for per-user permissions and the account list)</span>
+        </label>
         <input id="az-sub" class="form-control font-monospace" @bind="subscriptionId"
                placeholder="00000000-0000-0000-0000-000000000000" aria-describedby="az-sub-help" />
         <div id="az-sub-help" class="form-text">
-            The subscription whose role and deny assignments per-user filtering reads. Required for
-            Azure permission filtering — without it, Azure searches fail closed.
-        </div>
-    </div>
-
-    <div class="col-12">
-        <hr class="my-1" />
-        <div class="small text-uppercase text-muted">App registration (certificate)</div>
-        <div class="form-text mt-0">Leave these blank to use the host's ambient managed identity instead.</div>
-    </div>
-
-    <div class="col-12">
-        <label class="form-label" for="az-client">Application (client) ID</label>
-        <input id="az-client" class="form-control font-monospace" @bind="clientId"
-               placeholder="00000000-0000-0000-0000-000000000000" />
-    </div>
-
-    <div class="col-12">
-        <label class="form-label" for="az-cert">Client certificate path</label>
-        <input id="az-cert" class="form-control font-monospace" @bind="certPath"
-               placeholder="/certs/azure.pem" aria-describedby="az-cert-help" />
-        <div id="az-cert-help" class="form-text">
-            Path on the Connapse host to the PEM or PFX the app registration trusts. Connapse reads
-            it; it is never uploaded here.
-        </div>
-    </div>
-
-    <div class="col-12">
-        <label class="form-label" for="az-cert-pw">
-            Certificate password <span class="text-muted">(PFX only)</span>
-        </label>
-        <SecretTextArea Id="az-cert-pw" Multiline="false" @bind-Value="certPassword"
-                        Placeholder="@(Settings.ClientCertificatePassword is { Length: > 0 } ? "Leave blank to keep the stored password" : "Leave blank for a PEM certificate")"
-                        DescribedBy="az-cert-pw-help" />
-        <div id="az-cert-pw-help" class="form-text">
-            Only for a password-protected PFX. The stored value is never shown here; leave it blank to keep it.
-        </div>
-    </div>
-
-    <div class="col-12">
-        <hr class="my-1" />
-        <div class="small text-uppercase text-muted">Or a managed identity</div>
-    </div>
-
-    <div class="col-12">
-        <label class="form-label" for="az-mi">
-            User-assigned managed identity client ID <span class="text-muted">(optional)</span>
-        </label>
-        <input id="az-mi" class="form-control font-monospace" @bind="miClientId"
-               placeholder="Leave blank to use the certificate above, or the ambient identity"
-               aria-describedby="az-mi-help" />
-        <div id="az-mi-help" class="form-text">
-            On Azure, leave the certificate blank and Connapse uses the host's managed identity; set
-            this to pick a specific user-assigned one.
+            The subscription holding the storage accounts. Per-user filtering reads role assignments from
+            it, and the connection form lists its accounts. Copy it from
+            <a href="https://portal.azure.com/#view/Microsoft_Azure_Billing/SubscriptionsBladeV2" target="_blank" rel="noopener">Subscriptions</a>
+            in the Azure portal.
         </div>
     </div>
 </div>
+
+@if (problem is not null)
+{
+    <div class="alert alert-danger py-2 mt-3 mb-0 small" role="alert">
+        <span class="bi-x-circle me-1" aria-hidden="true"></span>@problem
+    </div>
+}
 
 <div class="d-flex gap-2 mt-3">
     <button type="button" class="btn btn-primary" @onclick="HandleSubmit">Save</button>
@@ -87,12 +149,32 @@
     [Parameter] public AzureProviderSettings Settings { get; set; } = new();
     [Parameter] public EventCallback<AzureProviderSettings> OnSave { get; set; }
 
+    private enum AuthMode { Certificate, HostManagedIdentity, UserAssignedManagedIdentity }
+
     // Local strings rather than binding the record directly: AzureProviderSettings is init-only, so
     // it cannot be @bound; the record is rebuilt on save.
     private string? tenantId, clientId, subscriptionId, certPath, certPassword, miClientId;
 
+    /// <summary>Which branch of the form is shown, read from what is stored; the certificate app,
+    /// which is what the easy setup off Azure produces, when nothing says otherwise.</summary>
+    private AuthMode mode;
+
+    /// <summary>The first thing stopping a save, and the id of the field it is about; null until Save is tried.</summary>
+    private string? problem, problemField;
+
+    /// <summary>Which stored settings this form was last loaded from. Parameters arrive again on every
+    /// parent render; only a different record means the values on screen should be replaced.</summary>
+    private AzureProviderSettings? loadedFrom;
+
     protected override void OnParametersSet()
     {
+        if (ReferenceEquals(Settings, loadedFrom)) return;
+        Load();
+    }
+
+    private void Load()
+    {
+        loadedFrom = Settings;
         tenantId = Settings.TenantId;
         clientId = Settings.ClientId;
         subscriptionId = Settings.SubscriptionId;
@@ -100,20 +182,85 @@
         // The stored password is never rehydrated into the browser; blank on save keeps it.
         certPassword = null;
         miClientId = Settings.UserAssignedManagedIdentityClientId;
+        mode = AzureCredentialChainFactory.IsHostManagedIdentity(Settings) ? AuthMode.HostManagedIdentity
+            : AzureCredentialChainFactory.IsUserAssignedManagedIdentity(Settings) ? AuthMode.UserAssignedManagedIdentity
+            : AuthMode.Certificate;
     }
 
-    private Task HandleSubmit() =>
-        OnSave.InvokeAsync(new AzureProviderSettings
+    private void ChooseAuth(AuthMode chosen)
+    {
+        mode = chosen;
+        problem = problemField = null;
+    }
+
+    /// <summary>What is missing for the chosen branch, checked only when Save is pressed.</summary>
+    private (string Message, string Field)? Validate()
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            return ("Enter the Directory (tenant) ID.", "az-tenant");
+        // A managed identity's token names its tenant by id, and the check that compares the two
+        // needs an id on this side too; a certificate app may also use a verified domain name.
+        if (mode != AuthMode.Certificate && !Guid.TryParse(tenantId.Trim(), out _))
+            return ("Enter the Directory (tenant) ID as its ID — the GUID shown on the tenant overview.", "az-tenant");
+        return mode switch
+        {
+            AuthMode.HostManagedIdentity => null,
+            AuthMode.UserAssignedManagedIdentity when string.IsNullOrWhiteSpace(miClientId) =>
+                ("Enter the managed identity's client ID.", "az-mi"),
+            AuthMode.UserAssignedManagedIdentity => null,
+            _ when string.IsNullOrWhiteSpace(clientId) => ("Enter the Application (client) ID.", "az-client"),
+            _ when string.IsNullOrWhiteSpace(certPath) => ("Enter the path to the client certificate on the Connapse host.", "az-cert"),
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Saves only the chosen branch. The credential chain refuses a half-filled certificate setup
+    /// rather than falling back to a managed identity, so switching branches must clear the other
+    /// ones' fields instead of leaving them to trip that check.
+    /// </summary>
+    private Task HandleSubmit()
+    {
+        if (Validate() is { } failed)
+        {
+            (problem, problemField) = failed;
+            return Task.CompletedTask;
+        }
+
+        problem = problemField = null;
+        bool certificate = mode == AuthMode.Certificate;
+        bool userAssigned = mode == AuthMode.UserAssignedManagedIdentity;
+        return OnSave.InvokeAsync(new AzureProviderSettings
         {
             TenantId = Trim(tenantId),
-            ClientId = Trim(clientId),
             SubscriptionId = Trim(subscriptionId),
-            ClientCertificatePath = Trim(certPath),
-            ClientCertificatePassword = string.IsNullOrWhiteSpace(certPassword) ? Settings.ClientCertificatePassword : certPassword,
-            UserAssignedManagedIdentityClientId = Trim(miClientId),
+            ClientId = certificate ? Trim(clientId) : null,
+            ClientCertificatePath = certificate ? Trim(certPath) : null,
+            ClientCertificatePassword = !certificate ? null
+                : string.IsNullOrWhiteSpace(certPassword) ? Settings.ClientCertificatePassword : certPassword,
+            UserAssignedManagedIdentityClientId = userAssigned ? Trim(miClientId) : null,
+            UseHostManagedIdentity = mode == AuthMode.HostManagedIdentity,
+            // Only the guided setup learns the principal, and it belongs to one identity: it is kept
+            // only while the identity is the same one — the host's, or the same user-assigned client
+            // id. Carried onto a different identity it would send the permissions script's Graph
+            // grants to the wrong principal.
+            ManagedIdentityPrincipalId = mode switch
+            {
+                AuthMode.HostManagedIdentity when Settings.UseHostManagedIdentity => Settings.ManagedIdentityPrincipalId,
+                AuthMode.UserAssignedManagedIdentity
+                    when !Settings.UseHostManagedIdentity
+                    && string.Equals(Trim(miClientId), Settings.UserAssignedManagedIdentityClientId, StringComparison.OrdinalIgnoreCase)
+                    => Settings.ManagedIdentityPrincipalId,
+                _ => null,
+            },
         });
+    }
 
     private static string? Trim(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
-    private void Reset() => OnParametersSet();
+    private void Reset()
+    {
+        Load();
+        problem = problemField = null;
+    }
 }

--- a/src/Connapse.Web/Components/Settings/ConnectionForm.cs
+++ b/src/Connapse.Web/Components/Settings/ConnectionForm.cs
@@ -23,6 +23,12 @@ public sealed record ConnectionForm
     public string? Region { get; set; }
     public string? RoleArn { get; set; }
 
+    // AzureBlob
+    public string? StorageAccountName { get; set; }
+
+    /// <summary>Overrides https://{account}.blob.core.windows.net — Azurite or another local emulator.</summary>
+    public string? BlobEndpoint { get; set; }
+
     // Filesystem and SFTP both bound a source with a root, so this is shared.
     public string? AllowedRoot { get; set; }
 
@@ -66,7 +72,7 @@ public sealed record ConnectionForm
     /// </para>
     /// </summary>
     public bool IsCloudProvider =>
-        Provider is ConnectionProvider.S3;
+        Provider is ConnectionProvider.S3 or ConnectionProvider.AzureBlob;
 
 
     /// <summary>
@@ -187,6 +193,8 @@ public sealed record ConnectionForm
 
         form.Region = Str(node, "region");
         form.RoleArn = Str(node, "roleArn");
+        form.StorageAccountName = Str(node, "accountName");
+        form.BlobEndpoint = Str(node, "blobEndpoint");
         form.AllowedRoot = Str(node, "allowedRoot");
         form.Host = Str(node, "host");
         form.Username = Str(node, "username");
@@ -236,6 +244,11 @@ public sealed record ConnectionForm
             case ConnectionProvider.S3:
                 node["region"] = Blank(Region) ? "us-east-1" : Region!.Trim();
                 if (!Blank(RoleArn)) node["roleArn"] = RoleArn!.Trim();
+                break;
+
+            case ConnectionProvider.AzureBlob:
+                node["accountName"] = StorageAccountName?.Trim() ?? "";
+                if (!Blank(BlobEndpoint)) node["blobEndpoint"] = BlobEndpoint!.Trim();
                 break;
 
             case ConnectionProvider.Filesystem:
@@ -302,6 +315,24 @@ public sealed record ConnectionForm
     }
 
     /// <summary>
+    /// The container (and optional prefix) to test a cloud connection against: the
+    /// operator-entered probe target when there is one, otherwise the first allowed location,
+    /// and null when neither is available.
+    /// <para>
+    /// Extracted so "nothing to test against" can be told apart from "test some
+    /// account-wide default container" by the caller. Azure storage accounts do not
+    /// auto-create a root container the way S3 always has a bucket once one is named, so a
+    /// caller that turned a null here into a guessed container name would report a perfectly
+    /// valid account as unreachable.
+    /// </para>
+    /// </summary>
+    public (string Container, string? Prefix)? ResolveProbeTarget(string? probeTarget)
+    {
+        string? target = string.IsNullOrWhiteSpace(probeTarget) ? FirstAllowedLocation() : probeTarget.Trim();
+        return target is null ? null : SplitLocation(target);
+    }
+
+    /// <summary>
     /// The credential to store, or null to leave any existing one untouched.
     /// </summary>
     /// <remarks>
@@ -332,6 +363,8 @@ public sealed record ConnectionForm
 
         return Provider switch
         {
+            ConnectionProvider.AzureBlob when Blank(StorageAccountName) => "A storage account name is required.",
+
             ConnectionProvider.Filesystem when Blank(AllowedRoot) => "Choose an allowed root.",
 
             ConnectionProvider.Sftp when Blank(Host) => "A host is required.",

--- a/src/Connapse.Web/Components/Settings/ConnectionForm.cs
+++ b/src/Connapse.Web/Components/Settings/ConnectionForm.cs
@@ -247,7 +247,9 @@ public sealed record ConnectionForm
                 break;
 
             case ConnectionProvider.AzureBlob:
-                node["accountName"] = StorageAccountName?.Trim() ?? "";
+                // Stored as Azure spells it. Role and deny assignments name the account in lower
+                // case, and the resource URIs the permission checks compare are built from this.
+                node["accountName"] = StorageAccountName?.Trim().ToLowerInvariant() ?? "";
                 if (!Blank(BlobEndpoint)) node["blobEndpoint"] = BlobEndpoint!.Trim();
                 break;
 
@@ -364,6 +366,10 @@ public sealed record ConnectionForm
         return Provider switch
         {
             ConnectionProvider.AzureBlob when Blank(StorageAccountName) => "A storage account name is required.",
+            // The endpoint must be the named account's: documents are labelled and authorised by
+            // the account name, so an endpoint reading a different one would mislabel everything.
+            ConnectionProvider.AzureBlob when AzureBlobEndpoint.Validate(StorageAccountName, BlobEndpoint, out _) is { } endpointProblem =>
+                endpointProblem,
 
             ConnectionProvider.Filesystem when Blank(AllowedRoot) => "Choose an allowed root.",
 

--- a/src/Connapse.Web/Components/Settings/SourceForm.cs
+++ b/src/Connapse.Web/Components/Settings/SourceForm.cs
@@ -55,6 +55,11 @@ public sealed record SourceForm
                 if (!Blank(Prefix)) node["prefix"] = Prefix!.Trim();
                 break;
 
+            case ConnectionProvider.AzureBlob:
+                node["containerName"] = Container?.Trim() ?? "";
+                if (!Blank(Prefix)) node["prefix"] = Prefix!.Trim();
+                break;
+
             // One case for both. The SFTP scope was deliberately given the same shape as the
             // filesystem one so that this form, the preflight and the scope summary each gained
             // a provider here rather than a parallel implementation to keep in step.
@@ -93,6 +98,9 @@ public sealed record SourceForm
 
         if (provider is ConnectionProvider.S3 && Blank(Container))
             return "A bucket name is required.";
+
+        if (provider is ConnectionProvider.AzureBlob && Blank(Container))
+            return "A container name is required.";
 
         if (SyncIntervalSeconds is { } interval && interval < 60)
             return "Sync interval must be at least 60 seconds.";

--- a/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
@@ -1,6 +1,8 @@
 using System.Security.Claims;
+using System.Security.Cryptography;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Core.Utilities;
 using Connapse.Identity.Services;
 using ITfoxtec.Identity.Saml2;
 using Microsoft.AspNetCore.Http;
@@ -22,6 +24,19 @@ public static class CloudIdentityEndpoints
     private const string SamlConfirmCookieName = "__connapse_aws_link";
 
     private const string SamlConfirmCookiePath = "/api/v1/auth/cloud/aws";
+
+    /// <summary>Carries the one-time code that claims a validated Entra id_token outcome.</summary>
+    /// <remarks>
+    /// Same rationale as <see cref="SamlConfirmCookieName"/>: not readable by script, not in
+    /// browser history, not something a person could paste to somebody else. Unlike the AWS
+    /// cookie, this one is set on a same-site top-level redirect rather than a cross-site POST —
+    /// but the same-site session cookie present on that request is exactly what an attacker who
+    /// merely captured the /azure/connect URL and sent it to a colleague never gets to see, which
+    /// is the property this whole confirm hop exists to use.
+    /// </remarks>
+    private const string AzureConfirmCookieName = "__connapse_azure_link";
+
+    private const string AzureConfirmCookiePath = "/api/v1/auth/cloud/azure";
 
     public static IEndpointRouteBuilder MapCloudIdentityEndpoints(this IEndpointRouteBuilder app)
     {
@@ -217,10 +232,168 @@ public static class CloudIdentityEndpoints
             return Results.Redirect("/profile/integrations");
         }).RequireAuthorization();
 
+        // --- Azure (Entra user identity link) ---
+        //
+        // Same purpose as the AWS link above — a per-user record so search can resolve Entra
+        // permissions, holding no credential of its own — but the sign-in itself is OIDC
+        // authorization-code + PKCE against Entra ID rather than SAML against Identity Center.
+        //
+        // This still needs the same confirm hop AWS uses, even though the callback below is a
+        // same-site top-level GET (unlike AWS's cross-site POST) and so may well carry a session
+        // cookie. `state` only proves the callback belongs to a sign-in this deployment started —
+        // it does not prove the browser completing it is the browser that started it. Anybody
+        // with a Connapse account can call /azure/connect, capture the resulting Entra
+        // authorization URL without following it, and send it to a colleague; the colleague's own
+        // genuine Entra sign-in then returns here carrying the attacker's `state`, with a valid
+        // PKCE exchange (bound to the code, not to a person) and a matching `nonce` (it was in the
+        // request the colleague actually completed). Saving at this point would link the
+        // attacker's Connapse account to the colleague's Entra identity. So, exactly like AWS, the
+        // validated outcome is parked and claimed at /azure/confirm, where a session exists and
+        // can be checked against who started the sign-in.
+
+        // GET /api/v1/auth/cloud/azure/connect — send the browser to Entra ID.
+        group.MapGet("/azure/connect", (
+            HttpContext http,
+            [FromServices] IOptionsMonitor<AzureAdSignInSettings> settings,
+            [FromServices] AzureSignInRequests pending) =>
+        {
+            var userId = GetUserId(http);
+            if (userId is null) return Results.Unauthorized();
+
+            var azureAd = settings.CurrentValue;
+            if (!azureAd.IsConfigured)
+                return Results.Redirect("/profile/integrations?error=azure_not_configured");
+
+            var (verifier, challenge) = OidcPkce.Create();
+            string state = GenerateRandomToken();
+            string nonce = GenerateRandomToken();
+
+            // Recorded before redirecting: the callback below trusts `state` to name a sign-in
+            // this deployment actually started, and consumes it exactly once.
+            pending.Add(new AzurePendingSignIn(state, verifier, nonce, userId.Value, DateTime.UtcNow.AddMinutes(10)));
+
+            return Results.Redirect(AzureAuthorizationUrl.Build(azureAd, state, nonce, challenge));
+        }).RequireAuthorization();
+
+        // GET /api/v1/auth/cloud/azure/callback — where Entra redirects back with the code.
+        //
+        // Anonymous, and deliberately saves nothing — see the remark above. Every step still
+        // fails closed: an unknown/expired state, a failed exchange, a failed validation, or any
+        // other exception all take the same generic error redirect, so no internal detail (an
+        // exception message, a validator's rejection reason) ever reaches the query string.
+        group.MapGet("/azure/callback", async (
+            HttpContext http,
+            string? code,
+            string? state,
+            [FromServices] AzureSignInRequests pending,
+            [FromServices] IOidcTokenExchanger exchanger,
+            [FromServices] AzureIdTokenValidator validator,
+            [FromServices] AzureLinkConfirmations confirmations,
+            [FromServices] ILoggerFactory loggerFactory,
+            CancellationToken ct) =>
+        {
+            var logger = loggerFactory.CreateLogger("CloudIdentityEndpoints.Azure");
+
+            try
+            {
+                AzurePendingSignIn? p = string.IsNullOrEmpty(state) ? null : pending.TakeByState(state);
+                if (p is null)
+                {
+                    logger.LogWarning(
+                        "An Entra callback arrived for a sign-in this deployment did not start or that already expired");
+                    return Results.Redirect("/profile/integrations?error=azure_link_failed");
+                }
+
+                string raw = await exchanger.ExchangeAsync(code ?? string.Empty, p.CodeVerifier, ct);
+                AzureIdTokenResult r = await validator.ValidateAsync(raw, p.Nonce, ct);
+
+                if (!r.Ok)
+                {
+                    // r.Error may echo exception text or a validator message — never put it in
+                    // the redirect a browser can carry in history; log it server-side instead.
+                    logger.LogWarning("Entra id_token validation failed: {Error}", LogSanitizer.Sanitize(r.Error ?? "unknown"));
+                    return Results.Redirect("/profile/integrations?error=azure_link_failed");
+                }
+
+                // Parked, not saved — StartedByUserId travels with it and is checked against the
+                // session at /azure/confirm before anything is written.
+                string confirmCode = confirmations.Start(new PendingAzureLink(
+                    p.UserId, r.ObjectId!, r.TenantId!, r.DisplayName ?? ""));
+
+                http.Response.Cookies.Append(AzureConfirmCookieName, confirmCode, new CookieOptions
+                {
+                    HttpOnly = true,
+                    Secure = http.Request.IsHttps,
+                    SameSite = SameSiteMode.Lax,
+                    MaxAge = AzureLinkConfirmations.Lifetime,
+                    Path = AzureConfirmCookiePath,
+                });
+
+                return Results.Redirect("/api/v1/auth/cloud/azure/confirm");
+            }
+            catch (Exception ex)
+            {
+                // Fail closed on anything unanticipated (a network failure in the exchange, a
+                // malformed response, ...): nothing gets parked or stored on an exception either.
+                logger.LogWarning(ex, "Entra sign-in callback failed");
+                return Results.Redirect("/profile/integrations?error=azure_link_failed");
+            }
+        }).AllowAnonymous();
+
+        // GET /api/v1/auth/cloud/azure/confirm — where the link is actually saved.
+        //
+        // Reached by a same-site top-level redirect, so the session cookie is present. Two things
+        // must agree before anything is written: the browser must hold the confirmation cookie
+        // the callback set, and the signed-in user must be the one who started the sign-in.
+        //
+        // That is what closes the attack described above. An attacker who starts a sign-in and
+        // has a colleague complete it never receives the cookie — it is HttpOnly in the
+        // colleague's browser — and the colleague, who does hold it, is not the user the sign-in
+        // was started by. Neither of them can save the link.
+        group.MapGet("/azure/confirm", async (
+            HttpContext http,
+            [FromServices] AzureLinkConfirmations confirmations,
+            [FromServices] IAzureIdentityLinkService linkService,
+            [FromServices] ILoggerFactory loggerFactory,
+            CancellationToken ct) =>
+        {
+            var logger = loggerFactory.CreateLogger("CloudIdentityEndpoints.Azure");
+
+            string? code = http.Request.Cookies[AzureConfirmCookieName];
+            http.Response.Cookies.Delete(
+                AzureConfirmCookieName, new CookieOptions { Path = AzureConfirmCookiePath });
+
+            var userId = GetUserId(http);
+            if (userId is null) return Results.Unauthorized();
+
+            // Single-use, so an interrupted confirmation cannot be retried from history.
+            var link = confirmations.Consume(code);
+            if (link is null)
+            {
+                logger.LogWarning("An Entra link confirmation arrived without a claim this deployment issued");
+                return Results.Redirect("/profile/integrations?error=azure_link_failed");
+            }
+
+            if (link.StartedByUserId != userId.Value)
+            {
+                // The cross-user case. Worth a warning rather than an information line: the
+                // ordinary flow cannot produce it, so it means somebody completed a sign-in that
+                // somebody else began.
+                logger.LogWarning(
+                    "An Entra sign-in was completed by a different user than the one who started it; refusing to link");
+                return Results.Redirect("/profile/integrations?error=azure_link_failed");
+            }
+
+            await linkService.StoreAsync(userId.Value, link.ObjectId, link.TenantId, link.DisplayName, ct);
+
+            return Results.Redirect("/profile/integrations");
+        }).RequireAuthorization();
+
         group.MapDelete("/{provider}", async (
             string provider,
             HttpContext httpContext,
             [FromServices] IAwsIdentityLinkService awsLinks,
+            [FromServices] IAzureIdentityLinkService azureLinks,
             [FromServices] IConnectorScopeCache scopeCache,
             [FromServices] ISourceStore sourceStore,
             [FromServices] IConnectionStore connectionStore,
@@ -229,8 +402,24 @@ public static class CloudIdentityEndpoints
             var userId = GetUserId(httpContext);
             if (userId is null) return Results.Unauthorized();
 
-            if (!Enum.TryParse<CloudProvider>(provider, ignoreCase: true, out var cloudProvider) || cloudProvider != CloudProvider.AWS)
-                return Results.BadRequest(new { error = "invalid_provider", message = $"Unknown provider: {provider}. Valid values: AWS." });
+            if (!Enum.TryParse<CloudProvider>(provider, ignoreCase: true, out var cloudProvider)
+                || cloudProvider is not (CloudProvider.AWS or CloudProvider.Azure))
+            {
+                return Results.BadRequest(new
+                {
+                    error = "invalid_provider",
+                    message = $"Unknown provider: {provider}. Valid values: AWS, Azure."
+                });
+            }
+
+            if (cloudProvider == CloudProvider.Azure)
+            {
+                // Azure links hold no cloud-scoped search permissions yet — the scope cache only
+                // ever gets populated for S3 sources today, so there is nothing Azure-shaped to
+                // invalidate here. Wiring that up is Phase 4's job (#478 covers only the link).
+                bool azureDeleted = await azureLinks.DisconnectAsync(userId.Value, ct);
+                return azureDeleted ? Results.NoContent() : Results.NotFound();
+            }
 
             // AWS links live in their own store, the one the integrations page reads and
             // deletes through; the cloud-identity table this route used to consult never holds
@@ -283,4 +472,13 @@ public static class CloudIdentityEndpoints
         var idClaim = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
         return Guid.TryParse(idClaim, out var id) ? id : null;
     }
+
+    /// <summary>
+    /// A CSPRNG-sourced, base64url-encoded random value for use as an OAuth <c>state</c> or OIDC
+    /// <c>nonce</c> — both need to be unguessable, not merely unique, since either being
+    /// predictable would let an attacker forge a callback for a sign-in they never started.
+    /// </summary>
+    private static string GenerateRandomToken() =>
+        Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))
+            .TrimEnd('=').Replace('+', '-').Replace('/', '_');
 }

--- a/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
@@ -414,9 +414,8 @@ public static class CloudIdentityEndpoints
 
             if (cloudProvider == CloudProvider.Azure)
             {
-                // Azure links hold no cloud-scoped search permissions yet — the scope cache only
-                // ever gets populated for S3 sources today, so there is nothing Azure-shaped to
-                // invalidate here. Wiring that up is Phase 4's job (#478 covers only the link).
+                // Azure permissions are resolved live per search hit rather than cached against
+                // the link, so removing the link is the whole revocation.
                 bool azureDeleted = await azureLinks.DisconnectAsync(userId.Value, ct);
                 return azureDeleted ? Results.NoContent() : Results.NotFound();
             }

--- a/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
+++ b/src/Connapse.Web/Endpoints/CloudIdentityEndpoints.cs
@@ -270,7 +270,7 @@ public static class CloudIdentityEndpoints
 
             // Recorded before redirecting: the callback below trusts `state` to name a sign-in
             // this deployment actually started, and consumes it exactly once.
-            pending.Add(new AzurePendingSignIn(state, verifier, nonce, userId.Value, DateTime.UtcNow.AddMinutes(10)));
+            pending.Add(new AzurePendingSignIn(state, verifier, nonce, userId.Value, DateTime.UtcNow.AddMinutes(10), StartedAtUtc: DateTime.UtcNow));
 
             return Results.Redirect(AzureAuthorizationUrl.Build(azureAd, state, nonce, challenge));
         }).RequireAuthorization();

--- a/src/Connapse.Web/Program.cs
+++ b/src/Connapse.Web/Program.cs
@@ -100,7 +100,7 @@ builder.Services.AddHostedService(sp => sp.GetRequiredService<SourceSyncService>
 // Carries an existing deployment's per-user permissions across the upgrade that separated
 // "enforcing" from "configured". Without it, an installation that already had filtering working
 // would come back up unfiltered -- the exact failure that separation exists to prevent.
-builder.Services.AddHostedService<SamlEnforcementLatch>();
+builder.Services.AddHostedService<CloudEnforcementLatch>();
 
 // Tracks background reindex state so admins can see success/failure via the status endpoint.
 builder.Services.AddSingleton<ReindexStateService>();

--- a/src/Connapse.Web/Services/CloudEnforcementLatch.cs
+++ b/src/Connapse.Web/Services/CloudEnforcementLatch.cs
@@ -35,14 +35,19 @@ namespace Connapse.Web.Services;
 /// It only ever turns enforcement on, and only when the effective configuration is complete.
 /// Switching it off is an administrator's decision and has its own path through the UI.
 /// </para>
+/// <para>
+/// Enforcement is opt-in via SAML or Azure AD, either one. A deployment that configured either
+/// identity provider had per-user permissions working, so either configuration latches it.
+/// </para>
 /// </remarks>
-public sealed class SamlEnforcementLatch(
+public sealed class CloudEnforcementLatch(
     IServiceScopeFactory scopes,
     IOptionsMonitor<SamlSignInSettings> signIn,
+    IOptionsMonitor<AzureAdSignInSettings> azureAd,
     IOptionsMonitor<PermissionEnforcementSettings> enforcement,
     EnforcementMigration migration,
     ISettingsReloader settingsReloader,
-    ILogger<SamlEnforcementLatch> logger) : IHostedService
+    ILogger<CloudEnforcementLatch> logger) : IHostedService
 {
     public async Task StartAsync(CancellationToken cancellationToken)
     {
@@ -62,35 +67,38 @@ public sealed class SamlEnforcementLatch(
                 return;
             }
 
-            // Already recorded, by a previous boot or by an administrator saving the settings.
-            if (enforcement.CurrentValue.IsEnforcing)
-            {
-                migration.Complete();
-                return;
-            }
+            // Enforcement is opt-in and latches PER identity provider, independently. Each provider
+            // that is configured now, or was already marked as enforcing, stays enforcing; a provider
+            // that was never configured stays unfiltered. The two markers must not be conflated:
+            // sharing one bit would make configuring Azure AD flip SAML/AWS into "enforcing but
+            // unusable", hiding every S3 document (and vice versa).
+            PermissionEnforcementSettings current = enforcement.CurrentValue;
+            bool samlLatched = current.IsEnforcing || signIn.CurrentValue.IsConfigured;
+            bool azureLatched = current.AzureEnforcing || azureAd.CurrentValue.IsConfigured;
 
-            // Never set this up. A deployment that does not filter stays unrestricted, which is the
-            // documented default and the only legitimate one.
-            if (!signIn.CurrentValue.IsConfigured)
+            // Nothing new to latch (a fresh install, or a steady-state boot): leave the stored row
+            // untouched so no SAML/Azure value is ever copied into a shadowing row.
+            if (samlLatched == current.IsEnforcing && azureLatched == current.AzureEnforcing)
             {
                 migration.Complete();
                 return;
             }
 
             // Configured but unmarked: filtering was in force under the old rule, so it stays in
-            // force. Only the marker is written -- no SAML value is copied anywhere.
+            // force. Only the markers are written -- no sign-in value is copied anywhere.
             await using var scope = scopes.CreateAsyncScope();
             var settings = scope.ServiceProvider.GetRequiredService<ISettingsStore>();
 
             await settings.SaveAsync(
                 PermissionEnforcementSettings.Category,
-                new PermissionEnforcementSettings { IsEnforcing = true },
+                new PermissionEnforcementSettings { IsEnforcing = samlLatched, AzureEnforcing = azureLatched },
                 cancellationToken);
 
             migration.Complete();
 
             logger.LogInformation(
-                "Per-user search permissions were already configured; recorded that this deployment enforces them");
+                "Per-user search permissions were already configured; recorded that this deployment enforces them (SAML={SamlEnforcing}, Azure={AzureEnforcing})",
+                samlLatched, azureLatched);
         }
         catch (Exception ex)
         {

--- a/src/Connapse.Web/Services/CloudEnforcementLatch.cs
+++ b/src/Connapse.Web/Services/CloudEnforcementLatch.cs
@@ -89,10 +89,30 @@ public sealed class CloudEnforcementLatch(
             await using var scope = scopes.CreateAsyncScope();
             var settings = scope.ServiceProvider.GetRequiredService<ISettingsStore>();
 
-            await settings.SaveAsync(
+            // A merge under the store's lock, not a replace: a save on the Providers page can be
+            // latching the other provider at this same moment, and a replace from this snapshot
+            // would switch that one back off. A latch only ever goes on, so the merge is an OR.
+            PermissionEnforcementSettings merged = await settings.UpdateAsync<PermissionEnforcementSettings>(
                 PermissionEnforcementSettings.Category,
-                new PermissionEnforcementSettings { IsEnforcing = samlLatched, AzureEnforcing = azureLatched },
+                stored => new PermissionEnforcementSettings
+                {
+                    IsEnforcing = (stored?.IsEnforcing ?? false) || samlLatched,
+                    AzureEnforcing = (stored?.AzureEnforcing ?? false) || azureLatched,
+                },
                 cancellationToken);
+
+            // Stored is not applied. The resolvers read the live options, and the store's reload
+            // after its commit can fail; completing the migration then would declare a flag that
+            // this process cannot see, and the resolver would answer unfiltered. Undetermined
+            // denies, which is the right posture until the next successful reload.
+            PermissionEnforcementSettings live = enforcement.CurrentValue;
+            if (live.IsEnforcing != merged.IsEnforcing || live.AzureEnforcing != merged.AzureEnforcing)
+            {
+                logger.LogError(
+                    "Per-user enforcement was recorded (SAML={SamlEnforcing}, Azure={AzureEnforcing}) but the stored settings could not be reloaded into this process; searches will be refused until Connapse is restarted with the database reachable",
+                    merged.IsEnforcing, merged.AzureEnforcing);
+                return;
+            }
 
             migration.Complete();
 

--- a/src/Connapse.Web/Services/ProviderSetupReader.cs
+++ b/src/Connapse.Web/Services/ProviderSetupReader.cs
@@ -1,5 +1,6 @@
 ﻿using Connapse.Core;
 using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
 using Microsoft.Extensions.Options;
 
 namespace Connapse.Web.Services;
@@ -19,6 +20,8 @@ public class ProviderSetupReader(
     IOptionsMonitor<AzureProviderSettings> azureProvider,
     IOptionsMonitor<AzureAdSignInSettings> azureAd,
     IS3Discovery s3Discovery,
+    IAzureBlobDiscovery azureDiscovery,
+    IOptionsMonitor<PermissionEnforcementSettings> enforcement,
     IConnectionStore connections,
     IProviderCredentialStore credentials,
     TimeProvider clock,
@@ -56,8 +59,11 @@ public class ProviderSetupReader(
     {
         var providers = await InUseProvidersAsync(ct);
 
-        var azureAccess = AzureAccess(azureProvider.CurrentValue);
-        var azurePermissions = AzurePerUserPermissions(azureAd.CurrentValue, azureProvider.CurrentValue);
+        // Two round trips to Entra, made together: a page load should not pay for them in series.
+        Task<ProviderRequirement> azureAccessTask = AzureAccessAsync(azureProvider.CurrentValue, ct);
+        Task<ProviderRequirement> azurePermissionsTask = AzurePerUserPermissionsAsync(azureAd.CurrentValue, azureProvider.CurrentValue, ct);
+        var azureAccess = await azureAccessTask;
+        var azurePermissions = await azurePermissionsTask;
 
         return
         [
@@ -80,16 +86,19 @@ public class ProviderSetupReader(
     }
 
     /// <summary>
-    /// Whether Connapse has an Azure app identity to read Blob storage (and Entra/ARM) with.
+    /// Whether Connapse has an Azure app identity to read Blob storage (and Entra/ARM) with, and
+    /// whether Entra still accepts it.
     /// </summary>
     /// <remarks>
-    /// Config-only for now — it reports whether a tenant and a credential are set, not a live probe.
     /// A credential is a certificate-based app registration (<c>ClientId</c> + a certificate) or a
-    /// user-assigned managed identity. An ambient <i>system</i>-assigned managed identity cannot be
-    /// seen from settings, so a deployment relying on one reads as not-configured here even when it
-    /// works; a later iteration adds a live check (parity with AWS's access probe).
+    /// user-assigned managed identity; a deployment relying on an ambient system-assigned identity
+    /// has nothing in settings to check and reads as not set up. Once something is configured the
+    /// answer comes from Entra: a token issued means the certificate is registered and unexpired,
+    /// a refusal carrying an <c>AADSTS</c> code means it is not, and anything else is the check
+    /// failing to complete — reported as a warning, as the AWS probe does, because "cannot confirm"
+    /// is a different claim from "does not work".
     /// </remarks>
-    private static ProviderRequirement AzureAccess(AzureProviderSettings settings)
+    private async Task<ProviderRequirement> AzureAccessAsync(AzureProviderSettings settings, CancellationToken ct)
     {
         const string name = "Access";
         const string description = "The Azure app identity Connapse reads Blob storage with.";
@@ -97,15 +106,37 @@ public class ProviderSetupReader(
         bool hasCredential =
             (!string.IsNullOrWhiteSpace(settings.ClientId)
                 && !string.IsNullOrWhiteSpace(settings.ClientCertificatePath))
-            || !string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId);
+            || AzureCredentialChainFactory.IsManagedIdentity(settings);
 
         if (string.IsNullOrWhiteSpace(settings.TenantId) || !hasCredential)
             return new ProviderRequirement(name, description, RequirementStatus.NotConfigured,
-                "Set under the Providers:Azure settings — a tenant and either a certificate app "
-                + "registration or a managed identity — so Connapse can read Azure.");
+                "Nothing can read Azure until this is set up: run the script below, or enter an "
+                + "existing app registration or managed identity under Manual values.");
 
-        return new ProviderRequirement(name, description, RequirementStatus.Satisfied,
-            $"Tenant {settings.TenantId}");
+        var probe = await azureDiscovery.CheckAccessAsync(ct);
+
+        return probe.Outcome switch
+        {
+            AzureProbeOutcome.Succeeded => new ProviderRequirement(name, description,
+                RequirementStatus.Satisfied, probe.Value),
+
+            AzureProbeOutcome.Denied => new ProviderRequirement(name, description,
+                RequirementStatus.Failed,
+                "Entra refused Connapse's credential, so Azure sources cannot sync. The certificate "
+                + "is not registered on the app, has expired, or the app no longer exists — set "
+                + $"access up again below. Entra said: {probe.Detail}"),
+
+            AzureProbeOutcome.Unusable => new ProviderRequirement(name, description,
+                RequirementStatus.Failed,
+                "Connapse's Azure identity cannot be used from this host, so Azure sources cannot "
+                + "sync: the certificate file is missing or unreadable, the settings are only partly "
+                + "filled in, or the managed identity they name is not available on this host. Fix the "
+                + $"file or the identity, or set access up again below. Detail: {probe.Detail}"),
+
+            _ => new ProviderRequirement(name, description, RequirementStatus.Warning,
+                "Connapse could not confirm its identity with Azure, so this may or may not "
+                + $"work. Test a connection to be sure. The check reported: {probe.Detail}")
+        };
     }
 
     /// <summary>
@@ -113,13 +144,14 @@ public class ProviderSetupReader(
     /// what they may read.
     /// </summary>
     /// <remarks>
-    /// Two parts: the Entra sign-in application (<c>Identity:AzureAd</c>) and the subscription the
-    /// RBAC resolver queries (<c>Providers:Azure</c> <c>SubscriptionId</c>). Both are needed for
-    /// per-user Azure filtering; sign-in without the subscription fails closed, so that is a warning
-    /// rather than a clean state.
+    /// Three parts: Entra still accepting the sign-in application's certificate (checked live, the
+    /// same way as Access — an expired or removed certificate must not read as Ready), the
+    /// subscription the RBAC resolver queries (<c>Providers:Azure</c> <c>SubscriptionId</c>), and
+    /// admin consent. Sign-in without the subscription or consent fails closed, so those are
+    /// warnings rather than a clean state.
     /// </remarks>
-    private static ProviderRequirement AzurePerUserPermissions(
-        AzureAdSignInSettings signIn, AzureProviderSettings provider)
+    private async Task<ProviderRequirement> AzurePerUserPermissionsAsync(
+        AzureAdSignInSettings signIn, AzureProviderSettings provider, CancellationToken ct)
     {
         const string name = "Per-user permissions";
         const string description =
@@ -128,22 +160,61 @@ public class ProviderSetupReader(
 
         if (!signIn.IsConfigured)
             return new ProviderRequirement(name, description, RequirementStatus.NotConfigured,
-                "Set the Identity:AzureAd sign-in application so people can connect their Entra identity.");
+                "Nobody can connect an Entra identity until the sign-in application is set up below.");
+
+        // Sign-in configured with the enforcement latch off is the one state that is open: the
+        // resolver returns every Azure result to everyone. Saving the sign-in application writes
+        // the latch first, and a restart latches it too, so this only shows when both failed.
+        if (!enforcement.CurrentValue.AzureEnforcing)
+            return new ProviderRequirement(name, description, RequirementStatus.Failed,
+                "Sign-in is set, but per-user enforcement for Azure is switched off, so Azure results "
+                + "are not filtered by who is asking. Save the sign-in application again, or restart "
+                + "Connapse, to switch it on.");
+
+        var probe = await azureDiscovery.CheckAccessAsync(SignInIdentity(signIn), ct);
+        switch (probe.Outcome)
+        {
+            case AzureProbeOutcome.Denied:
+                return new ProviderRequirement(name, description, RequirementStatus.Failed,
+                    "Entra refused the sign-in application's credential, so nobody can connect an Entra "
+                    + "identity. The certificate is not registered on the app, has expired, or the app no "
+                    + $"longer exists — set the application up again below. Entra said: {probe.Detail}");
+            case AzureProbeOutcome.Unusable:
+                return new ProviderRequirement(name, description, RequirementStatus.Failed,
+                    "The sign-in application's certificate cannot be used from this host — the file is "
+                    + "missing or unreadable, or the settings are only partly filled in — so nobody can "
+                    + $"connect an Entra identity. Fix the file, or set the application up again below. Detail: {probe.Detail}");
+            case AzureProbeOutcome.Failed:
+                return new ProviderRequirement(name, description, RequirementStatus.Warning,
+                    "Connapse could not confirm the sign-in application's credential with Azure, so "
+                    + $"this may or may not work. The check reported: {probe.Detail}");
+        }
 
         if (string.IsNullOrWhiteSpace(provider.SubscriptionId))
             return new ProviderRequirement(name, description, RequirementStatus.Warning,
-                "Sign-in is set, but Providers:Azure SubscriptionId is missing — the RBAC resolver "
-                + "needs it, so Azure filtering fails closed until it is set.");
+                "Sign-in is set, but the Access step has no subscription ID. Per-user filtering reads "
+                + "role assignments from that subscription, so Azure searches return nothing for "
+                + "anyone until it is set.");
 
         if (signIn.AdminConsentPending)
             return new ProviderRequirement(name, description, RequirementStatus.Warning,
-                "Sign-in is set, but the access app's Microsoft Graph permissions still need an "
-                + "administrator's consent — directory lookups fail until then, so Azure filtering "
-                + "fails closed.");
+                "Sign-in is set, but the access identity's Microsoft Graph permissions still need an "
+                + "administrator's consent (for a managed identity, the two app-role grants). Until then "
+                + "Connapse cannot look people up, so Azure searches return nothing for anyone.");
 
         return new ProviderRequirement(name, description, RequirementStatus.Satisfied,
             $"Tenant {signIn.TenantId}, subscription {provider.SubscriptionId}");
     }
+
+    /// <summary>The sign-in application in the shape the credential check takes: it authenticates
+    /// with a certificate exactly as the access app does, so the same check applies.</summary>
+    public static AzureProviderSettings SignInIdentity(AzureAdSignInSettings signIn) => new()
+    {
+        TenantId = signIn.TenantId,
+        ClientId = signIn.ClientId,
+        ClientCertificatePath = signIn.ClientCertificatePath,
+        ClientCertificatePassword = signIn.ClientCertificatePassword,
+    };
 
     /// <summary>
     /// Which cloud providers this installation has actually taken up.

--- a/src/Connapse.Web/Services/ProviderSetupReader.cs
+++ b/src/Connapse.Web/Services/ProviderSetupReader.cs
@@ -16,6 +16,8 @@ namespace Connapse.Web.Services;
 public class ProviderSetupReader(
     IOptionsMonitor<SamlSignInSettings> samlSignIn,
     IOptionsMonitor<IdentityCenterSettings> identityCenter,
+    IOptionsMonitor<AzureProviderSettings> azureProvider,
+    IOptionsMonitor<AzureAdSignInSettings> azureAd,
     IS3Discovery s3Discovery,
     IConnectionStore connections,
     IProviderCredentialStore credentials,
@@ -54,6 +56,9 @@ public class ProviderSetupReader(
     {
         var providers = await InUseProvidersAsync(ct);
 
+        var azureAccess = AzureAccess(azureProvider.CurrentValue);
+        var azurePermissions = AzurePerUserPermissions(azureAd.CurrentValue, azureProvider.CurrentValue);
+
         return
         [
             new ProviderSetup("aws", "AWS",
@@ -62,8 +67,82 @@ public class ProviderSetupReader(
                     IdentityCentre(identityCenter.CurrentValue),
                     PerUserPermissions(samlSignIn.CurrentValue)
                 ],
-                InUse: providers.Contains(ConnectionProvider.S3))
+                InUse: providers.Contains(ConnectionProvider.S3) || samlSignIn.CurrentValue.IsConfigured),
+
+            // Azure access is settings-only (no ambient credential can make it read as configured),
+            // so a saved Access step is as deliberate a choice as sign-in or a connection.
+            new ProviderSetup("azure", "Azure",
+                [azureAccess, azurePermissions],
+                InUse: providers.Contains(ConnectionProvider.AzureBlob)
+                    || azureAd.CurrentValue.IsConfigured
+                    || azureAccess.Status != RequirementStatus.NotConfigured)
         ];
+    }
+
+    /// <summary>
+    /// Whether Connapse has an Azure app identity to read Blob storage (and Entra/ARM) with.
+    /// </summary>
+    /// <remarks>
+    /// Config-only for now — it reports whether a tenant and a credential are set, not a live probe.
+    /// A credential is a certificate-based app registration (<c>ClientId</c> + a certificate) or a
+    /// user-assigned managed identity. An ambient <i>system</i>-assigned managed identity cannot be
+    /// seen from settings, so a deployment relying on one reads as not-configured here even when it
+    /// works; a later iteration adds a live check (parity with AWS's access probe).
+    /// </remarks>
+    private static ProviderRequirement AzureAccess(AzureProviderSettings settings)
+    {
+        const string name = "Access";
+        const string description = "The Azure app identity Connapse reads Blob storage with.";
+
+        bool hasCredential =
+            (!string.IsNullOrWhiteSpace(settings.ClientId)
+                && !string.IsNullOrWhiteSpace(settings.ClientCertificatePath))
+            || !string.IsNullOrWhiteSpace(settings.UserAssignedManagedIdentityClientId);
+
+        if (string.IsNullOrWhiteSpace(settings.TenantId) || !hasCredential)
+            return new ProviderRequirement(name, description, RequirementStatus.NotConfigured,
+                "Set under the Providers:Azure settings — a tenant and either a certificate app "
+                + "registration or a managed identity — so Connapse can read Azure.");
+
+        return new ProviderRequirement(name, description, RequirementStatus.Satisfied,
+            $"Tenant {settings.TenantId}");
+    }
+
+    /// <summary>
+    /// Whether people can sign in with their Entra identity so their Azure results are scoped to
+    /// what they may read.
+    /// </summary>
+    /// <remarks>
+    /// Two parts: the Entra sign-in application (<c>Identity:AzureAd</c>) and the subscription the
+    /// RBAC resolver queries (<c>Providers:Azure</c> <c>SubscriptionId</c>). Both are needed for
+    /// per-user Azure filtering; sign-in without the subscription fails closed, so that is a warning
+    /// rather than a clean state.
+    /// </remarks>
+    private static ProviderRequirement AzurePerUserPermissions(
+        AzureAdSignInSettings signIn, AzureProviderSettings provider)
+    {
+        const string name = "Per-user permissions";
+        const string description =
+            "The Entra application people sign in through, so their Azure results are scoped to what "
+            + "that identity may read.";
+
+        if (!signIn.IsConfigured)
+            return new ProviderRequirement(name, description, RequirementStatus.NotConfigured,
+                "Set the Identity:AzureAd sign-in application so people can connect their Entra identity.");
+
+        if (string.IsNullOrWhiteSpace(provider.SubscriptionId))
+            return new ProviderRequirement(name, description, RequirementStatus.Warning,
+                "Sign-in is set, but Providers:Azure SubscriptionId is missing — the RBAC resolver "
+                + "needs it, so Azure filtering fails closed until it is set.");
+
+        if (signIn.AdminConsentPending)
+            return new ProviderRequirement(name, description, RequirementStatus.Warning,
+                "Sign-in is set, but the access app's Microsoft Graph permissions still need an "
+                + "administrator's consent — directory lookups fail until then, so Azure filtering "
+                + "fails closed.");
+
+        return new ProviderRequirement(name, description, RequirementStatus.Satisfied,
+            $"Tenant {signIn.TenantId}, subscription {provider.SubscriptionId}");
     }
 
     /// <summary>

--- a/src/Connapse.Web/Services/SourceScopePreflight.cs
+++ b/src/Connapse.Web/Services/SourceScopePreflight.cs
@@ -53,6 +53,7 @@ public class SourceScopePreflight(IOptionsMonitor<SourceSecuritySettings> source
         return connection.Provider switch
         {
             ConnectionProvider.S3 => CheckLocation(credential, scope, "bucketName", "bucket", connection.Name),
+            ConnectionProvider.AzureBlob => CheckLocation(credential, scope, "containerName", "container", connection.Name),
             ConnectionProvider.Filesystem => CheckRoot(credential, scope, connection.Name),
             ConnectionProvider.Sftp => CheckSftpScope(credential, scope, connection.Name),
             _ => ScopePreflightResult.Refuse(

--- a/src/Connapse.Web/appsettings.json
+++ b/src/Connapse.Web/appsettings.json
@@ -31,6 +31,16 @@
       "Audience": "Connapse"
     }
   },
+  "Providers": {
+    "Azure": {
+      "//": "Connapse's own Azure app identity, used by the Azure Blob connector and its connection tester. When ClientId + ClientCertificatePath are set, Connapse authenticates as that service principal; otherwise it falls back to the ambient managed identity (optionally pinned via UserAssignedManagedIdentityClientId). Never a client secret.",
+      "TenantId": "",
+      "ClientId": "",
+      "ClientCertificatePath": "",
+      "ClientCertificatePassword": "",
+      "UserAssignedManagedIdentityClientId": ""
+    }
+  },
   "Sources": {
     "Security": {
       "//AllowedFilesystemRoots": "Directories a filesystem connection's allowedRoot may name; a root must equal one of these or sit beneath it. Empty means unrestricted, which is retained for one release so upgrades keep working, and logs a warning naming each root in use. Configuration only — never settable through the API or the settings table, because the authority a root confers is the same class of thing as a cloud credential.",

--- a/src/Connapse.Web/appsettings.json
+++ b/src/Connapse.Web/appsettings.json
@@ -29,6 +29,14 @@
       "RefreshTokenLifetimeDays": 7,
       "Issuer": "Connapse",
       "Audience": "Connapse"
+    },
+    "AzureAd": {
+      "//": "The Entra ID (Azure AD) application a person signs in through to link their Connapse account to a directory user. Connapse authenticates to Entra with a client certificate, never a client secret. Empty here means Entra sign-in is unconfigured.",
+      "TenantId": "",
+      "ClientId": "",
+      "RedirectUri": "",
+      "ClientCertificatePath": "",
+      "ClientCertificatePassword": ""
     }
   },
   "Providers": {

--- a/tests/Connapse.Core.Tests/CloudScope/AzureTagConditionEvaluatorTests.cs
+++ b/tests/Connapse.Core.Tests/CloudScope/AzureTagConditionEvaluatorTests.cs
@@ -1,0 +1,41 @@
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureTagConditionEvaluatorTests
+{
+    private static AzureTagCondition Cond(bool keyCase = true, bool valueCase = false) =>
+        new("azblob://acct/docs/", "Project", "Cascade", keyCase, valueCase);
+
+    [Fact]
+    public void Matches_KeyAndValuePresent_True() =>
+        AzureTagConditionEvaluator.Matches(Cond(), new Dictionary<string, string> { ["Project"] = "Cascade" })
+            .Should().BeTrue();
+
+    [Fact]
+    public void Matches_MissingKey_False() =>
+        AzureTagConditionEvaluator.Matches(Cond(), new Dictionary<string, string> { ["Other"] = "Cascade" })
+            .Should().BeFalse();
+
+    [Fact]
+    public void Matches_KeyCaseSensitive_DoesNotMatchDifferentCaseKey() =>
+        AzureTagConditionEvaluator.Matches(Cond(keyCase: true), new Dictionary<string, string> { ["project"] = "Cascade" })
+            .Should().BeFalse();
+
+    [Fact]
+    public void Matches_ValueCaseInsensitive_MatchesDifferentCaseValue() =>
+        AzureTagConditionEvaluator.Matches(Cond(valueCase: false), new Dictionary<string, string> { ["Project"] = "cascade" })
+            .Should().BeTrue();
+
+    [Fact]
+    public void Matches_ValueCaseSensitive_DoesNotMatchDifferentCaseValue() =>
+        AzureTagConditionEvaluator.Matches(Cond(valueCase: true), new Dictionary<string, string> { ["Project"] = "cascade" })
+            .Should().BeFalse();
+
+    [Fact]
+    public void Matches_WrongValue_False() =>
+        AzureTagConditionEvaluator.Matches(Cond(), new Dictionary<string, string> { ["Project"] = "Other" })
+            .Should().BeFalse();
+}

--- a/tests/Connapse.Core.Tests/CloudScope/PosixAclEvaluatorTests.cs
+++ b/tests/Connapse.Core.Tests/CloudScope/PosixAclEvaluatorTests.cs
@@ -1,0 +1,151 @@
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class PosixAclEvaluatorTests
+{
+    private const Gen2Permission RX = Gen2Permission.Read | Gen2Permission.Execute;
+
+    private static Gen2Acl Acl(
+        string? owner = "owner", string? group = "group",
+        Gen2Permission ownerPerms = RX, Gen2Permission groupPerms = RX, Gen2Permission other = Gen2Permission.None,
+        Gen2Permission? mask = null,
+        IReadOnlyList<Gen2NamedAce>? namedUsers = null, IReadOnlyList<Gen2NamedAce>? namedGroups = null) =>
+        new(owner, group, ownerPerms, groupPerms, other, mask, namedUsers ?? [], namedGroups ?? []);
+
+    private static IReadOnlySet<string> Groups(params string[] oids) => new HashSet<string>(oids);
+    private static readonly IReadOnlySet<string> NoGroups = new HashSet<string>();
+
+    [Fact]
+    public void Owner_Decides_AndIgnoresMask()
+    {
+        // Owner has X; a restrictive mask must NOT cut the owner down.
+        var acl = Acl(ownerPerms: RX, mask: Gen2Permission.None);
+        PosixAclEvaluator.Grants(acl, "owner", NoGroups, Gen2Permission.Execute).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Owner_WithoutTheBit_IsDenied_NotFallingThroughToGroup()
+    {
+        // Requester owns the dir (owner has no X) AND is in the owning group (group has X). Owner is
+        // terminal: no X for the owner means denied, group never consulted.
+        var acl = Acl(ownerPerms: Gen2Permission.Read, groupPerms: RX);
+        PosixAclEvaluator.Grants(acl, "owner", Groups("group"), Gen2Permission.Execute).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NamedUser_Matched_IsCappedByMask()
+    {
+        var acl = Acl(other: RX,
+            mask: Gen2Permission.Read, // mask strips X from named entries
+            namedUsers: [new Gen2NamedAce("alice", RX)]);
+        // Named-user match is terminal and masked → no X, even though "other" would have granted it.
+        PosixAclEvaluator.Grants(acl, "alice", NoGroups, Gen2Permission.Execute).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NamedUser_Matched_Grants_WhenMaskAllows()
+    {
+        var acl = Acl(mask: RX, namedUsers: [new Gen2NamedAce("alice", RX)]);
+        PosixAclEvaluator.Grants(acl, "alice", NoGroups, Gen2Permission.Execute).Should().BeTrue();
+    }
+
+    [Fact]
+    public void OwningGroup_Grants_WhenMaskAllows()
+    {
+        var acl = Acl(owner: "someone-else", groupPerms: RX, mask: RX);
+        PosixAclEvaluator.Grants(acl, "not-owner", Groups("group"), Gen2Permission.Execute).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnyNamedGroup_Granting_Suffices()
+    {
+        // Two group matches: one denies X, one grants it. Any one granting → allow.
+        var acl = Acl(owner: "someone-else", group: "not-mine",
+            mask: RX,
+            namedGroups: [new Gen2NamedAce("g1", Gen2Permission.Read), new Gen2NamedAce("g2", RX)]);
+        PosixAclEvaluator.Grants(acl, "user", Groups("g1", "g2"), Gen2Permission.Execute).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GroupMatch_ButNoneGrant_IsDenied_NotFallingThroughToOther()
+    {
+        var acl = Acl(owner: "someone-else", group: "not-mine", other: RX,
+            mask: RX, namedGroups: [new Gen2NamedAce("g1", Gen2Permission.Read)]);
+        PosixAclEvaluator.Grants(acl, "user", Groups("g1"), Gen2Permission.Execute).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GroupClass_CappedByMask()
+    {
+        var acl = Acl(owner: "someone-else", group: "g", groupPerms: RX, mask: Gen2Permission.Read);
+        PosixAclEvaluator.Grants(acl, "not-owner", Groups("g"), Gen2Permission.Execute).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Other_Decides_WhenNoOwnerNamedOrGroupMatch()
+    {
+        var acl = Acl(owner: "someone-else", group: "not-mine", other: RX);
+        PosixAclEvaluator.Grants(acl, "stranger", NoGroups, Gen2Permission.Execute).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Other_WithoutTheBit_IsDenied()
+    {
+        var acl = Acl(owner: "someone-else", group: "not-mine", other: Gen2Permission.Read);
+        PosixAclEvaluator.Grants(acl, "stranger", NoGroups, Gen2Permission.Execute).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Other_IgnoresMask()
+    {
+        // "other" is never capped by the mask. A stranger (no owner/named/group match) with X in
+        // "other" is granted even when a restrictive mask is present.
+        var acl = Acl(owner: "someone-else", group: "not-mine",
+            other: Gen2Permission.Read | Gen2Permission.Execute, mask: Gen2Permission.None);
+        PosixAclEvaluator.Grants(acl, "stranger", NoGroups, Gen2Permission.Execute).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Owner_TakesPrecedence_OverANamedUserEntryForTheSamePrincipal()
+    {
+        // Same principal is both owner and a named user; owner class wins (terminal, unmasked).
+        var acl = Acl(ownerPerms: RX, mask: Gen2Permission.None,
+            namedUsers: [new Gen2NamedAce("owner", Gen2Permission.None)]);
+        PosixAclEvaluator.Grants(acl, "owner", NoGroups, Gen2Permission.Execute).Should().BeTrue();
+    }
+
+    // ---- Adversarial: user classes must NEVER be satisfied by group membership, and group classes
+    // must NEVER be satisfied by the requester's own user oid. This is the over-grant the untyped
+    // combined principal set allowed.
+
+    [Fact]
+    public void NamedUserEntry_WhoseOidIsAGroupOid_DoesNotGrantViaGroupMembership()
+    {
+        // An anomalous ACE: a user-typed entry whose id is actually a group's oid. ADLS evaluates
+        // named-user entries by requester identity, so this grants nobody. It must NOT match a member
+        // of that group here (which would be a cross-class over-grant).
+        var acl = Acl(owner: "someone-else", group: "not-mine", other: Gen2Permission.None,
+            mask: RX, namedUsers: [new Gen2NamedAce("grp-oid", RX)]);
+        PosixAclEvaluator.Grants(acl, "member", Groups("grp-oid"), Gen2Permission.Execute).Should().BeFalse();
+    }
+
+    [Fact]
+    public void OwningGroup_IsNotSatisfiedByTheRequestersUserOid()
+    {
+        // The requester's own user oid equals the owning-group oid (anomalous). The owning-group
+        // class must match only via group membership, not the user oid → deny (other is None).
+        var acl = Acl(owner: "someone-else", group: "g", groupPerms: RX, other: Gen2Permission.None, mask: RX);
+        PosixAclEvaluator.Grants(acl, "g", NoGroups, Gen2Permission.Execute).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NamedGroup_IsNotSatisfiedByTheRequestersUserOid()
+    {
+        var acl = Acl(owner: "someone-else", group: "not-mine", other: Gen2Permission.None,
+            mask: RX, namedGroups: [new Gen2NamedAce("devs", RX)]);
+        PosixAclEvaluator.Grants(acl, "devs", NoGroups, Gen2Permission.Execute).Should().BeFalse();
+    }
+}

--- a/tests/Connapse.Core.Tests/ConnectionTesterTests.cs
+++ b/tests/Connapse.Core.Tests/ConnectionTesterTests.cs
@@ -1,9 +1,11 @@
 using System.Net;
 using System.Text.Json;
 using Connapse.Core;
+using Connapse.Storage.CloudScope;
 using Connapse.Storage.ConnectionTesters;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
 
@@ -195,6 +197,27 @@ public class MinioConnectionTesterTests
     }
 
     // Note: Full MinIO integration tests require real service and are covered in Integration.Tests
+}
+
+[Trait("Category", "Unit")]
+public class AzureBlobConnectionTesterTests
+{
+    [Fact]
+    public async Task AzureBlobTester_WrongSettingsType_Fails()
+    {
+        var tester = new AzureBlobConnectionTester(
+            new ConnapseAzureCredentials(new TestOptionsMonitor<AzureProviderSettings>(new())));
+        var result = await tester.TestConnectionAsync("not-a-config", TimeSpan.FromSeconds(1));
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("AzureBlobConnectorConfig");
+    }
+
+    private sealed class TestOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; private set; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
 }
 
 /// <summary>

--- a/tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
@@ -1,0 +1,68 @@
+using Azure.Storage.Blobs;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Connectors;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Connectors;
+
+[Trait("Category", "Unit")]
+public class AzureBlobConnectorUnitTests
+{
+    private static AzureBlobConnector Make() =>
+        new(new AzureBlobConnectorConfig { AccountName = "acct", ContainerName = "docs", Prefix = "reports/" },
+            new BlobServiceClient(new Uri("http://127.0.0.1:10000/devstoreaccount1")));
+
+    [Fact] public void Type_IsAzureBlob() => Make().Type.Should().Be(ConnectorType.AzureBlob);
+    [Fact] public void SupportsLiveWatch_False() => Make().SupportsLiveWatch.Should().BeFalse();
+
+    [Fact]
+    public void ResolveJobPath_JoinsUnderPrefix()
+        => Make().ResolveJobPath("q1.pdf").Should().Be("reports/q1.pdf");
+
+    [Fact]
+    public async Task WatchAsync_Throws()
+    {
+        var act = async () => { await foreach (var _ in Make().WatchAsync()) { } };
+        await act.Should().ThrowAsync<NotSupportedException>();
+    }
+
+    [Fact]
+    public async Task ReadFileAsync_OutOfPrefixPath_ThrowsUnauthorizedAccessException()
+    {
+        var act = async () => await Make().ReadFileAsync("hr/secret.pdf");
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_OutOfPrefixPath_ReturnsFalse()
+        => (await Make().ExistsAsync("hr/secret.pdf")).Should().BeFalse();
+
+    private static AzureBlobConnector MakeWithPrefix(string? prefix) =>
+        new(new AzureBlobConnectorConfig { AccountName = "acct", ContainerName = "docs", Prefix = prefix },
+            new BlobServiceClient(new Uri("http://127.0.0.1:10000/devstoreaccount1")));
+
+    [Fact]
+    public void IsInPrefixScope_SiblingPrefix_IsRejected()
+        => MakeWithPrefix("team/").IsInPrefixScope("team-archive/secret.txt").Should().BeFalse();
+
+    [Fact]
+    public void IsInPrefixScope_MatchingSubtree_IsAllowed()
+        => MakeWithPrefix("team/").IsInPrefixScope("team/ok.txt").Should().BeTrue();
+
+    [Fact]
+    public async Task ReadFileAsync_SiblingPrefixPath_ThrowsUnauthorizedAccessException()
+    {
+        var act = async () => await MakeWithPrefix("team/").ReadFileAsync("team-archive/secret.txt");
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_SiblingPrefixPath_ReturnsFalse()
+        => (await MakeWithPrefix("team/").ExistsAsync("team-archive/secret.txt")).Should().BeFalse();
+
+    [Fact]
+    public void IsInPrefixScope_EmptyPrefix_AllowsAnyPath()
+        => MakeWithPrefix(null).IsInPrefixScope("anything/at/all.txt").Should().BeTrue();
+}

--- a/tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/AzureBlobConnectorUnitTests.cs
@@ -14,6 +14,21 @@ public class AzureBlobConnectorUnitTests
         new(new AzureBlobConnectorConfig { AccountName = "acct", ContainerName = "docs", Prefix = "reports/" },
             new BlobServiceClient(new Uri("http://127.0.0.1:10000/devstoreaccount1")));
 
+    [Theory]
+    [InlineData("reports/", 0, null, true)]              // flat-namespace folder marker
+    [InlineData("reports/q1", 0, "true", true)]          // Gen2 directory placeholder
+    [InlineData("reports/q1", 0, "True", true)]
+    [InlineData("reports/q1.pdf", 1234, "false", false)]
+    [InlineData("reports/q1.pdf", 1234, null, false)]
+    [InlineData("README", 0, null, false)]               // an empty extension-less real file is still a file
+    [InlineData("reports/", 512, null, false)]           // a real blob that merely ends in '/' is a file
+    [InlineData("reports/q1", 512, "true", false)]       // content wins over app-controlled metadata
+    public void IsDirectoryPlaceholder_OnlyZeroByteFolderMarkersAreDropped(string name, long length, string? hdiIsFolder, bool expected)
+    {
+        var metadata = hdiIsFolder is null ? null : new Dictionary<string, string> { ["hdi_isfolder"] = hdiIsFolder };
+        AzureBlobConnector.IsDirectoryPlaceholder(name, length, metadata).Should().Be(expected);
+    }
+
     [Fact] public void Type_IsAzureBlob() => Make().Type.Should().Be(ConnectorType.AzureBlob);
     [Fact] public void SupportsLiveWatch_False() => Make().SupportsLiveWatch.Should().BeFalse();
 

--- a/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
+++ b/tests/Connapse.Core.Tests/Connectors/SourceConnectorFactoryTests.cs
@@ -67,10 +67,16 @@ public class SourceConnectorFactoryTests
         services.AddSingleton(credentialStore);
         var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
+        // No network is touched: Create() never calls GetToken, so a default,
+        // unconfigured AzureProviderSettings is enough to construct the credential.
+        var azureOptions = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        azureOptions.CurrentValue.Returns(new AzureProviderSettings());
+
         return new ConnectorFactory(
             monitor,
             hostKeyStore ?? Substitute.For<ISshHostKeyStore>(),
             new ConnapseAwsCredentials(scopeFactory, NullLogger<ConnapseAwsCredentials>.Instance),
+            new ConnapseAzureCredentials(azureOptions),
             logger ?? NullLogger<ConnectorFactory>.Instance);
     }
 
@@ -109,6 +115,18 @@ public class SourceConnectorFactoryTests
         connector.Config.Region.Should().Be("eu-west-1", "the region comes from the connection");
         connector.Config.BucketName.Should().Be("my-bucket", "the bucket comes from the source scope");
         connector.Config.Prefix.Should().Be("docs/");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Create_AzureBlob_BuildsConnectorFromSplitConfig()
+    {
+        var connection = MakeConnection(ConnectionProvider.AzureBlob, """{"accountName":"acct"}""");
+        var source = MakeSource(connection.Id, """{"containerName":"docs","prefix":"reports/"}""");
+
+        var connector = (AzureBlobConnector)_factory.Create(source, connection);
+
+        connector.Type.Should().Be(ConnectorType.AzureBlob);
     }
 
     [Fact]

--- a/tests/Connapse.Core.Tests/Models/AzblobUriTests.cs
+++ b/tests/Connapse.Core.Tests/Models/AzblobUriTests.cs
@@ -1,0 +1,37 @@
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Models;
+
+[Trait("Category", "Unit")]
+public class AzblobUriTests
+{
+    [Theory]
+    [InlineData("azblob://acct/docs/a/b/file.txt", "acct", "docs", "a/b/file.txt")]
+    [InlineData("azblob://acct/docs/file.txt", "acct", "docs", "file.txt")]
+    public void TryParse_WellFormed_ReturnsComponents(string uri, string acct, string fs, string path)
+    {
+        AzblobUri.TryParse(uri, out Gen2Path p).Should().BeTrue();
+        p.Account.Should().Be(acct);
+        p.FileSystem.Should().Be(fs);
+        p.Path.Should().Be(path);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("s3://bucket/key")]
+    [InlineData("azblob://acct")]          // no container or path
+    [InlineData("azblob://acct/docs")]     // no blob path
+    [InlineData("azblob://acct/docs/")]    // empty blob path
+    public void TryParse_MalformedOrNonAzblob_ReturnsFalse(string? uri) =>
+        AzblobUri.TryParse(uri, out _).Should().BeFalse();
+
+    [Fact]
+    public void IsAzblob_MatchesSchemeOnly()
+    {
+        AzblobUri.IsAzblob("azblob://a/c/x").Should().BeTrue();
+        AzblobUri.IsAzblob("s3://b/k").Should().BeFalse();
+        AzblobUri.IsAzblob(null).Should().BeFalse();
+    }
+}

--- a/tests/Connapse.Core.Tests/Models/AzureIdentitySetTests.cs
+++ b/tests/Connapse.Core.Tests/Models/AzureIdentitySetTests.cs
@@ -1,0 +1,30 @@
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Models;
+
+[Trait("Category", "Unit")]
+public class AzureIdentitySetTests
+{
+    [Fact]
+    public void Resolved_IsEnabled_AndCarriesPrincipals()
+    {
+        AzureIdentitySet set = AzureIdentitySet.Resolved(["oid-1", "group-a"]);
+
+        set.Enabled.Should().BeTrue();
+        set.Outcome.Should().Be(AzureIdentityOutcome.Resolved);
+        set.PrincipalOids.Should().Equal("oid-1", "group-a");
+    }
+
+    [Fact]
+    public void Deprovisioned_And_Failed_DenyWithNoPrincipals()
+    {
+        AzureIdentitySet.Deprovisioned().Enabled.Should().BeFalse();
+        AzureIdentitySet.Deprovisioned().Outcome.Should().Be(AzureIdentityOutcome.Deprovisioned);
+        AzureIdentitySet.Deprovisioned().PrincipalOids.Should().BeEmpty();
+
+        AzureIdentitySet.Failed().Enabled.Should().BeFalse();
+        AzureIdentitySet.Failed().Outcome.Should().Be(AzureIdentityOutcome.Failed);
+        AzureIdentitySet.Failed().PrincipalOids.Should().BeEmpty();
+    }
+}

--- a/tests/Connapse.Core.Tests/Models/Gen2AclTests.cs
+++ b/tests/Connapse.Core.Tests/Models/Gen2AclTests.cs
@@ -1,0 +1,60 @@
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Models;
+
+[Trait("Category", "Unit")]
+public class Gen2AclTests
+{
+    [Theory]
+    [InlineData('r', '-', 'x', Gen2Permission.Read | Gen2Permission.Execute)]
+    [InlineData('r', 'w', 'x', Gen2Permission.Read | Gen2Permission.Write | Gen2Permission.Execute)]
+    [InlineData('-', '-', '-', Gen2Permission.None)]
+    [InlineData('-', '-', 'x', Gen2Permission.Execute)]
+    public void FromRwx_MapsEachBit(char r, char w, char x, Gen2Permission expected) =>
+        Gen2Permissions.FromRwx(r, w, x).Should().Be(expected);
+
+    [Fact]
+    public void ParseSymbolic_NineChars_SplitsOwnerGroupOther()
+    {
+        var (owner, group, other, extended) = Gen2Permissions.ParseSymbolic("rwxr-x---");
+        owner.Should().Be(Gen2Permission.Read | Gen2Permission.Write | Gen2Permission.Execute);
+        group.Should().Be(Gen2Permission.Read | Gen2Permission.Execute);
+        other.Should().Be(Gen2Permission.None);
+        extended.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseSymbolic_TrailingPlus_MarksExtendedAcl()
+    {
+        var (_, _, _, extended) = Gen2Permissions.ParseSymbolic("rwxr-x---+");
+        extended.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseSymbolic_TenCharLeadingType_IgnoresTypeChar()
+    {
+        // Some listings prefix a file-type char (e.g. 'd' for directory): "drwxr-x---".
+        var (owner, _, _, _) = Gen2Permissions.ParseSymbolic("drwxr-x---");
+        owner.Should().Be(Gen2Permission.Read | Gen2Permission.Write | Gen2Permission.Execute);
+    }
+
+    [Fact]
+    public void ModeBits_ToAcl_CarriesOwnerGroupOther_NoNamedNoMask()
+    {
+        var bits = new Gen2ModeBits("owner-oid", "group-oid",
+            Gen2Permission.Read | Gen2Permission.Execute, Gen2Permission.Execute, Gen2Permission.None,
+            HasExtendedAcl: false);
+
+        Gen2Acl acl = bits.ToAcl();
+
+        acl.OwnerOid.Should().Be("owner-oid");
+        acl.OwningGroupOid.Should().Be("group-oid");
+        acl.OwnerPermissions.Should().Be(Gen2Permission.Read | Gen2Permission.Execute);
+        acl.OwningGroupPermissions.Should().Be(Gen2Permission.Execute);
+        acl.OtherPermissions.Should().Be(Gen2Permission.None);
+        acl.Mask.Should().BeNull();
+        acl.NamedUsers.Should().BeEmpty();
+        acl.NamedGroups.Should().BeEmpty();
+    }
+}

--- a/tests/Connapse.Core.Tests/Models/PermissionEnforcementBoolStateTests.cs
+++ b/tests/Connapse.Core.Tests/Models/PermissionEnforcementBoolStateTests.cs
@@ -1,0 +1,63 @@
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Models;
+
+/// <summary>
+/// The Azure enforcement gate (<see cref="PermissionEnforcementSettings.StateForAzure"/>) reads its
+/// own latch, and the SAML and Azure latches are independent: configuring one provider must never
+/// change the enforcement state the other's resolver sees.
+/// </summary>
+[Trait("Category", "Unit")]
+public class PermissionEnforcementBoolStateTests
+{
+    [Fact]
+    public void Azure_Undetermined_IsEnforcingButUnusable()
+    {
+        var s = new PermissionEnforcementSettings { AzureEnforcing = true };
+        s.StateForAzure(azureConfigured: true, determined: false).Should().Be(EnforcementState.EnforcingButUnusable);
+    }
+
+    [Fact]
+    public void Azure_NotLatched_IsNotEnforcing()
+    {
+        var s = new PermissionEnforcementSettings { AzureEnforcing = false };
+        s.StateForAzure(azureConfigured: true).Should().Be(EnforcementState.NotEnforcing);
+    }
+
+    [Fact]
+    public void Azure_Latched_ProviderConfigured_IsEnforcing()
+    {
+        var s = new PermissionEnforcementSettings { AzureEnforcing = true };
+        s.StateForAzure(azureConfigured: true).Should().Be(EnforcementState.Enforcing);
+    }
+
+    [Fact]
+    public void Azure_Latched_ProviderNotConfigured_IsEnforcingButUnusable()
+    {
+        var s = new PermissionEnforcementSettings { AzureEnforcing = true };
+        s.StateForAzure(azureConfigured: false).Should().Be(EnforcementState.EnforcingButUnusable);
+    }
+
+    [Fact]
+    public void AzureLatch_DoesNotAffectTheSamlGate()
+    {
+        // Azure AD is latched and configured; SAML was never configured. The AWS/SAML gate must stay
+        // NotEnforcing (its corpus unfiltered), not slide into EnforcingButUnusable. This is the
+        // regression the shared single bit caused: configuring Azure hid every S3 document.
+        var s = new PermissionEnforcementSettings { AzureEnforcing = true, IsEnforcing = false };
+
+        s.StateFor(new SamlSignInSettings()).Should().Be(EnforcementState.NotEnforcing);
+        s.StateForAzure(azureConfigured: true).Should().Be(EnforcementState.Enforcing);
+    }
+
+    [Fact]
+    public void SamlLatch_DoesNotAffectTheAzureGate()
+    {
+        // The mirror: SAML latched and configured, Azure never configured. Azure's gate stays
+        // NotEnforcing rather than denying every azblob document.
+        var s = new PermissionEnforcementSettings { IsEnforcing = true, AzureEnforcing = false };
+
+        s.StateForAzure(azureConfigured: false).Should().Be(EnforcementState.NotEnforcing);
+    }
+}

--- a/tests/Connapse.Core.Tests/Settings/AzureAdSignInSettingsTests.cs
+++ b/tests/Connapse.Core.Tests/Settings/AzureAdSignInSettingsTests.cs
@@ -1,0 +1,64 @@
+using Connapse.Core;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Settings;
+
+[Trait("Category", "Unit")]
+public class AzureAdSignInSettingsTests
+{
+    private static AzureAdSignInSettings CreateConfigured() => new()
+    {
+        TenantId = "tenant-id",
+        ClientId = "client-id",
+        RedirectUri = "https://connapse.example.com/signin-oidc",
+        ClientCertificatePath = "/certs/entra.pem",
+    };
+
+    [Fact]
+    public void IsConfigured_AllRequiredFieldsSet_ReturnsTrue()
+    {
+        var settings = CreateConfigured();
+
+        settings.IsConfigured.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsConfigured_ClientCertificatePasswordOmitted_StillReturnsTrue()
+    {
+        var settings = CreateConfigured() with { ClientCertificatePassword = null };
+
+        settings.IsConfigured.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsConfigured_TenantIdBlank_ReturnsFalse()
+    {
+        var settings = CreateConfigured() with { TenantId = "  " };
+
+        settings.IsConfigured.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsConfigured_ClientIdBlank_ReturnsFalse()
+    {
+        var settings = CreateConfigured() with { ClientId = null };
+
+        settings.IsConfigured.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsConfigured_RedirectUriBlank_ReturnsFalse()
+    {
+        var settings = CreateConfigured() with { RedirectUri = string.Empty };
+
+        settings.IsConfigured.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsConfigured_ClientCertificatePathBlank_ReturnsFalse()
+    {
+        var settings = CreateConfigured() with { ClientCertificatePath = null };
+
+        settings.IsConfigured.Should().BeFalse();
+    }
+}

--- a/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
+++ b/tests/Connapse.Core.Tests/Settings/ConnectionFormTests.cs
@@ -215,6 +215,91 @@ public class ConnectionFormTests
             .Validate().Should().BeNull();
     }
 
+    // ── AzureBlob ────────────────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ConnectionForm_AzureBlob_BuildsConfigJson()
+    {
+        // Name is required for every provider (see Validate_RequiresAName above), so it is set
+        // here even though the brief's test body omitted it — otherwise this can never pass.
+        var form = new ConnectionForm { Name = "c", Provider = ConnectionProvider.AzureBlob, StorageAccountName = "acct" };
+        form.Validate().Should().BeNull();               // valid
+        form.ToConfigJson().Should().Contain("\"accountName\":\"acct\"");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ConnectionForm_AzureBlob_MissingAccount_FailsValidation()
+    {
+        var form = new ConnectionForm { Provider = ConnectionProvider.AzureBlob };
+        form.Validate().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AzureBlobConnection_RoundTripsEveryField()
+    {
+        var stored = Stored(ConnectionProvider.AzureBlob,
+            """{"accountName":"acct","blobEndpoint":"http://azurite:10000/acct","allowedLocations":["docs"]}""");
+
+        var form = ConnectionForm.FromConnection(stored);
+
+        form.StorageAccountName.Should().Be("acct");
+        form.BlobEndpoint.Should().Be("http://azurite:10000/acct");
+        form.AllowedLocations.Should().Be("docs");
+
+        var reserialized = JsonNode.Parse(form.ToConfigJson())!.AsObject();
+        reserialized["accountName"]!.GetValue<string>().Should().Be("acct");
+        reserialized["blobEndpoint"]!.GetValue<string>().Should().Be("http://azurite:10000/acct");
+    }
+
+    [Fact]
+    public void ToConfigJson_AzureBlob_OmitsBlankBlobEndpoint()
+    {
+        var form = new ConnectionForm { Name = "c", Provider = ConnectionProvider.AzureBlob, StorageAccountName = "acct" };
+
+        JsonNode.Parse(form.ToConfigJson())!.AsObject()
+            .ContainsKey("blobEndpoint").Should().BeFalse();
+    }
+
+    [Fact]
+    public void AzureBlob_IsACloudProvider()
+    {
+        new ConnectionForm { Provider = ConnectionProvider.AzureBlob }.IsCloudProvider.Should().BeTrue();
+    }
+
+    // ── ResolveProbeTarget, for the test-connection probe ───────────────
+
+    [Fact]
+    public void ResolveProbeTarget_PrefersTheOperatorEnteredTarget()
+    {
+        var form = new ConnectionForm { AllowedLocations = "allowlisted-container" };
+
+        form.ResolveProbeTarget("typed-container/docs")
+            .Should().Be(("typed-container", "docs"));
+    }
+
+    [Fact]
+    public void ResolveProbeTarget_FallsBackToTheFirstAllowedLocation()
+    {
+        var form = new ConnectionForm { AllowedLocations = "first-container\nsecond-container" };
+
+        form.ResolveProbeTarget(null).Should().Be(("first-container", (string?)null));
+        form.ResolveProbeTarget("   ").Should().Be(("first-container", (string?)null));
+    }
+
+    /// <summary>
+    /// This is the regression this test guards: with nothing typed and nothing allow-listed,
+    /// there is no container to test that is known to exist. "$root" is not auto-created by
+    /// Azure, so a caller that guessed it here would report a valid account as unreachable.
+    /// </summary>
+    [Fact]
+    public void ResolveProbeTarget_NoTargetAndNoAllowlist_IsNullRatherThanAGuessedContainer()
+    {
+        new ConnectionForm().ResolveProbeTarget(null).Should().BeNull();
+        new ConnectionForm().ResolveProbeTarget("  ").Should().BeNull();
+    }
+
     // ── SFTP ───────────────────────────────────────────────────────────────
 
     private static ConnectionForm SftpForm() => new()

--- a/tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceFormTests.cs
@@ -117,10 +117,45 @@ public class SourceFormTests
 
     [Theory]
     [InlineData(ConnectionProvider.S3, "bucket")]
+    [InlineData(ConnectionProvider.AzureBlob, "container")]
     public void Validate_CloudProviderWithoutAContainer_IsRejected(ConnectionProvider provider, string noun)
     {
         var form = new SourceForm { Name = "n", ConnectionId = Guid.NewGuid() };
         form.Validate(provider).Should().Contain(noun);
+    }
+
+    // ── AzureBlob ────────────────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void SourceForm_AzureBlob_BuildsScopeJson()
+    {
+        var form = new SourceForm { Container = "docs", Prefix = "reports/" };
+        form.ToScopeJson(ConnectionProvider.AzureBlob)
+            .Should().Contain("\"containerName\":\"docs\"").And.Contain("\"prefix\":\"reports/\"");
+    }
+
+    [Fact]
+    public void ToScopeJson_AzureBlob_WritesContainerNameNotBucketName()
+    {
+        var scope = Parse(Filled().ToScopeJson(ConnectionProvider.AzureBlob));
+
+        scope.GetProperty("containerName").GetString().Should().Be("company-knowledge");
+        scope.GetProperty("prefix").GetString().Should().Be("docs/");
+
+        // The S3 key must not leak into an Azure scope: the connector reads one or the other,
+        // so a stray key is silently ignored rather than rejected.
+        scope.TryGetProperty("bucketName", out _).Should().BeFalse();
+        scope.TryGetProperty("subPath", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToScopeJson_AzureBlobBlankPrefix_IsOmittedRatherThanWrittenEmpty()
+    {
+        var form = new SourceForm { Name = "n", Container = "c", Prefix = "   " };
+
+        Parse(form.ToScopeJson(ConnectionProvider.AzureBlob))
+            .TryGetProperty("prefix", out _).Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
+++ b/tests/Connapse.Core.Tests/Sources/SourceScopePreflightTests.cs
@@ -258,6 +258,50 @@ public class SourceScopePreflightTests
 
         result.IsRefused.Should().BeFalse();
     }
+    // ── Azure Blob ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Check_AzureContainerInsideAllowedLocations_IsAllowed()
+    {
+        var connection = Conn(ConnectionProvider.AzureBlob, """{"allowedLocations":["company-knowledge"]}""");
+
+        var result = Build().Check(connection, """{"containerName":"company-knowledge"}""");
+
+        result.IsRefused.Should().BeFalse();
+        result.Warning.Should().BeNull();
+    }
+
+    [Fact]
+    public void Check_AzureContainerOutsideAllowedLocations_IsRefusedNamingTheScope()
+    {
+        var connection = Conn(ConnectionProvider.AzureBlob, """{"allowedLocations":["company-knowledge"]}""");
+
+        var result = Build().Check(connection, """{"containerName":"payroll-data"}""");
+
+        result.IsRefused.Should().BeTrue();
+        result.Error.Should().Contain("payroll-data").And.Contain("conn");
+    }
+
+    [Fact]
+    public void Check_AzureMissingContainerName_IsRefusedBeforeThePolicyRuns()
+    {
+        var connection = Conn(ConnectionProvider.AzureBlob, """{"allowedLocations":["c"]}""");
+
+        Build().Check(connection, "{}").IsRefused.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Check_AzureNoAllowedLocations_IsAcceptedWithAWarning()
+    {
+        // Matches ConnectorFactory, which warns and proceeds for Azure exactly as it does for S3.
+        var connection = Conn(ConnectionProvider.AzureBlob, """{"accountName":"acct"}""");
+
+        var result = Build().Check(connection, """{"containerName":"anything"}""");
+
+        result.IsRefused.Should().BeFalse();
+        result.Warning.Should().NotBeNullOrEmpty();
+    }
+
     // ── SFTP ───────────────────────────────────────────────────────────────
 
     private const string SftpConn = """{"host":"h","port":22,"username":"u","allowedRoot":"/D:/CodeProjects"}""";

--- a/tests/Connapse.Core.Tests/Utilities/AzureBlobEndpointTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureBlobEndpointTests.cs
@@ -1,0 +1,85 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Core.Tests.Utilities;
+
+/// <summary>
+/// The endpoint a connection reads from must be the account its documents are labelled as. A
+/// mismatch is not a configuration nuance: every permission decision is made against the label,
+/// and Connapse's storage token would go to whatever host the endpoint named.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AzureBlobEndpointTests
+{
+    [Fact]
+    public void NoOverride_IsTheAccountsPublicEndpoint()
+    {
+        AzureBlobEndpoint.Validate("myacct", null, out Uri? endpoint).Should().BeNull();
+        endpoint.Should().Be(new Uri("https://myacct.blob.core.windows.net"));
+    }
+
+    [Theory]
+    [InlineData("MyAcct")]
+    [InlineData("  myacct ")]
+    public void AccountName_IsNormalisedToAzuresSpelling(string typed)
+    {
+        AzureBlobEndpoint.NormaliseAccount(typed).Should().Be("myacct");
+        AzureBlobEndpoint.Validate(typed, null, out Uri? endpoint).Should().BeNull();
+        endpoint!.Host.Should().Be("myacct.blob.core.windows.net");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("ab")]
+    [InlineData("has-dash")]
+    [InlineData("waytoolongforanazurestorageaccountname")]
+    public void AccountName_OutsideAzuresRule_IsRefused(string typed) =>
+        AzureBlobEndpoint.Validate(typed, null, out _).Should().Contain("3 to 24 lowercase");
+
+    [Theory]
+    [InlineData("https://myacct.blob.core.windows.net")]
+    [InlineData("https://MYACCT.blob.core.windows.net/")]
+    [InlineData("https://myacct.blob.core.usgovcloudapi.net")]
+    [InlineData("https://myacct.blob.core.chinacloudapi.cn")]
+    public void Override_OnAnAzureCloud_MustBeTheAccountItself(string endpoint) =>
+        AzureBlobEndpoint.Validate("myacct", endpoint, out _).Should().BeNull();
+
+    [Theory]
+    [InlineData("https://otheracct.blob.core.windows.net")]
+    [InlineData("https://myacct.blob.attacker.example")]
+    [InlineData("https://attacker.example/myacct")]
+    [InlineData("https://myacct.blob.core.windows.net.attacker.example")]
+    public void Override_ForAnotherHost_IsRefused(string endpoint)
+    {
+        // The content would be read from one place and labelled — and authorised — as another,
+        // and the token would be sent to a host Connapse has no business talking to.
+        AzureBlobEndpoint.Validate("myacct", endpoint, out Uri? resolved).Should().Contain("is not storage account 'myacct'");
+        resolved.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1:10000/myacct")]
+    [InlineData("http://localhost:10000/myacct/")]
+    [InlineData("https://[::1]:10000/MYACCT")]
+    public void Override_OnALoopbackEmulator_MustServeTheAccount(string endpoint) =>
+        AzureBlobEndpoint.Validate("myacct", endpoint, out _).Should().BeNull();
+
+    [Fact]
+    public void Override_OnALoopbackEmulator_ForAnotherAccount_IsRefused() =>
+        AzureBlobEndpoint.Validate("myacct", "http://127.0.0.1:10000/devstoreaccount1", out _)
+            .Should().Contain("expected http://127.0.0.1:10000/myacct");
+
+    [Theory]
+    [InlineData("not a url")]
+    [InlineData("ftp://myacct.blob.core.windows.net")]
+    public void Override_ThatIsNotAnHttpAddress_IsRefused(string endpoint) =>
+        AzureBlobEndpoint.Validate("myacct", endpoint, out _).Should().Contain("full https:// address");
+
+    [Fact]
+    public void Resolve_ThrowsOnAMismatch_SoAConnectorCannotBeBuiltForTheWrongHost()
+    {
+        var act = () => AzureBlobEndpoint.Resolve("myacct", "https://otheracct.blob.core.windows.net");
+        act.Should().Throw<InvalidOperationException>().WithMessage("*is not storage account 'myacct'*");
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -102,8 +102,160 @@ public class AzureCloudShellSetupTests
     public void AccessScript_PrintsTheKeys_ParseAccessResultReads()
     {
         string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
-        foreach (string key in new[] { "tenantId=", "subscriptionId=", "accessAppClientId=" })
+        foreach (string key in new[] { "tenantId=", "subscriptionId=", "accessAppClientId=", "certificateThumbprint=" })
             s.Should().Contain(key);
+    }
+
+    [Fact]
+    public void Scripts_ReadTheThumbprintBeforeDeletingTheCertificateFile()
+    {
+        // The thumbprint is what lets the page refuse to keep a certificate other than the one the
+        // script registered; it has to be taken while the file still exists.
+        foreach (string s in new[]
+                 {
+                     AzureCloudShellSetup.GenerateAccessScript(AccessInput()),
+                     AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput()),
+                 })
+        {
+            int thumb = s.IndexOf("CERT_THUMBPRINT=$(openssl x509 -in \"$CERT_FILE\"", StringComparison.Ordinal);
+            int remove = s.IndexOf("rm -f \"$CERT_FILE\"", StringComparison.Ordinal);
+            thumb.Should().BeGreaterThan(0);
+            remove.Should().BeGreaterThan(thumb);
+        }
+    }
+
+    [Theory]
+    [InlineData("ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01", "ABCDEF0123456789ABCDEF0123456789ABCDEF01")]
+    [InlineData("ABCDEF0123456789ABCDEF0123456789ABCDEF01", "ABCDEF0123456789ABCDEF0123456789ABCDEF01")]
+    [InlineData("", null)]
+    [InlineData("not-a-thumbprint", null)]
+    public void ParseAccessResult_ReadsTheThumbprint_NormalisedOrNone(string printed, string? expected)
+    {
+        string block = AzureCloudShellSetup.AccessBeginMarker
+            + $"\ntenantId={Tenant}\nsubscriptionId={Sub}\naccessAppClientId={AccessId}\ncertificateThumbprint={printed}\n"
+            + AzureCloudShellSetup.AccessEndMarker;
+
+        AzureCloudShellSetup.ParseAccessResult(block)!.CertificateThumbprint.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseAccessResult_OlderPasteWithoutThumbprint_StillParses() =>
+        AzureCloudShellSetup.ParseAccessResult(AccessBlock())!.CertificateThumbprint.Should().BeNull();
+
+    // ---- Access step on an Azure host: the managed identity ----
+
+    private const string MiPrincipal = "55555555-5555-5555-5555-555555555555";
+    private const string MiClient = "66666666-6666-6666-6666-666666666666";
+
+    private static AzureManagedIdentityAccessSetupInput ManagedIdentityInput(bool userAssigned = false) =>
+        new(MiPrincipal, MiClient, userAssigned);
+
+    [Fact]
+    public void ManagedIdentityAccessScript_AssignsByObjectId_AndNeverRegistersAnApp()
+    {
+        string s = AzureCloudShellSetup.GenerateManagedIdentityAccessScript(ManagedIdentityInput());
+
+        s.Should().Contain($"MI_PRINCIPAL_ID='{MiPrincipal}'");
+        s.Should().Contain("--assignee-object-id \"$MI_PRINCIPAL_ID\" --assignee-principal-type ServicePrincipal");
+        s.Should().Contain(AzureCloudShellSetup.BlobDataRoleName).And.Contain(AzureCloudShellSetup.RbacReadRoleName);
+        // No app registration, no certificate: that is the whole point of this path.
+        s.Should().NotContain("az ad app").And.NotContain("CERT_FILE").And.NotContain("BEGIN CERTIFICATE");
+        s.Should().Contain("MI_KIND='system-assigned'");
+        AzureCloudShellSetup.GenerateManagedIdentityAccessScript(ManagedIdentityInput(userAssigned: true))
+            .Should().Contain("MI_KIND='user-assigned'");
+    }
+
+    [Fact]
+    public void ManagedIdentityAccessScript_PrintsTheKeys_ParseReads()
+    {
+        string s = AzureCloudShellSetup.GenerateManagedIdentityAccessScript(ManagedIdentityInput());
+        foreach (string key in new[] { "tenantId=", "subscriptionId=", "managedIdentityPrincipalId=", "managedIdentityClientId=", "managedIdentityKind=" })
+            s.Should().Contain(key);
+        s.Should().Contain(AzureCloudShellSetup.ManagedIdentityBeginMarker).And.Contain(AzureCloudShellSetup.ManagedIdentityEndMarker);
+    }
+
+    [Fact]
+    public void ManagedIdentityAccessScript_RunsInASubshell_LikeTheOthers()
+    {
+        string s = AzureCloudShellSetup.GenerateManagedIdentityAccessScript(ManagedIdentityInput()).Replace("\r\n", "\n");
+        s.Should().Contain("\n(\nset -euo pipefail\ntrap 'echo; echo \"Connapse setup failed at: $BASH_COMMAND\" >&2' ERR");
+        s.Should().Contain(") || echo \"----- CONNAPSE SETUP FAILED");
+    }
+
+    private static string ManagedIdentityBlock(string principal = MiPrincipal, string kind = "system-assigned") =>
+        AzureCloudShellSetup.ManagedIdentityBeginMarker
+        + $"\ntenantId={Tenant}\nsubscriptionId={Sub}\nmanagedIdentityPrincipalId={principal}\nmanagedIdentityClientId={MiClient}\nmanagedIdentityKind={kind}\n"
+        + AzureCloudShellSetup.ManagedIdentityEndMarker;
+
+    [Fact]
+    public void ParseManagedIdentityAccessResult_WellFormed_ReturnsEverything()
+    {
+        AzureManagedIdentityAccessResult? r = AzureCloudShellSetup.ParseManagedIdentityAccessResult(ManagedIdentityBlock());
+
+        r.Should().NotBeNull();
+        r!.TenantId.Should().Be(Tenant);
+        r.SubscriptionId.Should().Be(Sub);
+        r.PrincipalId.Should().Be(MiPrincipal);
+        r.ClientId.Should().Be(MiClient);
+        r.IsUserAssigned.Should().BeFalse();
+        AzureCloudShellSetup.ParseManagedIdentityAccessResult(ManagedIdentityBlock(kind: "user-assigned"))!.IsUserAssigned.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseManagedIdentityAccessResult_NonGuid_ReturnsNull() =>
+        AzureCloudShellSetup.ParseManagedIdentityAccessResult(ManagedIdentityBlock(principal: "bad")).Should().BeNull();
+
+    [Fact]
+    public void ParseManagedIdentityAccessResult_DoesNotReadTheCertificateAppBlock() =>
+        AzureCloudShellSetup.ParseManagedIdentityAccessResult(AccessBlock()).Should().BeNull();
+
+    [Fact]
+    public void PermissionsScript_ForAManagedIdentity_GrantsAppRolesByRest_AndNeverConsentsAnApp()
+    {
+        string s = AzureCloudShellSetup.GeneratePermissionsScript(
+            PermissionsInput() with { AccessManagedIdentityPrincipalId = MiPrincipal });
+
+        s.Should().Contain($"ACCESS_MI_PRINCIPAL_ID='{MiPrincipal}'");
+        s.Should().Contain("/servicePrincipals/$ACCESS_MI_PRINCIPAL_ID/appRoleAssignments");
+        s.Should().Contain("\\\"principalId\\\":\\\"$ACCESS_MI_PRINCIPAL_ID\\\"")
+            .And.Contain("\\\"resourceId\\\":\\\"$GRAPH_SP_ID\\\"")
+            .And.Contain("\\\"appRoleId\\\":\\\"$1\\\"");
+        s.Should().NotContain("az ad app permission add").And.NotContain("admin-consent");
+        s.Should().Contain("CONSENT_URL=\"\"");
+        // The sign-in app is still a certificate app: people cannot sign in through a managed identity.
+        s.Should().Contain("register_cert \"$SIGNIN_APP_ID\"");
+    }
+
+    [Fact]
+    public void PermissionsScript_ForAnApp_StillAddsPermissionsAndConsents()
+    {
+        string s = AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput());
+
+        s.Should().Contain("az ad app permission add").And.Contain("admin-consent");
+        s.Should().NotContain("appRoleAssignments");
+        s.Should().NotContain("{{graphGrant}}");
+    }
+
+    [Fact]
+    public void GraphAppRoleGrantCommands_NameTheIdentity_AndBothRoles()
+    {
+        string s = AzureCloudShellSetup.GraphAppRoleGrantCommands(MiPrincipal);
+
+        s.Should().Contain($"MI='{MiPrincipal}'");
+        s.Should().Contain("User.Read.All GroupMember.Read.All");
+        s.Should().Contain("appRoleAssignments");
+        s.Should().NotContain("{{");
+    }
+
+    [Fact]
+    public void ParsePermissionsResult_ReadsTheThumbprint()
+    {
+        string block = AzureCloudShellSetup.PermissionsBeginMarker
+            + $"\nsignInAppClientId={SignInId}\nconsentGranted=true\nconsentUrl=\ncertificateThumbprint=abcdef0123456789abcdef0123456789abcdef01\n"
+            + AzureCloudShellSetup.PermissionsEndMarker;
+
+        AzureCloudShellSetup.ParsePermissionsResult(block)!.CertificateThumbprint
+            .Should().Be("ABCDEF0123456789ABCDEF0123456789ABCDEF01");
     }
 
     // ---- Per-user permissions step ----
@@ -160,12 +312,15 @@ public class AzureCloudShellSetupTests
     {
         // `set -e` pasted into an interactive shell closes the session on the first failure, taking
         // the error message with it. Both scripts wrap the body and print what failed.
-        foreach (string s in new[]
+        foreach (string script in new[]
                  {
                      AzureCloudShellSetup.GenerateAccessScript(AccessInput()),
                      AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput()),
                  })
         {
+            // The template is a raw string literal, so it carries the source file's line endings;
+            // a CRLF checkout must not fail an assertion about the script's structure.
+            string s = script.Replace("\r\n", "\n");
             s.Should().Contain("\n(\nset -euo pipefail\ntrap 'echo; echo \"Connapse setup failed at: $BASH_COMMAND\" >&2' ERR");
             s.Should().Contain(") || echo \"----- CONNAPSE SETUP FAILED");
         }

--- a/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureCloudShellSetupTests.cs
@@ -1,0 +1,250 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class AzureCloudShellSetupTests
+{
+    private const string Sub = "33333333-3333-3333-3333-333333333333";
+    private const string Tenant = "11111111-1111-1111-1111-111111111111";
+    private const string AccessId = "22222222-2222-2222-2222-222222222222";
+    private const string SignInId = "44444444-4444-4444-4444-444444444444";
+    private const string Cert = "-----BEGIN CERTIFICATE-----\nMIIBfakefakefake\n-----END CERTIFICATE-----";
+
+    // ---- Access step ----
+
+    private static AzureAccessSetupInput AccessInput() => new("Connapse-Azure-Access", Cert);
+
+    [Fact]
+    public void AccessScript_ContainsRolesAppCertAndMarkers_ButNeverThePrivateKey()
+    {
+        string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+
+        s.Should().Contain(AzureCloudShellSetup.AccessBeginMarker).And.Contain(AzureCloudShellSetup.AccessEndMarker);
+        s.Should().Contain("ACCESS_APP_NAME='Connapse-Azure-Access'");
+        s.Should().Contain(AzureCloudShellSetup.BlobDataRoleName).And.Contain("blobs/tags/read");
+        s.Should().Contain(AzureCloudShellSetup.RbacReadRoleName).And.Contain("Microsoft.Authorization/denyAssignments/read");
+        s.Should().Contain("az ad app create --display-name \"$ACCESS_APP_NAME\"");
+        s.Should().Contain("az ad app credential reset").And.Contain("--append");
+        s.Should().Contain("MIIBfakefakefake");
+        s.Should().NotContain("PRIVATE KEY");
+        s.Should().NotContain("admin-consent"); // consent belongs to the Permissions step
+    }
+
+    [Fact]
+    public void AccessScript_RolesGrantListing_AndAreUpdatedInPlaceOnReRun()
+    {
+        string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+
+        // Container listing is a control-plane Action even over the data plane; account listing is
+        // subscription-wide metadata. Both read-only, neither touches keys.
+        s.Should().Contain("\\\"Actions\\\": [\\\"Microsoft.Storage/storageAccounts/blobServices/containers/read\\\"]");
+        s.Should().Contain("\\\"Microsoft.Storage/storageAccounts/read\\\"");
+        s.Should().NotContain("listKeys");
+        // `update` takes the `list` shape (roleName/permissions), not the create shape — the existing
+        // definition is patched. Resending the create shape fails with KeyError: 'roleName'.
+        s.Should().Contain("az role definition update --role-definition \"$(jq -n --argjson e \"$existing\" --argjson d \"$2\"");
+        s.Should().Contain(".permissions = [{actions: $d.Actions");
+    }
+
+    [Fact]
+    public void AccessScript_ReadsTheSignedInSubscription_NothingToTypeUpFront()
+    {
+        string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+
+        s.Should().Contain("SUBSCRIPTION_ID=$(az account show --query id -o tsv)");
+        s.Should().NotContain("{{"); // no unfilled placeholders
+    }
+
+    [Fact]
+    public void AccessScript_StorageScope_DefaultsToWholeSubscription_AndIsEditableInline()
+    {
+        string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+
+        s.Should().Contain("STORAGE_SCOPE=\"\"");
+        s.Should().Contain("STORAGE_SCOPE=\"/subscriptions/$SUBSCRIPTION_ID\"");
+    }
+
+    private static string AccessBlock(string tenant = Tenant, string sub = Sub, string access = AccessId) =>
+        $"{AzureCloudShellSetup.AccessBeginMarker}\ntenantId={tenant}\nsubscriptionId={sub}\naccessAppClientId={access}\n{AzureCloudShellSetup.AccessEndMarker}";
+
+    [Fact]
+    public void ParseAccessResult_WellFormed_ReturnsIds()
+    {
+        AzureAccessResult? r = AzureCloudShellSetup.ParseAccessResult(AccessBlock());
+        r.Should().NotBeNull();
+        r!.TenantId.Should().Be(Tenant);
+        r.SubscriptionId.Should().Be(Sub);
+        r.AccessAppClientId.Should().Be(AccessId);
+    }
+
+    [Fact]
+    public void ParseAccessResult_AnchorsOnLastMarkerPair_WhenTerminalIsPasted()
+    {
+        string terminal = "echo script\n" + AzureCloudShellSetup.AccessBeginMarker + "\nnoise\n" + AzureCloudShellSetup.AccessEndMarker
+            + "\n...\n" + AccessBlock();
+        AzureCloudShellSetup.ParseAccessResult(terminal)!.AccessAppClientId.Should().Be(AccessId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("no markers")]
+    public void ParseAccessResult_NoBlock_ReturnsNull(string? pasted) =>
+        AzureCloudShellSetup.ParseAccessResult(pasted).Should().BeNull();
+
+    [Fact]
+    public void ParseAccessResult_NonGuid_ReturnsNull() =>
+        AzureCloudShellSetup.ParseAccessResult(AccessBlock(tenant: "not-a-guid")).Should().BeNull();
+
+    [Fact]
+    public void AccessScript_PrintsTheKeys_ParseAccessResultReads()
+    {
+        string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+        foreach (string key in new[] { "tenantId=", "subscriptionId=", "accessAppClientId=" })
+            s.Should().Contain(key);
+    }
+
+    // ---- Per-user permissions step ----
+
+    private static AzurePermissionsSetupInput PermissionsInput() =>
+        new(AccessId,
+            "https://connapse.example.com/api/v1/auth/cloud/azure/callback",
+            "https://connapse.example.com/admin/providers/azure",
+            "Connapse-Azure-SignIn",
+            Cert);
+
+    [Fact]
+    public void PermissionsScript_ContainsSignInAppGraphPermsConsentAndMarkers()
+    {
+        string s = AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput());
+
+        s.Should().Contain(AzureCloudShellSetup.PermissionsBeginMarker).And.Contain(AzureCloudShellSetup.PermissionsEndMarker);
+        s.Should().Contain($"ACCESS_APP_ID='{AccessId}'");
+        s.Should().Contain("az ad app update --id \"$SIGNIN_APP_ID\" --web-redirect-uris \"$REDIRECT_URI\"");
+        s.Should().Contain("https://connapse.example.com/api/v1/auth/cloud/azure/callback");
+        s.Should().Contain("User.Read.All").And.Contain("GroupMember.Read.All");
+        s.Should().Contain("az ad app permission admin-consent");
+        s.Should().Contain("/adminconsent?client_id=");
+        s.Should().Contain("MIIBfakefakefake");
+        s.Should().NotContain("PRIVATE KEY");
+        s.Should().NotContain("az role definition create"); // roles belong to the Access step
+    }
+
+    private static string PermissionsBlock(string signIn = SignInId, string consent = "true") =>
+        $"{AzureCloudShellSetup.PermissionsBeginMarker}\nsignInAppClientId={signIn}\nconsentGranted={consent}\n"
+        + $"consentUrl=https://login.microsoftonline.com/{Tenant}/adminconsent?client_id={AccessId}\n{AzureCloudShellSetup.PermissionsEndMarker}";
+
+    [Fact]
+    public void PermissionsScript_RegistersConsentLandingOnAccessApp_AndPassesItAsRedirectUri()
+    {
+        // The v1 adminconsent endpoint needs a registered reply URL on the app being consented to,
+        // else it fails with AADSTS500113 before showing the prompt.
+        string s = AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput());
+
+        s.Should().Contain("az ad app update --id \"$ACCESS_APP_ID\" --web-redirect-uris \"$CONSENT_REDIRECT_URI\"");
+        s.Should().Contain("CONSENT_REDIRECT_URI='https://connapse.example.com/admin/providers/azure'");
+        s.Should().Contain("&redirect_uri=https%3A%2F%2Fconnapse.example.com%2Fadmin%2Fproviders%2Fazure");
+    }
+
+    [Fact]
+    public void PermissionsScript_PreConsentsSignInAppForEveryone_WhenAdminConsentSucceeds()
+    {
+        string s = AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput());
+        s.Should().Contain("az ad app permission grant --id \"$SIGNIN_APP_ID\" --api \"$GRAPH_API\" --scope \"openid profile offline_access\"");
+    }
+
+    [Fact]
+    public void Scripts_RunInASubshell_SoAPasteIntoTheInteractiveShellSurvivesAnError()
+    {
+        // `set -e` pasted into an interactive shell closes the session on the first failure, taking
+        // the error message with it. Both scripts wrap the body and print what failed.
+        foreach (string s in new[]
+                 {
+                     AzureCloudShellSetup.GenerateAccessScript(AccessInput()),
+                     AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput()),
+                 })
+        {
+            s.Should().Contain("\n(\nset -euo pipefail\ntrap 'echo; echo \"Connapse setup failed at: $BASH_COMMAND\" >&2' ERR");
+            s.Should().Contain(") || echo \"----- CONNAPSE SETUP FAILED");
+        }
+    }
+
+    [Fact]
+    public void Scripts_NeverDiscoverAppsByDisplayName()
+    {
+        // A display name is not unique or authoritative: a look-alike registered by another tenant
+        // user must never be handed Connapse's roles and Graph permissions.
+        AzureCloudShellSetup.GenerateAccessScript(AccessInput()).Should().NotContain("--display-name \"$ACCESS_APP_NAME\" --query '[0]");
+        AzureCloudShellSetup.GenerateAccessScript(AccessInput()).Should().NotContain("az ad app list");
+        AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput()).Should().NotContain("az ad app list");
+    }
+
+    [Fact]
+    public void AccessScript_FirstRun_CreatesAFreshApp_ReRunReusesOnlyTheRecordedId()
+    {
+        string fresh = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+        fresh.Should().Contain("ACCESS_APP_ID=''");
+        fresh.Should().Contain("az ad app create --display-name \"$ACCESS_APP_NAME\"");
+
+        string rerun = AzureCloudShellSetup.GenerateAccessScript(AccessInput() with { ExistingAccessAppClientId = AccessId });
+        rerun.Should().Contain($"ACCESS_APP_ID='{AccessId}'");
+        rerun.Should().Contain("az ad app show --id \"$ACCESS_APP_ID\"");
+
+        // Anything that is not a GUID is treated as "nothing recorded", so it cannot inject shell.
+        AzureCloudShellSetup.GenerateAccessScript(AccessInput() with { ExistingAccessAppClientId = "'; rm -rf / #" })
+            .Should().Contain("ACCESS_APP_ID=''");
+    }
+
+    [Fact]
+    public void PermissionsScript_ReRunReusesOnlyTheRecordedSignInId()
+    {
+        AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput()).Should().Contain("SIGNIN_APP_ID=''");
+        AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput() with { ExistingSignInAppClientId = SignInId })
+            .Should().Contain($"SIGNIN_APP_ID='{SignInId}'").And.Contain("az ad app show --id \"$SIGNIN_APP_ID\"");
+    }
+
+    [Fact]
+    public void AccessScript_RoleAssignmentFailsLoudly_InsteadOfPrintingAPasteBlock()
+    {
+        string s = AzureCloudShellSetup.GenerateAccessScript(AccessInput());
+        s.Should().Contain("assign_role '" + AzureCloudShellSetup.BlobDataRoleName + "' \"$STORAGE_SCOPE\"");
+        s.Should().Contain("after 5 attempts");
+        s.Should().NotContain("&& break || sleep");
+    }
+
+    [Fact]
+    public void ParsePermissionsResult_ConsentGranted_ReturnsIdAndTrue()
+    {
+        AzurePermissionsResult? r = AzureCloudShellSetup.ParsePermissionsResult(PermissionsBlock());
+        r.Should().NotBeNull();
+        r!.SignInAppClientId.Should().Be(SignInId);
+        r.ConsentGranted.Should().BeTrue();
+        r.ConsentUrl.Should().Contain("adminconsent");
+    }
+
+    [Fact]
+    public void ParsePermissionsResult_ConsentPending_ReturnsFalseAndUrl()
+    {
+        AzurePermissionsResult? r = AzureCloudShellSetup.ParsePermissionsResult(PermissionsBlock(consent: "false"));
+        r!.ConsentGranted.Should().BeFalse();
+        r.ConsentUrl.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ParsePermissionsResult_NonGuid_ReturnsNull() =>
+        AzureCloudShellSetup.ParsePermissionsResult(PermissionsBlock(signIn: "bad")).Should().BeNull();
+
+    [Fact]
+    public void ParsePermissionsResult_DoesNotReadTheAccessBlock() =>
+        AzureCloudShellSetup.ParsePermissionsResult(AccessBlock()).Should().BeNull();
+
+    [Fact]
+    public void PermissionsScript_PrintsTheKeys_ParsePermissionsResultReads()
+    {
+        string s = AzureCloudShellSetup.GeneratePermissionsScript(PermissionsInput());
+        foreach (string key in new[] { "signInAppClientId=", "consentGranted=", "consentUrl=" })
+            s.Should().Contain(key);
+    }
+}

--- a/tests/Connapse.Core.Tests/Utilities/AzureSetupRoleTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/AzureSetupRoleTests.cs
@@ -1,0 +1,34 @@
+using Connapse.Core.Utilities;
+using FluentAssertions;
+
+namespace Connapse.Core.Tests.Utilities;
+
+[Trait("Category", "Unit")]
+public class AzureSetupRoleTests
+{
+    private const string Client = "22222222-2222-2222-2222-222222222222";
+    private const string Account = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+
+    [Fact]
+    public void AssignmentsFor_OneCommandPerDistinctContainer_PrefixesCollapseToTheirContainer()
+    {
+        string s = AzureSetupRole.AssignmentsFor(Client, Account, ["docs/2024", "docs", "Images/raw"]);
+
+        string[] lines = s.Split('\n');
+        lines.Should().HaveCount(2);
+        lines[0].Should().Contain($"--scope '{Account}/blobServices/default/containers/docs'");
+        lines[1].Should().Contain($"--scope '{Account}/blobServices/default/containers/Images'");
+        lines.Should().OnlyContain(l => l.Contains($"--assignee '{Client}'")
+                                     && l.Contains($"--role '{AzureCloudShellSetup.BlobDataRoleName}'"));
+    }
+
+    [Fact]
+    public void AssignmentsFor_NoLocations_GrantsTheWholeAccount() =>
+        AzureSetupRole.AssignmentsFor(Client, Account + "/", [])
+            .Should().Be($"az role assignment create --assignee '{Client}' --role '{AzureCloudShellSetup.BlobDataRoleName}' --scope '{Account}'");
+
+    [Fact]
+    public void AssignmentsFor_EscapesSingleQuotes() =>
+        AzureSetupRole.AssignmentsFor(Client, Account, ["it's"])
+            .Should().Contain("containers/it'\\''s'");
+}

--- a/tests/Connapse.Core.Tests/Utilities/ResourceUriTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/ResourceUriTests.cs
@@ -54,4 +54,20 @@ public class ResourceUriTests
             .Should().Throw<ArgumentException>();
     }
 
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ForAzureBlob_BuildsAzblobUri()
+    {
+        ResourceUri.ForAzureBlob("acct", "docs", "reports/q1.pdf")
+            .Should().Be("azblob://acct/docs/reports/q1.pdf");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ForAzureBlob_BlankAccount_Throws()
+    {
+        var act = () => ResourceUri.ForAzureBlob("", "docs", "k");
+        act.Should().Throw<ArgumentException>();
+    }
+
 }

--- a/tests/Connapse.Core.Tests/Utilities/ResourceUriTests.cs
+++ b/tests/Connapse.Core.Tests/Utilities/ResourceUriTests.cs
@@ -64,6 +64,17 @@ public class ResourceUriTests
 
     [Fact]
     [Trait("Category", "Unit")]
+    public void ForAzureBlob_LowerCasesAccountAndContainer_KeepsThePathAsIs()
+    {
+        // Azure names accounts and containers in lower case, and the deny assignments the
+        // verifier compares against are spelled that way; a URI typed with capitals would miss
+        // them. Blob names are case-sensitive and stay exactly as listed.
+        ResourceUri.ForAzureBlob("ACCT", "Docs", "Reports/Q1.pdf")
+            .Should().Be("azblob://acct/docs/Reports/Q1.pdf");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
     public void ForAzureBlob_BlankAccount_Throws()
     {
         var act = () => ResourceUri.ForAzureBlob("", "docs", "k");

--- a/tests/Connapse.Identity.Tests/AzureAuthorizationUrlTests.cs
+++ b/tests/Connapse.Identity.Tests/AzureAuthorizationUrlTests.cs
@@ -1,0 +1,22 @@
+using Connapse.Core;
+using Connapse.Identity.Services;
+using FluentAssertions;
+
+namespace Connapse.Identity.Tests;
+
+[Trait("Category", "Unit")]
+public class AzureAuthorizationUrlTests
+{
+    [Fact]
+    public void AuthUrl_ContainsRequiredParams()
+    {
+        var s = new AzureAdSignInSettings { TenantId = "t", ClientId = "c", RedirectUri = "https://app/azure/callback" };
+        var url = AzureAuthorizationUrl.Build(s, "st", "no", "ch");
+        url.Should().StartWith("https://login.microsoftonline.com/t/oauth2/v2.0/authorize?");
+        url.Should().Contain("client_id=c").And.Contain("response_type=code")
+           .And.Contain("code_challenge=ch").And.Contain("code_challenge_method=S256")
+           .And.Contain("state=st").And.Contain("nonce=no")
+           .And.Contain("redirect_uri=https%3A%2F%2Fapp%2Fazure%2Fcallback")
+           .And.Contain("scope=openid%20profile");
+    }
+}

--- a/tests/Connapse.Identity.Tests/AzureIdTokenValidatorTests.cs
+++ b/tests/Connapse.Identity.Tests/AzureIdTokenValidatorTests.cs
@@ -1,0 +1,126 @@
+using System.Security.Cryptography;
+using Connapse.Core;
+using Connapse.Identity.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using NSubstitute;
+
+namespace Connapse.Identity.Tests;
+
+[Trait("Category", "Unit")]
+public class AzureIdTokenValidatorTests
+{
+    private const string TenantId = "11111111-1111-1111-1111-111111111111";
+    private const string ClientId = "22222222-2222-2222-2222-222222222222";
+    private const string Issuer = $"https://login.microsoftonline.com/{TenantId}/v2.0";
+
+    [Fact]
+    public async Task ValidToken_ExtractsOidTid()
+    {
+        (string token, RsaSecurityKey key) = CreateToken(nonce: "expected-nonce", oid: "oid-1", tid: TenantId, name: "Ada Lovelace");
+        AzureIdTokenValidator validator = BuildValidator(key);
+
+        AzureIdTokenResult result = await validator.ValidateAsync(token, "expected-nonce", CancellationToken.None);
+
+        result.Ok.Should().BeTrue();
+        result.ObjectId.Should().Be("oid-1");
+        result.TenantId.Should().Be(TenantId);
+        result.DisplayName.Should().Be("Ada Lovelace");
+        result.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WrongNonce_Fails()
+    {
+        (string token, RsaSecurityKey key) = CreateToken(nonce: "actual-nonce", oid: "oid-1", tid: TenantId, name: "Ada Lovelace");
+        AzureIdTokenValidator validator = BuildValidator(key);
+
+        AzureIdTokenResult result = await validator.ValidateAsync(token, "different-nonce", CancellationToken.None);
+
+        result.Ok.Should().BeFalse();
+        result.ObjectId.Should().BeNull();
+        result.TenantId.Should().BeNull();
+        result.DisplayName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WrongAudience_Fails()
+    {
+        (string token, RsaSecurityKey key) = CreateToken(
+            nonce: "expected-nonce", oid: "oid-1", tid: TenantId, name: "Ada Lovelace", audience: "some-other-client-id");
+        AzureIdTokenValidator validator = BuildValidator(key);
+
+        AzureIdTokenResult result = await validator.ValidateAsync(token, "expected-nonce", CancellationToken.None);
+
+        result.Ok.Should().BeFalse();
+        result.ObjectId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Expired_Fails()
+    {
+        DateTime now = DateTime.UtcNow;
+        (string token, RsaSecurityKey key) = CreateToken(
+            nonce: "expected-nonce", oid: "oid-1", tid: TenantId, name: "Ada Lovelace",
+            notBefore: now.AddMinutes(-20), expires: now.AddMinutes(-10));
+        AzureIdTokenValidator validator = BuildValidator(key);
+
+        AzureIdTokenResult result = await validator.ValidateAsync(token, "expected-nonce", CancellationToken.None);
+
+        result.Ok.Should().BeFalse();
+        result.ObjectId.Should().BeNull();
+    }
+
+    private static AzureIdTokenValidator BuildValidator(RsaSecurityKey key)
+    {
+        var settings = new AzureAdSignInSettings { TenantId = TenantId, ClientId = ClientId };
+        IOptionsMonitor<AzureAdSignInSettings> options = Substitute.For<IOptionsMonitor<AzureAdSignInSettings>>();
+        options.CurrentValue.Returns(settings);
+
+        var keySource = new StubKeySource(new List<SecurityKey> { key });
+        return new AzureIdTokenValidator(options, keySource);
+    }
+
+    private static (string Token, RsaSecurityKey Key) CreateToken(
+        string nonce,
+        string oid,
+        string tid,
+        string name,
+        string? audience = null,
+        DateTime? notBefore = null,
+        DateTime? expires = null)
+    {
+        RSA rsa = RSA.Create(2048);
+        var key = new RsaSecurityKey(rsa) { KeyId = "test-key" };
+        var signingCredentials = new SigningCredentials(key, SecurityAlgorithms.RsaSha256);
+
+        DateTime now = DateTime.UtcNow;
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = audience ?? ClientId,
+            NotBefore = notBefore ?? now.AddMinutes(-5),
+            Expires = expires ?? now.AddMinutes(5),
+            SigningCredentials = signingCredentials,
+            Claims = new Dictionary<string, object>
+            {
+                ["nonce"] = nonce,
+                ["oid"] = oid,
+                ["tid"] = tid,
+                ["name"] = name,
+            },
+        };
+
+        var handler = new JsonWebTokenHandler();
+        string token = handler.CreateToken(descriptor);
+        return (token, key);
+    }
+
+    private sealed class StubKeySource(IReadOnlyList<SecurityKey> keys) : IAzureSigningKeySource
+    {
+        public Task<IReadOnlyList<SecurityKey>> GetSigningKeysAsync(string tenantId, CancellationToken ct) =>
+            Task.FromResult(keys);
+    }
+}

--- a/tests/Connapse.Identity.Tests/AzureIdentityLinkServiceTests.cs
+++ b/tests/Connapse.Identity.Tests/AzureIdentityLinkServiceTests.cs
@@ -1,0 +1,106 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Identity.Data;
+using Connapse.Identity.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+
+namespace Connapse.Identity.Tests;
+
+/// <summary>
+/// Storing, reading, and disconnecting a user's Entra identity link, end to end through
+/// <see cref="AzureIdentityLinkService"/>, <see cref="AzureIdentityLinkStore"/>, and the
+/// <see cref="IAzureIdentityLinkReader"/> it also implements.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AzureIdentityLinkServiceTests
+{
+    private static AzureIdentityLinkStore CreateStore(string dbName) =>
+        new(CreateFactory(dbName), TimeProvider.System);
+
+    private static IDbContextFactory<ConnapseIdentityDbContext> CreateFactory(string dbName)
+    {
+        var factory = Substitute.For<IDbContextFactory<ConnapseIdentityDbContext>>();
+        factory.CreateDbContextAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(new ConnapseIdentityDbContext(
+                new DbContextOptionsBuilder<ConnapseIdentityDbContext>()
+                    .UseInMemoryDatabase(dbName)
+                    .Options)));
+        return factory;
+    }
+
+    private static AzureIdentityLinkService CreateService(AzureIdentityLinkStore store) => new(store);
+
+    [Fact]
+    public async Task Store_Get_Disconnect_RoundTrips()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var userId = Guid.NewGuid();
+        var store = CreateStore(dbName);
+        var svc = CreateService(store);
+
+        await svc.StoreAsync(userId, "oid-1", "tid-1", "Ada Lovelace", default);
+
+        var dto = await svc.GetAsync(userId, default);
+        dto.Should().NotBeNull();
+        dto!.ObjectId.Should().Be("oid-1");
+        dto.TenantId.Should().Be("tid-1");
+        dto.DisplayName.Should().Be("Ada Lovelace");
+
+        IAzureIdentityLinkReader reader = store;
+        (await reader.GetLinkAsync(userId, default)).Should().Be(new AzureIdentityRef("oid-1", "tid-1"));
+
+        (await svc.DisconnectAsync(userId, default)).Should().BeTrue();
+        (await svc.GetAsync(userId, default)).Should().BeNull();
+        (await reader.GetLinkAsync(userId, default)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_NoLinkExists_ReturnsFalse()
+    {
+        var store = CreateStore(Guid.NewGuid().ToString());
+
+        (await CreateService(store).DisconnectAsync(Guid.NewGuid())).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StoreAsync_Again_ReplacesTheRowRatherThanAddingASecond()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var userId = Guid.NewGuid();
+        var store = CreateStore(dbName);
+        var svc = CreateService(store);
+
+        await svc.StoreAsync(userId, "oid-1", "tid-1", "Ada Lovelace", default);
+        await svc.StoreAsync(userId, "oid-2", "tid-2", "Ada Renamed", default);
+
+        var link = await store.GetAsync(userId);
+        link.Should().NotBeNull();
+        link!.ObjectId.Should().Be("oid-2");
+        link.TenantId.Should().Be("tid-2");
+        link.DisplayName.Should().Be("Ada Renamed");
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithoutAnObjectId_IsRefused()
+    {
+        // oid+tid together are the join key. A link without one resolves to nobody, and a row
+        // that cannot resolve is worse than no row: it presents as connected while filtering
+        // nothing.
+        var store = CreateStore(Guid.NewGuid().ToString());
+
+        var save = async () => await store.SaveAsync(Guid.NewGuid(), "  ", "tid-1", "Ada Lovelace");
+
+        await save.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GetAsync_NoLink_ReturnsNull()
+    {
+        var store = CreateStore(Guid.NewGuid().ToString());
+
+        (await CreateService(store).GetAsync(Guid.NewGuid())).Should().BeNull();
+    }
+}

--- a/tests/Connapse.Identity.Tests/AzureIdentityLinkServiceTests.cs
+++ b/tests/Connapse.Identity.Tests/AzureIdentityLinkServiceTests.cs
@@ -31,7 +31,11 @@ public class AzureIdentityLinkServiceTests
         return factory;
     }
 
-    private static AzureIdentityLinkService CreateService(AzureIdentityLinkStore store) => new(store);
+    private static AzureIdentityLinkService CreateService(AzureIdentityLinkStore store)
+    {
+        var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+        return new(store, new AzureSignInRequests(cache), new AzureLinkConfirmations(cache));
+    }
 
     [Fact]
     public async Task Store_Get_Disconnect_RoundTrips()

--- a/tests/Connapse.Identity.Tests/AzureLinkConfirmationsTests.cs
+++ b/tests/Connapse.Identity.Tests/AzureLinkConfirmationsTests.cs
@@ -1,0 +1,60 @@
+using Connapse.Identity.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Connapse.Identity.Tests;
+
+[Trait("Category", "Unit")]
+public class AzureLinkConfirmationsTests
+{
+    private static AzureLinkConfirmations NewStore() =>
+        new(new MemoryCache(new MemoryCacheOptions()));
+
+    private static PendingAzureLink SampleLink() =>
+        new(Guid.NewGuid(), "oid-1", "tid-1", "Ada Lovelace");
+
+    [Fact]
+    public void Consume_ReturnsParkedLink_ThenNullOnReuse()
+    {
+        var store = NewStore();
+        PendingAzureLink link = SampleLink();
+
+        string code = store.Start(link);
+
+        store.Consume(code).Should().BeEquivalentTo(link);
+        store.Consume(code).Should().BeNull(); // single use
+    }
+
+    [Fact]
+    public void Consume_UnknownOrBlankCode_ReturnsNull()
+    {
+        var store = NewStore();
+
+        store.Consume(null).Should().BeNull();
+        store.Consume("").Should().BeNull();
+        store.Consume("not-a-real-code").Should().BeNull();
+    }
+
+    [Fact]
+    public void Consume_UnderConcurrency_YieldsLinkToExactlyOneCaller()
+    {
+        // Regression: TryGetValue + Remove is not atomic, so two concurrent /azure/confirm
+        // requests carrying the same code could both retrieve the parked link before either
+        // removed it and both go on to save it — the advertised single-use boundary would be
+        // false. The interlocked claim flag must let exactly one caller win.
+        const int racers = 16;
+        var store = NewStore();
+        string code = store.Start(SampleLink());
+
+        int winners = 0;
+        using var barrier = new Barrier(racers);
+        Parallel.For(0, racers, _ =>
+        {
+            barrier.SignalAndWait(); // release all threads into Consume at once
+            if (store.Consume(code) is not null)
+                Interlocked.Increment(ref winners);
+        });
+
+        winners.Should().Be(1);
+    }
+}

--- a/tests/Connapse.Identity.Tests/AzureLinkRevocationTests.cs
+++ b/tests/Connapse.Identity.Tests/AzureLinkRevocationTests.cs
@@ -1,0 +1,96 @@
+using Connapse.Identity.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Connapse.Identity.Tests;
+
+/// <summary>
+/// Disconnecting an Entra identity must also end every flow the person started before it.
+/// Otherwise a second tab that already reached the callback — its confirmation parked, or its
+/// sign-in still pending — could finish afterwards and put the link back.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AzureLinkRevocationTests
+{
+    private static readonly Guid User = Guid.NewGuid();
+
+    [Fact]
+    public void Confirmation_ParkedBeforeDisconnect_IsRefusedAfterIt()
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var confirmations = new AzureLinkConfirmations(cache);
+        string code = confirmations.Start(new PendingAzureLink(User, "oid-1", "tid-1", "Ada"));
+
+        confirmations.RevokeFor(User);
+
+        confirmations.Consume(code).Should().BeNull("the disconnect came after the flow started");
+    }
+
+    [Fact]
+    public void Confirmation_ParkedAfterDisconnect_StillWorks()
+    {
+        // A fresh link after a disconnect is the ordinary re-connect; only older flows are ended.
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var confirmations = new AzureLinkConfirmations(cache);
+
+        confirmations.RevokeFor(User);
+        Thread.Sleep(5);
+        string code = confirmations.Start(new PendingAzureLink(User, "oid-1", "tid-1", "Ada"));
+
+        confirmations.Consume(code).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Disconnect_OfOneUser_LeavesAnotherUsersFlowAlone()
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var confirmations = new AzureLinkConfirmations(cache);
+        var other = Guid.NewGuid();
+        string code = confirmations.Start(new PendingAzureLink(other, "oid-2", "tid-1", "Bob"));
+
+        confirmations.RevokeFor(User);
+
+        confirmations.Consume(code).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void SignIn_StartedBeforeDisconnect_IsRefusedAfterIt()
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var signIns = new AzureSignInRequests(cache);
+        DateTime started = DateTime.UtcNow.AddSeconds(-1);
+        signIns.Add(new AzurePendingSignIn("state-1", "verifier", "nonce", User, DateTime.UtcNow.AddMinutes(10), started));
+
+        signIns.RevokeFor(User);
+
+        signIns.TakeByState("state-1").Should().BeNull();
+    }
+
+    [Fact]
+    public void SignIn_StartedAfterDisconnect_StillWorks()
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var signIns = new AzureSignInRequests(cache);
+
+        signIns.RevokeFor(User);
+        Thread.Sleep(5);
+        signIns.Add(new AzurePendingSignIn("state-2", "verifier", "nonce", User, DateTime.UtcNow.AddMinutes(10), DateTime.UtcNow));
+
+        signIns.TakeByState("state-2").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void BothStores_ShareTheRevocation_ThroughTheCache()
+    {
+        // The web app hands the service both stores on one cache; a disconnect recorded through
+        // either must be seen by the other, which is what lets DisconnectAsync revoke once each.
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var signIns = new AzureSignInRequests(cache);
+        var confirmations = new AzureLinkConfirmations(cache);
+        string code = confirmations.Start(new PendingAzureLink(User, "oid-1", "tid-1", "Ada"));
+
+        signIns.RevokeFor(User);
+
+        confirmations.Consume(code).Should().BeNull();
+    }
+}

--- a/tests/Connapse.Identity.Tests/AzureOidcTokenExchangerTests.cs
+++ b/tests/Connapse.Identity.Tests/AzureOidcTokenExchangerTests.cs
@@ -1,0 +1,53 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Connapse.Core;
+using Connapse.Identity.Services;
+using FluentAssertions;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Connapse.Identity.Tests;
+
+[Trait("Category", "Unit")]
+public class AzureOidcTokenExchangerTests
+{
+    private const string ClientId = "44444444-4444-4444-4444-444444444444";
+    private const string TokenEndpoint = "https://login.microsoftonline.com/tenant/oauth2/v2.0/token";
+
+    [Fact]
+    public void BuildClientAssertion_SignsWithTheCertificate_AndCarriesEntraX5tHeader()
+    {
+        // Regression: setting x5t via AdditionalHeaderClaims throws IDX14116 at sign-in time; the
+        // handler must supply it from the X509 signing credentials instead.
+        (string pemPath, string expectedX5t) = WriteSelfSignedPem();
+        try
+        {
+            var settings = new AzureAdSignInSettings { ClientId = ClientId, ClientCertificatePath = pemPath };
+
+            string assertion = AzureOidcTokenExchanger.BuildClientAssertion(settings, TokenEndpoint);
+
+            var jwt = new JsonWebToken(assertion);
+            jwt.Alg.Should().Be(SecurityAlgorithms.RsaSha256);
+            jwt.X5t.Should().Be(expectedX5t);
+            jwt.Issuer.Should().Be(ClientId);
+            jwt.Subject.Should().Be(ClientId);
+            jwt.Audiences.Should().ContainSingle().Which.Should().Be(TokenEndpoint);
+            jwt.GetClaim("jti").Value.Should().NotBeNullOrEmpty();
+        }
+        finally
+        {
+            File.Delete(pemPath);
+        }
+    }
+
+    private static (string Path, string X5t) WriteSelfSignedPem()
+    {
+        using RSA key = RSA.Create(2048);
+        var request = new CertificateRequest("CN=connapse-test", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using X509Certificate2 cert = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+
+        string path = Path.Combine(Path.GetTempPath(), $"connapse-signin-{Guid.NewGuid():N}.pem");
+        File.WriteAllText(path, cert.ExportCertificatePem() + "\n" + key.ExportPkcs8PrivateKeyPem() + "\n");
+        return (path, Base64UrlEncoder.Encode(cert.GetCertHash()));
+    }
+}

--- a/tests/Connapse.Identity.Tests/AzureSignInRequestsTests.cs
+++ b/tests/Connapse.Identity.Tests/AzureSignInRequestsTests.cs
@@ -1,0 +1,47 @@
+using Connapse.Identity.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Connapse.Identity.Tests;
+
+[Trait("Category", "Unit")]
+public class AzureSignInRequestsTests
+{
+    private static AzureSignInRequests NewStore(out IMemoryCache cache)
+    {
+        cache = new MemoryCache(new MemoryCacheOptions());
+        return new AzureSignInRequests(cache);
+    }
+
+    [Fact]
+    public void Pending_TakeByState_RemovesAndDropsExpired()
+    {
+        var store = NewStore(out _);
+        store.Add(new AzurePendingSignIn("s1", "v", "n", Guid.NewGuid(), DateTime.UtcNow.AddMinutes(5)));
+        store.TakeByState("s1").Should().NotBeNull();
+        store.TakeByState("s1").Should().BeNull(); // removed
+        store.Add(new AzurePendingSignIn("s2", "v", "n", Guid.NewGuid(), DateTime.UtcNow.AddMinutes(-1)));
+        store.TakeByState("s2").Should().BeNull(); // expired
+    }
+
+    [Fact]
+    public void Pending_AbandonedSignIn_IsNotRetainedInCachePastItsDeadline()
+    {
+        // Regression: the store used to be a raw dictionary that only removed an entry when its
+        // state was redeemed, so a sign-in started and never completed lived for the life of the
+        // process. Backing it with the memory cache makes each entry's own deadline the eviction
+        // trigger. Assert against the cache's own count, not through TakeByState, so this proves
+        // the entry is physically not retained rather than merely filtered on read.
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var store = new AzureSignInRequests(cache);
+
+        // A sign-in already past its deadline is not held at all.
+        store.Add(new AzurePendingSignIn("abandoned", "v", "n", Guid.NewGuid(), DateTime.UtcNow.AddMilliseconds(-1)));
+        cache.Count.Should().Be(0);
+
+        // A live one is held by the cache — so reclaiming it is the cache's job on expiry, not a
+        // manual sweep the old dictionary never had.
+        store.Add(new AzurePendingSignIn("live", "v", "n", Guid.NewGuid(), DateTime.UtcNow.AddMinutes(5)));
+        cache.Count.Should().Be(1);
+    }
+}

--- a/tests/Connapse.Identity.Tests/OidcPkceTests.cs
+++ b/tests/Connapse.Identity.Tests/OidcPkceTests.cs
@@ -1,0 +1,23 @@
+using System.Security.Cryptography;
+using System.Text;
+using Connapse.Identity.Services;
+using FluentAssertions;
+
+namespace Connapse.Identity.Tests;
+
+[Trait("Category", "Unit")]
+public class OidcPkceTests
+{
+    private static string Base64Url(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    [Fact]
+    public void Pkce_ChallengeIsBase64UrlSha256OfVerifier()
+    {
+        var (verifier, challenge) = OidcPkce.Create();
+        using var sha = SHA256.Create();
+        var expected = Base64Url(sha.ComputeHash(Encoding.ASCII.GetBytes(verifier)));
+        challenge.Should().Be(expected);
+        challenge.Should().NotContain("+").And.NotContain("/").And.NotContain("=");
+    }
+}

--- a/tests/Connapse.Integration.Tests/AzureBlobConnectorIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureBlobConnectorIntegrationTests.cs
@@ -1,0 +1,63 @@
+using Azure.Storage.Blobs;
+using Connapse.Storage.Connectors;
+using FluentAssertions;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Integration tests for AzureBlobConnector against Azurite. Azurite cannot authenticate an
+/// AAD TokenCredential, so the connector is constructed via its internal ctor with a
+/// shared-key BlobServiceClient pointed at the emulator.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("AzureBlobConnector")]
+public class AzureBlobConnectorIntegrationTests(AzuriteFixture fixture)
+{
+    [Fact]
+    public async Task ListAndRead_ScopedToPrefix()
+    {
+        var service = new BlobServiceClient(fixture.ConnectionString); // shared-key, Azurite
+        var container = service.GetBlobContainerClient("docs");
+        await container.CreateIfNotExistsAsync();
+        await container.UploadBlobAsync("reports/q1.pdf", new BinaryData("hello"));
+        await container.UploadBlobAsync("other/skip.txt", new BinaryData("nope"));
+
+        var connector = new AzureBlobConnector(
+            new AzureBlobConnectorConfig { AccountName = "devstoreaccount1", ContainerName = "docs", Prefix = "reports/" },
+            service); // internal test ctor
+
+        var files = await connector.ListFilesAsync();
+        files.Should().ContainSingle();
+        files[0].Path.Should().Be("reports/q1.pdf");
+        files[0].ResourceUri.Should().Be("azblob://devstoreaccount1/docs/reports/q1.pdf");
+
+        (await connector.ExistsAsync("reports/q1.pdf")).Should().BeTrue();
+        using var stream = await connector.ReadFileAsync("reports/q1.pdf");
+        (await new StreamReader(stream).ReadToEndAsync()).Should().Be("hello");
+    }
+
+    [Fact]
+    public async Task ReadFileAsync_BlobOutsideConfiguredPrefix_IsConfined()
+    {
+        var service = new BlobServiceClient(fixture.ConnectionString); // shared-key, Azurite
+        var container = service.GetBlobContainerClient("docs-confinement");
+        await container.CreateIfNotExistsAsync();
+        await container.UploadBlobAsync("reports/q1.pdf", new BinaryData("hello"));
+        await container.UploadBlobAsync("hr/secret.pdf", new BinaryData("confidential"));
+
+        var connector = new AzureBlobConnector(
+            new AzureBlobConnectorConfig { AccountName = "devstoreaccount1", ContainerName = "docs-confinement", Prefix = "reports/" },
+            service); // internal test ctor
+
+        // In-scope blob still reads fine.
+        using var stream = await connector.ReadFileAsync("reports/q1.pdf");
+        (await new StreamReader(stream).ReadToEndAsync()).Should().Be("hello");
+
+        // A blob that exists in the SAME container but outside the source's configured
+        // prefix must not be reachable via this connector, even though the underlying
+        // Azure SDK client has no such restriction.
+        var act = async () => await connector.ReadFileAsync("hr/secret.pdf");
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+        (await connector.ExistsAsync("hr/secret.pdf")).Should().BeFalse();
+    }
+}

--- a/tests/Connapse.Integration.Tests/AzureCompositeResolverDiIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureCompositeResolverDiIntegrationTests.cs
@@ -1,0 +1,21 @@
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureCompositeResolverDiIntegrationTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public void Di_Resolves_CompositeAsTheScopeResolver()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        ISearchScopeResolver resolver = scope.ServiceProvider.GetRequiredService<ISearchScopeResolver>();
+        resolver.Should().BeOfType<CompositeSearchScopeResolver>();
+        scope.ServiceProvider.GetRequiredService<AzureSearchScopeResolver>().Should().NotBeNull();
+        scope.ServiceProvider.GetRequiredService<AwsSearchScopeResolver>().Should().NotBeNull();
+    }
+}

--- a/tests/Connapse.Integration.Tests/AzureDirectoryReaderDiIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureDirectoryReaderDiIntegrationTests.cs
@@ -1,0 +1,22 @@
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Proves the Phase 4a Graph identity-reader DI graph resolves from a real host — a clean container
+/// start does not catch a missing registration, only constructing the service does. Guards the
+/// TokenCredential mapping + typed HttpClient landing together.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureDirectoryReaderDiIntegrationTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public void Di_Resolves_AzureDirectoryReader()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IAzureDirectoryReader>().Should().NotBeNull();
+    }
+}

--- a/tests/Connapse.Integration.Tests/AzureEntraLinkDiIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureEntraLinkDiIntegrationTests.cs
@@ -1,0 +1,33 @@
+using Connapse.Core.Interfaces;
+using Connapse.Identity.Services;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Proves the Entra user-identity-link DI graph actually resolves from a real host — a clean
+/// container start does not catch a missing registration, only constructing the services does.
+/// Tasks 2-6 of the Azure Phase 3 (Entra user identity link) feature each registered one piece of
+/// this graph (the link store/reader/service, <see cref="AzureAdSignInSettings"/> options, the
+/// sign-in request cache, the id-token validator + token exchanger HttpClient, and the link
+/// confirmation cache); this test is the guard that all of them landed together and stayed
+/// resolvable as later tasks touched the same registration block.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureEntraLinkDiIntegrationTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public void Di_Resolves_EntraUserIdentityLinkGraph()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+
+        scope.ServiceProvider.GetRequiredService<IAzureIdentityLinkService>().Should().NotBeNull();
+        scope.ServiceProvider.GetRequiredService<IAzureIdentityLinkReader>().Should().NotBeNull();
+        scope.ServiceProvider.GetRequiredService<IOidcTokenExchanger>().Should().NotBeNull();
+        scope.ServiceProvider.GetRequiredService<AzureIdTokenValidator>().Should().NotBeNull();
+        scope.ServiceProvider.GetRequiredService<AzureSignInRequests>().Should().NotBeNull();
+        scope.ServiceProvider.GetRequiredService<AzureLinkConfirmations>().Should().NotBeNull();
+    }
+}

--- a/tests/Connapse.Integration.Tests/AzureFlatEnforcementTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureFlatEnforcementTests.cs
@@ -1,0 +1,113 @@
+using Connapse.Core;
+using Connapse.Search.Keyword;
+using Connapse.Storage.Data;
+using Connapse.Storage.Data.Entities;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// The flat end-to-end proof for Azure: the composite's per-scheme scopes narrow a real search the
+/// same way the AWS-only <see cref="SearchScopeEnforcementTests"/> proves for S3, and a non-cloud
+/// document survives regardless of which cloud is enforcing or failing.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureFlatEnforcementTests(SharedWebAppFixture fixture)
+{
+    private const string Term = "zarquon";
+
+    private static KeywordSearchService Build(KnowledgeDbContext db) =>
+        new(db, NullLogger<KeywordSearchService>.Instance);
+
+    private static Task<KnowledgeDbContext> NewContextAsync(IServiceProvider sp) =>
+        sp.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>().CreateDbContextAsync();
+
+    private static SearchOptions For(Guid containerId) =>
+        new(TopK: 20, ContainerId: containerId.ToString(), Mode: SearchMode.Keyword);
+
+    /// <summary>Four documents in one container: an in-scope Azure doc, an out-of-scope Azure doc,
+    /// an AWS doc, and a non-cloud doc (resource_uri NULL).</summary>
+    private static async Task<Guid> SeedAsync(KnowledgeDbContext db)
+    {
+        var container = new ContainerEntity { Id = Guid.NewGuid(), Name = $"c-{Guid.NewGuid():N}" };
+        db.Containers.Add(container);
+
+        foreach (var (name, uri) in new (string, string?)[]
+                 {
+                     ("in-scope.md", "azblob://acct/docs/a"),
+                     ("out-of-scope.md", "azblob://acct/secret/b"),
+                     ("aws.md", "s3://bucket/x"),
+                     ("non-cloud.md", null),
+                 })
+        {
+            var document = new DocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                ContainerId = container.Id,
+                FileName = name,
+                Path = "/" + name,
+                ResourceUri = uri,
+                ContentHash = Guid.NewGuid().ToString("N"),
+                Status = "Ready",
+                CreatedAt = DateTime.UtcNow,
+                Metadata = [],
+            };
+            db.Documents.Add(document);
+
+            db.Chunks.Add(new ChunkEntity
+            {
+                Id = Guid.NewGuid(),
+                DocumentId = document.Id,
+                OwnerId = container.Id,
+                Content = $"the {Term} appears here",
+                ChunkIndex = 0,
+                Metadata = [],
+            });
+        }
+
+        await db.SaveChangesAsync();
+        return container.Id;
+    }
+
+    [Fact]
+    public async Task AzurePrefixPlusAwsWildcard_AdmitsInScopeAzure_AwsAndNonCloud_ExcludesOutOfScopeAzure()
+    {
+        // What the composite yields for an Azure-granted / AWS-unrestricted user: the Azure prefix
+        // plus the AWS scheme wildcard.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        await using var db = await NewContextAsync(scope.ServiceProvider);
+        var containerId = await SeedAsync(db);
+
+        var scopes = SearchScopes.Of(
+        [
+            new GrantMatch("azblob://acct/docs/", IsExact: false),
+            new GrantMatch("s3://", IsExact: false),
+        ]);
+
+        var hits = await Build(db).SearchAsync(Term, For(containerId), scopes);
+
+        hits.Select(h => h.Metadata.GetValueOrDefault("fileName")).Should().BeEquivalentTo(
+            "in-scope.md", "aws.md", "non-cloud.md");
+    }
+
+    [Fact]
+    public async Task AzureFailed_HidesAllAzure_ButKeepsNonCloud()
+    {
+        // Azure contributed nothing (denied/failed); only the AWS wildcard survives.
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        await using var db = await NewContextAsync(scope.ServiceProvider);
+        var containerId = await SeedAsync(db);
+
+        var scopes = SearchScopes.Of([new GrantMatch("s3://", IsExact: false)]);
+
+        var hits = await Build(db).SearchAsync(Term, For(containerId), scopes);
+
+        hits.Select(h => h.Metadata.GetValueOrDefault("fileName")).Should().BeEquivalentTo(
+            "aws.md", "non-cloud.md");
+    }
+}

--- a/tests/Connapse.Integration.Tests/AzureOidcTestDoubles.cs
+++ b/tests/Connapse.Integration.Tests/AzureOidcTestDoubles.cs
@@ -1,0 +1,51 @@
+using System.Collections.Concurrent;
+using Connapse.Identity.Services;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Test doubles for the Entra OIDC user-identity-link flow (<see cref="CloudIdentityEndpointTests"/>),
+/// registered into the shared integration-test host in place of the real
+/// <see cref="AzureOidcTokenExchanger"/> and Entra JWKS lookup. Neither makes a network call, so
+/// the callback endpoint can be exercised end to end without a real Entra tenant.
+/// </summary>
+/// <remarks>
+/// Both are singletons in a host shared across the whole integration-test collection, so state is
+/// keyed by the authorization <c>code</c> a test makes up (a fresh GUID per test) rather than held
+/// as a single mutable field — concurrent tests must not be able to see or clobber each other's
+/// fake token.
+/// </remarks>
+public sealed class FakeOidcTokenExchanger : IOidcTokenExchanger
+{
+    private readonly ConcurrentDictionary<string, string> _tokensByCode = new();
+
+    /// <summary>Makes <paramref name="code"/> exchange for <paramref name="idToken"/>.</summary>
+    public void SetToken(string code, string idToken) => _tokensByCode[code] = idToken;
+
+    public Task<string> ExchangeAsync(string code, string codeVerifier, CancellationToken ct)
+    {
+        if (_tokensByCode.TryRemove(code, out string? token))
+            return Task.FromResult(token);
+
+        throw new InvalidOperationException(
+            $"FakeOidcTokenExchanger has no id_token registered for code '{code}'. " +
+            "The test must call SetToken before driving the callback.");
+    }
+}
+
+/// <summary>
+/// Hands back a fixed signing key set so tokens signed with <see cref="SigningKey"/> in a test
+/// validate as if they came from Entra's real JWKS.
+/// </summary>
+public sealed class FakeAzureSigningKeySource : IAzureSigningKeySource
+{
+    /// <summary>The one key this test double ever reports — generated once per test host.</summary>
+    public static readonly RsaSecurityKey SigningKey = CreateKey();
+
+    private static RsaSecurityKey CreateKey() =>
+        new(System.Security.Cryptography.RSA.Create(2048)) { KeyId = "integration-test-key" };
+
+    public Task<IReadOnlyList<SecurityKey>> GetSigningKeysAsync(string tenantId, CancellationToken ct) =>
+        Task.FromResult<IReadOnlyList<SecurityKey>>(new[] { (SecurityKey)SigningKey });
+}

--- a/tests/Connapse.Integration.Tests/AzureProviderDiIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureProviderDiIntegrationTests.cs
@@ -1,0 +1,35 @@
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using Connapse.Storage.ConnectionTesters;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Proves the Azure provider's DI graph actually resolves from a real host — a clean container
+/// start does not catch a missing registration, only constructing the services does. Covers the
+/// gap left when <see cref="Connapse.Storage.Connectors.ConnectorFactory"/> gained a
+/// <see cref="ConnapseAzureCredentials"/> constructor parameter before that type (and the Azure
+/// connection tester) were registered.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureProviderDiIntegrationTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public void Di_Resolves_AzureCredentialsAndTester()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+
+        scope.ServiceProvider.GetRequiredService<ConnapseAzureCredentials>().Should().NotBeNull();
+
+        // Registered concrete-only, matching S3ConnectionTester/SftpConnectionTester — this is
+        // the exact path Connections.razor's `@inject AzureBlobConnectionTester` resolves
+        // through. A prior interface-only registration (AddScoped<IConnectionTester,
+        // AzureBlobConnectionTester>) satisfied GetServices<IConnectionTester>() but left the
+        // concrete type unresolvable, which threw InvalidOperationException at component init.
+        scope.ServiceProvider.GetRequiredService<AzureBlobConnectionTester>().Should().NotBeNull();
+        scope.ServiceProvider.GetRequiredService<IConnectorFactory>().Should().NotBeNull();
+    }
+}

--- a/tests/Connapse.Integration.Tests/AzureRbacReaderDiIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureRbacReaderDiIntegrationTests.cs
@@ -1,0 +1,17 @@
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureRbacReaderDiIntegrationTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public void Di_Resolves_AzureRbacReader()
+    {
+        using var scope = fixture.Factory.Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IAzureRbacReader>().Should().NotBeNull();
+    }
+}

--- a/tests/Connapse.Integration.Tests/AzureVerifyEnforcementTests.cs
+++ b/tests/Connapse.Integration.Tests/AzureVerifyEnforcementTests.cs
@@ -1,0 +1,190 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using Connapse.Storage.Data;
+using Connapse.Storage.Data.Entities;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// End-to-end proof of the Phase 4e verify seam: <see cref="AzureSearchResultVerifier"/> built with
+/// the real <see cref="IDocumentStore"/> from the shared fixture (so
+/// <c>GetResourceUrisAsync</c> runs against the actual database) plus faked Azure identity/RBAC/ACL
+/// readers, verifying seeded azblob/s3/non-cloud documents the same way
+/// <see cref="AzureFlatEnforcementTests"/> proves the composite scope resolver end to end.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class AzureVerifyEnforcementTests(SharedWebAppFixture fixture)
+{
+    private static readonly Guid TestUser = Guid.NewGuid();
+    private static readonly AzureIdentityRef Link = new("user-oid", "tid");
+
+    private static SearchHit Hit(Guid docId, double score) =>
+        new($"chunk-{docId}", docId.ToString(), "content", (float)score, new Dictionary<string, string>());
+
+    private static IOptionsMonitor<T> Opt<T>(T v) where T : class
+    {
+        var m = Substitute.For<IOptionsMonitor<T>>();
+        m.CurrentValue.Returns(v);
+        return m;
+    }
+
+    /// <summary>Four documents in one container: an azblob doc under an RBAC-readable prefix, an
+    /// azblob doc with no grant, an AWS doc, and a non-cloud doc (resource_uri NULL).</summary>
+    private static async Task<(Guid ContainerId, Guid InRbac, Guid NoGrant, Guid Aws, Guid NonCloud)> SeedAsync(
+        KnowledgeDbContext db)
+    {
+        var container = new ContainerEntity { Id = Guid.NewGuid(), Name = $"c-{Guid.NewGuid():N}" };
+        db.Containers.Add(container);
+
+        Guid inRbac = Guid.NewGuid(), noGrant = Guid.NewGuid(), aws = Guid.NewGuid(), nonCloud = Guid.NewGuid();
+
+        foreach (var (id, name, uri) in new (Guid, string, string?)[]
+                 {
+                     (inRbac, "in-rbac.md", "azblob://acct/docs/a"),
+                     (noGrant, "no-grant.md", "azblob://acct/secret/b"),
+                     (aws, "aws.md", "s3://bucket/x"),
+                     (nonCloud, "non-cloud.md", null),
+                 })
+        {
+            db.Documents.Add(new DocumentEntity
+            {
+                Id = id,
+                ContainerId = container.Id,
+                FileName = name,
+                Path = "/" + name,
+                ResourceUri = uri,
+                ContentHash = Guid.NewGuid().ToString("N"),
+                Status = "Ready",
+                CreatedAt = DateTime.UtcNow,
+                Metadata = [],
+            });
+        }
+
+        await db.SaveChangesAsync();
+        return (container.Id, inRbac, noGrant, aws, nonCloud);
+    }
+
+    /// <summary>Builds the verifier against the real <paramref name="documents"/> store with every
+    /// Azure identity/RBAC/ACL seam faked — live calls to Entra/ARM/ADLS/Blob can't run in CI, only
+    /// the resource_uri lookup needs to be real.</summary>
+    private static AzureSearchResultVerifier BuildVerifier(
+        IDocumentStore documents, bool azureEnforcing, IReadOnlyList<AzureScope> readablePrefixes)
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(TestUser, Arg.Any<CancellationToken>()).Returns(Link);
+
+        var directory = Substitute.For<IAzureDirectoryReader>();
+        directory.ResolveAsync(Link, Arg.Any<CancellationToken>())
+            .Returns(AzureIdentitySet.Resolved(["user-oid"]));
+
+        var rbac = Substitute.For<IAzureRbacReader>();
+        rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+            .Returns(AzureRbacScopes.Resolved(readablePrefixes, []));
+
+        var fileAcl = Substitute.For<IGen2FileAclReader>();
+        var blobTags = Substitute.For<IBlobTagReader>();
+        var gen2DirReader = Substitute.For<IGen2DirectoryReader>();
+        var traverse = new AncestorTraverseResolver(gen2DirReader, new MemoryCache(new MemoryCacheOptions()));
+
+        var azureAd = Opt(new AzureAdSignInSettings
+        {
+            TenantId = "t",
+            ClientId = "c",
+            RedirectUri = "https://x/cb",
+            ClientCertificatePath = "p.pem",
+        });
+        var enforcement = Opt(new PermissionEnforcementSettings { AzureEnforcing = azureEnforcing });
+
+        return new AzureSearchResultVerifier(
+            documents, links, directory, rbac, fileAcl, blobTags, traverse,
+            azureAd, enforcement, EnforcementMigration.Completed(),
+            Options.Create(new AzureVerifierSettings { MaxParallelism = 16, CandidateMultiplier = 5 }),
+            NullLogger<AzureSearchResultVerifier>.Instance);
+    }
+
+    [Fact]
+    public async Task Enforcing_AdmitsRbacCoveredAzblob_DropsUngranted_PassesAwsAndNonCloud()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factoryDb = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var db = await factoryDb.CreateDbContextAsync();
+        var (containerId, inRbac, noGrant, aws, nonCloud) = await SeedAsync(db);
+
+        try
+        {
+            var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+            var verifier = BuildVerifier(documents, azureEnforcing: true, [new AzureScope("azblob://acct/docs/")]);
+
+            SearchHit[] ranked =
+            [
+                Hit(inRbac, 0.9),
+                Hit(noGrant, 0.85),
+                Hit(aws, 0.8),
+                Hit(nonCloud, 0.7),
+            ];
+
+            IReadOnlyList<SearchHit> result = await verifier.VerifyAsync(ranked, TestUser, topK: 10);
+
+            result.Select(h => h.DocumentId).Should().BeEquivalentTo(
+                inRbac.ToString(), aws.ToString(), nonCloud.ToString());
+        }
+        finally
+        {
+            await CleanupAsync(factoryDb, containerId);
+        }
+    }
+
+    [Fact]
+    public async Task NotEnforcing_PassesEverythingThrough()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factoryDb = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+        await using var db = await factoryDb.CreateDbContextAsync();
+        var (containerId, inRbac, noGrant, aws, nonCloud) = await SeedAsync(db);
+
+        try
+        {
+            var documents = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+            // No RBAC scopes at all — proves the pass-through is because enforcement is off, not
+            // because a grant happens to cover everything.
+            var verifier = BuildVerifier(documents, azureEnforcing: false, []);
+
+            SearchHit[] ranked =
+            [
+                Hit(inRbac, 0.9),
+                Hit(noGrant, 0.85),
+                Hit(aws, 0.8),
+                Hit(nonCloud, 0.7),
+            ];
+
+            IReadOnlyList<SearchHit> result = await verifier.VerifyAsync(ranked, TestUser, topK: 10);
+
+            result.Select(h => h.DocumentId).Should().BeEquivalentTo(
+                inRbac.ToString(), noGrant.ToString(), aws.ToString(), nonCloud.ToString());
+        }
+        finally
+        {
+            await CleanupAsync(factoryDb, containerId);
+        }
+    }
+
+    private static async Task CleanupAsync(IDbContextFactory<KnowledgeDbContext> factoryDb, Guid containerId)
+    {
+        await using var ctx = await factoryDb.CreateDbContextAsync();
+        var docs = await ctx.Documents.Where(d => d.ContainerId == containerId).ToListAsync();
+        ctx.Documents.RemoveRange(docs);
+        var container = await ctx.Containers.FirstOrDefaultAsync(c => c.Id == containerId);
+        if (container is not null) ctx.Containers.Remove(container);
+        await ctx.SaveChangesAsync();
+    }
+}

--- a/tests/Connapse.Integration.Tests/AzuriteFixture.cs
+++ b/tests/Connapse.Integration.Tests/AzuriteFixture.cs
@@ -1,0 +1,27 @@
+using Testcontainers.Azurite;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Shared fixture that starts an Azurite container for Azure Blob connector testing.
+/// Azurite cannot authenticate an AAD TokenCredential, so tests drive the connector
+/// through its internal ctor with a shared-key BlobServiceClient built from
+/// <see cref="ConnectionString"/>.
+/// </summary>
+public sealed class AzuriteFixture : IAsyncLifetime
+{
+    // Testcontainers.Azurite 4.3.0's default image (3.28.0) rejects the x-ms-version header
+    // sent by Azure.Storage.Blobs 12.24.0 (the version Connapse.Storage references) with
+    // "The API version 2025-05-05 is not supported by Azurite" on every request. Pin to a
+    // concrete newer version (not :latest, which floats) whose supported API surface keeps
+    // pace with the client SDK. 3.37.0 is confirmed via `docker manifest inspect` to be the
+    // exact version :latest resolved to at the time this was verified working
+    // (manifest-list digest sha256:830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5).
+    private readonly AzuriteContainer _container = new AzuriteBuilder()
+        .WithImage("mcr.microsoft.com/azure-storage/azurite:3.37.0")
+        .Build();
+    public string ConnectionString => _container.GetConnectionString();
+    public Task InitializeAsync() => _container.StartAsync();
+    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+}

--- a/tests/Connapse.Integration.Tests/CloudConnectorTestCollection.cs
+++ b/tests/Connapse.Integration.Tests/CloudConnectorTestCollection.cs
@@ -4,3 +4,8 @@ namespace Connapse.Integration.Tests;
 public class S3ConnectorTestCollection : ICollectionFixture<LocalStackFixture>
 {
 }
+
+[CollectionDefinition("AzureBlobConnector")]
+public class AzureBlobConnectorTestCollection : ICollectionFixture<AzuriteFixture>
+{
+}

--- a/tests/Connapse.Integration.Tests/CloudIdentityEndpointTests.cs
+++ b/tests/Connapse.Integration.Tests/CloudIdentityEndpointTests.cs
@@ -1,8 +1,17 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Connapse.Core;
+using Connapse.Identity.Data.Entities;
 using Connapse.Identity.Services;
 using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Connapse.Integration.Tests;
 
@@ -73,5 +82,332 @@ public class CloudIdentityEndpointTests(SharedWebAppFixture fixture)
         await using var scope = fixture.Factory.Services.CreateAsyncScope();
         var store = scope.ServiceProvider.GetRequiredService<AwsIdentityLinkStore>();
         return await store.GetDirectoryUserIdAsync(userId);
+    }
+
+    // --- Azure (Entra user identity link) ---
+
+    private const string AzureIssuer = $"https://login.microsoftonline.com/{SharedWebAppFixture.AzureTestTenantId}/v2.0";
+
+    /// <summary>Mirrors the production cookie name in CloudIdentityEndpoints — there is no public
+    /// constant to reuse, so this is kept in sync by hand, the same way
+    /// SamlLinkConfirmationTests does for the AWS cookie.</summary>
+    private const string AzureConfirmCookieName = "__connapse_azure_link";
+
+    private const string VictimEmail = "azure-victim@integration-tests.connapse.io";
+    private const string VictimPassword = "AzureVictimTest1!";
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    private HttpClient NoRedirectClient(bool authenticated = true)
+    {
+        var client = fixture.Factory.CreateClient(
+            new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        if (authenticated)
+        {
+            client.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", fixture.AdminToken);
+        }
+        return client;
+    }
+
+    /// <summary>
+    /// A second, unprivileged Connapse account distinct from the shared admin — the "colleague" an
+    /// attacker sends a captured /azure/connect URL to. Seeded once and reused; idempotent so
+    /// running alongside other tests in the shared fixture is safe.
+    /// </summary>
+    private async Task<(Guid Id, string Token)> EnsureVictimUserAsync()
+    {
+        await using (var scope = fixture.Factory.Services.CreateAsyncScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ConnapseUser>>();
+            if (await userManager.FindByEmailAsync(VictimEmail) is null)
+            {
+                var user = new ConnapseUser
+                {
+                    UserName = VictimEmail,
+                    Email = VictimEmail,
+                    EmailConfirmed = true,
+                    DisplayName = "Azure CSRF Victim",
+                    CreatedAt = DateTime.UtcNow,
+                };
+
+                var result = await userManager.CreateAsync(user, VictimPassword);
+                result.Succeeded.Should().BeTrue(
+                    because: string.Join(", ", result.Errors.Select(e => e.Description)));
+            }
+        }
+
+        using HttpClient anonClient = fixture.Factory.CreateClient();
+        var response = await anonClient.PostAsJsonAsync(
+            "/api/v1/auth/token", new LoginRequest(VictimEmail, VictimPassword));
+        response.EnsureSuccessStatusCode();
+        var token = await response.Content.ReadFromJsonAsync<TokenResponse>(JsonOptions);
+
+        await using var idScope = fixture.Factory.Services.CreateAsyncScope();
+        var lookup = idScope.ServiceProvider.GetRequiredService<UserManager<ConnapseUser>>();
+        ConnapseUser victim = (await lookup.FindByEmailAsync(VictimEmail))!;
+
+        return (victim.Id, token!.AccessToken);
+    }
+
+    /// <summary>Reads the value Set-Cookie gave a named cookie — the callback's confirm cookie is
+    /// HttpOnly, so a client without a cookie jar (as these no-redirect clients are) has to be
+    /// handed it explicitly to carry into the next request, exactly like
+    /// SamlLinkConfirmationTests does for the AWS cookie.</summary>
+    private static string ExtractCookieValue(HttpResponseMessage response, string cookieName)
+    {
+        foreach (string setCookie in response.Headers.GetValues("Set-Cookie"))
+        {
+            if (!setCookie.StartsWith($"{cookieName}=", StringComparison.Ordinal))
+                continue;
+
+            string valuePart = setCookie[(cookieName.Length + 1)..];
+            int semicolon = valuePart.IndexOf(';');
+            return semicolon >= 0 ? valuePart[..semicolon] : valuePart;
+        }
+
+        throw new InvalidOperationException($"Response did not set the '{cookieName}' cookie.");
+    }
+
+    private static async Task<HttpResponseMessage> ConfirmAsync(HttpClient client, string? cookieValue)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/v1/auth/cloud/azure/confirm");
+        if (cookieValue is not null)
+            request.Headers.Add("Cookie", $"{AzureConfirmCookieName}={cookieValue}");
+
+        return await client.SendAsync(request);
+    }
+
+    /// <summary>Builds a raw id_token JWT signed with the fake host's signing key.</summary>
+    private static string BuildIdToken(string nonce, string oid, string tid, string name)
+    {
+        var signingCredentials = new SigningCredentials(
+            FakeAzureSigningKeySource.SigningKey, SecurityAlgorithms.RsaSha256);
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = AzureIssuer,
+            Audience = SharedWebAppFixture.AzureTestClientId,
+            NotBefore = DateTime.UtcNow.AddMinutes(-5),
+            Expires = DateTime.UtcNow.AddMinutes(5),
+            SigningCredentials = signingCredentials,
+            Claims = new Dictionary<string, object>
+            {
+                ["nonce"] = nonce,
+                ["oid"] = oid,
+                ["tid"] = tid,
+                ["name"] = name,
+            },
+        };
+
+        return new JsonWebTokenHandler().CreateToken(descriptor);
+    }
+
+    /// <summary>Naive query-string parser — avoids pulling in an extra package for the test.</summary>
+    private static Dictionary<string, string> ParseQuery(string query) =>
+        query.TrimStart('?')
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(pair => pair.Split('=', 2))
+            .ToDictionary(
+                kv => Uri.UnescapeDataString(kv[0]),
+                kv => Uri.UnescapeDataString(kv.Length > 1 ? kv[1] : string.Empty));
+
+    private async Task<UserAzureIdentityLinkEntity?> AzureLinkAsync(Guid userId)
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<AzureIdentityLinkStore>();
+        return await store.GetAsync(userId);
+    }
+
+    private async Task DeleteAzureLinkAsync(Guid userId)
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<AzureIdentityLinkStore>();
+        await store.DeleteAsync(userId);
+    }
+
+    [Fact]
+    public async Task AzureConnect_WhenConfigured_RedirectsToEntraWithPkceAndRecordsPending()
+    {
+        using var client = NoRedirectClient();
+
+        var response = await client.GetAsync("/api/v1/auth/cloud/azure/connect");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        Uri location = response.Headers.Location!;
+        location.Host.Should().Be("login.microsoftonline.com");
+
+        var query = ParseQuery(location.Query);
+        query.Should().ContainKey("state");
+        query.Should().ContainKey("code_challenge");
+        query["code_challenge_method"].Should().Be("S256");
+        query["response_type"].Should().Be("code");
+
+        // Consuming here doubles as the "a pending entry exists" assertion — TakeByState is the
+        // only way this store exposes to check, and nothing else in this test needs the entry
+        // afterwards.
+        var pending = fixture.Factory.Services.GetRequiredService<AzureSignInRequests>();
+        AzurePendingSignIn? p = pending.TakeByState(query["state"]);
+
+        p.Should().NotBeNull("connect must record a pending sign-in for the state it redirects with");
+        p!.UserId.Should().Be(AdminUserId());
+        p.Nonce.Should().Be(query["nonce"]);
+    }
+
+    [Fact]
+    public async Task AzureCallback_UnknownState_RedirectsWithGenericErrorAndStoresNothing()
+    {
+        using var client = NoRedirectClient(authenticated: false);
+
+        var response = await client.GetAsync(
+            "/api/v1/auth/cloud/azure/callback?code=whatever&state=a-state-this-deployment-never-issued");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location!.OriginalString.Should().Contain("error=azure_link_failed");
+
+        (await AzureLinkAsync(AdminUserId())).Should().BeNull("an unknown state must not store a link");
+    }
+
+    [Fact]
+    public async Task AzureCallback_HappyPath_RoutesThroughConfirm_StoresLinkAndRedirectsToIntegrations()
+    {
+        // The ordinary flow: the same user starts the sign-in and completes the confirm step. The
+        // callback itself must not store anything directly any more — it can only park the outcome
+        // and hand back a cookie, exactly like AWS's /acs.
+        Guid admin = AdminUserId();
+        string state = $"state-{Guid.NewGuid():N}";
+        string nonce = $"nonce-{Guid.NewGuid():N}";
+        string code = $"code-{Guid.NewGuid():N}";
+        string oid = $"oid-{Guid.NewGuid():N}";
+
+        var pending = fixture.Factory.Services.GetRequiredService<AzureSignInRequests>();
+        pending.Add(new AzurePendingSignIn(state, "unused-verifier", nonce, admin, DateTime.UtcNow.AddMinutes(10)));
+
+        var exchanger = (FakeOidcTokenExchanger)fixture.Factory.Services.GetRequiredService<IOidcTokenExchanger>();
+        exchanger.SetToken(code, BuildIdToken(nonce, oid, SharedWebAppFixture.AzureTestTenantId, "Ada Lovelace"));
+
+        try
+        {
+            using var anonymous = NoRedirectClient(authenticated: false);
+            var callbackResponse = await anonymous.GetAsync(
+                $"/api/v1/auth/cloud/azure/callback?code={code}&state={state}");
+
+            callbackResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
+            callbackResponse.Headers.Location!.OriginalString.Should().Be("/api/v1/auth/cloud/azure/confirm");
+            (await AzureLinkAsync(admin)).Should().BeNull("the callback must only park the outcome, never store it directly");
+
+            string confirmCookie = ExtractCookieValue(callbackResponse, AzureConfirmCookieName);
+
+            using var adminClient = NoRedirectClient();
+            var confirmResponse = await ConfirmAsync(adminClient, confirmCookie);
+
+            confirmResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
+            confirmResponse.Headers.Location!.OriginalString.Should().Be("/profile/integrations");
+
+            var link = await AzureLinkAsync(admin);
+            link.Should().NotBeNull();
+            link!.ObjectId.Should().Be(oid);
+            link.TenantId.Should().Be(SharedWebAppFixture.AzureTestTenantId);
+            link.DisplayName.Should().Be("Ada Lovelace");
+        }
+        finally
+        {
+            await DeleteAzureLinkAsync(admin);
+        }
+    }
+
+    [Fact]
+    public async Task AzureConfirm_CompletedByADifferentUserThanStartedIt_RefusesAndStoresNothing()
+    {
+        // The CSRF this whole confirm hop exists to close. The admin (the "attacker") starts a
+        // sign-in and — without ever following the redirect — hands the resulting authorize URL to
+        // a colleague (the "victim"). The colleague signs in as themselves at Entra; PKCE binds the
+        // authorization code to the verifier, not to a person, and the id_token's nonce matches
+        // because it really was in the request the colleague completed. The callback parks the
+        // outcome under the admin's pending entry regardless of who's browser lands on it — the
+        // cookie it sets only reaches whoever's browser is completing the redirect (the victim's).
+        // If the victim's own session were accepted at /confirm, the admin's Connapse account would
+        // end up linked to the victim's Entra identity.
+        Guid admin = AdminUserId();
+        (Guid victimId, string victimToken) = await EnsureVictimUserAsync();
+
+        string state = $"state-{Guid.NewGuid():N}";
+        string nonce = $"nonce-{Guid.NewGuid():N}";
+        string code = $"code-{Guid.NewGuid():N}";
+        string victimOid = $"oid-{Guid.NewGuid():N}";
+
+        var pending = fixture.Factory.Services.GetRequiredService<AzureSignInRequests>();
+        // Started by the admin — this is the pending entry the admin's own /connect call would
+        // have produced, captured before being followed.
+        pending.Add(new AzurePendingSignIn(state, "unused-verifier", nonce, admin, DateTime.UtcNow.AddMinutes(10)));
+
+        var exchanger = (FakeOidcTokenExchanger)fixture.Factory.Services.GetRequiredService<IOidcTokenExchanger>();
+        // A genuine id_token for the colleague's own Entra identity — nothing about it is forged.
+        exchanger.SetToken(code, BuildIdToken(nonce, victimOid, SharedWebAppFixture.AzureTestTenantId, "Victim Person"));
+
+        try
+        {
+            using var anonymous = NoRedirectClient(authenticated: false);
+            var callbackResponse = await anonymous.GetAsync(
+                $"/api/v1/auth/cloud/azure/callback?code={code}&state={state}");
+
+            callbackResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
+            callbackResponse.Headers.Location!.OriginalString.Should().Be("/api/v1/auth/cloud/azure/confirm");
+
+            string confirmCookie = ExtractCookieValue(callbackResponse, AzureConfirmCookieName);
+
+            // The victim's own browser is what actually receives this cookie and follows the
+            // redirect — so it reaches /confirm carrying the victim's session, not the admin's.
+            using var victimClient = fixture.Factory.CreateClient(
+                new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+            victimClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", victimToken);
+
+            var confirmResponse = await ConfirmAsync(victimClient, confirmCookie);
+
+            confirmResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
+            confirmResponse.Headers.Location!.OriginalString.Should().Contain("error=azure_link_failed");
+
+            (await AzureLinkAsync(admin)).Should().BeNull(
+                "the attacker's account must not end up linked to the victim's Entra identity");
+            (await AzureLinkAsync(victimId)).Should().BeNull(
+                "nothing should be stored for the victim either — they never started this sign-in");
+
+            // Single-use: the confirmation must be burned by the refusal above, not left claimable
+            // by a second attempt (e.g. the admin retrying with their own session).
+            using var adminClient = NoRedirectClient();
+            var secondAttempt = await ConfirmAsync(adminClient, confirmCookie);
+            secondAttempt.Headers.Location!.OriginalString.Should().Contain("error=azure_link_failed");
+            (await AzureLinkAsync(admin)).Should().BeNull("a burned confirmation must not become claimable by anyone afterwards");
+        }
+        finally
+        {
+            await DeleteAzureLinkAsync(admin);
+            await DeleteAzureLinkAsync(victimId);
+        }
+    }
+
+    [Fact]
+    public async Task DisconnectAzure_WithALink_DeletesTheLinkAndReturns204()
+    {
+        Guid admin = AdminUserId();
+
+        await using (var scope = fixture.Factory.Services.CreateAsyncScope())
+        {
+            var store = scope.ServiceProvider.GetRequiredService<AzureIdentityLinkStore>();
+            await store.SaveAsync(admin, $"oid-{Guid.NewGuid():N}", SharedWebAppFixture.AzureTestTenantId, "Ada Lovelace");
+        }
+
+        try
+        {
+            var response = await fixture.AdminClient.DeleteAsync("/api/v1/auth/cloud/Azure");
+
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            (await AzureLinkAsync(admin)).Should().BeNull("the link was deleted");
+        }
+        finally
+        {
+            await DeleteAzureLinkAsync(admin);
+        }
     }
 }

--- a/tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj
+++ b/tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj
@@ -27,6 +27,7 @@
     -->
     <PackageReference Include="SSH.NET" Version="2026.0.0" />
     <PackageReference Include="Testcontainers" Version="4.3.0" />
+    <PackageReference Include="Testcontainers.Azurite" Version="4.3.0" />
     <PackageReference Include="Testcontainers.LocalStack" Version="4.3.0" />
     <PackageReference Include="Testcontainers.Minio" Version="4.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.3.0" />

--- a/tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj
+++ b/tests/Connapse.Integration.Tests/Connapse.Integration.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NSubstitute" Version="6.2.0" />
     <!--
       Direct reference purely to lift the transitive SSH.NET that Testcontainers brings in.
       2024.2.0 carries GHSA-q939-rpr3-3284 (CVE-2026-48798, CVSS 7.1) — a path traversal in

--- a/tests/Connapse.Integration.Tests/GetResourceUrisTests.cs
+++ b/tests/Connapse.Integration.Tests/GetResourceUrisTests.cs
@@ -1,0 +1,102 @@
+using Connapse.Core.Interfaces;
+using Connapse.Storage.Data;
+using Connapse.Storage.Data.Entities;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="IDocumentStore.GetResourceUrisAsync"/> — the batched lookup
+/// the search verifier uses to map ranked hits back to their governing <c>resource_uri</c> in one
+/// query instead of N.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class GetResourceUrisTests(SharedWebAppFixture fixture)
+{
+    [Fact]
+    public async Task SeededIdsAndUnknownId_ResolveToTheirUriOrNull()
+    {
+        Guid containerId = Guid.NewGuid();
+        Guid azureDocId = Guid.NewGuid();
+        Guid nonCloudDocId = Guid.NewGuid();
+        Guid unknownDocId = Guid.NewGuid();
+
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var factoryDb = scope.ServiceProvider.GetRequiredService<IDbContextFactory<KnowledgeDbContext>>();
+
+        try
+        {
+            await using (var ctx = await factoryDb.CreateDbContextAsync())
+            {
+                ctx.Containers.Add(new ContainerEntity
+                {
+                    Id = containerId,
+                    Name = $"c-{containerId:N}",
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow,
+                });
+
+                ctx.Documents.Add(new DocumentEntity
+                {
+                    Id = azureDocId,
+                    ContainerId = containerId,
+                    FileName = "a.md",
+                    Path = "/a.md",
+                    ResourceUri = "azblob://acct/docs/a",
+                    ContentHash = Guid.NewGuid().ToString("N"),
+                    Status = "Ready",
+                    CreatedAt = DateTime.UtcNow,
+                    Metadata = [],
+                });
+
+                ctx.Documents.Add(new DocumentEntity
+                {
+                    Id = nonCloudDocId,
+                    ContainerId = containerId,
+                    FileName = "b.md",
+                    Path = "/b.md",
+                    ResourceUri = null,
+                    ContentHash = Guid.NewGuid().ToString("N"),
+                    Status = "Ready",
+                    CreatedAt = DateTime.UtcNow,
+                    Metadata = [],
+                });
+
+                await ctx.SaveChangesAsync();
+            }
+
+            var docStore = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+            var result = await docStore.GetResourceUrisAsync(
+                [azureDocId.ToString(), nonCloudDocId.ToString(), unknownDocId.ToString()],
+                CancellationToken.None);
+
+            result[azureDocId.ToString()].Should().Be("azblob://acct/docs/a");
+            result[nonCloudDocId.ToString()].Should().BeNull();
+            result.GetValueOrDefault(unknownDocId.ToString()).Should().BeNull();
+        }
+        finally
+        {
+            await using var ctx = await factoryDb.CreateDbContextAsync();
+            var docs = await ctx.Documents.Where(d => d.ContainerId == containerId).ToListAsync();
+            ctx.Documents.RemoveRange(docs);
+            var container = await ctx.Containers.FirstOrDefaultAsync(c => c.Id == containerId);
+            if (container is not null) ctx.Containers.Remove(container);
+            await ctx.SaveChangesAsync();
+        }
+    }
+
+    [Fact]
+    public async Task EmptyInput_ReturnsEmptyMap()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        var docStore = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+
+        var result = await docStore.GetResourceUrisAsync([], CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+}

--- a/tests/Connapse.Integration.Tests/SettingsStoreUpdateIntegrationTests.cs
+++ b/tests/Connapse.Integration.Tests/SettingsStoreUpdateIntegrationTests.cs
@@ -1,0 +1,78 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Connapse.Integration.Tests;
+
+/// <summary>
+/// <see cref="ISettingsStore.UpdateAsync{T}"/> against PostgreSQL: a read-modify-write under a row
+/// lock, so concurrent updaters merge rather than overwrite. The enforcement latches depend on it —
+/// two administrators saving the AWS and Azure sign-in applications at once must end with both
+/// flags on, never one switched back off by the other's stale copy.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Integration Tests")]
+public class SettingsStoreUpdateIntegrationTests(SharedWebAppFixture fixture)
+{
+    private const string Category = "integrationtest-update";
+
+    private ISettingsStore Store(AsyncServiceScope scope) => scope.ServiceProvider.GetRequiredService<ISettingsStore>();
+
+    [Fact]
+    public async Task UpdateAsync_ConcurrentMergesFromSeparateScopes_LoseNothing()
+    {
+        await using var setup = fixture.Factory.Services.CreateAsyncScope();
+        await Store(setup).ResetAsync(Category);
+
+        try
+        {
+            // Each task owns a scope (its own DbContext) and switches one flag on, ORing the rest.
+            var tasks = Enumerable.Range(0, 12).Select(async i =>
+            {
+                await using var scope = fixture.Factory.Services.CreateAsyncScope();
+                await Store(scope).UpdateAsync<PermissionEnforcementSettings>(Category, stored => new PermissionEnforcementSettings
+                {
+                    IsEnforcing = (stored?.IsEnforcing ?? false) || i % 2 == 0,
+                    AzureEnforcing = (stored?.AzureEnforcing ?? false) || i % 2 == 1,
+                });
+            });
+            await Task.WhenAll(tasks);
+
+            var final = await Store(setup).GetAsync<PermissionEnforcementSettings>(Category);
+            final.Should().NotBeNull();
+            final!.IsEnforcing.Should().BeTrue();
+            final.AzureEnforcing.Should().BeTrue();
+        }
+        finally
+        {
+            await Store(setup).ResetAsync(Category);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenNothingIsStored_HandsTheUpdaterNull_AndStoresItsResult()
+    {
+        await using var scope = fixture.Factory.Services.CreateAsyncScope();
+        await Store(scope).ResetAsync(Category);
+
+        try
+        {
+            PermissionEnforcementSettings? seen = new();
+            var stored = await Store(scope).UpdateAsync<PermissionEnforcementSettings>(Category, current =>
+            {
+                seen = current;
+                return new PermissionEnforcementSettings { AzureEnforcing = true };
+            });
+
+            seen.Should().BeNull();
+            stored.AzureEnforcing.Should().BeTrue();
+            (await Store(scope).GetAsync<PermissionEnforcementSettings>(Category))!.AzureEnforcing.Should().BeTrue();
+        }
+        finally
+        {
+            await Store(scope).ResetAsync(Category);
+        }
+    }
+
+}

--- a/tests/Connapse.Integration.Tests/SharedWebAppFixture.cs
+++ b/tests/Connapse.Integration.Tests/SharedWebAppFixture.cs
@@ -2,7 +2,11 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Connapse.Core;
+using Connapse.Identity.Services;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Testcontainers.Minio;
 using Testcontainers.PostgreSql;
 
@@ -18,6 +22,14 @@ public sealed class SharedWebAppFixture : IAsyncLifetime
     public const string AdminEmail = "admin@integration-tests.connapse.io";
     public const string AdminPassword = "SharedAdminTest1!";
     public const string TestJwtSecret = "shared-test-jwt-secret-for-integration-tests-64chars!!";
+
+    // Fake Entra AD application identity — good enough to make AzureAdSignInSettings.IsConfigured
+    // true and to build the token issuer/audience the fake id_tokens in CloudIdentityEndpointTests
+    // assert against. Nothing ever dials out to login.microsoftonline.com with these: the token
+    // exchange and JWKS lookup are both replaced below with in-process fakes.
+    public const string AzureTestTenantId = "11111111-1111-1111-1111-111111111111";
+    public const string AzureTestClientId = "22222222-2222-2222-2222-222222222222";
+    public const string AzureTestRedirectUri = "https://localhost/api/v1/auth/cloud/azure/callback";
 
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
@@ -69,6 +81,28 @@ public sealed class SharedWebAppFixture : IAsyncLifetime
                 builder.UseSetting("RateLimiting:AuthPermitLimit", "100000");
                 builder.UseSetting("RateLimiting:ApiPermitLimit", "100000");
                 builder.UseSetting("RateLimiting:McpPermitLimit", "100000");
+
+                // Entra AD sign-in configuration for the Azure identity-link flow
+                // (CloudIdentityEndpointTests). IsConfigured only checks these are non-empty — no
+                // certificate is ever actually loaded, because the token exchange itself is faked
+                // below rather than performed for real.
+                builder.UseSetting("Identity:AzureAd:TenantId", AzureTestTenantId);
+                builder.UseSetting("Identity:AzureAd:ClientId", AzureTestClientId);
+                builder.UseSetting("Identity:AzureAd:RedirectUri", AzureTestRedirectUri);
+                builder.UseSetting("Identity:AzureAd:ClientCertificatePath", "unused-in-tests.pem");
+
+                builder.ConfigureTestServices(services =>
+                {
+                    // Replaces the real AzureOidcTokenExchanger (dials login.microsoftonline.com)
+                    // and the real JWKS lookup (fetches the tenant's signing keys) with in-process
+                    // fakes, so the callback endpoint can be driven end to end without a real
+                    // Entra tenant. See AzureOidcTestDoubles.cs.
+                    services.RemoveAll<IOidcTokenExchanger>();
+                    services.AddSingleton<IOidcTokenExchanger, FakeOidcTokenExchanger>();
+
+                    services.RemoveAll<IAzureSigningKeySource>();
+                    services.AddSingleton<IAzureSigningKeySource, FakeAzureSigningKeySource>();
+                });
             });
 
         AdminClient = Factory.CreateClient();

--- a/tests/Connapse.Storage.Tests/CloudScope/AncestorTraverseResolverTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AncestorTraverseResolverTests.cs
@@ -1,0 +1,156 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using NSubstitute;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AncestorTraverseResolverTests
+{
+    private const Gen2Permission RX = Gen2Permission.Read | Gen2Permission.Execute;
+    private const string Me = "me";
+    private static IReadOnlySet<string> Groups(params string[] g) => new HashSet<string>(g);
+    private static readonly IReadOnlySet<string> NoGroups = new HashSet<string>();
+
+    private static Gen2Path File(string path) => new("acct", "fs", path);
+
+    // Mode bits where "other" carries X (so anyone traverses), no extended ACL.
+    private static Gen2ModeBits OpenDir() =>
+        new("owner", "group", RX, RX, RX, HasExtendedAcl: false);
+
+    // Mode bits where nobody but owner/group traverses (other has no X), no extended ACL.
+    private static Gen2ModeBits ClosedDir() =>
+        new("owner", "group", RX, RX, Gen2Permission.None, HasExtendedAcl: false);
+
+    private static AncestorTraverseResolver Build(IGen2DirectoryReader reader) =>
+        new(reader, new MemoryCache(new MemoryCacheOptions()));
+
+    [Fact]
+    public async Task AllAncestorsGrantX_IsReadable()
+    {
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns(OpenDir());
+
+        bool ok = await Build(reader).HoldsTraverseOnAllAncestorsAsync(File("a/b/file.txt"), Me, NoGroups);
+
+        ok.Should().BeTrue();
+        // root, "a", "a/b" — three ancestor directories, file excluded.
+        await reader.Received(3).ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task LosingXOnOneAncestor_IsNotReadable()
+    {
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Is<Gen2Path>(p => p.Path == "a"), Arg.Any<CancellationToken>()).Returns(ClosedDir());
+        reader.ReadModeBitsAsync(Arg.Is<Gen2Path>(p => p.Path != "a"), Arg.Any<CancellationToken>()).Returns(OpenDir());
+
+        bool ok = await Build(reader).HoldsTraverseOnAllAncestorsAsync(File("a/b/file.txt"), Me, NoGroups);
+
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExtendedAcl_AndNotOwner_ReadsFullAcl_ForTheTieBreak()
+    {
+        // Mode bits say "other" has no X and the ACL is extended → a named entry could grant X, so
+        // the full ACL is consulted; a named GROUP the requester belongs to grants X.
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, Gen2Permission.None, HasExtendedAcl: true));
+        reader.ReadAccessAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, Gen2Permission.None, Gen2Permission.None,
+                Mask: RX, NamedUsers: [], NamedGroups: [new Gen2NamedAce("devs", RX)]));
+
+        bool ok = await Build(reader).HoldsTraverseOnAllAncestorsAsync(File("file.txt"), "someone", Groups("devs"));
+
+        ok.Should().BeTrue();
+        await reader.Received(1).ReadAccessAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Owner_ShortCircuits_WithoutReadingFullAcl_EvenWhenExtended()
+    {
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("me", "group", RX, Gen2Permission.None, Gen2Permission.None, HasExtendedAcl: true));
+
+        bool ok = await Build(reader).HoldsTraverseOnAllAncestorsAsync(File("file.txt"), Me, NoGroups);
+
+        ok.Should().BeTrue();
+        await reader.DidNotReceive().ReadAccessAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UnreadableAncestor_FailsClosed_AndIsNotCached()
+    {
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns((Gen2ModeBits?)null);
+
+        var resolver = Build(reader);
+        (await resolver.HoldsTraverseOnAllAncestorsAsync(File("file.txt"), Me, NoGroups)).Should().BeFalse();
+        (await resolver.HoldsTraverseOnAllAncestorsAsync(File("file.txt"), Me, NoGroups)).Should().BeFalse();
+
+        // Not cached → read attempted again on the second call (root only, one dir).
+        await reader.Received(2).ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ConfidentDecision_IsCached_SecondCallDoesNotReRead()
+    {
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns(OpenDir());
+
+        var resolver = Build(reader);
+        await resolver.HoldsTraverseOnAllAncestorsAsync(File("a/file.txt"), Me, NoGroups); // root + "a" = 2 reads
+        await resolver.HoldsTraverseOnAllAncestorsAsync(File("a/file.txt"), Me, NoGroups); // served from cache
+
+        await reader.Received(2).ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DifferentPrincipalSet_IsNotServedFromAnotherSetsCache()
+    {
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        // "other" has no X and not extended → decision depends purely on owning-group membership.
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, Gen2Permission.None, HasExtendedAcl: false));
+
+        var resolver = Build(reader);
+        (await resolver.HoldsTraverseOnAllAncestorsAsync(File("file.txt"), "in-group", Groups("group"))).Should().BeTrue();
+        (await resolver.HoldsTraverseOnAllAncestorsAsync(File("file.txt"), "stranger", NoGroups)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GroupMembership_DoesNotSatisfyANamedUserEntry_ViaTheResolver()
+    {
+        // End-to-end guard for the cross-class over-grant: a named-USER entry whose oid is a group the
+        // requester belongs to must not grant traverse (ADLS would grant nobody). "other" is None.
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "owning-group", RX, Gen2Permission.None, Gen2Permission.None, HasExtendedAcl: true));
+        reader.ReadAccessAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "owning-group", RX, Gen2Permission.None, Gen2Permission.None,
+                Mask: RX, NamedUsers: [new Gen2NamedAce("grp-oid", RX)], NamedGroups: []));
+
+        bool ok = await Build(reader).HoldsTraverseOnAllAncestorsAsync(File("file.txt"), "member", Groups("grp-oid"));
+
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CallerCancellation_IsRethrown()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var reader = Substitute.For<IGen2DirectoryReader>();
+        reader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns<Gen2ModeBits?>(_ => throw new OperationCanceledException());
+
+        Func<Task> act = () => Build(reader).HoldsTraverseOnAllAncestorsAsync(File("file.txt"), Me, NoGroups, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
@@ -1,0 +1,408 @@
+using System.Net;
+using System.Text;
+using Azure.Core;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class ArmRbacReaderTests
+{
+    private const string Oid = "11111111-1111-1111-1111-111111111111";
+    private const string Sub = "22222222-2222-2222-2222-222222222222";
+    private const string ReaderRole = "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1";
+
+    // Records every request URL so tests can assert which ARM endpoints were called.
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        public List<string> Urls { get; } = [];
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Urls.Add(request.RequestUri!.ToString());
+            return Task.FromResult(respond(request));
+        }
+    }
+
+    private sealed class StubTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext c, CancellationToken ct) =>
+            new("stub", DateTimeOffset.UtcNow.AddHours(1));
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext c, CancellationToken ct) =>
+            new(GetToken(c, ct));
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode s, string body) =>
+        new(s) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    private static string RoleAssignmentsBody(params (string roleGuid, string scope, string? condition)[] rows)
+    {
+        string items = string.Join(",", rows.Select(r =>
+        {
+            string cond = r.condition is null ? "null" : $"\"{r.condition.Replace("\"", "\\\"")}\"";
+            return $$$"""
+            {"properties":{"roleDefinitionId":"/subscriptions/{{{Sub}}}/providers/Microsoft.Authorization/roleDefinitions/{{{r.roleGuid}}}","principalId":"{{{Oid}}}","scope":"{{{r.scope}}}","condition":{{{cond}}},"conditionVersion":null}}
+            """;
+        }));
+        return $$"""{"value":[{{items}}]}""";
+    }
+
+    private static readonly string EmptyDeny = """{"value":[]}""";
+
+    // A reader whose roleAssignments call returns `roles` and whose denyAssignments call returns empty.
+    private static ArmRbacReader NewReader(string rolesBody, string? subId = Sub, IMemoryCache? cache = null)
+    {
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.OK, EmptyDeny)
+                : Json(HttpStatusCode.OK, rolesBody));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = subId });
+        return new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            cache ?? new MemoryCache(new MemoryCacheOptions()), opts);
+    }
+
+    [Fact]
+    public async Task Resolve_AccountScopedReaderRole_NoCondition_YieldsAccountPrefix()
+    {
+        string body = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().Contain("azblob://acct/");
+    }
+
+    [Fact]
+    public async Task Resolve_IgnoresNonBlobDataRoles()
+    {
+        // Owner of the *control plane* role "Contributor" for ARM is a different GUID; use a random one.
+        string body = RoleAssignmentsBody(("00000000-0000-0000-0000-000000000000",
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_PathCondition_NarrowsPrefix()
+    {
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'} AND NOT SubOperationMatches{'Blob.List'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*'))";
+        string body = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", cond));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().Contain("azblob://acct/docs/readonly/");
+    }
+
+    [Fact]
+    public async Task Resolve_TagCondition_GoesToTagResidue_NotPrefix()
+    {
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Project<$key_case_sensitive$>] StringEquals 'Cascade'))";
+        string body = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", cond));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Should().BeEmpty();
+        r.TagConditioned.Should().ContainSingle().Which.TagValue.Should().Be("Cascade");
+    }
+
+    [Fact]
+    public async Task Resolve_UnparseableCondition_DropsThatGrantOnly()
+    {
+        string bad = "((!(ActionMatches{'x'})) OR (@Request[foo] DateTimeGreaterThan '2024-01-01'))";
+        string body = RoleAssignmentsBody(
+            (ReaderRole, "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/bad", bad),
+            (ReaderRole, "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/good", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/good/");
+    }
+
+    [Fact]
+    public async Task Resolve_NoSubscriptionConfigured_FailsClosed()
+    {
+        AzureRbacScopes r = await NewReader(RoleAssignmentsBody(), subId: null).ResolveAsync(Oid, CancellationToken.None);
+        r.Outcome.Should().Be(RbacOutcome.Failed);
+    }
+
+    // (Subscription-scope / no-atScope URL shape is asserted in
+    // Resolve_Resolved_IsCached_SecondCallDoesNotHitArm, which captures request URLs.)
+
+    // Build a reader whose deny call returns `denyBody`.
+    private static ArmRbacReader NewReaderWithDeny(string rolesBody, string denyBody, string? subId = Sub)
+    {
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.OK, denyBody)
+                : Json(HttpStatusCode.OK, rolesBody));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = subId });
+        return new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+    }
+
+    private static string DenyBody(string scope) => $$$"""
+    {"value":[{"properties":{"scope":"{{{scope}}}","permissions":[{"dataActions":["Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"],"notDataActions":[]}]}}]}
+    """;
+
+    [Fact]
+    public async Task Resolve_DenyCoveringGrant_RemovesIt()
+    {
+        string acctScope = "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+        string roles = RoleAssignmentsBody((ReaderRole, acctScope + "/blobServices/default/containers/docs", null));
+        // Deny at the whole account covers the container grant.
+        AzureRbacScopes r = await NewReaderWithDeny(roles, DenyBody(acctScope)).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().BeEmpty(); // deny wins
+    }
+
+    [Fact]
+    public async Task Resolve_DenyElsewhere_DoesNotRemoveUnrelatedGrant()
+    {
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", null));
+        string denyOther = DenyBody("/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/other");
+        AzureRbacScopes r = await NewReaderWithDeny(roles, denyOther).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/docs/");
+    }
+
+    [Fact]
+    public async Task Resolve_DenyCallFails_FailsClosed()
+    {
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.InternalServerError, "{}")
+                : Json(HttpStatusCode.OK, RoleAssignmentsBody((ReaderRole,
+                    "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null))));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        (await reader.ResolveAsync(Oid, CancellationToken.None)).Outcome.Should().Be(RbacOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_Resolved_IsCached_SecondCallDoesNotHitArm()
+    {
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.OK, EmptyDeny) : Json(HttpStatusCode.OK, roles));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        await reader.ResolveAsync(Oid, CancellationToken.None);
+        int after = handler.Urls.Count;
+        await reader.ResolveAsync(Oid, CancellationToken.None);
+
+        handler.Urls.Count.Should().Be(after); // served from cache
+        handler.Urls.Should().Contain(u => u.Contains("/roleAssignments") && u.Contains("assignedTo") && !u.Contains("atScope"));
+        handler.Urls.Should().Contain(u => u.Contains("/subscriptions/" + Sub + "/"));
+    }
+
+    [Fact]
+    public async Task Resolve_DenyNarrowerThanGrant_DropsTheWholeGrant()
+    {
+        // Account-scoped grant with a container-scoped deny beneath it. The prefix model cannot
+        // represent "account minus one container", so the whole grant is dropped (deny wins;
+        // over-subtraction = under-grant, the fail-closed direction). Never leave the container
+        // readable through the broad grant.
+        string acctScope = "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+        string roles = RoleAssignmentsBody((ReaderRole, acctScope, null)); // whole account
+        string deny = DenyBody(acctScope + "/blobServices/default/containers/secret"); // one container
+        AzureRbacScopes r = await NewReaderWithDeny(roles, deny).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_ContainerNameCondition_OnBroaderThanAccountScope_DropsGrant()
+    {
+        // A container-name ABAC condition on a subscription-scoped grant cannot be reduced to a
+        // prefix (the account is unknown), so it must drop — not resolve to azblob:// (all accounts).
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'reports'))";
+        string roles = RoleAssignmentsBody((ReaderRole, "/subscriptions/" + Sub, cond)); // subscription scope
+        AzureRbacScopes r = await NewReader(roles).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_CompoundCondition_PathAndTag_IsDroppedNotPartiallyHonored()
+    {
+        // A compound condition (path AND tag) must not be partially honored — the path restriction
+        // would be lost if only the tag matched. More than one attribute reference → unparseable → drop.
+        string cond = "((!(ActionMatches{'x'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*' AND @Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Secret<$key_case_sensitive$>] StringEquals 'no'))";
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", cond));
+        AzureRbacScopes r = await NewReader(roles).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Should().BeEmpty();
+        r.TagConditioned.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_RoleAssignmentsCallFails_FailsClosed()
+    {
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/roleAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.InternalServerError, "{}")
+                : Json(HttpStatusCode.OK, EmptyDeny));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        (await reader.ResolveAsync(Oid, CancellationToken.None)).Outcome.Should().Be(RbacOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_InternalTimeout_TokenNotCancelled_FailsClosed()
+    {
+        var handler = new StubHandler(_ => throw new TaskCanceledException("http timeout"));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        (await reader.ResolveAsync(Oid, CancellationToken.None)).Outcome.Should().Be(RbacOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_CallerCancellation_IsRethrown()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var handler = new StubHandler(_ => throw new OperationCanceledException());
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        Func<Task> act = () => reader.ResolveAsync(Oid, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task Resolve_PathCondition_OnAccountScope_IsDropped()
+    {
+        // A blob-path condition on an account scope can't be expressed as a prefix (it applies
+        // inside every container, not a container named for the path) → drop, not azblob://acct/<path>/.
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*'))";
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", cond));
+        AzureRbacScopes r = await NewReader(roles).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_ContainerNameCondition_OnAccountScope_NarrowsToNamedContainer()
+    {
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'reports'))";
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", cond));
+        AzureRbacScopes r = await NewReader(roles).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/reports/");
+    }
+
+    [Fact]
+    public async Task Resolve_ContainerNameCondition_NamingDifferentContainerThanScope_IsDropped()
+    {
+        // Assignment scoped to container "A" but condition names container "B" → Azure grants
+        // nothing (A != B); must NOT emit azblob://acct/B/ (would escape the assignment scope).
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'B'))";
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/A", cond));
+        AzureRbacScopes r = await NewReader(roles).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_ContainerNameCondition_MatchingScopeContainer_IsKept()
+    {
+        string cond = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'docs'))";
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs", cond));
+        AzureRbacScopes r = await NewReader(roles).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/docs/");
+    }
+
+    [Fact]
+    public async Task Resolve_MalformedDenyPage_NullValue_FailsClosed()
+    {
+        string roles = RoleAssignmentsBody((ReaderRole,
+            "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct", null));
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase)
+                ? Json(HttpStatusCode.OK, """{"value":null}""")
+                : Json(HttpStatusCode.OK, roles));
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(new AzureProviderSettings { SubscriptionId = Sub });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        (await reader.ResolveAsync(Oid, CancellationToken.None)).Outcome.Should().Be(RbacOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_DenyWithBlobReadInNotDataActions_DoesNotSubtractGrant()
+    {
+        // A deny that grants dataActions:["*"] but excludes blob read via notDataActions does NOT
+        // deny blob reads → the grant must survive (ignoring notDataActions would over-subtract).
+        string acctScope = "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+        string roles = RoleAssignmentsBody((ReaderRole, acctScope, null));
+        string deny = $$$"""
+        {"value":[{"properties":{"scope":"{{{acctScope}}}","permissions":[{"dataActions":["*"],"notDataActions":["Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"]}]}}]}
+        """;
+        AzureRbacScopes r = await NewReaderWithDeny(roles, deny).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct/");
+    }
+
+    [Fact]
+    public async Task Resolve_CacheKey_IncludesSubscription_NotReusedAcrossSubscriptionChange()
+    {
+        // Same reader + cache, but the subscription changes between calls (settings reload). The
+        // second call must NOT reuse the first subscription's result.
+        var handler = new StubHandler(req =>
+        {
+            if (req.RequestUri!.AbsolutePath.Contains("/denyAssignments", StringComparison.OrdinalIgnoreCase))
+                return Json(HttpStatusCode.OK, EmptyDeny);
+            // Grant an account named after whichever subscription is in the request path.
+            string sub = req.RequestUri.AbsolutePath.Split("/subscriptions/")[1].Split('/')[0];
+            return Json(HttpStatusCode.OK, $$$"""
+            {"value":[{"properties":{"roleDefinitionId":"/x/{{{ReaderRole}}}","scope":"/subscriptions/{{{sub}}}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct-{{{sub}}}","condition":null}}]}
+            """);
+        });
+        var opts = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        opts.CurrentValue.Returns(
+            new AzureProviderSettings { SubscriptionId = "sub-a" },
+            new AzureProviderSettings { SubscriptionId = "sub-b" });
+        var reader = new ArmRbacReader(new HttpClient(handler), new StubTokenCredential(),
+            new MemoryCache(new MemoryCacheOptions()), opts);
+
+        AzureRbacScopes a = await reader.ResolveAsync(Oid, CancellationToken.None);
+        AzureRbacScopes b = await reader.ResolveAsync(Oid, CancellationToken.None);
+
+        a.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct-sub-a/");
+        b.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://acct-sub-b/");
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
@@ -426,6 +426,22 @@ public class ArmRbacReaderTests
     }
 
     [Fact]
+    public async Task Resolve_DenyAssignment_IsExposedOnDeniedPrefixes()
+    {
+        // A Blob Data role grant on the account, plus a deny assignment on a container beneath it.
+        // The grant itself is unaffected (deny doesn't cover the whole account), but the resolved
+        // result must also surface the deny as a DeniedPrefix so the verifier can block ACL fallback
+        // reads under it.
+        string acctScope = "/subscriptions/" + Sub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+        string roles = RoleAssignmentsBody((ReaderRole, acctScope, null));
+        string containerScope = acctScope + "/blobServices/default/containers/secret";
+        AzureRbacScopes r = await NewReaderWithDeny(roles, DenyBody(containerScope)).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.DeniedPrefixes.Should().Contain("azblob://acct/secret/");
+    }
+
+    [Fact]
     public async Task Resolve_CacheKey_IncludesSubscription_NotReusedAcrossSubscriptionChange()
     {
         // Same reader + cache, but the subscription changes between calls (settings reload). The

--- a/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ArmRbacReaderTests.cs
@@ -78,6 +78,54 @@ public class ArmRbacReaderTests
     }
 
     [Fact]
+    public async Task Resolve_ResourceGroupScopedGrant_IsDropped_NotWidenedToAllAccounts()
+    {
+        // A Blob Data Reader assignment scoped to a resource group is bounded to the accounts IN that
+        // RG, which cannot be enumerated here. It must NOT translate to azblob:// (every account in
+        // the subscription) — that would disclose storage in other resource groups. Drop it.
+        string body = RoleAssignmentsBody((ReaderRole, "/subscriptions/" + Sub + "/resourceGroups/rg-a", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_SubscriptionScopedGrant_YieldsGlobalAzureWildcard()
+    {
+        // A subscription-scoped assignment genuinely covers every storage account Connapse's
+        // configured subscription can see, so the azblob:// wildcard is sound and kept.
+        string body = RoleAssignmentsBody((ReaderRole, "/subscriptions/" + Sub, null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://");
+    }
+
+    [Fact]
+    public async Task Resolve_ManagementGroupScopedGrant_YieldsGlobalAzureWildcard()
+    {
+        // A management-group scope is above the subscription, so it too covers everything Connapse
+        // can see → azblob:// is sound.
+        string body = RoleAssignmentsBody((ReaderRole, "/providers/Microsoft.Management/managementGroups/mg", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().ContainSingle().Which.Should().Be("azblob://");
+    }
+
+    [Fact]
+    public async Task Resolve_ResourceGroupGrant_DoesNotLeakAnotherResourceGroupsAccount()
+    {
+        // The concrete disclosure: the user holds Blob Data Reader on rg-a only. A precise account
+        // grant in rg-a would be fine, but a resource-group-level grant must not become the wildcard
+        // that also matches acct-b (in rg-b). Nothing is emitted rather than everything.
+        string body = RoleAssignmentsBody((ReaderRole, "/subscriptions/" + Sub + "/resourceGroups/rg-a", null));
+        AzureRbacScopes r = await NewReader(body).ResolveAsync(Oid, CancellationToken.None);
+
+        r.ReadablePrefixes.Select(p => p.Prefix).Should().NotContain("azblob://");
+        r.ReadablePrefixes.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task Resolve_IgnoresNonBlobDataRoles()
     {
         // Owner of the *control plane* role "Contributor" for ARM is a different GUID; use a random one.

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureAbacConditionParserTests.cs
@@ -1,0 +1,114 @@
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureAbacConditionParserTests
+{
+    private const string PathCond =
+        "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'} AND NOT SubOperationMatches{'Blob.List'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*'))";
+    private const string NameCond =
+        "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'reports'))";
+    private const string TagCond =
+        "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Project<$key_case_sensitive$>] StringEquals 'Cascade'))";
+
+    [Fact]
+    public void Parse_Null_IsNone() =>
+        AzureAbacConditionParser.Parse(null).Kind.Should().Be(AbacKind.None);
+
+    [Fact]
+    public void Parse_Path_ReturnsPrefix_TrailingStarStripped()
+    {
+        AbacResult r = AzureAbacConditionParser.Parse(PathCond);
+        r.Kind.Should().Be(AbacKind.PathPrefix);
+        r.PathPrefix.Should().Be("readonly/");
+    }
+
+    [Fact]
+    public void Parse_ContainerName_ReturnsName()
+    {
+        AbacResult r = AzureAbacConditionParser.Parse(NameCond);
+        r.Kind.Should().Be(AbacKind.ContainerName);
+        r.ContainerName.Should().Be("reports");
+    }
+
+    [Fact]
+    public void Parse_Tag_ReturnsKeyValue()
+    {
+        AbacResult r = AzureAbacConditionParser.Parse(TagCond);
+        r.Kind.Should().Be(AbacKind.Tag);
+        r.TagKey.Should().Be("Project");
+        r.TagValue.Should().Be("Cascade");
+        r.TagKeyCaseSensitive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_UnknownExpression_IsUnparseable() =>
+        AzureAbacConditionParser.Parse("@Request[...] DateTimeGreaterThan '2024-01-01'")
+            .Kind.Should().Be(AbacKind.Unparseable);
+
+    [Fact]
+    public void Parse_CompoundCondition_MoreThanOneAttribute_IsUnparseable()
+    {
+        // A recognized clause combined with anything else must not be partially honored.
+        string compound =
+            "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'readonly/*' AND @Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Secret<$key_case_sensitive$>] StringEquals 'no'))";
+        AzureAbacConditionParser.Parse(compound).Kind.Should().Be(AbacKind.Unparseable);
+    }
+
+    private const string Guard =
+        "(!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'}))";
+
+    [Fact]
+    public void Parse_PathStringStartsWith_IsPrefix()
+    {
+        string cond = $"({Guard} OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringStartsWith 'reports/'))";
+        AbacResult r = AzureAbacConditionParser.Parse(cond);
+        r.Kind.Should().Be(AbacKind.PathPrefix);
+        r.PathPrefix.Should().Be("reports/");
+    }
+
+    [Fact]
+    public void Parse_PathStringLike_MidWildcard_IsUnparseable()
+    {
+        string cond = $"({Guard} OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'a*b*'))";
+        AzureAbacConditionParser.Parse(cond).Kind.Should().Be(AbacKind.Unparseable);
+    }
+
+    [Fact]
+    public void Parse_PathStringLike_NoWildcard_IsUnparseable()
+    {
+        // StringLike with no wildcard is an EXACT match in Azure, not a prefix — must not become one.
+        string cond = $"({Guard} OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike 'exact.txt'))";
+        AzureAbacConditionParser.Parse(cond).Kind.Should().Be(AbacKind.Unparseable);
+    }
+
+    [Fact]
+    public void Parse_TagStringEqualsIgnoreCase_IsValueCaseInsensitive()
+    {
+        string cond = $"({Guard} OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags:Project<$key_case_sensitive$>] StringEqualsIgnoreCase 'Cascade'))";
+        AbacResult r = AzureAbacConditionParser.Parse(cond);
+        r.Kind.Should().Be(AbacKind.Tag);
+        r.TagValue.Should().Be("Cascade");
+        r.ValueCaseSensitive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_NameStringEqualsIgnoreCase_ReturnsName()
+    {
+        string cond = $"({Guard} OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEqualsIgnoreCase 'Reports'))";
+        AbacResult r = AzureAbacConditionParser.Parse(cond);
+        r.Kind.Should().Be(AbacKind.ContainerName);
+        r.ContainerName.Should().Be("Reports");
+    }
+
+    [Fact]
+    public void Parse_RecognizedPredicate_WithoutActionGuard_IsUnparseable()
+    {
+        // A predicate not wrapped in the canonical action guard must not be honored (an inverted or
+        // absent guard could make the predicate NOT gate reads).
+        string cond = "(@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringStartsWith 'private/')";
+        AzureAbacConditionParser.Parse(cond).Kind.Should().Be(AbacKind.Unparseable);
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
@@ -1,0 +1,82 @@
+using Azure;
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureBlobDiscoveryTests
+{
+    private static AzureBlobDiscovery Build(AzureProviderSettings settings)
+    {
+        var monitor = Substitute.For<IOptionsMonitor<AzureProviderSettings>>();
+        monitor.CurrentValue.Returns(settings);
+        return new AzureBlobDiscovery(new ConnapseAzureCredentials(monitor), monitor, NullLogger<AzureBlobDiscovery>.Instance);
+    }
+
+    private static AzureProviderSettings Configured() => new()
+    {
+        TenantId = "11111111-1111-1111-1111-111111111111",
+        ClientId = "22222222-2222-2222-2222-222222222222",
+        ClientCertificatePath = "/nonexistent.pem",
+        SubscriptionId = "33333333-3333-3333-3333-333333333333",
+    };
+
+    [Fact]
+    public async Task ListStorageAccounts_NoIdentity_IsNotConfigured_WithoutCallingAzure()
+    {
+        var probe = await Build(new AzureProviderSettings()).ListStorageAccountsAsync();
+
+        probe.Outcome.Should().Be(AzureProbeOutcome.NotConfigured);
+        probe.Detail.Should().Contain("provider page");
+    }
+
+    [Fact]
+    public async Task ListStorageAccounts_NoSubscription_IsNotConfigured()
+    {
+        var probe = await Build(Configured() with { SubscriptionId = null }).ListStorageAccountsAsync();
+
+        probe.Outcome.Should().Be(AzureProbeOutcome.NotConfigured);
+        probe.Detail.Should().Contain("subscription");
+    }
+
+    [Fact]
+    public async Task ListContainers_NoIdentity_IsNotConfigured()
+    {
+        var probe = await Build(new AzureProviderSettings()).ListContainersAsync("https://acct.blob.core.windows.net");
+        probe.Outcome.Should().Be(AzureProbeOutcome.NotConfigured);
+    }
+
+    [Fact]
+    public async Task ListContainers_NoEndpoint_Fails_WithoutCallingAzure()
+    {
+        var probe = await Build(Configured()).ListContainersAsync("");
+        probe.Outcome.Should().Be(AzureProbeOutcome.Failed);
+        probe.Detail.Should().Contain("No storage account");
+    }
+
+    [Theory]
+    [InlineData(401, true)]
+    [InlineData(403, true)]
+    [InlineData(404, false)]
+    [InlineData(500, false)]
+    public void IsDenial_OnlyForAuthFailures(int status, bool expected) =>
+        AzureBlobDiscovery.IsDenial(new RequestFailedException(status, "x")).Should().Be(expected);
+
+    [Fact]
+    public void IsConfigured_MatchesTheProvidersPageRule()
+    {
+        AzureBlobDiscovery.IsConfigured(Configured()).Should().BeTrue();
+        AzureBlobDiscovery.IsConfigured(Configured() with { ClientCertificatePath = null }).Should().BeFalse();
+        AzureBlobDiscovery.IsConfigured(new AzureProviderSettings
+        {
+            TenantId = "t", UserAssignedManagedIdentityClientId = "mi",
+        }).Should().BeTrue();
+        AzureBlobDiscovery.IsConfigured(Configured() with { TenantId = null }).Should().BeFalse();
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
@@ -1,4 +1,5 @@
 using Azure;
+using Azure.Identity;
 using Connapse.Core;
 using Connapse.Core.Interfaces;
 using Connapse.Storage.CloudScope;
@@ -60,6 +61,67 @@ public class AzureBlobDiscoveryTests
         probe.Detail.Should().Contain("No storage account");
     }
 
+    [Fact]
+    public async Task CheckAccess_NoIdentity_IsNotConfigured_WithoutCallingAzure()
+    {
+        var probe = await Build(new AzureProviderSettings()).CheckAccessAsync();
+
+        probe.Outcome.Should().Be(AzureProbeOutcome.NotConfigured);
+        probe.Detail.Should().Contain("provider page");
+    }
+
+    [Fact]
+    public async Task CheckAccess_CertificateFileMissing_IsUnusable_WithTheReason()
+    {
+        // The credential chain refuses to build without a readable certificate, and refuses to
+        // fall through to a managed identity. Azure was never asked: this host is what needs
+        // fixing, which is neither Entra saying no nor "could not confirm".
+        var probe = await Build(Configured()).CheckAccessAsync();
+
+        probe.Outcome.Should().Be(AzureProbeOutcome.Unusable);
+        probe.Detail.Should().Contain("certificate");
+    }
+
+    [Fact]
+    public async Task CheckAccess_Candidate_IsCheckedInsteadOfTheStoredSettings()
+    {
+        // Stored settings are blank (NotConfigured); the candidate is complete but its certificate
+        // file is missing, so it is the candidate that produced the answer.
+        var probe = await Build(new AzureProviderSettings()).CheckAccessAsync(Configured());
+
+        probe.Outcome.Should().Be(AzureProbeOutcome.Unusable);
+        probe.Detail.Should().Contain("certificate");
+    }
+
+    [Fact]
+    public async Task CheckAccess_Candidate_NotConfigured_NeverCallsAzure()
+    {
+        var probe = await Build(Configured()).CheckAccessAsync(new AzureProviderSettings { TenantId = "t" });
+
+        probe.Outcome.Should().Be(AzureProbeOutcome.NotConfigured);
+    }
+
+    [Theory]
+    [InlineData("AADSTS700027: Client assertion contains an invalid signature", true)]
+    [InlineData("AADSTS7000215: Invalid client secret provided", true)]
+    [InlineData("AADSTS7000222: The provided client secret keys are expired", true)]
+    [InlineData("AADSTS7000229: The client application is missing service principal in the tenant", true)]
+    [InlineData("AADSTS7000112: Application 'x' is disabled", true)]
+    [InlineData("AADSTS700016: Application with identifier 'x' was not found in the directory", true)]
+    [InlineData("AADSTS90002: Tenant 'x' not found", true)]
+    // Entra answered, but about itself, not the credential: transient, throttled, or unavailable.
+    [InlineData("AADSTS90024: The request body must contain the following parameter", false)]
+    [InlineData("AADSTS90033: A transient error has occurred. Please try again.", false)]
+    [InlineData("AADSTS50196: The server terminated an operation because it encountered a client request loop", false)]
+    [InlineData("No such host is known (login.microsoftonline.com:443)", false)]
+    public void IsCredentialRefusal_OnlyForCodesThatMeanTheCredentialIsWrong(string message, bool expected) =>
+        AzureBlobDiscovery.IsCredentialRefusal(new AuthenticationFailedException(message)).Should().Be(expected);
+
+    [Fact]
+    public void IsCredentialRefusal_ManagedIdentityUnavailable_IsNotARefusal() =>
+        AzureBlobDiscovery.IsCredentialRefusal(new CredentialUnavailableException("AADSTS-looking text from the IMDS probe"))
+            .Should().BeFalse();
+
     [Theory]
     [InlineData(401, true)]
     [InlineData(403, true)]
@@ -78,5 +140,11 @@ public class AzureBlobDiscoveryTests
             TenantId = "t", UserAssignedManagedIdentityClientId = "mi",
         }).Should().BeTrue();
         AzureBlobDiscovery.IsConfigured(Configured() with { TenantId = null }).Should().BeFalse();
+        // The host's own managed identity, as the guided setup on an Azure host records it.
+        AzureBlobDiscovery.IsConfigured(new AzureProviderSettings
+        {
+            TenantId = "t", UseHostManagedIdentity = true,
+        }).Should().BeTrue();
+        AzureBlobDiscovery.IsConfigured(new AzureProviderSettings { UseHostManagedIdentity = true }).Should().BeFalse();
     }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureBlobDiscoveryTests.cs
@@ -117,6 +117,16 @@ public class AzureBlobDiscoveryTests
     public void IsCredentialRefusal_OnlyForCodesThatMeanTheCredentialIsWrong(string message, bool expected) =>
         AzureBlobDiscovery.IsCredentialRefusal(new AuthenticationFailedException(message)).Should().Be(expected);
 
+    [Theory]
+    [InlineData("[Managed Identity] Authentication unavailable. Error Code: invalid_request Error Description: Identity not found", true)]
+    [InlineData("AADSTS90033: A transient error has occurred", false)]
+    [InlineData("No such host is known", false)]
+    public void IsNoManagedIdentityHere_MetadataServiceSaysNoIdentity_OrIsAbsent(string message, bool expected)
+    {
+        AzureBlobDiscovery.IsNoManagedIdentityHere(new AuthenticationFailedException(message)).Should().Be(expected);
+        AzureBlobDiscovery.IsNoManagedIdentityHere(new CredentialUnavailableException("no IMDS")).Should().BeTrue();
+    }
+
     [Fact]
     public void IsCredentialRefusal_ManagedIdentityUnavailable_IsNotARefusal() =>
         AzureBlobDiscovery.IsCredentialRefusal(new CredentialUnavailableException("AADSTS-looking text from the IMDS probe"))

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCertificateFileTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCertificateFileTests.cs
@@ -1,0 +1,96 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+/// <summary>
+/// The one loader every reader of Connapse's Azure certificate files goes through. A file it cannot
+/// read is a fact for the provider page to show, never an exception that stops the page rendering.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AzureCertificateFileTests : IDisposable
+{
+    private readonly string directory = Path.Combine(Path.GetTempPath(), "connapse-cert-tests-" + Guid.NewGuid().ToString("N"));
+
+    public AzureCertificateFileTests() => Directory.CreateDirectory(directory);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(directory, recursive: true); } catch (IOException) { }
+    }
+
+    private string Write(string name, string content)
+    {
+        string path = Path.Combine(directory, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Fact]
+    public void Expiry_MissingFile_IsNull()
+    {
+        AzureCertificateFile.Expiry(Path.Combine(directory, "nope.pem"), null).Should().BeNull();
+        AzureCertificateFile.Expiry(null, null).Should().BeNull();
+        AzureCertificateFile.Expiry("   ", null).Should().BeNull();
+    }
+
+    [Fact]
+    public void Expiry_GeneratedPem_IsTheCertificatesNotAfter()
+    {
+        AzureCertificateMaterial material = AzureCertificateGenerator.Generate("connapse-test");
+        string path = Write("good.pem", material.CombinedPem);
+
+        DateTime? expiry = AzureCertificateFile.Expiry(path, null);
+
+        using var expected = X509Certificate2.CreateFromPem(material.PublicCertificatePem);
+        expiry.Should().Be(expected.NotAfter.ToUniversalTime());
+    }
+
+    [Fact]
+    public void Expiry_FileThatIsNotACertificate_IsNull_NotAnException()
+    {
+        string path = Write("junk.pem", "this is not a certificate");
+
+        AzureCertificateFile.Expiry(path, null).Should().BeNull();
+    }
+
+    [Fact]
+    public void Expiry_FileHeldOpenExclusively_IsNull_NotAnException()
+    {
+        AzureCertificateMaterial material = AzureCertificateGenerator.Generate("connapse-test");
+        string path = Write("locked.pem", material.CombinedPem);
+
+        using var _ = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+        AzureCertificateFile.Expiry(path, null).Should().BeNull();
+    }
+
+    [Fact]
+    public void Thumbprint_MatchesTheCertificatesOwn_UpperCaseNoSeparators()
+    {
+        AzureCertificateMaterial material = AzureCertificateGenerator.Generate("connapse-test");
+
+        string thumbprint = AzureCertificateFile.Thumbprint(material.PublicCertificatePem);
+
+        using var certificate = X509Certificate2.CreateFromPem(material.PublicCertificatePem);
+        thumbprint.Should().Be(certificate.Thumbprint.ToUpperInvariant());
+        thumbprint.Should().HaveLength(40).And.MatchRegex("^[0-9A-F]+$");
+    }
+
+    [Theory]
+    [InlineData(typeof(CryptographicException))]
+    [InlineData(typeof(IOException))]
+    [InlineData(typeof(UnauthorizedAccessException))]
+    [InlineData(typeof(ArgumentException))]
+    public void IsUnreadable_CoversTheWaysAFileFailsToRead(Type exceptionType)
+    {
+        var exception = (Exception)Activator.CreateInstance(exceptionType)!;
+        AzureCertificateFile.IsUnreadable(exception).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsUnreadable_DoesNotSwallowEverything() =>
+        AzureCertificateFile.IsUnreadable(new InvalidOperationException()).Should().BeFalse();
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCertificateGeneratorTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCertificateGeneratorTests.cs
@@ -1,0 +1,45 @@
+using System.Security.Cryptography.X509Certificates;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureCertificateGeneratorTests
+{
+    [Fact]
+    public void Generate_PublicPem_IsACertificateWithoutThePrivateKey()
+    {
+        AzureCertificateMaterial material = AzureCertificateGenerator.Generate("connapse-test");
+
+        material.PublicCertificatePem.Should().Contain("BEGIN CERTIFICATE");
+        material.PublicCertificatePem.Should().NotContain("PRIVATE KEY");
+
+        using X509Certificate2 cert = X509Certificate2.CreateFromPem(material.PublicCertificatePem);
+        cert.Subject.Should().Contain("connapse-test");
+        cert.HasPrivateKey.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Generate_CombinedPem_HasBothAndLoadsWithItsPrivateKey_LikeProduction()
+    {
+        AzureCertificateMaterial material = AzureCertificateGenerator.Generate("connapse-test");
+
+        material.CombinedPem.Should().Contain("BEGIN CERTIFICATE");
+        material.CombinedPem.Should().Contain("PRIVATE KEY");
+
+        // Production loads the cert via X509Certificate2.CreateFromPemFile on a single .pem holding both.
+        string path = Path.Combine(Path.GetTempPath(), $"connapse-azure-{Guid.NewGuid():N}.pem");
+        try
+        {
+            File.WriteAllText(path, material.CombinedPem);
+            using X509Certificate2 loaded = X509Certificate2.CreateFromPemFile(path);
+            loaded.HasPrivateKey.Should().BeTrue();
+            loaded.Subject.Should().Contain("connapse-test");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
@@ -1,0 +1,117 @@
+using Azure.Core;
+using Azure.Identity;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureCredentialChainFactoryTests
+{
+    private static X509Certificate2 SelfSigned() =>
+        new CertificateRequest("CN=connapse-test",
+            System.Security.Cryptography.ECDsa.Create(),
+            HashAlgorithmName.SHA256)
+            .CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
+
+    [Fact]
+    public void Create_WithClientIdAndCert_UsesCertificateCredential()
+    {
+        var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        cred.Should().BeOfType<ChainedTokenCredential>();
+        // First source is the cert credential when configured.
+        FirstSource(cred).Should().BeOfType<ClientCertificateCredential>();
+    }
+
+    [Fact]
+    public void Create_NoCert_SystemAssignedManagedIdentity()
+    {
+        var cred = AzureCredentialChainFactory.Create(new AzureProviderSettings(), _ => null);
+        FirstSource(cred).Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    [Fact]
+    public void Create_NoCert_UserAssignedManagedIdentity()
+    {
+        var settings = new AzureProviderSettings { UserAssignedManagedIdentityClientId = "mi-client" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => null);
+        FirstSource(cred).Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    [Fact]
+    public void Create_ClientIdSetButCertMissing_Throws()
+    {
+        var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => null);
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*certificate*");
+    }
+
+    [Fact]
+    public void Create_TenantIdAndCertPathSetButClientIdBlank_Throws()
+    {
+        // Partial service-principal config: ClientId lost/blank must not silently
+        // fall through to managed identity (a broader, ambient identity).
+        var settings = new AzureProviderSettings { TenantId = "t", ClientCertificatePath = "cert.pfx" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Create_ClientIdAndTenantIdSetButCertPathBlank_Throws()
+    {
+        var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => null);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Create_OnlyClientCertificatePasswordSet_Throws()
+    {
+        // A lone SP field is still "intent to use certificate auth" and must fail
+        // closed rather than silently becoming managed-identity-only.
+        var settings = new AzureProviderSettings { ClientCertificatePassword = "pw" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Create_OnlyClientIdSetButTenantIdBlank_Throws()
+    {
+        var settings = new AzureProviderSettings { ClientId = "c", ClientCertificatePath = "cert.pfx" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Create_FullServicePrincipalSet_UsesCertificateCredentialOnly()
+    {
+        // When the SP set is complete, the chain must not also carry a managed-identity
+        // fallback source — that fallback is exactly the broader-identity fall-open path.
+        var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c", ClientCertificatePath = "cert.pfx" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        Sources(cred).Should().ContainSingle().Which.Should().BeOfType<ClientCertificateCredential>();
+    }
+
+    [Fact]
+    public void Create_NoServicePrincipalFields_ManagedIdentityOnlyChain()
+    {
+        var cred = AzureCredentialChainFactory.Create(new AzureProviderSettings(), _ => null);
+        Sources(cred).Should().ContainSingle().Which.Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    // Reads the private _sources array ChainedTokenCredential stores, to assert ordering/contents.
+    private static TokenCredential FirstSource(TokenCredential chain) => Sources(chain)[0];
+
+    private static TokenCredential[] Sources(TokenCredential chain)
+    {
+        var field = typeof(ChainedTokenCredential)
+            .GetField("_sources", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        return (TokenCredential[])field.GetValue(chain)!;
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
@@ -29,10 +29,24 @@ public class AzureCredentialChainFactoryTests
     }
 
     [Fact]
-    public void Create_NoCert_SystemAssignedManagedIdentity()
+    public void Create_NothingConfigured_Throws_RatherThanUsingWhateverIdentityTheHostHas()
     {
-        var cred = AzureCredentialChainFactory.Create(new AzureProviderSettings(), _ => null);
-        FirstSource(cred).Should().BeOfType<ManagedIdentityCredential>();
+        // An empty record is a reset or a lost row, not a request to use the host's identity;
+        // that request is the explicit flag. Continuing as the host would be a broader identity
+        // nobody chose.
+        var act = () => AzureCredentialChainFactory.Create(new AzureProviderSettings(), _ => null);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*No Azure identity is configured*");
+    }
+
+    [Fact]
+    public void Create_CertificateAppBesideUserAssignedIdentity_Throws_RatherThanPickingTheCertificate()
+    {
+        var settings = new AzureProviderSettings
+        {
+            TenantId = "t", ClientId = "c", ClientCertificatePath = "x.pem", UserAssignedManagedIdentityClientId = "mi",
+        };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => SelfSigned());
+        act.Should().Throw<InvalidOperationException>().WithMessage("*both*");
     }
 
     [Fact]
@@ -160,9 +174,10 @@ public class AzureCredentialChainFactoryTests
     }
 
     [Fact]
-    public void Create_NoServicePrincipalFields_ManagedIdentityOnlyChain()
+    public void Create_HostIdentityFlag_ManagedIdentityOnlyChain()
     {
-        var cred = AzureCredentialChainFactory.Create(new AzureProviderSettings(), _ => null);
+        // The only way to the host's identity is asking for it.
+        var cred = AzureCredentialChainFactory.Create(new AzureProviderSettings { UseHostManagedIdentity = true }, _ => null);
         Sources(cred).Should().ContainSingle().Which.Should().BeOfType<ManagedIdentityCredential>();
     }
 

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureCredentialChainFactoryTests.cs
@@ -44,6 +44,67 @@ public class AzureCredentialChainFactoryTests
     }
 
     [Fact]
+    public void Create_TenantAndUserAssignedManagedIdentity_UsesManagedIdentity()
+    {
+        // The provider page records the tenant for every identity. A tenant beside a managed
+        // identity id is not certificate intent, and must not be refused as a half-filled one.
+        var settings = new AzureProviderSettings { TenantId = "t", UserAssignedManagedIdentityClientId = "mi-client" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => null);
+        Sources(cred).Should().ContainSingle().Which.Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    [Fact]
+    public void Create_HostManagedIdentityFlag_UsesTheSystemAssignedIdentity_TenantOrNot()
+    {
+        // The guided setup on an Azure host records only the flag (and the tenant, for display);
+        // that must be the host's own identity, never a refusal for a "half-filled" certificate.
+        var settings = new AzureProviderSettings { TenantId = "t", UseHostManagedIdentity = true, ManagedIdentityPrincipalId = "oid" };
+        var cred = AzureCredentialChainFactory.Create(settings, _ => null);
+        Sources(cred).Should().ContainSingle().Which.Should().BeOfType<ManagedIdentityCredential>();
+        AzureCredentialChainFactory.IsHostManagedIdentity(settings).Should().BeTrue();
+        AzureCredentialChainFactory.IsManagedIdentity(settings).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Create_HostFlagAndUserAssignedIdTogether_Throws_RatherThanChoosing()
+    {
+        // Neither side is picked: the flag and the id name different identities.
+        var settings = new AzureProviderSettings { UseHostManagedIdentity = true, UserAssignedManagedIdentityClientId = "mi" };
+        var act = () => AzureCredentialChainFactory.Create(settings, _ => null);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*both*");
+        AzureCredentialChainFactory.IsManagedIdentity(settings).Should().BeFalse();
+
+        // The same for the flag beside a certificate app: the certificate must not win silently.
+        var withApp = new AzureProviderSettings { TenantId = "t", UseHostManagedIdentity = true, ClientId = "c", ClientCertificatePath = "x.pem" };
+        var actApp = () => AzureCredentialChainFactory.Create(withApp, _ => SelfSigned());
+        actApp.Should().Throw<InvalidOperationException>().WithMessage("*both*");
+    }
+
+    [Fact]
+    public void IsHostManagedIdentity_FalseWhenACertificateOrUserAssignedFieldIsSet()
+    {
+        // The flag beside a certificate field is a mix the form can never produce; if it arrives
+        // from configuration it is certificate intent and must fail closed like any other mix.
+        AzureCredentialChainFactory.IsHostManagedIdentity(
+            new AzureProviderSettings { UseHostManagedIdentity = true, ClientId = "c" }).Should().BeFalse();
+        AzureCredentialChainFactory.IsHostManagedIdentity(
+            new AzureProviderSettings { UseHostManagedIdentity = true, UserAssignedManagedIdentityClientId = "mi" }).Should().BeFalse();
+        AzureCredentialChainFactory.IsHostManagedIdentity(new AzureProviderSettings { TenantId = "t" }).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsUserAssignedManagedIdentity_FalseWhenAnyCertificateFieldIsSet()
+    {
+        AzureCredentialChainFactory.IsUserAssignedManagedIdentity(
+            new AzureProviderSettings { TenantId = "t", UserAssignedManagedIdentityClientId = "mi" }).Should().BeTrue();
+        AzureCredentialChainFactory.IsUserAssignedManagedIdentity(
+            new AzureProviderSettings { UserAssignedManagedIdentityClientId = "mi", ClientId = "c" }).Should().BeFalse();
+        AzureCredentialChainFactory.IsUserAssignedManagedIdentity(
+            new AzureProviderSettings { UserAssignedManagedIdentityClientId = "mi", ClientCertificatePath = "x.pem" }).Should().BeFalse();
+        AzureCredentialChainFactory.IsUserAssignedManagedIdentity(new AzureProviderSettings { TenantId = "t" }).Should().BeFalse();
+    }
+
+    [Fact]
     public void Create_ClientIdSetButCertMissing_Throws()
     {
         var settings = new AzureProviderSettings { TenantId = "t", ClientId = "c" };

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureHostIdentityTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureHostIdentityTests.cs
@@ -1,0 +1,145 @@
+using Azure.Identity;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+/// <summary>
+/// Detecting the host's managed identity from the token Azure issues it. The claims are what the
+/// guided setup names the identity by, so each one has to be read from where Azure puts it.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AzureHostIdentityTests
+{
+    private const string Tenant = "11111111-1111-1111-1111-111111111111";
+    private const string Principal = "22222222-2222-2222-2222-222222222222";
+    private const string Client = "33333333-3333-3333-3333-333333333333";
+    private const string Subscription = "44444444-4444-4444-4444-444444444444";
+
+    private static string SystemAssignedToken() => AzureHostIdentity.EncodePayload(new
+    {
+        tid = Tenant, oid = Principal, appid = Client,
+        xms_mirid = $"/subscriptions/{Subscription}/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
+    });
+
+    [Fact]
+    public void Describe_SystemAssignedToken_ReadsTenantPrincipalClientAndSubscription()
+    {
+        AzureHostIdentityInfo? info = AzureHostIdentity.Describe(SystemAssignedToken());
+
+        info.Should().NotBeNull();
+        info!.TenantId.Should().Be(Tenant);
+        info.PrincipalId.Should().Be(Principal);
+        info.ClientId.Should().Be(Client);
+        info.SubscriptionId.Should().Be(Subscription);
+        info.IsUserAssigned.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Describe_UserAssignedToken_IsMarkedUserAssigned()
+    {
+        string token = AzureHostIdentity.EncodePayload(new
+        {
+            tid = Tenant, oid = Principal, appid = Client,
+            xms_mirid = $"/subscriptions/{Subscription}/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/connapse",
+        });
+
+        AzureHostIdentity.Describe(token)!.IsUserAssigned.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Describe_WithoutTheNamingClaims_IsNull()
+    {
+        AzureHostIdentity.Describe(AzureHostIdentity.EncodePayload(new { tid = Tenant })).Should().BeNull();
+        AzureHostIdentity.Describe("not.a.token").Should().BeNull();
+        AzureHostIdentity.Describe("garbage").Should().BeNull();
+    }
+
+    [Fact]
+    public void Describe_WithoutAResourceId_StillNamesTheIdentity_WithoutASubscription()
+    {
+        AzureHostIdentityInfo? info = AzureHostIdentity.Describe(
+            AzureHostIdentity.EncodePayload(new { tid = Tenant, oid = Principal, appid = Client }));
+
+        info!.SubscriptionId.Should().BeNull();
+        info.ResourceId.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("/subscriptions/44444444-4444-4444-4444-444444444444/resourceGroups/rg/providers/x", "44444444-4444-4444-4444-444444444444")]
+    [InlineData("/SUBSCRIPTIONS/44444444-4444-4444-4444-444444444444/x", "44444444-4444-4444-4444-444444444444")]
+    [InlineData("/subscriptions/not-a-guid/x", null)]
+    [InlineData("", null)]
+    public void SubscriptionFrom_ReadsTheSegmentAfterSubscriptions(string resourceId, string? expected) =>
+        AzureHostIdentity.SubscriptionFrom(resourceId).Should().Be(expected);
+
+    [Fact]
+    public async Task DetectAsync_NoMetadataService_IsNull_NotAnException()
+    {
+        var probe = new AzureHostIdentity(NullLogger<AzureHostIdentity>.Instance)
+        {
+            AcquireToken = _ => throw new CredentialUnavailableException("ManagedIdentityCredential authentication unavailable"),
+        };
+
+        (await probe.DetectAsync()).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DetectAsync_FoundOnce_IsRememberedWithoutAskingAgain()
+    {
+        int calls = 0;
+        var probe = new AzureHostIdentity(NullLogger<AzureHostIdentity>.Instance)
+        {
+            AcquireToken = _ => { calls++; return Task.FromResult(SystemAssignedToken()); },
+        };
+
+        var first = await probe.DetectAsync();
+        var second = await probe.DetectAsync();
+
+        first.Should().NotBeNull();
+        second.Should().BeSameAs(first);
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DetectAsync_Refresh_AsksAgain_AndForgetsAnIdentityThatIsGone()
+    {
+        // Recheck asks with refresh: an identity re-created since the process cached it comes back
+        // new, and one that was removed is not handed out from the cache any more.
+        int calls = 0;
+        var probe = new AzureHostIdentity(NullLogger<AzureHostIdentity>.Instance)
+        {
+            AcquireToken = _ =>
+            {
+                calls++;
+                if (calls == 1) return Task.FromResult(SystemAssignedToken());
+                throw new CredentialUnavailableException("gone");
+            },
+        };
+
+        (await probe.DetectAsync()).Should().NotBeNull();
+        (await probe.DetectAsync(refresh: true)).Should().BeNull();
+        (await probe.DetectAsync()).Should().BeNull("the cache must not resurrect a removed identity");
+        calls.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task DetectAsync_NotFound_AsksAgainNextTime()
+    {
+        // A host that had no identity may gain one (or the metadata service may have been slow);
+        // only a found identity is worth remembering.
+        int calls = 0;
+        var probe = new AzureHostIdentity(NullLogger<AzureHostIdentity>.Instance)
+        {
+            AcquireToken = _ => { calls++; throw new CredentialUnavailableException("none"); },
+        };
+
+        await probe.DetectAsync();
+        await probe.DetectAsync();
+
+        calls.Should().Be(2);
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureRbacScopeTranslatorTests.cs
@@ -1,0 +1,51 @@
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureRbacScopeTranslatorTests
+{
+    [Fact]
+    public void RbacScopes_Failed_IsEmptyAndFailed()
+    {
+        AzureRbacScopes f = AzureRbacScopes.Failed();
+        f.Outcome.Should().Be(RbacOutcome.Failed);
+        f.ReadablePrefixes.Should().BeEmpty();
+        f.TagConditioned.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RbacScopes_Resolved_CarriesPrefixesAndTags()
+    {
+        AzureRbacScopes r = AzureRbacScopes.Resolved(
+            [new AzureScope("azblob://acct/c/")],
+            [new AzureTagCondition("azblob://acct/c/", "Project", "Cascade", true)]);
+        r.Outcome.Should().Be(RbacOutcome.Resolved);
+        r.ReadablePrefixes.Should().ContainSingle().Which.Prefix.Should().Be("azblob://acct/c/");
+        r.TagConditioned.Should().ContainSingle();
+    }
+
+    [Theory]
+    [InlineData(
+        "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/docs",
+        "azblob://acct/docs/")]
+    [InlineData(
+        "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct",
+        "azblob://acct/")]
+    [InlineData(
+        "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default",
+        "azblob://acct/")]
+    [InlineData("/subscriptions/s/resourceGroups/rg", "azblob://")]
+    [InlineData("/subscriptions/s", "azblob://")]
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg", "azblob://")]
+    public void ToAzblobPrefix_MapsScopeToPrefix(string armScope, string expected) =>
+        AzureRbacScopeTranslator.ToAzblobPrefix(armScope).Should().Be(expected);
+
+    [Fact]
+    public void ToAzblobPrefix_IsCaseInsensitiveOnResourceProviderSegments() =>
+        AzureRbacScopeTranslator.ToAzblobPrefix(
+            "/subscriptions/s/resourceGroups/rg/providers/microsoft.storage/STORAGEACCOUNTS/Acct/blobservices/default/CONTAINERS/Docs")
+            .Should().Be("azblob://Acct/Docs/");
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureSearchResultVerifierTests.cs
@@ -1,0 +1,324 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureSearchResultVerifierTests
+{
+    private const Gen2Permission RX = Gen2Permission.Read | Gen2Permission.Execute;
+    private static readonly Guid User = Guid.NewGuid();
+    private static readonly AzureIdentityRef Link = new("user-oid", "tid");
+
+    private static SearchHit Hit(string docId, double score) =>
+        new($"chunk-{docId}", docId, "content", (float)score, new Dictionary<string, string>());
+
+    private static IOptionsMonitor<T> Opt<T>(T v) where T : class
+    {
+        var m = Substitute.For<IOptionsMonitor<T>>();
+        m.CurrentValue.Returns(v);
+        return m;
+    }
+
+    // Builds a verifier with all seams faked; each test overrides what it needs.
+    private sealed class Harness
+    {
+        public IDocumentStore Docs = Substitute.For<IDocumentStore>();
+        public IAzureIdentityLinkReader Links = Substitute.For<IAzureIdentityLinkReader>();
+        public IAzureDirectoryReader Directory = Substitute.For<IAzureDirectoryReader>();
+        public IAzureRbacReader Rbac = Substitute.For<IAzureRbacReader>();
+        public IGen2FileAclReader FileAcl = Substitute.For<IGen2FileAclReader>();
+        public IBlobTagReader Tags = Substitute.For<IBlobTagReader>();
+        public IGen2DirectoryReader DirReader = Substitute.For<IGen2DirectoryReader>();
+        public bool AzureConfigured = true;
+        public bool AzureEnforcing = true;
+
+        public Harness()
+        {
+            // Defaults are wired here (construction time) rather than in Build(), so that any
+            // test-specific override set on these substitutes between `new Harness()` and
+            // `Build()` is the LAST configuration registered for that call and therefore wins
+            // (NSubstitute resolves repeat `.Returns()` on identical arguments by last-write).
+            Links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+            Directory.ResolveAsync(Link, Arg.Any<CancellationToken>())
+                .Returns(AzureIdentitySet.Resolved(["user-oid", "group-1"]));
+            Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+                .Returns(AzureRbacScopes.Resolved([], []));
+        }
+
+        public AzureSearchResultVerifier Build()
+        {
+            var azureAd = Opt(AzureConfigured
+                ? new AzureAdSignInSettings { TenantId = "t", ClientId = "c", RedirectUri = "https://x/cb", ClientCertificatePath = "p.pem" }
+                : new AzureAdSignInSettings());
+            var enf = Opt(new PermissionEnforcementSettings { AzureEnforcing = AzureEnforcing });
+            var traverse = new AncestorTraverseResolver(DirReader, new MemoryCache(new MemoryCacheOptions()));
+            return new AzureSearchResultVerifier(
+                Docs, Links, Directory, Rbac, FileAcl, Tags, traverse,
+                azureAd, enf, EnforcementMigration.Completed(),
+                Options.Create(new AzureVerifierSettings { MaxParallelism = 16, CandidateMultiplier = 5 }),
+                NullLogger<AzureSearchResultVerifier>.Instance);
+        }
+    }
+
+    private void ResourceUris(Harness h, params (string doc, string? uri)[] map) =>
+        h.Docs.GetResourceUrisAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
+            .Returns(map.ToDictionary(m => m.doc, m => m.uri));
+
+    [Fact]
+    public async Task NonAzureHits_PassUntouched()
+    {
+        var h = new Harness();
+        ResourceUris(h, ("d1", "s3://b/k"), ("d2", null));
+        var hits = new[] { Hit("d1", 0.9), Hit("d2", 0.8) };
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync(hits, User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("d1", "d2");
+    }
+
+    [Fact]
+    public async Task AzureNotEnforcing_PassesEverything()
+    {
+        var h = new Harness { AzureEnforcing = false };
+        ResourceUris(h, ("d1", "azblob://acct/docs/secret"));
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+        r.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RbacCoveredHit_Passes_WithoutAnyLiveAclOrTagRead()
+    {
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+            .Returns(AzureRbacScopes.Resolved([new AzureScope("azblob://acct/docs/")], []));
+        ResourceUris(h, ("d1", "azblob://acct/docs/a/file.txt"));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().ContainSingle();
+        await h.FileAcl.DidNotReceive().ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+        await h.Tags.DidNotReceive().ReadTagsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task LockedFileBeneathReadableFolder_IsDropped()
+    {
+        // Soundness: no RBAC/tag; file's own ACL denies Read → drop, even if ancestors traverse.
+        var h = new Harness();
+        ResourceUris(h, ("d1", "azblob://acct/docs/locked.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, RX, Gen2Permission.None, null, [], [])); // other = no read
+        h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, RX, HasExtendedAcl: false)); // ancestors traverse
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CaseC_PerFileGrantBeneathUnreadableFolder_IsReturned()
+    {
+        // Completeness: file's own ACL grants Read to the user AND ancestors are traversable (X),
+        // even though the folder is not readable as a listing (R). No RBAC. → pass.
+        var h = new Harness();
+        ResourceUris(h, ("d1", "azblob://acct/docs/secret/case-c.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, Gen2Permission.None, Gen2Permission.None,
+                Mask: RX, NamedUsers: [new Gen2NamedAce("user-oid", RX)], NamedGroups: []));
+        h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, Gen2Permission.Execute, HasExtendedAcl: false));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Gen2FileAclUnreadable_IsDropped_FailClosed()
+    {
+        var h = new Harness();
+        ResourceUris(h, ("d1", "azblob://acct/docs/x.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns((Gen2Acl?)null);
+
+        (await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TagConditioned_MatchingTag_Passes_And_NonMatching_FallsThroughToAcl_AndDrops()
+    {
+        // The tag branch itself only ever grants on a match. A non-match falls through to the Gen2
+        // ACL check; with FileAcl unstubbed (returns null / unreadable), that fallthrough still
+        // fails closed, so the non-matching hit drops — same observable outcome as before the fix,
+        // but now via the ACL path rather than the tag branch being terminal.
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>()).Returns(
+            AzureRbacScopes.Resolved([], [new AzureTagCondition("azblob://acct/docs/", "Project", "Cascade", true, false)]));
+        ResourceUris(h, ("hit-ok", "azblob://acct/docs/a.txt"), ("hit-no", "azblob://acct/docs/b.txt"));
+        h.Tags.ReadTagsAsync(Arg.Is<Gen2Path>(p => p.Path == "a.txt"), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, string> { ["Project"] = "Cascade" });
+        h.Tags.ReadTagsAsync(Arg.Is<Gen2Path>(p => p.Path == "b.txt"), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, string> { ["Project"] = "Other" });
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("hit-ok", 0.9), Hit("hit-no", 0.8)], User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("hit-ok");
+    }
+
+    [Fact]
+    public async Task DenyCoveredHit_IsDropped_EvenWhenAclWouldGrant()
+    {
+        // A deny assignment outranks every grant, including the Gen2 ACL fallback. Even though the
+        // file's own ACL (and every ancestor) would grant read, the hit sits under a denied prefix
+        // and must be dropped before the ACL check ever runs.
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+            .Returns(AzureRbacScopes.Resolved([], [], ["azblob://acct/secret/"]));
+        ResourceUris(h, ("d1", "azblob://acct/secret/x.txt"));
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, RX, Gen2Permission.Read | Gen2Permission.Execute,
+                Mask: null, NamedUsers: [], NamedGroups: [])); // grants "user-oid" Read via the "other" class
+        h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, Gen2Permission.Execute, HasExtendedAcl: false)); // ancestors traverse via "other"
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TagNonMatch_FallsThroughToAcl_AndAclReadableFilePasses()
+    {
+        // Azure evaluates ACLs when an ABAC condition doesn't grant. A tag condition that covers the
+        // scope but doesn't match this blob's tags must not drop the hit outright — the file's own
+        // ACL (plus ancestor traverse) still grants it, so it passes via the Gen2 ACL fallback.
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>()).Returns(
+            AzureRbacScopes.Resolved([], [new AzureTagCondition("azblob://acct/docs/", "Project", "Cascade", true, false)]));
+        ResourceUris(h, ("d1", "azblob://acct/docs/a.txt"));
+        h.Tags.ReadTagsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, string> { ["Project"] = "Other" });
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2Acl("owner", "group", RX, Gen2Permission.None, Gen2Permission.None,
+                Mask: RX, NamedUsers: [new Gen2NamedAce("user-oid", RX)], NamedGroups: []));
+        h.DirReader.ReadModeBitsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Gen2ModeBits("owner", "group", RX, RX, RX, HasExtendedAcl: false));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10);
+
+        r.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task TagNonMatch_FallsThroughToAcl_AndAclDeniesDrops()
+    {
+        // Same as above, but the file's own ACL is unreadable — the ACL fallback is itself
+        // fail-closed, so the hit still drops.
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>()).Returns(
+            AzureRbacScopes.Resolved([], [new AzureTagCondition("azblob://acct/docs/", "Project", "Cascade", true, false)]));
+        ResourceUris(h, ("d1", "azblob://acct/docs/a.txt"));
+        h.Tags.ReadTagsAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, string> { ["Project"] = "Other" });
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns((Gen2Acl?)null);
+
+        (await h.Build().VerifyAsync([Hit("d1", 0.9)], User, 10)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeprovisionedIdentity_DropsAllAzure_ButKeepsNonCloud()
+    {
+        var h = new Harness();
+        h.Directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Deprovisioned());
+        ResourceUris(h, ("az", "azblob://acct/docs/x"), ("nc", null));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("az", 0.9), Hit("nc", 0.8)], User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("nc");
+    }
+
+    [Fact]
+    public async Task Backfill_KeepsTopKInRankOrder_AfterDroppingUnreadable()
+    {
+        var h = new Harness();
+        h.Rbac.ResolveAsync("user-oid", Arg.Any<CancellationToken>())
+            .Returns(AzureRbacScopes.Resolved([new AzureScope("azblob://acct/ok/")], []));
+        ResourceUris(h,
+            ("d1", "azblob://acct/no/1"),  // dropped (not covered, file acl null)
+            ("d2", "azblob://acct/ok/2"),  // pass
+            ("d3", "azblob://acct/ok/3")); // pass
+        h.FileAcl.ReadFileAclAsync(Arg.Any<Gen2Path>(), Arg.Any<CancellationToken>()).Returns((Gen2Acl?)null);
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync(
+            [Hit("d1", 0.9), Hit("d2", 0.8), Hit("d3", 0.7)], User, 2);
+
+        r.Select(x => x.DocumentId).Should().Equal("d2", "d3"); // rank order preserved, d1 backfilled out
+    }
+
+    [Fact]
+    public async Task EnforcingButUnusable_DropsAllAzure_ButKeepsNonCloud()
+    {
+        // AzureEnforcing latched on but the provider isn't configured → EnforcingButUnusable, which
+        // the sibling AzureSearchScopeResolver treats as SearchScopes.Failed ("searches deny"). The
+        // verifier must not fall back to passing everything through.
+        var h = new Harness { AzureConfigured = false, AzureEnforcing = true };
+        ResourceUris(h, ("az", "azblob://acct/docs/x"), ("nc", null));
+
+        IReadOnlyList<SearchHit> r = await h.Build().VerifyAsync([Hit("az", 0.9), Hit("nc", 0.8)], User, 10);
+
+        r.Select(x => x.DocumentId).Should().BeEquivalentTo("nc");
+    }
+
+    [Fact]
+    public async Task UnparseableAzblobUri_IsDropped_FailClosed()
+    {
+        var h = new Harness();
+        ResourceUris(h, ("bad", "azblob://acct/docs/")); // azblob scheme, empty blob path → unparseable
+
+        (await h.Build().VerifyAsync([Hit("bad", 0.9)], User, 10)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DocumentIdNotFound_IsDropped_FailClosed()
+    {
+        var h = new Harness();
+        ResourceUris(h); // no entries at all — "gone" is absent from the map, not merely null
+
+        (await h.Build().VerifyAsync([Hit("gone", 0.9)], User, 10)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CandidateMultiplier_IsOne_WhenAzureAdNotConfigured()
+    {
+        // Not configured -> EnforcingButUnusable (latched on by the harness default), not Enforcing -> 1.
+        var h = new Harness { AzureConfigured = false, AzureEnforcing = true };
+
+        h.Build().CandidateMultiplier.Should().Be(1);
+    }
+
+    [Fact]
+    public void CandidateMultiplier_IsOne_WhenAzureConfiguredButNotEnforcing()
+    {
+        // Configured but the latch is off -> NotEnforcing, not Enforcing -> 1. A deployment with
+        // Azure AD wired up that hasn't switched enforcement on must not pay the over-fetch cost.
+        var h = new Harness { AzureConfigured = true, AzureEnforcing = false };
+
+        h.Build().CandidateMultiplier.Should().Be(1);
+    }
+
+    [Fact]
+    public void CandidateMultiplier_UsesSetting_WhenAzureConfigured()
+    {
+        // Configured AND enforcing -> Enforcing -> the configured setting (5) applies.
+        var h = new Harness { AzureConfigured = true, AzureEnforcing = true };
+
+        h.Build().CandidateMultiplier.Should().Be(5);
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs
@@ -25,7 +25,6 @@ public class AzureSearchScopeResolverTests
     private static AzureSearchScopeResolver Build(
         IAzureIdentityLinkReader? links = null,
         IAzureDirectoryReader? directory = null,
-        IAzureRbacReader? rbac = null,
         bool azureAdConfigured = true,
         bool isEnforcing = true,
         bool determined = true)
@@ -44,7 +43,6 @@ public class AzureSearchScopeResolverTests
         return new AzureSearchScopeResolver(
             links ?? Substitute.For<IAzureIdentityLinkReader>(),
             directory ?? Substitute.For<IAzureDirectoryReader>(),
-            rbac ?? Substitute.For<IAzureRbacReader>(),
             azureAd, enforcement, migration,
             new MemoryCache(new MemoryCacheOptions()),
             NullLogger<AzureSearchScopeResolver>.Instance);
@@ -110,47 +108,18 @@ public class AzureSearchScopeResolverTests
     }
 
     [Fact]
-    public async Task RbacFailed_Fails()
+    public async Task ValidEnforcingIdentity_RetrievesAllAzblob_ForTheVerifierToTighten()
     {
         var links = Substitute.For<IAzureIdentityLinkReader>();
         links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
         var directory = Substitute.For<IAzureDirectoryReader>();
         directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
-        var rbac = Substitute.For<IAzureRbacReader>();
-        rbac.ResolveAsync("oid-1", Arg.Any<CancellationToken>()).Returns(AzureRbacScopes.Failed());
-        var r = Build(links: links, directory: directory, rbac: rbac);
-        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.ResolverFailed);
-    }
-
-    [Fact]
-    public async Task Enabled_WithRbacPrefixes_ReturnsGrantedAzblobMatches()
-    {
-        var links = Substitute.For<IAzureIdentityLinkReader>();
-        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
-        var directory = Substitute.For<IAzureDirectoryReader>();
-        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
-        var rbac = Substitute.For<IAzureRbacReader>();
-        rbac.ResolveAsync("oid-1", Arg.Any<CancellationToken>()).Returns(
-            AzureRbacScopes.Resolved([new AzureScope("azblob://acct/docs/")], []));
-        var r = Build(links: links, directory: directory, rbac: rbac);
+        var r = Build(links: links, directory: directory);
 
         SearchScopes s = await r.ResolveAsync(User);
+
         s.Outcome.Should().Be(ScopeOutcome.Granted);
-        s.Matches.Should().ContainSingle().Which.Value.Should().Be("azblob://acct/docs/");
+        s.Matches.Should().ContainSingle().Which.Value.Should().Be("azblob://");
         s.Matches[0].IsExact.Should().BeFalse();
-    }
-
-    [Fact]
-    public async Task Enabled_NoRbacPrefixes_IsNoGrants()
-    {
-        var links = Substitute.For<IAzureIdentityLinkReader>();
-        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
-        var directory = Substitute.For<IAzureDirectoryReader>();
-        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
-        var rbac = Substitute.For<IAzureRbacReader>();
-        rbac.ResolveAsync("oid-1", Arg.Any<CancellationToken>()).Returns(AzureRbacScopes.Resolved([], []));
-        var r = Build(links: links, directory: directory, rbac: rbac);
-
-        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.NoGrants);
     }
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/AzureSearchScopeResolverTests.cs
@@ -1,0 +1,156 @@
+using Connapse.Core;
+using Connapse.Core.Interfaces;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class AzureSearchScopeResolverTests
+{
+    private static readonly Guid User = Guid.NewGuid();
+    private static readonly AzureIdentityRef Link = new("oid-1", "tid-1");
+
+    private static IOptionsMonitor<T> Opt<T>(T value) where T : class
+    {
+        var m = Substitute.For<IOptionsMonitor<T>>();
+        m.CurrentValue.Returns(value);
+        return m;
+    }
+
+    private static AzureSearchScopeResolver Build(
+        IAzureIdentityLinkReader? links = null,
+        IAzureDirectoryReader? directory = null,
+        IAzureRbacReader? rbac = null,
+        bool azureAdConfigured = true,
+        bool isEnforcing = true,
+        bool determined = true)
+    {
+        var azureAd = Opt(new AzureAdSignInSettings
+        {
+            TenantId = azureAdConfigured ? "t" : null,
+            ClientId = azureAdConfigured ? "c" : null,
+            RedirectUri = azureAdConfigured ? "https://x/cb" : null,
+            ClientCertificatePath = azureAdConfigured ? "cert.pem" : null,
+        });
+        // The Azure resolver gates on the independent Azure latch, not the SAML/AWS one.
+        var enforcement = Opt(new PermissionEnforcementSettings { AzureEnforcing = isEnforcing });
+        EnforcementMigration migration = determined ? EnforcementMigration.Completed() : new EnforcementMigration();
+
+        return new AzureSearchScopeResolver(
+            links ?? Substitute.For<IAzureIdentityLinkReader>(),
+            directory ?? Substitute.For<IAzureDirectoryReader>(),
+            rbac ?? Substitute.For<IAzureRbacReader>(),
+            azureAd, enforcement, migration,
+            new MemoryCache(new MemoryCacheOptions()),
+            NullLogger<AzureSearchScopeResolver>.Instance);
+    }
+
+    [Fact]
+    public async Task NotEnforcing_IsUnrestricted()
+    {
+        var r = Build(isEnforcing: false);
+        (await r.ResolveAsync(User)).IsUnrestricted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Enforcing_ButAzureAdNotConfigured_Fails()
+    {
+        var r = Build(azureAdConfigured: false);
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.ResolverFailed);
+    }
+
+    [Fact]
+    public async Task Undetermined_Fails()
+    {
+        var r = Build(determined: false);
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.ResolverFailed);
+    }
+
+    [Fact]
+    public async Task NullUser_IsNoPrincipal()
+    {
+        var r = Build();
+        (await r.ResolveAsync(null)).Outcome.Should().Be(ScopeOutcome.NoPrincipal);
+    }
+
+    [Fact]
+    public async Task NoLink_IsNoPrincipal()
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns((AzureIdentityRef?)null);
+        var r = Build(links: links);
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.NoPrincipal);
+    }
+
+    [Fact]
+    public async Task Deprovisioned_IsNoPrincipal()
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+        var directory = Substitute.For<IAzureDirectoryReader>();
+        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Deprovisioned());
+        var r = Build(links: links, directory: directory);
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.NoPrincipal);
+    }
+
+    [Fact]
+    public async Task IdentityResolutionFailed_Fails()
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+        var directory = Substitute.For<IAzureDirectoryReader>();
+        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Failed());
+        var r = Build(links: links, directory: directory);
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.ResolverFailed);
+    }
+
+    [Fact]
+    public async Task RbacFailed_Fails()
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+        var directory = Substitute.For<IAzureDirectoryReader>();
+        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
+        var rbac = Substitute.For<IAzureRbacReader>();
+        rbac.ResolveAsync("oid-1", Arg.Any<CancellationToken>()).Returns(AzureRbacScopes.Failed());
+        var r = Build(links: links, directory: directory, rbac: rbac);
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.ResolverFailed);
+    }
+
+    [Fact]
+    public async Task Enabled_WithRbacPrefixes_ReturnsGrantedAzblobMatches()
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+        var directory = Substitute.For<IAzureDirectoryReader>();
+        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
+        var rbac = Substitute.For<IAzureRbacReader>();
+        rbac.ResolveAsync("oid-1", Arg.Any<CancellationToken>()).Returns(
+            AzureRbacScopes.Resolved([new AzureScope("azblob://acct/docs/")], []));
+        var r = Build(links: links, directory: directory, rbac: rbac);
+
+        SearchScopes s = await r.ResolveAsync(User);
+        s.Outcome.Should().Be(ScopeOutcome.Granted);
+        s.Matches.Should().ContainSingle().Which.Value.Should().Be("azblob://acct/docs/");
+        s.Matches[0].IsExact.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Enabled_NoRbacPrefixes_IsNoGrants()
+    {
+        var links = Substitute.For<IAzureIdentityLinkReader>();
+        links.GetLinkAsync(User, Arg.Any<CancellationToken>()).Returns(Link);
+        var directory = Substitute.For<IAzureDirectoryReader>();
+        directory.ResolveAsync(Link, Arg.Any<CancellationToken>()).Returns(AzureIdentitySet.Resolved(["oid-1"]));
+        var rbac = Substitute.For<IAzureRbacReader>();
+        rbac.ResolveAsync("oid-1", Arg.Any<CancellationToken>()).Returns(AzureRbacScopes.Resolved([], []));
+        var r = Build(links: links, directory: directory, rbac: rbac);
+
+        (await r.ResolveAsync(User)).Outcome.Should().Be(ScopeOutcome.NoGrants);
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/BlobTagReaderTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/BlobTagReaderTests.cs
@@ -1,0 +1,23 @@
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class BlobTagReaderTests
+{
+    [Fact]
+    public void MapTags_CopiesAllPairs()
+    {
+        IReadOnlyDictionary<string, string> result = BlobTagReader.MapTags(
+            new Dictionary<string, string> { ["Project"] = "Cascade", ["Env"] = "prod" });
+        result.Should().HaveCount(2);
+        result["Project"].Should().Be("Cascade");
+        result["Env"].Should().Be("prod");
+    }
+
+    [Fact]
+    public void MapTags_Null_ReturnsEmpty() =>
+        BlobTagReader.MapTags(null).Should().BeEmpty();
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/CompositeSearchScopeResolverTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/CompositeSearchScopeResolverTests.cs
@@ -1,0 +1,96 @@
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class CompositeSearchScopeResolverTests
+{
+    // The composite composes two ISearchScopeResolver results; drive it through tiny fakes for each
+    // cloud rather than the concrete resolvers (those have their own tests).
+    private sealed class FakeResolver(SearchScopes result) : ISearchScopeResolver
+    {
+        public Task<SearchScopes> ResolveAsync(Guid? userId, CancellationToken ct = default) =>
+            Task.FromResult(result);
+    }
+
+    private sealed class ThrowingResolver(Exception ex) : ISearchScopeResolver
+    {
+        public Task<SearchScopes> ResolveAsync(Guid? userId, CancellationToken ct = default) => throw ex;
+    }
+
+    private static async Task<SearchScopes> Combine(SearchScopes aws, SearchScopes azure)
+    {
+        var c = new CompositeSearchScopeResolver.Combiner();
+        return await Task.FromResult(c.Combine(aws, azure));
+    }
+
+    [Fact]
+    public async Task BothUnrestricted_IsUnrestricted() =>
+        (await Combine(SearchScopes.Unrestricted, SearchScopes.Unrestricted)).IsUnrestricted.Should().BeTrue();
+
+    [Fact]
+    public async Task AwsGranted_AzureUnrestricted_UnionsPrefixesAndAzureWildcard()
+    {
+        SearchScopes r = await Combine(SearchScopes.OfPrefixes(["s3://bucket/team/"]), SearchScopes.Unrestricted);
+        r.IsUnrestricted.Should().BeFalse();
+        r.Matches.Select(m => m.Value).Should().BeEquivalentTo("s3://bucket/team/", "azblob://");
+    }
+
+    [Fact]
+    public async Task AwsUnrestricted_AzureGranted_UnionsAwsWildcardAndAzurePrefixes()
+    {
+        SearchScopes r = await Combine(SearchScopes.Unrestricted, SearchScopes.OfPrefixes(["azblob://acct/docs/"]));
+        r.Matches.Select(m => m.Value).Should().BeEquivalentTo("s3://", "azblob://acct/docs/");
+    }
+
+    [Fact]
+    public async Task OneCloudFailed_DoesNotDenyTheOther()
+    {
+        SearchScopes r = await Combine(SearchScopes.Failed, SearchScopes.OfPrefixes(["azblob://acct/"]));
+        r.Matches.Select(m => m.Value).Should().BeEquivalentTo("azblob://acct/"); // AWS failed → no s3 matches
+    }
+
+    [Fact]
+    public async Task BothDeny_IsEmpty()
+    {
+        SearchScopes r = await Combine(SearchScopes.Failed, SearchScopes.None);
+        r.IsEmpty.Should().BeTrue(); // only non-cloud (resource_uri IS NULL) will survive in SQL
+    }
+
+    [Fact]
+    public async Task AwsGranted_AzureFailed_KeepsAwsHidesAzure()
+    {
+        SearchScopes r = await Combine(SearchScopes.OfPrefixes(["s3://b/"]), SearchScopes.Failed);
+        r.Matches.Select(m => m.Value).Should().BeEquivalentTo("s3://b/");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_OneInnerThrows_IsolatedToThatCloud_OtherSurvives()
+    {
+        // AWS resolver throws; the composite must fail only AWS closed (no s3 matches) while the
+        // healthy Azure cloud's grants still come through — a throw must never become a global deny.
+        var composite = new CompositeSearchScopeResolver(
+            new ThrowingResolver(new InvalidOperationException("aws down")),
+            new FakeResolver(SearchScopes.OfPrefixes(["azblob://acct/"])));
+
+        SearchScopes r = await composite.ResolveAsync(Guid.NewGuid(), CancellationToken.None);
+
+        r.Matches.Select(m => m.Value).Should().BeEquivalentTo("azblob://acct/");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_InnerThrowsOperationCanceled_Propagates()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var composite = new CompositeSearchScopeResolver(
+            new ThrowingResolver(new OperationCanceledException()),
+            new FakeResolver(SearchScopes.Unrestricted));
+
+        Func<Task> act = () => composite.ResolveAsync(Guid.NewGuid(), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs
@@ -1,0 +1,97 @@
+using Azure.Core;
+using Azure.Identity;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class ConnapseAzureCredentialsTests
+{
+    [Fact]
+    public void ProviderKey_IsAzure() => ConnapseAzureCredentials.ProviderKey.Should().Be("azure");
+
+    [Fact]
+    public void GetToken_WithNoAzureEnvironment_FailsClosed()
+    {
+        // No cert, no managed-identity endpoint reachable in a unit-test host → the chain
+        // cannot produce a token and throws, rather than returning a bogus token.
+        var monitor = new TestOptionsMonitor<AzureProviderSettings>(new AzureProviderSettings());
+        var creds = new ConnapseAzureCredentials(monitor);
+        var act = () => creds.GetToken(
+            new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
+        act.Should().Throw<CredentialUnavailableException>();
+    }
+
+    [Fact]
+    public void Constructor_WithInvalidPartialServicePrincipalSettings_DoesNotThrow()
+    {
+        // Host-safety: a broken/partial Azure config must not take down DI construction
+        // for installs that don't even use Azure (filesystem/S3/SFTP-only hosts share
+        // this singleton via ConnectorFactory -> SourceSyncService).
+        var settings = new AzureProviderSettings { TenantId = "t", ClientCertificatePath = "missing.pfx" };
+        var monitor = new TestOptionsMonitor<AzureProviderSettings>(settings);
+        var act = () => new ConnapseAzureCredentials(monitor);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void GetToken_WithInvalidPartialServicePrincipalSettings_Throws()
+    {
+        // The failure surfaces lazily, on first actual token request, and fails closed
+        // rather than falling through to managed identity.
+        var settings = new AzureProviderSettings { TenantId = "t", ClientCertificatePath = "missing.pfx" };
+        var monitor = new TestOptionsMonitor<AzureProviderSettings>(settings);
+        var creds = new ConnapseAzureCredentials(monitor);
+        var act = () => creds.GetToken(
+            new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void OnChange_AfterInvalidatingSettings_DoesNotThrowFromCallback()
+    {
+        // Settings reload must invalidate the cache without building/throwing inline.
+        var settings = new AzureProviderSettings();
+        var monitor = new TestOptionsMonitor<AzureProviderSettings>(settings);
+        var creds = new ConnapseAzureCredentials(monitor);
+
+        // Prime the cache with a valid (managed-identity-only) build.
+        var act1 = () => creds.GetToken(
+            new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
+        act1.Should().Throw<CredentialUnavailableException>();
+
+        // Reload into a broken partial config; the callback itself must not throw.
+        var broken = new AzureProviderSettings { TenantId = "t", ClientCertificatePath = "missing.pfx" };
+        var raiseChange = () => monitor.Set(broken);
+        raiseChange.Should().NotThrow();
+
+        // The next token request rebuilds and now fails closed on the bad config.
+        var act2 = () => creds.GetToken(
+            new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
+        act2.Should().Throw<InvalidOperationException>();
+    }
+
+    private sealed class TestOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        private Action<T, string?>? _listener;
+
+        public T CurrentValue { get; private set; } = value;
+        public T Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<T, string?> listener)
+        {
+            _listener += listener;
+            return null;
+        }
+
+        public void Set(T newValue)
+        {
+            CurrentValue = newValue;
+            _listener?.Invoke(newValue, null);
+        }
+    }
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs
@@ -17,16 +17,15 @@ public class ConnapseAzureCredentialsTests
     [Fact]
     public void GetToken_WithNoAzureEnvironment_FailsClosed()
     {
-        // No cert, and no managed identity for this process → the chain cannot produce a token
-        // and throws, rather than returning a bogus token. Which exception depends on where the
-        // test runs: off Azure there is no metadata service (CredentialUnavailableException);
-        // on an Azure VM without an identity — GitHub's hosted runners — the metadata service
-        // answers "Identity not found" (AuthenticationFailedException). Both are closed.
+        // Nothing configured is nothing: the chain refuses to build rather than continuing as
+        // whatever identity the host happens to have (on an Azure VM, GitHub's hosted runners
+        // included, that would be a real request to the metadata service). Deterministic wherever
+        // the test runs, and closed.
         var monitor = new TestOptionsMonitor<AzureProviderSettings>(new AzureProviderSettings());
         var creds = new ConnapseAzureCredentials(monitor);
         var act = () => creds.GetToken(
             new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
-        act.Should().Throw<AuthenticationFailedException>();
+        act.Should().Throw<InvalidOperationException>().WithMessage("*No Azure identity is configured*");
     }
 
     [Fact]
@@ -62,11 +61,11 @@ public class ConnapseAzureCredentialsTests
         var monitor = new TestOptionsMonitor<AzureProviderSettings>(settings);
         var creds = new ConnapseAzureCredentials(monitor);
 
-        // Prime the cache with a valid (managed-identity-only) build. The token request fails
-        // closed either way — see GetToken_WithNoAzureEnvironment_FailsClosed for the two shapes.
+        // Ask once with nothing configured: the build refuses (closed), and the failure must not
+        // leave anything cached that the reload below would then have to clear.
         var act1 = () => creds.GetToken(
             new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
-        act1.Should().Throw<AuthenticationFailedException>();
+        act1.Should().Throw<InvalidOperationException>();
 
         // Reload into a broken partial config; the callback itself must not throw.
         var broken = new AzureProviderSettings { TenantId = "t", ClientCertificatePath = "missing.pfx" };

--- a/tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/ConnapseAzureCredentialsTests.cs
@@ -17,13 +17,16 @@ public class ConnapseAzureCredentialsTests
     [Fact]
     public void GetToken_WithNoAzureEnvironment_FailsClosed()
     {
-        // No cert, no managed-identity endpoint reachable in a unit-test host → the chain
-        // cannot produce a token and throws, rather than returning a bogus token.
+        // No cert, and no managed identity for this process → the chain cannot produce a token
+        // and throws, rather than returning a bogus token. Which exception depends on where the
+        // test runs: off Azure there is no metadata service (CredentialUnavailableException);
+        // on an Azure VM without an identity — GitHub's hosted runners — the metadata service
+        // answers "Identity not found" (AuthenticationFailedException). Both are closed.
         var monitor = new TestOptionsMonitor<AzureProviderSettings>(new AzureProviderSettings());
         var creds = new ConnapseAzureCredentials(monitor);
         var act = () => creds.GetToken(
             new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
-        act.Should().Throw<CredentialUnavailableException>();
+        act.Should().Throw<AuthenticationFailedException>();
     }
 
     [Fact]
@@ -59,10 +62,11 @@ public class ConnapseAzureCredentialsTests
         var monitor = new TestOptionsMonitor<AzureProviderSettings>(settings);
         var creds = new ConnapseAzureCredentials(monitor);
 
-        // Prime the cache with a valid (managed-identity-only) build.
+        // Prime the cache with a valid (managed-identity-only) build. The token request fails
+        // closed either way — see GetToken_WithNoAzureEnvironment_FailsClosed for the two shapes.
         var act1 = () => creds.GetToken(
             new TokenRequestContext(new[] { "https://storage.azure.com/.default" }), default);
-        act1.Should().Throw<CredentialUnavailableException>();
+        act1.Should().Throw<AuthenticationFailedException>();
 
         // Reload into a broken partial config; the callback itself must not throw.
         var broken = new AzureProviderSettings { TenantId = "t", ClientCertificatePath = "missing.pfx" };

--- a/tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs
@@ -98,4 +98,9 @@ public class DataLakeGen2DirectoryReaderMappingTests
         // (a named entry would otherwise be uncapped) → deny the directory.
         DataLakeGen2DirectoryReader.IsStructurallyComplete(
             Acl(mask: null, namedGroups: [new Gen2NamedAce("devs", RX)])).Should().BeFalse();
+
+    [Fact]
+    public void Reader_Implements_FileAclReader() =>
+        typeof(Connapse.Core.Interfaces.IGen2FileAclReader)
+            .IsAssignableFrom(typeof(DataLakeGen2DirectoryReader)).Should().BeTrue();
 }

--- a/tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/DataLakeGen2DirectoryReaderMappingTests.cs
@@ -1,0 +1,101 @@
+using Azure.Storage.Files.DataLake.Models;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class DataLakeGen2DirectoryReaderMappingTests
+{
+    private const Gen2Permission RX = Gen2Permission.Read | Gen2Permission.Execute;
+
+    [Fact]
+    public void MapModeBits_ParsesOwnerGroupOther_AndExtendedFlag()
+    {
+        Gen2ModeBits bits = DataLakeGen2DirectoryReader.MapModeBits("owner-oid", "group-oid", "rwxr-x---+");
+
+        bits.OwnerOid.Should().Be("owner-oid");
+        bits.OwningGroupOid.Should().Be("group-oid");
+        bits.Owner.Should().Be(Gen2Permission.Read | Gen2Permission.Write | Gen2Permission.Execute);
+        bits.OwningGroup.Should().Be(RX);
+        bits.Other.Should().Be(Gen2Permission.None);
+        bits.HasExtendedAcl.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MapAccessControl_SplitsEntriesByType_AccessScopeOnly()
+    {
+        var items = new List<PathAccessControlItem>
+        {
+            new(AccessControlType.User,  RolePermissions.Read | RolePermissions.Execute, defaultScope: false, entityId: null),
+            new(AccessControlType.User,  RolePermissions.Read, defaultScope: false, entityId: "alice"),
+            new(AccessControlType.Group, RolePermissions.Execute, defaultScope: false, entityId: null),
+            new(AccessControlType.Group, RolePermissions.Read | RolePermissions.Execute, defaultScope: false, entityId: "devs"),
+            new(AccessControlType.Mask,  RolePermissions.Read | RolePermissions.Execute, defaultScope: false, entityId: null),
+            new(AccessControlType.Other, RolePermissions.None, defaultScope: false, entityId: null),
+            // A default-scope entry must be ignored (inheritance ACL, not the access ACL).
+            new(AccessControlType.User,  RolePermissions.Read | RolePermissions.Write | RolePermissions.Execute, defaultScope: true, entityId: "should-be-ignored"),
+        };
+
+        Gen2Acl acl = DataLakeGen2DirectoryReader.MapAccessControl("owner-oid", "group-oid", items);
+
+        acl.OwnerOid.Should().Be("owner-oid");
+        acl.OwningGroupOid.Should().Be("group-oid");
+        acl.OwnerPermissions.Should().Be(RX);
+        acl.OwningGroupPermissions.Should().Be(Gen2Permission.Execute);
+        acl.OtherPermissions.Should().Be(Gen2Permission.None);
+        acl.Mask.Should().Be(RX);
+        acl.NamedUsers.Should().ContainSingle().Which.Should().BeEquivalentTo(new Gen2NamedAce("alice", Gen2Permission.Read));
+        acl.NamedGroups.Should().ContainSingle().Which.Should().BeEquivalentTo(new Gen2NamedAce("devs", RX));
+    }
+
+    [Fact]
+    public void MapAccessControl_NoMaskEntry_LeavesMaskNull()
+    {
+        var items = new List<PathAccessControlItem>
+        {
+            new(AccessControlType.User,  RolePermissions.Read | RolePermissions.Execute, defaultScope: false, entityId: null),
+            new(AccessControlType.Group, RolePermissions.Read | RolePermissions.Execute, defaultScope: false, entityId: null),
+            new(AccessControlType.Other, RolePermissions.None, defaultScope: false, entityId: null),
+        };
+
+        DataLakeGen2DirectoryReader.MapAccessControl("o", "g", items).Mask.Should().BeNull();
+    }
+
+    private static Gen2Acl Acl(
+        string? owner = "owner-oid", string? group = "group-oid", Gen2Permission? mask = null,
+        IReadOnlyList<Gen2NamedAce>? namedUsers = null, IReadOnlyList<Gen2NamedAce>? namedGroups = null) =>
+        new(owner, group, RX, RX, Gen2Permission.None, mask, namedUsers ?? [], namedGroups ?? []);
+
+    [Fact]
+    public void IsStructurallyComplete_MinimalAcl_OwnerGroupOther_NoNamed_True() =>
+        DataLakeGen2DirectoryReader.IsStructurallyComplete(Acl()).Should().BeTrue();
+
+    [Fact]
+    public void IsStructurallyComplete_ExtendedAclWithMask_True() =>
+        DataLakeGen2DirectoryReader.IsStructurallyComplete(
+            Acl(mask: RX, namedUsers: [new Gen2NamedAce("alice", RX)])).Should().BeTrue();
+
+    [Fact]
+    public void IsStructurallyComplete_MissingOwnerOid_False()
+    {
+        // A missing owner would let the real owner fall through to a more permissive class → deny.
+        DataLakeGen2DirectoryReader.IsStructurallyComplete(Acl(owner: null)).Should().BeFalse();
+        DataLakeGen2DirectoryReader.IsStructurallyComplete(Acl(owner: "")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsStructurallyComplete_MissingOwningGroupOid_False()
+    {
+        DataLakeGen2DirectoryReader.IsStructurallyComplete(Acl(group: null)).Should().BeFalse();
+        DataLakeGen2DirectoryReader.IsStructurallyComplete(Acl(group: "")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsStructurallyComplete_NamedEntriesButNoMask_False() =>
+        // A real extended ACL always carries a mask; its absence alongside named entries is anomalous
+        // (a named entry would otherwise be uncapped) → deny the directory.
+        DataLakeGen2DirectoryReader.IsStructurallyComplete(
+            Acl(mask: null, namedGroups: [new Gen2NamedAce("devs", RX)])).Should().BeFalse();
+}

--- a/tests/Connapse.Storage.Tests/CloudScope/GraphDirectoryReaderTests.cs
+++ b/tests/Connapse.Storage.Tests/CloudScope/GraphDirectoryReaderTests.cs
@@ -1,0 +1,288 @@
+using System.Net;
+using System.Text;
+using Azure.Core;
+using Connapse.Core;
+using Connapse.Storage.CloudScope;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Connapse.Storage.Tests.CloudScope;
+
+[Trait("Category", "Unit")]
+public class GraphDirectoryReaderTests
+{
+    private const string Oid = "11111111-1111-1111-1111-111111111111";
+    private const string GroupA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    private const string GroupB = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    private static readonly AzureIdentityRef Link = new(Oid, "tenant-1");
+
+    // A minimal stub that returns a queued response and counts how many sends it saw, so caching
+    // tests can assert the network was hit exactly once.
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        public int Sends { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Sends++;
+            return Task.FromResult(respond(request));
+        }
+    }
+
+    private sealed class StubTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext c, CancellationToken ct) =>
+            new("stub-token", DateTimeOffset.UtcNow.AddHours(1));
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext c, CancellationToken ct) =>
+            new(GetToken(c, ct));
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
+        new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    // A well-formed $batch response for the requested user (real oid + GUID group values).
+    private static HttpResponseMessage BatchOk(bool accountEnabled, params string[] groups)
+    {
+        string groupJson = string.Join(",", groups.Select(g => $"\"{g}\""));
+        return Json(HttpStatusCode.OK, $$$"""
+        {"responses":[
+          {"id":"user","status":200,"body":{"id":"{{{Oid}}}","accountEnabled":{{{(accountEnabled ? "true" : "false")}}}}},
+          {"id":"groups","status":200,"body":{"value":[{{{groupJson}}}]}}
+        ]}
+        """);
+    }
+
+    private static GraphDirectoryReader NewReader(StubHandler handler, IMemoryCache? cache = null) =>
+        new(new HttpClient(handler), new StubTokenCredential(),
+            cache ?? new MemoryCache(new MemoryCacheOptions()));
+
+    [Fact]
+    public async Task Resolve_EnabledUser_ReturnsPrincipalSet_OidPlusGroups()
+    {
+        var handler = new StubHandler(_ => BatchOk(true, GroupA, GroupB));
+        GraphDirectoryReader reader = NewReader(handler);
+
+        AzureIdentitySet set = await reader.ResolveAsync(Link, CancellationToken.None);
+
+        set.Outcome.Should().Be(AzureIdentityOutcome.Resolved);
+        set.Enabled.Should().BeTrue();
+        set.PrincipalOids.Should().BeEquivalentTo(Oid, GroupA, GroupB);
+    }
+
+    [Fact]
+    public async Task Resolve_UserNotFound_IsDeprovisioned()
+    {
+        var handler = new StubHandler(_ => Json(HttpStatusCode.OK, """
+        {"responses":[
+          {"id":"user","status":404,"body":null},
+          {"id":"groups","status":200,"body":{"value":[]}}
+        ]}
+        """));
+        (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+            .Outcome.Should().Be(AzureIdentityOutcome.Deprovisioned);
+    }
+
+    [Fact]
+    public async Task Resolve_AccountDisabled_IsDeprovisioned()
+    {
+        var handler = new StubHandler(_ => BatchOk(accountEnabled: false, GroupA));
+        (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+            .Outcome.Should().Be(AzureIdentityOutcome.Deprovisioned);
+    }
+
+    [Fact]
+    public async Task Resolve_GroupsCallFailed_FailsClosed()
+    {
+        var handler = new StubHandler(_ => Json(HttpStatusCode.OK, """
+        {"responses":[
+          {"id":"user","status":200,"body":{"id":"11111111-1111-1111-1111-111111111111","accountEnabled":true}},
+          {"id":"groups","status":403,"body":null}
+        ]}
+        """));
+        AzureIdentitySet set = await NewReader(handler).ResolveAsync(Link, CancellationToken.None);
+        set.Outcome.Should().Be(AzureIdentityOutcome.Failed);
+        set.PrincipalOids.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_WholeBatchUnauthorized_FailsClosed()
+    {
+        var handler = new StubHandler(_ => Json(HttpStatusCode.Unauthorized, "{}"));
+        (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+            .Outcome.Should().Be(AzureIdentityOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_TransportThrows_FailsClosed()
+    {
+        var handler = new StubHandler(_ => throw new HttpRequestException("network down"));
+        (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+            .Outcome.Should().Be(AzureIdentityOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_MissingSubResponse_FailsClosed()
+    {
+        var handler = new StubHandler(_ => Json(HttpStatusCode.OK,
+            """{"responses":[{"id":"user","status":200,"body":{"id":"11111111-1111-1111-1111-111111111111","accountEnabled":true}}]}"""));
+        (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+            .Outcome.Should().Be(AzureIdentityOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_UserResponse200_ButAccountEnabledAbsent_FailsClosed_NotDeprovisioned()
+    {
+        // An anomalous 200 whose body omits accountEnabled is uncertain, not a confirmed
+        // deprovision — it must fail as Failed (retried, never cached), not Deprovisioned (cached).
+        var handler = new StubHandler(_ => Json(HttpStatusCode.OK, """
+        {"responses":[
+          {"id":"user","status":200,"body":{"id":"11111111-1111-1111-1111-111111111111"}},
+          {"id":"groups","status":200,"body":{"value":[]}}
+        ]}
+        """));
+
+        AzureIdentitySet set = await NewReader(handler).ResolveAsync(Link, CancellationToken.None);
+
+        set.Outcome.Should().Be(AzureIdentityOutcome.Failed);
+        set.PrincipalOids.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_UserBodyMissingId_FailsClosed()
+    {
+        // 200 + accountEnabled true but no id — the body cannot be confirmed to be the requested
+        // user, so the gate must not accept it.
+        var handler = new StubHandler(_ => Json(HttpStatusCode.OK, """
+        {"responses":[
+          {"id":"user","status":200,"body":{"accountEnabled":true}},
+          {"id":"groups","status":200,"body":{"value":[]}}
+        ]}
+        """));
+        (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+            .Outcome.Should().Be(AzureIdentityOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_UserBodyIdMismatch_FailsClosed()
+    {
+        // 200 + accountEnabled true but the body is for a DIFFERENT user — never authorize the
+        // requested oid off another user's enabled status.
+        var handler = new StubHandler(_ => Json(HttpStatusCode.OK, """
+        {"responses":[
+          {"id":"user","status":200,"body":{"id":"99999999-9999-9999-9999-999999999999","accountEnabled":true}},
+          {"id":"groups","status":200,"body":{"value":[]}}
+        ]}
+        """));
+        (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+            .Outcome.Should().Be(AzureIdentityOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_GroupValueNull_FailsClosed()
+    {
+        var handler = new StubHandler(_ => Json(HttpStatusCode.OK, """
+        {"responses":[
+          {"id":"user","status":200,"body":{"id":"11111111-1111-1111-1111-111111111111","accountEnabled":true}},
+          {"id":"groups","status":200,"body":{"value":[null,"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]}}
+        ]}
+        """));
+        (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+            .Outcome.Should().Be(AzureIdentityOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_GroupValueNotGuid_FailsClosed()
+    {
+        // A non-GUID group value (e.g. a display name) is an anomalous response — fail closed
+        // rather than admit a bogus principal into P.
+        var handler = new StubHandler(_ => Json(HttpStatusCode.OK, """
+        {"responses":[
+          {"id":"user","status":200,"body":{"id":"11111111-1111-1111-1111-111111111111","accountEnabled":true}},
+          {"id":"groups","status":200,"body":{"value":["privileged-name"]}}
+        ]}
+        """));
+        (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+            .Outcome.Should().Be(AzureIdentityOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_PrincipalOids_AreImmutable_CannotBeMutatedToPoisonCache()
+    {
+        var handler = new StubHandler(_ => BatchOk(true, GroupA));
+        AzureIdentitySet set = await NewReader(handler).ResolveAsync(Link, CancellationToken.None);
+
+        Action inject = () => ((IList<string>)set.PrincipalOids).Add("99999999-9999-9999-9999-999999999999");
+
+        inject.Should().Throw<NotSupportedException>();
+        set.PrincipalOids.Should().BeEquivalentTo(Oid, GroupA);
+    }
+
+    [Fact]
+    public async Task Resolve_ConfidentAnswer_IsCached_SecondCallDoesNotHitNetwork()
+    {
+        var handler = new StubHandler(_ => BatchOk(true, GroupA));
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        GraphDirectoryReader reader = NewReader(handler, cache);
+
+        await reader.ResolveAsync(Link, CancellationToken.None);
+        await reader.ResolveAsync(Link, CancellationToken.None);
+
+        handler.Sends.Should().Be(1); // second answer served from cache
+    }
+
+    [Fact]
+    public async Task Resolve_Failure_IsNotCached_NextCallRetries()
+    {
+        bool first = true;
+        var handler = new StubHandler(_ =>
+        {
+            if (first) { first = false; return Json(HttpStatusCode.Unauthorized, "{}"); }
+            return BatchOk(true, GroupA);
+        });
+        GraphDirectoryReader reader = NewReader(handler);
+
+        (await reader.ResolveAsync(Link, CancellationToken.None)).Outcome.Should().Be(AzureIdentityOutcome.Failed);
+        AzureIdentitySet second = await reader.ResolveAsync(Link, CancellationToken.None);
+
+        second.Outcome.Should().Be(AzureIdentityOutcome.Resolved); // failure was retried, not cached
+        handler.Sends.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Resolve_Cancellation_IsRethrown_NotSwallowedAsFailed()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var handler = new StubHandler(_ => throw new OperationCanceledException());
+        GraphDirectoryReader reader = NewReader(handler);
+
+        Func<Task> act = () => reader.ResolveAsync(Link, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task Resolve_InternalTimeout_TaskCanceledWithTokenNotCancelled_FailsClosed()
+    {
+        // HttpClient's own timeout surfaces as TaskCanceledException (an OperationCanceledException)
+        // with the caller's token NOT cancelled — a transport failure, so it must fail closed
+        // rather than propagate.
+        var handler = new StubHandler(_ => throw new TaskCanceledException("http timeout"));
+        AzureIdentitySet set = await NewReader(handler).ResolveAsync(Link, CancellationToken.None);
+        set.Outcome.Should().Be(AzureIdentityOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task Resolve_DisabledAccount_ButIdMismatch_FailsClosed_NotDeprovisioned()
+    {
+        // A 200 accountEnabled:false whose body is a DIFFERENT user must not cache-deny the
+        // requested searcher off another user's disabled status — id mismatch is uncertain → Failed.
+        var handler = new StubHandler(_ => Json(HttpStatusCode.OK, """
+        {"responses":[
+          {"id":"user","status":200,"body":{"id":"99999999-9999-9999-9999-999999999999","accountEnabled":false}},
+          {"id":"groups","status":200,"body":{"value":[]}}
+        ]}
+        """));
+        (await NewReader(handler).ResolveAsync(Link, CancellationToken.None))
+            .Outcome.Should().Be(AzureIdentityOutcome.Failed);
+    }
+}

--- a/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
+++ b/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
@@ -172,11 +172,20 @@ public class ProvidersPageTests
         string markup = File.ReadAllText(Path.Combine(
             PageTestPaths.RepositoryRoot(), "src", "Connapse.Web", "Components", "Pages", "Providers.razor"));
 
-        Regex.Matches(markup, "<ProviderStepCard").Should().HaveCount(3);
+        // Three AWS step cards plus the two Azure ones built on the same component.
+        Regex.Matches(markup, "<ProviderStepCard").Should().HaveCount(5);
         markup.Should().Contain("Id=\"access\"")
             .And.Contain("Id=\"identity-center\"")
-            .And.Contain("Id=\"permissions\"");
+            .And.Contain("Id=\"permissions\"")
+            .And.Contain("Id=\"azure-access\"")
+            .And.Contain("Id=\"azure-permissions\"");
         Regex.Matches(markup, "<ProviderResetAction").Count.Should().BeGreaterThanOrEqualTo(3);
+
+        // Saving Azure sign-in must latch Azure enforcement at save time, like the SAML save does —
+        // relying on the startup latch alone left azblob results unfiltered until the next restart.
+        int azureSave = markup.IndexOf("private async Task SaveAzureAdFromForm(", StringComparison.Ordinal);
+        azureSave.Should().BeGreaterThan(0);
+        markup[azureSave..].Should().Contain("AzureEnforcing = enforcing");
         markup.Should().NotContain("confirmResetAccess")
             .And.NotContain("confirmResetIdentityCenter")
             .And.NotContain("confirmResetSamlApplication");

--- a/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
+++ b/tests/Connapse.Web.Tests/Components/ProvidersPageTests.cs
@@ -183,9 +183,18 @@ public class ProvidersPageTests
 
         // Saving Azure sign-in must latch Azure enforcement at save time, like the SAML save does —
         // relying on the startup latch alone left azblob results unfiltered until the next restart.
-        int azureSave = markup.IndexOf("private async Task SaveAzureAdFromForm(", StringComparison.Ordinal);
+        int azureSave = markup.IndexOf("private async Task<bool?> SaveAzureAdFromForm(", StringComparison.Ordinal);
         azureSave.Should().BeGreaterThan(0);
-        markup[azureSave..].Should().Contain("AzureEnforcing = enforcing");
+        markup[azureSave..].Should().Contain("LatchEnforcementAsync(azure: true)");
+
+        // Each Azure card renders what the reader found out — the reason Entra refused a credential
+        // and what to do, or what was verified — not the status word alone. A bare "Failed" on a
+        // revoked certificate would leave the administrator with nothing to act on.
+        int azureAccessCard = markup.IndexOf("Id=\"azure-access\"", StringComparison.Ordinal);
+        int azurePermissionsCard = markup.IndexOf("Id=\"azure-permissions\"", StringComparison.Ordinal);
+        markup[azureAccessCard..azurePermissionsCard].Should().Contain("@RequirementDetail(AccessRequirement)");
+        markup[azurePermissionsCard..].Should().Contain("@RequirementDetail(PermissionsRequirement)");
+        markup.Should().Contain("RequirementStatus.Failed => (\"alert alert-danger py-2 mb-2 small\", \"alert\"");
         markup.Should().NotContain("confirmResetAccess")
             .And.NotContain("confirmResetIdentityCenter")
             .And.NotContain("confirmResetSamlApplication");

--- a/tests/Connapse.Web.Tests/Services/CloudEnforcementLatchTests.cs
+++ b/tests/Connapse.Web.Tests/Services/CloudEnforcementLatchTests.cs
@@ -22,7 +22,7 @@ namespace Connapse.Web.Tests.Services;
 /// unrestricted. These tests exist because that version passed everything else.
 /// </remarks>
 [Trait("Category", "Unit")]
-public class SamlEnforcementLatchTests
+public class CloudEnforcementLatchTests
 {
     private readonly ISettingsStore store = Substitute.For<ISettingsStore>();
 
@@ -38,6 +38,14 @@ public class SamlEnforcementLatchTests
         IdpSigningCertificate = "MIIDBTCCAe2gAwIBAgIFEXAMPLE",
     };
 
+    private static AzureAdSignInSettings CompleteAzureAd() => new()
+    {
+        TenantId = "tenant-1",
+        ClientId = "client-1",
+        RedirectUri = "https://connapse.example.com/api/v1/auth/cloud/azure/cb",
+        ClientCertificatePath = "cert.pem",
+    };
+
     private static IOptionsMonitor<T> Monitor<T>(T value) where T : class
     {
         var monitor = Substitute.For<IOptionsMonitor<T>>();
@@ -45,8 +53,12 @@ public class SamlEnforcementLatchTests
         return monitor;
     }
 
-    private (SamlEnforcementLatch Latch, EnforcementMigration Migration) Build(
-        SamlSignInSettings signIn, bool alreadyEnforcing = false, bool settingsReadable = true)
+    private (CloudEnforcementLatch Latch, EnforcementMigration Migration) Build(
+        SamlSignInSettings signIn,
+        AzureAdSignInSettings? azureAd = null,
+        bool alreadyEnforcing = false,
+        bool azureAlreadyEnforcing = false,
+        bool settingsReadable = true)
     {
         var services = new ServiceCollection();
         services.AddSingleton(store);
@@ -54,13 +66,18 @@ public class SamlEnforcementLatchTests
         var migration = new EnforcementMigration();
         reloader.Reload().Returns(settingsReadable);
 
-        return (new SamlEnforcementLatch(
+        return (new CloudEnforcementLatch(
             services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
             Monitor(signIn),
-            Monitor(new PermissionEnforcementSettings { IsEnforcing = alreadyEnforcing }),
+            Monitor(azureAd ?? new AzureAdSignInSettings()),
+            Monitor(new PermissionEnforcementSettings
+            {
+                IsEnforcing = alreadyEnforcing,
+                AzureEnforcing = azureAlreadyEnforcing,
+            }),
             migration,
             reloader,
-            NullLogger<SamlEnforcementLatch>.Instance), migration);
+            NullLogger<CloudEnforcementLatch>.Instance), migration);
     }
 
     private Task<PermissionEnforcementSettings?> SavedMarker()
@@ -88,6 +105,86 @@ public class SamlEnforcementLatchTests
 
         (await SavedMarker())!.IsEnforcing.Should().BeTrue();
         migration.Determined.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Latches_When_OnlyAzureAd_Configured()
+    {
+        // SAML not configured, Azure AD configured, not yet marked → the latch turns Azure enforcement
+        // on. Crucially it latches Azure INDEPENDENTLY: SAML stays off, so the AWS resolver keeps its
+        // corpus unfiltered rather than denying every S3 document.
+        var (latch, migration) = Build(new SamlSignInSettings(), azureAd: CompleteAzureAd());
+        await latch.StartAsync(CancellationToken.None);
+
+        PermissionEnforcementSettings marker = (await SavedMarker())!;
+        marker.AzureEnforcing.Should().BeTrue();
+        marker.IsEnforcing.Should().BeFalse("configuring Azure AD must not latch SAML/AWS enforcement");
+        migration.Determined.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Latches_Saml_Independently_LeavingAzureOff()
+    {
+        // The mirror of the Azure-only case: SAML configured, Azure AD blank → SAML latches, Azure
+        // stays off so the Azure resolver keeps its corpus unfiltered.
+        var (latch, _) = Build(Complete());
+        await latch.StartAsync(CancellationToken.None);
+
+        PermissionEnforcementSettings marker = (await SavedMarker())!;
+        marker.IsEnforcing.Should().BeTrue();
+        marker.AzureEnforcing.Should().BeFalse("configuring SAML must not latch Azure enforcement");
+    }
+
+    [Fact]
+    public async Task Latches_BothProviders_WhenBothConfigured()
+    {
+        var (latch, _) = Build(Complete(), azureAd: CompleteAzureAd());
+        await latch.StartAsync(CancellationToken.None);
+
+        PermissionEnforcementSettings marker = (await SavedMarker())!;
+        marker.IsEnforcing.Should().BeTrue();
+        marker.AzureEnforcing.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AlreadySamlEnforcing_AddingAzure_LatchesAzureWithoutClearingSaml()
+    {
+        // A deployment that was already SAML-enforcing later configures Azure AD. The old early-out
+        // ("already enforcing → return") would have skipped Azure entirely; the per-provider latch
+        // must record Azure while leaving SAML latched.
+        var (latch, _) = Build(Complete(), azureAd: CompleteAzureAd(), alreadyEnforcing: true);
+        await latch.StartAsync(CancellationToken.None);
+
+        PermissionEnforcementSettings marker = (await SavedMarker())!;
+        marker.IsEnforcing.Should().BeTrue();
+        marker.AzureEnforcing.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AlreadyEnforcingBoth_WritesNothing()
+    {
+        // Steady-state boot: both markers already set and both providers configured → no change, no
+        // write (never copy a sign-in value into a shadowing row).
+        var (latch, migration) = Build(
+            Complete(), azureAd: CompleteAzureAd(), alreadyEnforcing: true, azureAlreadyEnforcing: true);
+        await latch.StartAsync(CancellationToken.None);
+
+        (await SavedMarker()).Should().BeNull();
+        migration.Determined.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AzureOnly_KeepsSamlGateUnfiltered_EndToEnd()
+    {
+        // The end-to-end proof for the regression: run the real latch for an Azure-configured /
+        // SAML-unconfigured deployment, then feed the marker it produced into both resolver gates.
+        // AWS/SAML must read NotEnforcing (S3 stays visible — completeness), Azure must enforce.
+        var (latch, _) = Build(new SamlSignInSettings(), azureAd: CompleteAzureAd());
+        await latch.StartAsync(CancellationToken.None);
+
+        PermissionEnforcementSettings marker = (await SavedMarker())!;
+        marker.StateFor(new SamlSignInSettings()).Should().Be(EnforcementState.NotEnforcing);
+        marker.StateForAzure(azureConfigured: true).Should().Be(EnforcementState.Enforcing);
     }
 
     [Fact]

--- a/tests/Connapse.Web.Tests/Services/CloudEnforcementLatchTests.cs
+++ b/tests/Connapse.Web.Tests/Services/CloudEnforcementLatchTests.cs
@@ -29,6 +29,24 @@ public class CloudEnforcementLatchTests
     /// <summary>Reads the database successfully unless a test says otherwise.</summary>
     private readonly ISettingsReloader reloader = Substitute.For<ISettingsReloader>();
 
+    /// <summary>The live options the resolvers read. The store's reload after a commit is what
+    /// moves them; the default stub below plays that part, and a test can leave it out to stand
+    /// in for a reload that failed.</summary>
+    private readonly IOptionsMonitor<PermissionEnforcementSettings> enforcement =
+        Substitute.For<IOptionsMonitor<PermissionEnforcementSettings>>();
+
+    public CloudEnforcementLatchTests()
+    {
+        // Configured here, before any test's own stub, so a test that makes the store throw wins.
+        store.UpdateAsync(Arg.Any<string>(), Arg.Any<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var merged = call.ArgAt<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(1)(null);
+                enforcement.CurrentValue.Returns(merged);
+                return merged;
+            });
+    }
+
     private static SamlSignInSettings Complete() => new()
     {
         EntityId = "https://connapse.example.com/saml/connapse",
@@ -65,30 +83,53 @@ public class CloudEnforcementLatchTests
 
         var migration = new EnforcementMigration();
         reloader.Reload().Returns(settingsReadable);
+        enforcement.CurrentValue.Returns(new PermissionEnforcementSettings
+        {
+            IsEnforcing = alreadyEnforcing,
+            AzureEnforcing = azureAlreadyEnforcing,
+        });
 
         return (new CloudEnforcementLatch(
             services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
             Monitor(signIn),
             Monitor(azureAd ?? new AzureAdSignInSettings()),
-            Monitor(new PermissionEnforcementSettings
-            {
-                IsEnforcing = alreadyEnforcing,
-                AzureEnforcing = azureAlreadyEnforcing,
-            }),
+            enforcement,
             migration,
             reloader,
             NullLogger<CloudEnforcementLatch>.Instance), migration);
     }
 
+    /// <summary>What the latch asked the store to hold, computed the way the store would: the merge
+    /// function it passed, applied to an empty row.</summary>
     private Task<PermissionEnforcementSettings?> SavedMarker()
     {
         var calls = store.ReceivedCalls()
-            .Where(c => c.GetMethodInfo().Name == nameof(ISettingsStore.SaveAsync))
-            .Select(c => c.GetArguments()[1] as PermissionEnforcementSettings)
-            .Where(v => v is not null)
+            .Where(c => c.GetMethodInfo().Name == nameof(ISettingsStore.UpdateAsync))
+            .Select(c => c.GetArguments()[1] as Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>)
+            .Where(f => f is not null)
+            .Select(f => f!(null))
             .ToList();
 
         return Task.FromResult(calls.LastOrDefault());
+    }
+
+    [Fact]
+    public async Task TheMarkerIsMerged_SoALatchAlreadyStoredIsNeverSwitchedOff()
+    {
+        // Azure was latched by somebody else — the Providers page, another process — and this
+        // deployment only configures SAML. Writing the record from this snapshot would turn Azure
+        // back off; the merge keeps whatever is already on.
+        var (latch, _) = Build(Complete());
+        await latch.StartAsync(CancellationToken.None);
+
+        var merge = store.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(ISettingsStore.UpdateAsync))
+            .Select(c => c.GetArguments()[1] as Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>)
+            .Single(f => f is not null)!;
+
+        var merged = merge(new PermissionEnforcementSettings { IsEnforcing = false, AzureEnforcing = true });
+        merged.IsEnforcing.Should().BeTrue();
+        merged.AzureEnforcing.Should().BeTrue();
     }
 
     [Fact]
@@ -238,8 +279,8 @@ public class CloudEnforcementLatchTests
     {
         // Which makes the resolver deny. The first version logged this and carried on with
         // enforcement off, so one transient database error at boot opened the whole corpus.
-        store.SaveAsync(Arg.Any<string>(), Arg.Any<PermissionEnforcementSettings>(), Arg.Any<CancellationToken>())
-            .Returns<Task>(_ => throw new InvalidOperationException("database unavailable"));
+        store.UpdateAsync(Arg.Any<string>(), Arg.Any<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(), Arg.Any<CancellationToken>())
+            .Returns<Task<PermissionEnforcementSettings>>(_ => throw new InvalidOperationException("database unavailable"));
 
         var (latch, migration) = Build(Complete());
         await latch.StartAsync(CancellationToken.None);
@@ -248,12 +289,28 @@ public class CloudEnforcementLatchTests
     }
 
     [Fact]
+    public async Task WhenTheCommitSucceedsButTheReloadDoesNot_LeavesTheStateUndetermined()
+    {
+        // The store commits the marker and then fails to reload it into this process. The resolvers
+        // read the live options, which still say "not enforcing"; completing the migration would
+        // let them answer unfiltered. Undetermined denies until a later reload lands.
+        store.UpdateAsync(Arg.Any<string>(), Arg.Any<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(), Arg.Any<CancellationToken>())
+            .Returns(call => call.ArgAt<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(1)(null));
+
+        var (latch, migration) = Build(Complete());
+        await latch.StartAsync(CancellationToken.None);
+
+        (await SavedMarker())!.IsEnforcing.Should().BeTrue("the marker was committed");
+        migration.Determined.Should().BeFalse("the live options never showed it");
+    }
+
+    [Fact]
     public async Task WhenThePersistFails_StartupStillCompletes()
     {
         // Refusing to answer is the version of "never block startup" that does not fail open. The
         // deployment comes up, and searches deny until somebody looks.
-        store.SaveAsync(Arg.Any<string>(), Arg.Any<PermissionEnforcementSettings>(), Arg.Any<CancellationToken>())
-            .Returns<Task>(_ => throw new InvalidOperationException("database unavailable"));
+        store.UpdateAsync(Arg.Any<string>(), Arg.Any<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(), Arg.Any<CancellationToken>())
+            .Returns<Task<PermissionEnforcementSettings>>(_ => throw new InvalidOperationException("database unavailable"));
 
         var (latch, _) = Build(Complete());
 
@@ -270,10 +327,12 @@ public class CloudEnforcementLatchTests
 
         await store.DidNotReceive().SaveAsync(
             Arg.Any<string>(), Arg.Any<SamlSignInSettings>(), Arg.Any<CancellationToken>());
+        await store.DidNotReceive().UpdateAsync(
+            Arg.Any<string>(), Arg.Any<Func<SamlSignInSettings?, SamlSignInSettings>>(), Arg.Any<CancellationToken>());
 
-        await store.Received(1).SaveAsync(
+        await store.Received(1).UpdateAsync(
             PermissionEnforcementSettings.Category,
-            Arg.Any<PermissionEnforcementSettings>(),
+            Arg.Any<Func<PermissionEnforcementSettings?, PermissionEnforcementSettings>>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
+++ b/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
@@ -38,7 +38,10 @@ public class ProviderSetupReaderTests
         TimeSpan? sinceCreated = null,
         IProviderCredentialStore? credentials = null,
         SamlSignInSettings? samlSignIn = null,
-        IdentityCenterSettings? identityCenter = null)
+        IdentityCenterSettings? identityCenter = null,
+        AzureProviderSettings? azureProvider = null,
+        AzureAdSignInSettings? azureAd = null,
+        IConnectionStore? connections = null)
     {
         var discovery = Substitute.For<IS3Discovery>();
         discovery.WhoAmIAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(identity);
@@ -50,15 +53,20 @@ public class ProviderSetupReaderTests
             credentials.GetStatusAsync("aws", Arg.Any<CancellationToken>()).Returns(stored);
         }
 
-        var connections = Substitute.For<IConnectionStore>();
-        connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns([]);
+        if (connections is null)
+        {
+            connections = Substitute.For<IConnectionStore>();
+            connections.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns([]);
+        }
 
         return new ProviderSetupReader(
             Options.Create(samlSignIn ?? new SamlSignInSettings()).AsMonitor(),
             // Defaults to located, so a test that varies one thing is not also silently varying
             // this one. The tests that care pass an empty instance explicitly.
             Options.Create(identityCenter ?? LocatedInstance()).AsMonitor(),
+            Options.Create(azureProvider ?? new AzureProviderSettings()).AsMonitor(),
+            Options.Create(azureAd ?? new AzureAdSignInSettings()).AsMonitor(),
             discovery, connections, credentials,
             new FixedClock(new DateTimeOffset(Created) + (sinceCreated ?? TimeSpan.Zero)),
             NullLogger<ProviderSetupReader>.Instance);
@@ -299,6 +307,8 @@ public class ProviderSetupReaderTests
         var reader = new ProviderSetupReader(
             Options.Create(new SamlSignInSettings()).AsMonitor(),
             Options.Create(new IdentityCenterSettings()).AsMonitor(),
+            Options.Create(new AzureProviderSettings()).AsMonitor(),
+            Options.Create(new AzureAdSignInSettings()).AsMonitor(),
             Substitute.For<IS3Discovery>(), connections,
             Substitute.For<IProviderCredentialStore>(),
             new FixedClock(new DateTimeOffset(Created)),
@@ -506,6 +516,152 @@ public class ProviderSetupReaderTests
         ]);
 
         setup.Overall.Should().Be(RequirementStatus.Failed);
+    }
+
+    // ── Azure provider (surfaced on the Providers page) ───────────────
+
+    private static AzureProviderSettings ConfiguredAzureProvider() => new()
+    {
+        TenantId = "11111111-1111-1111-1111-111111111111",
+        ClientId = "22222222-2222-2222-2222-222222222222",
+        ClientCertificatePath = "/certs/azure.pem",
+        SubscriptionId = "33333333-3333-3333-3333-333333333333",
+    };
+
+    private static AzureAdSignInSettings ConfiguredAzureAd() => new()
+    {
+        TenantId = "11111111-1111-1111-1111-111111111111",
+        ClientId = "44444444-4444-4444-4444-444444444444",
+        RedirectUri = "https://connapse.example.com/api/v1/auth/cloud/azure/cb",
+        ClientCertificatePath = "/certs/azure-signin.pem",
+    };
+
+    private static async Task<ProviderSetup> AzureAsync(ProviderSetupReader reader) =>
+        (await reader.ReadAsync()).Single(p => p.Key == "azure");
+
+    private static IConnectionStore ConnectionsWith(params ConnectionProvider[] providers)
+    {
+        var store = Substitute.For<IConnectionStore>();
+        IReadOnlyList<Connection> page = providers
+            .Select(p => new Connection(Guid.NewGuid(), $"{p}", p, null, null, Created, Created))
+            .ToList();
+        // All-matcher stub with a callback: mixing a literal skip (0) with Arg matchers makes
+        // NSubstitute ignore the stub entirely (every page then comes back null).
+        store.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(call => call.ArgAt<int>(0) == 0 ? page : []);
+        return store;
+    }
+
+    [Fact]
+    public async Task Azure_IsListedAsAProvider()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one")));
+
+        azure.DisplayName.Should().Be("Azure");
+    }
+
+    [Fact]
+    public async Task Azure_WithNothingConfigured_IsNotInUseAndAllRequirementsNotConfigured()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one")));
+
+        azure.InUse.Should().BeFalse();
+        azure.Requirements.Should().OnlyContain(r => r.Status == RequirementStatus.NotConfigured);
+    }
+
+    [Fact]
+    public async Task Azure_Access_WithTenantAndCredential_IsSatisfied()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider()));
+
+        azure.Requirements.Single(r => r.Name == "Access").Status
+            .Should().Be(RequirementStatus.Satisfied);
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_SignInAndSubscription_IsSatisfied()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(), azureAd: ConfiguredAzureAd()));
+
+        azure.Requirements.Single(r => r.Name == "Per-user permissions").Status
+            .Should().Be(RequirementStatus.Satisfied);
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_SignInButNoSubscription_Warns()
+    {
+        // The RBAC resolver needs the subscription, so sign-in alone fails closed at query time —
+        // a warning, not a clean state.
+        var noSub = ConfiguredAzureProvider() with { SubscriptionId = null };
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: noSub, azureAd: ConfiguredAzureAd()));
+
+        azure.Requirements.Single(r => r.Name == "Per-user permissions").Status
+            .Should().Be(RequirementStatus.Warning);
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_ConsentPending_Warns_NotSatisfied()
+    {
+        // The pending flag is stored with the sign-in settings, so a reload cannot turn a
+        // consent-less setup into a green card.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(), azureAd: ConfiguredAzureAd() with { AdminConsentPending = true }));
+
+        var requirement = azure.Requirements.Single(r => r.Name == "Per-user permissions");
+        requirement.Status.Should().Be(RequirementStatus.Warning);
+        requirement.Detail.Should().Contain("consent");
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_WithoutSignIn_IsNotConfigured()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider()));
+
+        azure.Requirements.Single(r => r.Name == "Per-user permissions").Status
+            .Should().Be(RequirementStatus.NotConfigured);
+    }
+
+    [Fact]
+    public async Task Azure_WithAnAzureBlobConnection_IsInUse()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            connections: ConnectionsWith(ConnectionProvider.AzureBlob)));
+
+        azure.InUse.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Azure_WithAccessSavedButNoConnection_IsInUse_SoTheListShowsItsState()
+    {
+        // Saving the Access step is an explicit choice (Azure access is settings-only, nothing ambient
+        // can make it read as configured), so the list must show status rather than an offer.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider()));
+
+        azure.InUse.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Aws_WithSignInConfiguredButNoConnection_IsInUse()
+    {
+        // The documented rule: sign-in configured, or a connection built on it.
+        var setups = await Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            samlSignIn: ConfiguredSignIn()).ReadAsync();
+
+        setups.Single(p => p.Key == "aws").InUse.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Azure_WithSignInConfiguredButNoConnection_IsInUse()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureAd: ConfiguredAzureAd()));
+
+        azure.InUse.Should().BeTrue();
     }
 }
 

--- a/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
+++ b/tests/Connapse.Web.Tests/Services/ProviderSetupReaderTests.cs
@@ -41,11 +41,25 @@ public class ProviderSetupReaderTests
         IdentityCenterSettings? identityCenter = null,
         AzureProviderSettings? azureProvider = null,
         AzureAdSignInSettings? azureAd = null,
-        IConnectionStore? connections = null)
+        IConnectionStore? connections = null,
+        AzureProbe<string>? azureAccess = null,
+        AzureProbe<string>? azureSignIn = null,
+        PermissionEnforcementSettings? enforcement = null)
     {
         var discovery = Substitute.For<IS3Discovery>();
         discovery.WhoAmIAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(identity);
         discovery.ListBucketsAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(buckets);
+
+        // Defaults to Entra accepting both credentials, so a test about anything else is not also
+        // silently a test about the live checks. The sign-in check is told apart from the access
+        // check by the candidate it is handed: the sign-in app's client id.
+        var azureDiscovery = Substitute.For<IAzureBlobDiscovery>();
+        azureDiscovery.CheckAccessAsync(Arg.Any<CancellationToken>())
+            .Returns(azureAccess ?? AzureProbe<string>.Ok("Entra accepted the certificate."));
+        azureDiscovery.CheckAccessAsync(Arg.Any<AzureProviderSettings>(), Arg.Any<CancellationToken>())
+            .Returns(call => call.ArgAt<AzureProviderSettings>(0).ClientId == (azureAd ?? new AzureAdSignInSettings()).ClientId
+                ? azureSignIn ?? AzureProbe<string>.Ok("Entra accepted the sign-in certificate.")
+                : azureAccess ?? AzureProbe<string>.Ok("Entra accepted the certificate."));
 
         if (credentials is null)
         {
@@ -67,7 +81,11 @@ public class ProviderSetupReaderTests
             Options.Create(identityCenter ?? LocatedInstance()).AsMonitor(),
             Options.Create(azureProvider ?? new AzureProviderSettings()).AsMonitor(),
             Options.Create(azureAd ?? new AzureAdSignInSettings()).AsMonitor(),
-            discovery, connections, credentials,
+            discovery, azureDiscovery,
+            // Latched by default: a sign-in test is about sign-in, not about the latch. The test
+            // that cares passes the open state explicitly.
+            Options.Create(enforcement ?? new PermissionEnforcementSettings { IsEnforcing = true, AzureEnforcing = true }).AsMonitor(),
+            connections, credentials,
             new FixedClock(new DateTimeOffset(Created) + (sinceCreated ?? TimeSpan.Zero)),
             NullLogger<ProviderSetupReader>.Instance);
     }
@@ -309,7 +327,8 @@ public class ProviderSetupReaderTests
             Options.Create(new IdentityCenterSettings()).AsMonitor(),
             Options.Create(new AzureProviderSettings()).AsMonitor(),
             Options.Create(new AzureAdSignInSettings()).AsMonitor(),
-            Substitute.For<IS3Discovery>(), connections,
+            Substitute.For<IS3Discovery>(), Substitute.For<IAzureBlobDiscovery>(),
+            Options.Create(new PermissionEnforcementSettings()).AsMonitor(), connections,
             Substitute.For<IProviderCredentialStore>(),
             new FixedClock(new DateTimeOffset(Created)),
             NullLogger<ProviderSetupReader>.Instance);
@@ -532,7 +551,7 @@ public class ProviderSetupReaderTests
     {
         TenantId = "11111111-1111-1111-1111-111111111111",
         ClientId = "44444444-4444-4444-4444-444444444444",
-        RedirectUri = "https://connapse.example.com/api/v1/auth/cloud/azure/cb",
+        RedirectUri = "https://connapse.example.com/api/v1/auth/cloud/azure/callback",
         ClientCertificatePath = "/certs/azure-signin.pem",
     };
 
@@ -575,8 +594,73 @@ public class ProviderSetupReaderTests
         var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
             azureProvider: ConfiguredAzureProvider()));
 
-        azure.Requirements.Single(r => r.Name == "Access").Status
-            .Should().Be(RequirementStatus.Satisfied);
+        var access = azure.Requirements.Single(r => r.Name == "Access");
+        access.Status.Should().Be(RequirementStatus.Satisfied);
+        // A pass says what was verified, in the words the probe used.
+        access.Detail.Should().Contain("Entra accepted");
+    }
+
+    [Fact]
+    public async Task Azure_Access_WhenEntraRefusesTheCredential_IsFailed_AndSaysToSetUpAgain()
+    {
+        // An expired or unregistered certificate is the one thing settings alone cannot see, and
+        // the reason to ask Entra at all. It must read as Failed, not Ready.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(),
+            azureAccess: AzureProbe<string>.Denied("AADSTS700027: The certificate is not registered on application")));
+
+        var access = azure.Requirements.Single(r => r.Name == "Access");
+        access.Status.Should().Be(RequirementStatus.Failed);
+        access.Detail.Should().Contain("set access up again").And.Contain("AADSTS700027");
+    }
+
+    [Fact]
+    public async Task Azure_Access_WhenTheIdentityIsUnusableOnThisHost_IsFailed_AndNamesTheFile()
+    {
+        // A missing or unreadable certificate file is not "could not confirm": nothing was asked
+        // of Azure and nothing will work until the file is fixed. Failed, with the remedy.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(),
+            azureAccess: AzureProbe<string>.Unusable("no usable certificate was loaded (ClientCertificatePath='/certs/azure.pem')")));
+
+        var access = azure.Requirements.Single(r => r.Name == "Access");
+        access.Status.Should().Be(RequirementStatus.Failed);
+        access.Detail.Should().Contain("cannot be used from this host").And.Contain("/certs/azure.pem");
+    }
+
+    [Fact]
+    public async Task Azure_Access_WhenTheCheckCannotComplete_Warns_RatherThanFails()
+    {
+        // A network fault says nothing about the credential, so it is a warning: "cannot confirm",
+        // which the connection test can still answer.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(),
+            azureAccess: AzureProbe<string>.Failed("No such host is known")));
+
+        var access = azure.Requirements.Single(r => r.Name == "Access");
+        access.Status.Should().Be(RequirementStatus.Warning);
+        access.Detail.Should().Contain("could not confirm").And.Contain("No such host");
+    }
+
+    [Fact]
+    public async Task Azure_Access_WithNothingConfigured_NeverAsksEntra()
+    {
+        var azureDiscovery = Substitute.For<IAzureBlobDiscovery>();
+        var reader = new ProviderSetupReader(
+            Options.Create(new SamlSignInSettings()).AsMonitor(),
+            Options.Create(new IdentityCenterSettings()).AsMonitor(),
+            Options.Create(new AzureProviderSettings()).AsMonitor(),
+            Options.Create(new AzureAdSignInSettings()).AsMonitor(),
+            Substitute.For<IS3Discovery>(), azureDiscovery,
+            Options.Create(new PermissionEnforcementSettings()).AsMonitor(), ConnectionsWith(),
+            Substitute.For<IProviderCredentialStore>(),
+            new FixedClock(new DateTimeOffset(Created)),
+            NullLogger<ProviderSetupReader>.Instance);
+
+        var azure = await AzureAsync(reader);
+
+        azure.Requirements.Single(r => r.Name == "Access").Status.Should().Be(RequirementStatus.NotConfigured);
+        await azureDiscovery.DidNotReceive().CheckAccessAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -587,6 +671,60 @@ public class ProviderSetupReaderTests
 
         azure.Requirements.Single(r => r.Name == "Per-user permissions").Status
             .Should().Be(RequirementStatus.Satisfied);
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_WhenEntraRefusesTheSignInCredential_IsFailed()
+    {
+        // An expired or removed sign-in certificate is invisible to settings, and a Ready card over
+        // it would send people to a sign-in that fails. Failed, with the reason and the fix.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(), azureAd: ConfiguredAzureAd(),
+            azureSignIn: AzureProbe<string>.Denied("AADSTS700027: Client assertion contains an invalid signature")));
+
+        var requirement = azure.Requirements.Single(r => r.Name == "Per-user permissions");
+        requirement.Status.Should().Be(RequirementStatus.Failed);
+        requirement.Detail.Should().Contain("sign-in application").And.Contain("AADSTS700027");
+        // The access credential was fine; only the sign-in one was refused.
+        azure.Requirements.Single(r => r.Name == "Access").Status.Should().Be(RequirementStatus.Satisfied);
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_SignInSetButEnforcementOff_IsFailed_BecauseThatStateIsOpen()
+    {
+        // The one combination that returns every Azure result to everyone: sign-in configured, latch
+        // off. It must never read as Ready, and the fix is named.
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(), azureAd: ConfiguredAzureAd(),
+            enforcement: new PermissionEnforcementSettings { IsEnforcing = true, AzureEnforcing = false }));
+
+        var requirement = azure.Requirements.Single(r => r.Name == "Per-user permissions");
+        requirement.Status.Should().Be(RequirementStatus.Failed);
+        requirement.Detail.Should().Contain("not filtered").And.Contain("Save the sign-in application again");
+    }
+
+    [Fact]
+    public async Task Azure_PerUserPermissions_WhenTheSignInCheckCannotComplete_Warns()
+    {
+        var azure = await AzureAsync(Build(Authenticated(AwsCredentialKind.StoredKey), Buckets("one"),
+            azureProvider: ConfiguredAzureProvider(), azureAd: ConfiguredAzureAd(),
+            azureSignIn: AzureProbe<string>.Failed("No such host is known")));
+
+        var requirement = azure.Requirements.Single(r => r.Name == "Per-user permissions");
+        requirement.Status.Should().Be(RequirementStatus.Warning);
+        requirement.Detail.Should().Contain("could not confirm");
+    }
+
+    [Fact]
+    public void SignInIdentity_CarriesTheFourFieldsTheCredentialCheckNeeds()
+    {
+        var identity = ProviderSetupReader.SignInIdentity(ConfiguredAzureAd() with { ClientCertificatePassword = "pw" });
+
+        identity.TenantId.Should().Be(ConfiguredAzureAd().TenantId);
+        identity.ClientId.Should().Be(ConfiguredAzureAd().ClientId);
+        identity.ClientCertificatePath.Should().Be(ConfiguredAzureAd().ClientCertificatePath);
+        identity.ClientCertificatePassword.Should().Be("pw");
+        identity.UserAssignedManagedIdentityClientId.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #475. Also closes the phase and follow-up issues delivered on this epic: #477, #478, #479, #486, #487, #488, #489, #490, #499, #500, #501, #503.

Rebuilds Azure Blob Storage as a full provider mirroring the AWS per-user-permission work (epic #436), adapted to Azure's authorization model. Design spec: `docs/superpowers/specs/2026-09-05-azure-blob-provider-design.md`. Governing principle: every source is evaluated per object, at parity with the cloud's own authorization decision and never broader, failing closed on any uncertainty. Connapse only reads permissions the administrator authored in Azure; it never writes a grant.

## What ships

**Connapse's own Azure identity** (`a22b93f`) — a deterministic credential chain (certificate-authenticated app registration, a user-assigned managed identity, or the host's own managed identity; never a client secret, never a fall-through to a broader identity), a read-only Blob connector with a connection tester, and Data Lake Gen2 awareness.

**Entra user identity link** (`0cad97a`) — people link their Entra identity through an authorization-code + PKCE flow; the link records object id and tenant only, is confirmed in the user's own session (no cross-user linking), and is revocable.

**Per-object query-time live permission engine** (`a4e4807` → `9d8bb53`) — searcher identity resolved through Microsoft Graph (transitive group membership); RBAC scope resolution through Azure Resource Manager with ABAC condition support, deny assignments subtracted; flat accounts resolved once and pushed into SQL as prefixes; Gen2 accounts get directory-subtree prefixes for recall plus per-hit POSIX ACL and blob-tag verification for parity; a composite resolver so AWS and Azure enforcement coexist, each latched independently.

**Guided setup and connector parity** (`9295ef5`) — two Cloud Shell scripts (Access, Per-user permissions) that mint certificates on the Connapse host and upload only the public half, create two least-privilege custom roles, and register the sign-in app; storage-account and container pickers on the connection form; readiness on the Providers page; an RBAC snippet scoped to exactly the chosen containers.

**Config-page audit and hardening** (`ee1fa0a`, PR #504) — the Azure provider page, Blob connection form, source branch, Entra card, and setup doc audited against the config-page rubric (all gates pass; dimension score 1.93 → 2.51 of 3), then eight Codex and seven Claude adversarial review rounds with every finding fixed. Highlights:
- Certificate lifecycle is transactional: each candidate goes to its own thumbprint-and-attempt-named file, is verified with Entra from there, and settings are committed to name it before anything old is swept; the key in use is never moved or overwritten; expiry shown with a 30-day warning.
- Live health: Recheck acquires a token with a fresh credential; a refused certificate reads as Failed with the AADSTS reason (allowlisted codes only), an unusable identity as Failed, an unreachable Entra as Unconfirmed; both cards render the reason and the fix.
- Fail-closed enforcement: latches merge under a row lock (`ISettingsStore.UpdateAsync`), are written before sign-in settings, and must be visible in the live options before a save or the startup migration completes; the AWS sign-in save no longer resets the Azure flag; a managed identity with the tenant recorded is an explicit, recognised mode.
- When Connapse runs on an Azure host with a managed identity, the guided setup detects it and grants that identity the roles and the two Graph permissions directly — no app registration, no certificate.
- Forms: certificate app / host identity / user-assigned identity as a conditional reveal; a portal link and validation on every field; one optional convention; layered test-connection messages with the raw error on demand; `docs/azure-setup.md` with field tables, Recheck semantics, certificate lifetime, managed-identity grants, and troubleshooting matching every message.

## Tests

Unit: Web 142 (134 tagged), Storage 279, Core 1,126, Identity 109, Ingestion 219, Background 18 — all green. Integration (Testcontainers PostgreSQL, Azurite): connector, DI wiring for the provider, credential chain, directory readers, enforcement, cloud-identity endpoints, provider-page render, settings-store atomic update — green. CI runs on this PR; the epic's own branch-to-branch PRs did not run it.

## Not yet exercised live

The managed-identity guided path (detection from the instance metadata service, role assignment by object id, the Graph app-role REST grant) follows Microsoft's documented behaviour and has not run on a real Azure VM or App Service. The certificate path and the permission engine were exercised against a live tenant during `9295ef5`.

Reviewed by 15 adversarial rounds; residual non-blocking notes are in `docs/plans/azure-config-page-audit-report.md` and `docs/plans/azure-managed-identity-guided-setup.md` (local plan files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)